### PR TITLE
Add autocomplete trm 20179

### DIFF
--- a/__tests__/ui/pages/__snapshots__/HomePage.spec.jsx.snap
+++ b/__tests__/ui/pages/__snapshots__/HomePage.spec.jsx.snap
@@ -65,9 +65,35 @@ exports[`HomePage component should render 1`] = `
             <div
               className="dropdown-menu"
             >
-              <ul
-                className=""
-              />
+              <div
+                className="dropdown-container"
+              >
+                <form
+                  onSubmit={[Function]}
+                >
+                  <input
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder="Search for field"
+                    type="text"
+                    value=""
+                  />
+                </form>
+                <div
+                  className="autocomplete-menu"
+                >
+                  <div
+                    className="dropdown-menu__panel"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdown-menu__panel"
+              >
+                <ul
+                  className=""
+                />
+              </div>
             </div>
           </div>
           <div
@@ -130,9 +156,35 @@ exports[`HomePage component should render 1`] = `
             <div
               className="dropdown-menu"
             >
-              <ul
-                className=""
-              />
+              <div
+                className="dropdown-container"
+              >
+                <form
+                  onSubmit={[Function]}
+                >
+                  <input
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder="Search for field"
+                    type="text"
+                    value=""
+                  />
+                </form>
+                <div
+                  className="autocomplete-menu"
+                >
+                  <div
+                    className="dropdown-menu__panel"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdown-menu__panel"
+              >
+                <ul
+                  className=""
+                />
+              </div>
             </div>
           </div>
           <div
@@ -195,9 +247,35 @@ exports[`HomePage component should render 1`] = `
             <div
               className="dropdown-menu"
             >
-              <ul
-                className=""
-              />
+              <div
+                className="dropdown-container"
+              >
+                <form
+                  onSubmit={[Function]}
+                >
+                  <input
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder="Search for field"
+                    type="text"
+                    value=""
+                  />
+                </form>
+                <div
+                  className="autocomplete-menu"
+                >
+                  <div
+                    className="dropdown-menu__panel"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdown-menu__panel"
+              >
+                <ul
+                  className=""
+                />
+              </div>
             </div>
           </div>
           <div
@@ -260,9 +338,35 @@ exports[`HomePage component should render 1`] = `
             <div
               className="dropdown-menu"
             >
-              <ul
-                className=""
-              />
+              <div
+                className="dropdown-container"
+              >
+                <form
+                  onSubmit={[Function]}
+                >
+                  <input
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder="Search for field"
+                    type="text"
+                    value=""
+                  />
+                </form>
+                <div
+                  className="autocomplete-menu"
+                >
+                  <div
+                    className="dropdown-menu__panel"
+                  />
+                </div>
+              </div>
+              <div
+                className="dropdown-menu__panel"
+              >
+                <ul
+                  className=""
+                />
+              </div>
             </div>
           </div>
           <div

--- a/__tests__/ui/search/AdvancedSearchField.spec.jsx
+++ b/__tests__/ui/search/AdvancedSearchField.spec.jsx
@@ -17,6 +17,7 @@ describe('AdvancedSearchField component', () => {
         dataType: 'string',
         description: 'Search by UniProtKB Accession',
         example: 'P12345',
+        id: 'id_accession',
       },
       queryInput: {},
     };
@@ -44,6 +45,7 @@ describe('AdvancedSearchField component', () => {
         ],
         description: 'Search by protein existence',
         example: '1',
+        id: 'id_existence',
       },
       queryInput: {},
     };
@@ -79,6 +81,7 @@ describe('AdvancedSearchField component', () => {
         hasRange: true,
         description: 'Search by feature sites',
         example: 'translocation',
+        id: 'id_sites',
       },
       queryInput: {},
     };

--- a/__tests__/ui/search/__snapshots__/AdvancedSearch.spec.jsx.snap
+++ b/__tests__/ui/search/__snapshots__/AdvancedSearch.spec.jsx.snap
@@ -55,9 +55,35 @@ exports[`AdvancedSearch component should render 1`] = `
       <div
         className="dropdown-menu"
       >
-        <ul
-          className=""
-        />
+        <div
+          className="dropdown-container"
+        >
+          <form
+            onSubmit={[Function]}
+          >
+            <input
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search for field"
+              type="text"
+              value=""
+            />
+          </form>
+          <div
+            className="autocomplete-menu"
+          >
+            <div
+              className="dropdown-menu__panel"
+            />
+          </div>
+        </div>
+        <div
+          className="dropdown-menu__panel"
+        >
+          <ul
+            className=""
+          />
+        </div>
       </div>
     </div>
     <div
@@ -120,9 +146,35 @@ exports[`AdvancedSearch component should render 1`] = `
       <div
         className="dropdown-menu"
       >
-        <ul
-          className=""
-        />
+        <div
+          className="dropdown-container"
+        >
+          <form
+            onSubmit={[Function]}
+          >
+            <input
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search for field"
+              type="text"
+              value=""
+            />
+          </form>
+          <div
+            className="autocomplete-menu"
+          >
+            <div
+              className="dropdown-menu__panel"
+            />
+          </div>
+        </div>
+        <div
+          className="dropdown-menu__panel"
+        >
+          <ul
+            className=""
+          />
+        </div>
       </div>
     </div>
     <div
@@ -185,9 +237,35 @@ exports[`AdvancedSearch component should render 1`] = `
       <div
         className="dropdown-menu"
       >
-        <ul
-          className=""
-        />
+        <div
+          className="dropdown-container"
+        >
+          <form
+            onSubmit={[Function]}
+          >
+            <input
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search for field"
+              type="text"
+              value=""
+            />
+          </form>
+          <div
+            className="autocomplete-menu"
+          >
+            <div
+              className="dropdown-menu__panel"
+            />
+          </div>
+        </div>
+        <div
+          className="dropdown-menu__panel"
+        >
+          <ul
+            className=""
+          />
+        </div>
       </div>
     </div>
     <div
@@ -250,9 +328,35 @@ exports[`AdvancedSearch component should render 1`] = `
       <div
         className="dropdown-menu"
       >
-        <ul
-          className=""
-        />
+        <div
+          className="dropdown-container"
+        >
+          <form
+            onSubmit={[Function]}
+          >
+            <input
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search for field"
+              type="text"
+              value=""
+            />
+          </form>
+          <div
+            className="autocomplete-menu"
+          >
+            <div
+              className="dropdown-menu__panel"
+            />
+          </div>
+        </div>
+        <div
+          className="dropdown-menu__panel"
+        >
+          <ul
+            className=""
+          />
+        </div>
       </div>
     </div>
     <div

--- a/__tests__/ui/search/__snapshots__/AdvancedSearchField.spec.jsx.snap
+++ b/__tests__/ui/search/__snapshots__/AdvancedSearchField.spec.jsx.snap
@@ -35,24 +35,66 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
     className="advanced-search__inputs"
   >
     <label
-      htmlFor="input_ec"
+      htmlFor="input_undefined"
     >
       Enzyme classification [EC]
-      <input
-        id="input_ec"
-        onChange={[Function]}
-        placeholder="1.1.2.3"
-        type="text"
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
     </label>
   </div>,
 ]
@@ -93,9 +135,35 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
@@ -162,9 +230,35 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
@@ -229,24 +323,66 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
     className="advanced-search__inputs"
   >
     <label
-      htmlFor="input_cofactor_chebi"
+      htmlFor="input_undefined"
     >
       ChEBI term
-      <input
-        id="input_cofactor_chebi"
-        onChange={[Function]}
-        placeholder="29105"
-        type="text"
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
     </label>
   </div>,
   <div
@@ -301,20 +437,46 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
     className="advanced-search__inputs"
   >
     <label
-      htmlFor="input_sites"
+      htmlFor="input_id_sites"
     >
       Any
       <input
-        id="input_sites"
+        id="input_id_sites"
         onChange={[Function]}
         placeholder="translocation"
         type="text"
@@ -385,20 +547,46 @@ Array [
     <div
       className="dropdown-menu"
     >
-      <ul
-        className=""
-      />
+      <div
+        className="dropdown-container"
+      >
+        <form
+          onSubmit={[Function]}
+        >
+          <input
+            onChange={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Search for field"
+            type="text"
+            value=""
+          />
+        </form>
+        <div
+          className="autocomplete-menu"
+        >
+          <div
+            className="dropdown-menu__panel"
+          />
+        </div>
+      </div>
+      <div
+        className="dropdown-menu__panel"
+      >
+        <ul
+          className=""
+        />
+      </div>
     </div>
   </div>,
   <div
     className="advanced-search__inputs"
   >
     <label
-      htmlFor="input_accession"
+      htmlFor="input_id_accession"
     >
       UniProtKB AC
       <input
-        id="input_accession"
+        id="input_id_accession"
         onChange={[Function]}
         placeholder="P12345"
         type="text"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "franklin-sites": "^0.0.3-dev.8",
+    "franklin-sites": "^0.0.3-dev.9",
     "lodash": "^4.17.11",
     "node-sass-chokidar": "^1.3.3",
     "npm-run-all": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-router-dom": "^4.2.2",
+    "url-join": "^4.0.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "franklin-sites": "^0.0.3-dev.7",
+    "franklin-sites": "^0.0.3-dev.8",
     "lodash": "^4.17.11",
     "node-sass-chokidar": "^1.3.3",
     "npm-run-all": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "franklin-sites": "^0.0.3-dev.5",
+    "franklin-sites": "^0.0.3-dev.7",
     "lodash": "^4.17.11",
     "node-sass-chokidar": "^1.3.3",
     "npm-run-all": "^4.1.2",

--- a/src/ui/apiUrls.js
+++ b/src/ui/apiUrls.js
@@ -1,18 +1,24 @@
-const prefix = '//wwwdev.ebi.ac.uk/uniprot/api';
+import urljoin from 'url-join';
+
+const prefix = '//wwwdev.ebi.ac.uk/';
 
 export default {
   // uniprotkb advanced search terms
-  advanced_search_terms: `${prefix}/configure/uniprotkb/search_terms`,
+  advanced_search_terms: urljoin(prefix, '/uniprot/api/configure/uniprotkb/search_terms'),
   // Annotation evidence used by advanced search
-  annotation_evidences: `${prefix}/configure/uniprotkb/annotation_evidences`,
+  annotation_evidences: urljoin(prefix, '/uniprot/api/configure/uniprotkb/annotation_evidences'),
   // Go evidences used by advanced go search
   // "itemType": "goterm",
-  go_evidences: `${prefix}/configure/uniprotkb/go_evidences`,
+  go_evidences: urljoin(prefix, '/uniprot/api/configure/uniprotkb/go_evidences'),
   // Database cross references used by advanced search
-  database_xefs: `${prefix}/configure/uniprotkb/databases`,
+  database_xefs: urljoin(prefix, '/uniprot/api/configure/uniprotkb/databases'),
   // Database cross reference fields in result column configure
   // "itemType": "database",
-  database_fields: `${prefix}/configure/uniprotkb/databasefields`,
+  database_fields: urljoin(prefix, '/uniprot/api/configure/uniprotkb/databasefields'),
   // All result fields except database cross reference fields
-  results_fields: `${prefix}/configure/uniprotkb/resultfields`,
+  results_fields: urljoin(prefix, '/uniprot/api/configure/uniprotkb/resultfields'),
 };
+
+const RE_QUERY = /\?$/;
+
+export const getSuggesterUrl = (url, value) => urljoin(prefix, url.replace(RE_QUERY, value));

--- a/src/ui/hoc/fetchData.js
+++ b/src/ui/hoc/fetchData.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
-export default function fetchData(url) {
-  return axios.get(url);
+export default function fetchData(url, config={}) {
+  return axios.get(url, config);
 }

--- a/src/ui/hoc/fetchData.js
+++ b/src/ui/hoc/fetchData.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
-export default function fetchData(url, config={}) {
-  return axios.get(url, config);
+export default function fetchData(url) {
+  return axios.get(url);
 }

--- a/src/ui/hoc/prepareData.js
+++ b/src/ui/hoc/prepareData.js
@@ -1,11 +1,32 @@
 import { v1 as uuidv1 } from 'uuid';
 
-export default function appendUniqueValue(data) {
+function getUniqueIdFromItemProperties(item) {
+  let uid = '';
+  if (item.term) {
+    uid += `-${item.term}`;
+  }
+  if (item.label) {
+    uid += `-${item.label}`;
+  }
+  if (item.valuePrefix) {
+    uid += `-${item.valuePrefix}`;
+  }
+  if (item.itemType) {
+    uid += `-${item.itemType}`;
+  }
+  return uid;
+}
+
+export default function appendUniqueValue(data, idFromItemProperties = true) {
+  const idGenerator = idFromItemProperties ? getUniqueIdFromItemProperties : uuidv1;
   return data.map((item) => {
-    const newItem = { ...item, value: uuidv1() };
+    const newItem = {
+      ...item,
+      value: getUniqueIdFromItemProperties(item),
+    };
     const { items } = item;
     if (items) {
-      newItem.items = appendUniqueValue(items);
+      newItem.items = appendUniqueValue(items, idGenerator);
     }
     return newItem;
   });

--- a/src/ui/hoc/prepareData.js
+++ b/src/ui/hoc/prepareData.js
@@ -1,0 +1,12 @@
+import { v1 as uuidv1 } from 'uuid';
+
+export default function appendUniqueValue(data) {
+  return data.map((item) => {
+    const newItem = { ...item, value: uuidv1() };
+    const { items } = item;
+    if (items) {
+      newItem.items = appendUniqueValue(items);
+    }
+    return newItem;
+  });
+}

--- a/src/ui/hoc/prepareData.js
+++ b/src/ui/hoc/prepareData.js
@@ -1,32 +1,13 @@
-import { v1 as uuidv1 } from 'uuid';
-
-function getUniqueIdFromItemProperties(item) {
-  let uid = '';
-  if (item.term) {
-    uid += `-${item.term}`;
-  }
-  if (item.label) {
-    uid += `-${item.label}`;
-  }
-  if (item.valuePrefix) {
-    uid += `-${item.valuePrefix}`;
-  }
-  if (item.itemType) {
-    uid += `-${item.itemType}`;
-  }
-  return uid;
-}
-
-export default function appendUniqueValue(data, idFromItemProperties = true) {
-  const idGenerator = idFromItemProperties ? getUniqueIdFromItemProperties : uuidv1;
-  return data.map((item) => {
+export default function appendUniqueId(data, prefix = 'id') {
+  return data.map((item, index) => {
+    const id = `${prefix}_${index}`;
     const newItem = {
       ...item,
-      value: getUniqueIdFromItemProperties(item),
+      id,
     };
     const { items } = item;
     if (items) {
-      newItem.items = appendUniqueValue(items, idGenerator);
+      newItem.items = appendUniqueId(items, `${id}_`);
     }
     return newItem;
   });

--- a/src/ui/hoc/withData.jsx
+++ b/src/ui/hoc/withData.jsx
@@ -7,7 +7,8 @@ type State = {
   data: [],
 };
 
-const withData = (url, prepareData = x => x) => (WrappedComponent: Component) => {
+const withData = (url: Function,
+  prepareData: Function = x => x) => (WrappedComponent: Component) => {
   class WithData extends WrappedComponent<Props, State> {
     constructor(props: Props) {
       super(props);

--- a/src/ui/hoc/withData.jsx
+++ b/src/ui/hoc/withData.jsx
@@ -7,7 +7,7 @@ type State = {
   data: [],
 };
 
-const withData = url => (WrappedComponent: Component) => {
+const withData = (url, prepareData) => (WrappedComponent: Component) => {
   class WithData extends WrappedComponent<Props, State> {
     constructor(props: Props) {
       super(props);
@@ -19,8 +19,9 @@ const withData = url => (WrappedComponent: Component) => {
     componentDidMount() {
       const endpoint = url(this.props);
       fetchData(endpoint)
+        .then(data => prepareData(data.data))
         .then((data) => {
-          this.setState({ data: data.data });
+          this.setState({ data });
         })
         .catch(e => console.error(e));
     }

--- a/src/ui/hoc/withData.jsx
+++ b/src/ui/hoc/withData.jsx
@@ -7,7 +7,7 @@ type State = {
   data: [],
 };
 
-const withData = (url, prepareData) => (WrappedComponent: Component) => {
+const withData = (url, prepareData = x => x) => (WrappedComponent: Component) => {
   class WithData extends WrappedComponent<Props, State> {
     constructor(props: Props) {
       super(props);

--- a/src/ui/search/AdvancedSearch.jsx
+++ b/src/ui/search/AdvancedSearch.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { v1 } from 'uuid';
 import AdvancedSearchField from './AdvancedSearchField';
 import withData from '../hoc/withData';
+import appendUniqueValue from '../hoc/prepareData';
 import apiUrls from '../apiUrls';
 
 import type { Field } from './AdvancedSearchField';
@@ -135,4 +136,5 @@ class AdvancedSearch extends Component<Props, State> {
   }
 }
 
-export default withData(() => apiUrls.advanced_search_terms)(AdvancedSearch);
+const url = () => apiUrls.advanced_search_terms;
+export default withData(url, appendUniqueValue)(AdvancedSearch);

--- a/src/ui/search/AdvancedSearch.jsx
+++ b/src/ui/search/AdvancedSearch.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { v1 } from 'uuid';
 import AdvancedSearchField from './AdvancedSearchField';
 import withData from '../hoc/withData';
-import appendUniqueValue from '../hoc/prepareData';
+import appendUniqueId from '../hoc/prepareData';
 import apiUrls from '../apiUrls';
 
 import type { Field } from './AdvancedSearchField';
@@ -57,19 +57,19 @@ class AdvancedSearch extends Component<Props, State> {
       if (field.queryInput.rangeFrom || field.queryInput.rangeTo) {
         query = `${query}(${field.selectedNode.term}:[${
           field.queryInput.rangeFrom ? field.queryInput.rangeFrom : ''
-        }-${field.queryInput.rangeTo ? field.queryInput.rangeTo : ''}])`;
+          }-${field.queryInput.rangeTo ? field.queryInput.rangeTo : ''}])`;
       }
       if (field.queryInput.stringValue && field.queryInput.stringValue !== '') {
         query = `${query}(${field.selectedNode.term}:${
           field.queryInput.stringValue ? field.queryInput.stringValue : ''
-        })`;
+          })`;
       }
       if (field.queryInput.evidenceValue && field.queryInput.evidenceValue !== '') {
         query = `${query}AND(${field.selectedNode.term}:${field.queryInput.evidenceValue})`;
       }
       return `${queryAccumulator}${
         queryAccumulator.length > 0 && query.length > 0 ? field.logic : ''
-      }${query}`;
+        }${query}`;
     }, '');
   };
 
@@ -137,4 +137,4 @@ class AdvancedSearch extends Component<Props, State> {
 }
 
 const url = () => apiUrls.advanced_search_terms;
-export default withData(url, appendUniqueValue)(AdvancedSearch);
+export default withData(url)(AdvancedSearch);

--- a/src/ui/search/AdvancedSearch.jsx
+++ b/src/ui/search/AdvancedSearch.jsx
@@ -34,6 +34,7 @@ class AdvancedSearch extends Component<Props, State> {
       example: 'a4_human, P05067, cdc7 human',
       itemType: 'single',
       dataType: 'string',
+      id: 'All',
     },
     queryInput: {},
   });
@@ -56,19 +57,19 @@ class AdvancedSearch extends Component<Props, State> {
       if (field.queryInput.rangeFrom || field.queryInput.rangeTo) {
         query = `${query}(${field.selectedNode.term}:[${
           field.queryInput.rangeFrom ? field.queryInput.rangeFrom : ''
-          }-${field.queryInput.rangeTo ? field.queryInput.rangeTo : ''}])`;
+        }-${field.queryInput.rangeTo ? field.queryInput.rangeTo : ''}])`;
       }
       if (field.queryInput.stringValue && field.queryInput.stringValue !== '') {
         query = `${query}(${field.selectedNode.term}:${
           field.queryInput.stringValue ? field.queryInput.stringValue : ''
-          })`;
+        })`;
       }
       if (field.queryInput.evidenceValue && field.queryInput.evidenceValue !== '') {
         query = `${query}AND(${field.selectedNode.term}:${field.queryInput.evidenceValue})`;
       }
       return `${queryAccumulator}${
         queryAccumulator.length > 0 && query.length > 0 ? field.logic : ''
-        }${query}`;
+      }${query}`;
     }, '');
   };
 

--- a/src/ui/search/AdvancedSearch.jsx
+++ b/src/ui/search/AdvancedSearch.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { v1 } from 'uuid';
 import AdvancedSearchField from './AdvancedSearchField';
 import withData from '../hoc/withData';
-import appendUniqueId from '../hoc/prepareData';
 import apiUrls from '../apiUrls';
 
 import type { Field } from './AdvancedSearchField';

--- a/src/ui/search/AdvancedSearchField.jsx
+++ b/src/ui/search/AdvancedSearchField.jsx
@@ -237,7 +237,8 @@ class AdvancedSearchField extends Component<Props> {
                   : apiUrls.annotation_evidences
               }
             />
-          )}
+          )
+        }
       </Fragment>
     );
   }

--- a/src/ui/search/AdvancedSearchField.jsx
+++ b/src/ui/search/AdvancedSearchField.jsx
@@ -58,7 +58,6 @@ const rangeToName = 'to_';
 
 class AdvancedSearchField extends Component<Props> {
   selectNode = (node: TermNode) => {
-    console.log(node);
     const { field, updateField } = this.props;
     field.selectedNode = node;
     updateField(field);
@@ -120,14 +119,13 @@ class AdvancedSearchField extends Component<Props> {
         />
       );
     }
-
     return (
       <Fragment>
         {(!term.hasRange || term.dataType !== 'integer') && (
-          <div className="advanced-search__inputs" key={term.value}>
-            <label htmlFor={`input_${term.value}`}>
+          <div className="advanced-search__inputs" key={term.id}>
+            <label htmlFor={`input_${term.id}`}>
               {term.label}
-              {React.cloneElement(node, { id: `input_${term.value}` })}
+              {React.cloneElement(node, { id: `input_${term.id}` })}
             </label>
           </div>
         )}
@@ -237,7 +235,7 @@ class AdvancedSearchField extends Component<Props> {
                   : apiUrls.annotation_evidences
               }
             />
-          )
+        )
         }
       </Fragment>
     );

--- a/src/ui/search/AdvancedSearchField.jsx
+++ b/src/ui/search/AdvancedSearchField.jsx
@@ -1,8 +1,9 @@
 // @flow
 import React, { Component, Fragment } from 'react';
-import { TreeSelect } from 'franklin-sites';
+import { TreeSelect, Autocomplete } from 'franklin-sites';
 import EvidenceField from './EvidenceField';
 import apiUrls from '../apiUrls';
+import AutocompleteWrapper from './AutocompleteWrapper';
 
 const dataTypes = { string: 'text', integer: 'number' };
 
@@ -14,6 +15,8 @@ export type TermNode = {
   dataType: string,
   hasRange?: boolean,
   hasEvidence?: boolean,
+  value?: string,
+  autoComplete?: string,
   options?: Array<{
     name: string,
     values: Array<{
@@ -55,6 +58,7 @@ const rangeToName = 'to_';
 
 class AdvancedSearchField extends Component<Props> {
   selectNode = (node: TermNode) => {
+    console.log(node);
     const { field, updateField } = this.props;
     field.selectedNode = node;
     updateField(field);
@@ -92,19 +96,38 @@ class AdvancedSearchField extends Component<Props> {
     updateField(field);
   };
 
+  handleAutocompleteChange = (value: String) => {
+    console.log(value);
+  }
+
   renderField(term: TermNode) {
+    let node;
+    if (term.autoComplete) {
+      console.log('here');
+      node = (
+        <AutocompleteWrapper
+          data={[]}
+          onSelect={e => this.handleInputChange(e)}
+          onChange={v => this.handleAutocompleteChange(v)}
+        />
+      );
+    } else {
+      node = (
+        <input
+          type={dataTypes[term.dataType]}
+          onChange={e => this.handleInputChange(e)}
+          placeholder={term.example}
+        />
+      );
+    }
+
     return (
       <Fragment>
         {(!term.hasRange || term.dataType !== 'integer') && (
-          <div className="advanced-search__inputs" key={term.term}>
-            <label htmlFor={`input_${term.term}`}>
+          <div className="advanced-search__inputs" key={term.value}>
+            <label htmlFor={`input_${term.value}`}>
               {term.label}
-              <input
-                id={`input_${term.term}`}
-                type={dataTypes[term.dataType]}
-                onChange={e => this.handleInputChange(e)}
-                placeholder={term.example}
-              />
+              {React.cloneElement(node, {id: `input_${term.value}`})}
             </label>
           </div>
         )}
@@ -196,7 +219,12 @@ class AdvancedSearchField extends Component<Props> {
           ))}
         </select>
 
-        <TreeSelect data={data} onSelect={e => this.selectNode(e)} />
+        <TreeSelect
+          data={data}
+          onSelect={e => this.selectNode(e)}
+          autocompletePlaceholder="Search for field"
+          autocomplete
+        />
         {fieldRender}
         {field.selectedNode
           && field.selectedNode.hasEvidence && (

--- a/src/ui/search/AdvancedSearchField.jsx
+++ b/src/ui/search/AdvancedSearchField.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component, Fragment } from 'react';
-import { TreeSelect, Autocomplete } from 'franklin-sites';
+import { TreeSelect } from 'franklin-sites';
 import EvidenceField from './EvidenceField';
 import apiUrls from '../apiUrls';
 import AutocompleteWrapper from './AutocompleteWrapper';
@@ -96,19 +96,19 @@ class AdvancedSearchField extends Component<Props> {
     updateField(field);
   };
 
-  handleAutocompleteChange = (value: String) => {
-    console.log(value);
+  handleAutocompleteSelect = (value: string) => {
+    const { field, updateField } = this.props;
+    field.queryInput.stringValue = value;
+    updateField(field);
   }
 
   renderField(term: TermNode) {
     let node;
     if (term.autoComplete) {
-      console.log('here');
       node = (
         <AutocompleteWrapper
-          data={[]}
-          onSelect={e => this.handleInputChange(e)}
-          onChange={v => this.handleAutocompleteChange(v)}
+          url={term.autoComplete}
+          onSelect={v => this.handleAutocompleteSelect(v)}
         />
       );
     } else {
@@ -127,7 +127,7 @@ class AdvancedSearchField extends Component<Props> {
           <div className="advanced-search__inputs" key={term.value}>
             <label htmlFor={`input_${term.value}`}>
               {term.label}
-              {React.cloneElement(node, {id: `input_${term.value}`})}
+              {React.cloneElement(node, { id: `input_${term.value}` })}
             </label>
           </div>
         )}
@@ -237,7 +237,7 @@ class AdvancedSearchField extends Component<Props> {
                   : apiUrls.annotation_evidences
               }
             />
-        )}
+          )}
       </Fragment>
     );
   }

--- a/src/ui/search/AutocompleteWrapper.jsx
+++ b/src/ui/search/AutocompleteWrapper.jsx
@@ -1,12 +1,9 @@
 // @flow
 import React, { Component } from 'react';
-import urljoin from 'url-join';
 import { Autocomplete } from 'franklin-sites';
 import fetchData from '../hoc/fetchData';
 import appendUniqueId from '../hoc/prepareData';
-
-const SERVER = 'http://wwwdev.ebi.ac.uk/';
-const RE_QUERY = /\?$/;
+import { getSuggesterUrl } from '../apiUrls';
 
 type Props = {
   url: string,
@@ -27,7 +24,7 @@ type Chosen = {
   id: string,
   itemLabel: string,
   pathLabel: string,
-}
+};
 
 class AutocompleteWrapper extends Component<Props, State> {
   constructor(props: Props) {
@@ -37,9 +34,9 @@ class AutocompleteWrapper extends Component<Props, State> {
 
   handleChange = (textInputValue: string) => {
     const { url } = this.props;
-    const assembledUrl = urljoin(SERVER, url.replace(RE_QUERY, textInputValue));
-    this.fetchOptions(assembledUrl);
-  }
+    const suggesterUrl = getSuggesterUrl(url, textInputValue);
+    this.fetchOptions(suggesterUrl);
+  };
 
   fetchOptions = (url: string) => {
     fetchData(url)
@@ -49,12 +46,12 @@ class AutocompleteWrapper extends Component<Props, State> {
       .then(data => appendUniqueId(data, 'autocomplete'))
       .then(data => this.setState({ data }))
       .catch(e => console.error(e));
-  }
+  };
 
   handleSelect = (chosen: Chosen) => {
     const { onSelect } = this.props;
     onSelect(chosen.pathLabel);
-  }
+  };
 
   render() {
     const { data } = this.state;

--- a/src/ui/search/AutocompleteWrapper.jsx
+++ b/src/ui/search/AutocompleteWrapper.jsx
@@ -1,28 +1,54 @@
 import React, { Component, Fragment } from 'react';
+import urljoin from 'url-join';
 import { Autocomplete } from 'franklin-sites';
-// import withData from '../hoc/withData';
+import fetchData from '../hoc/fetchData';
+import appendUniqueId from '../hoc/prepareData';
+
+const SERVER = 'http://wwwdev.ebi.ac.uk/';
+const RE_QUERY = /\?$/;
 
 class AutocompleteWrapper extends Component {
   constructor(props) {
     super(props);
-    // this.handleSelect = this.handleSelect.bind(this);
+    this.state = { data: [] };
+    this.handleSelect = this.handleSelect.bind(this);
     this.handleChange = this.handleChange.bind(this);
   }
 
-  handleChange = (value) => {
-    console.log(value);
+  handleChange(textInputValue) {
+    const { url } = this.props;
+    const assembledUrl = urljoin(SERVER, url.replace(RE_QUERY, textInputValue));
+    this.fetchOptions(assembledUrl);
+  }
+
+  fetchOptions(url) {
+    fetchData(url).then((data) => {
+      return data.data.suggestions;
+    }).then(data => [...new Set(data)])
+      .then(data => data.map(x => ({ pathLabel: x, itemLabel: x })))
+      .then(data => appendUniqueId(data, 'autocomplete'))
+      .then((data) => {
+        this.setState({ data });
+      })
+      .catch(e => console.error(e));
+  }
+
+  handleSelect(chosen) {
+    const { onSelect } = this.props;
+    onSelect(chosen.pathLabel);
   }
 
   render() {
+    const { data } = this.state;
     return (
       <Autocomplete
-        data={[]}
-        // onSelect={e => this.handleSelect(e)}
-        onChange={v => this.handleChange(v)}
+        data={data}
+        onSelect={this.handleSelect}
+        onChange={this.handleChange}
+        filter={false}
       />
     );
   }
 }
 
 export default AutocompleteWrapper;
-// export default withData(url, appendUniqueValue)(EvidenceField);

--- a/src/ui/search/AutocompleteWrapper.jsx
+++ b/src/ui/search/AutocompleteWrapper.jsx
@@ -1,4 +1,5 @@
-import React, { Component, Fragment } from 'react';
+// @flow
+import React, { Component } from 'react';
 import urljoin from 'url-join';
 import { Autocomplete } from 'franklin-sites';
 import fetchData from '../hoc/fetchData';
@@ -7,8 +8,23 @@ import appendUniqueId from '../hoc/prepareData';
 const SERVER = 'http://wwwdev.ebi.ac.uk/';
 const RE_QUERY = /\?$/;
 
-class AutocompleteWrapper extends Component {
-  constructor(props) {
+type Props = {
+  url: string,
+  onSelect: Function,
+};
+
+type Suggestions = {
+  dictionary: string,
+  query: string,
+  suggestions: Array<string>,
+};
+
+type State = {
+  data: Array<Suggestions>,
+};
+
+class AutocompleteWrapper extends Component<Props, State> {
+  constructor(props: Props) {
     super(props);
     this.state = { data: [] };
     this.handleSelect = this.handleSelect.bind(this);
@@ -22,14 +38,12 @@ class AutocompleteWrapper extends Component {
   }
 
   fetchOptions(url) {
-    fetchData(url).then((data) => {
-      return data.data.suggestions;
-    }).then(data => [...new Set(data)])
+    fetchData(url)
+      // Remove duplicates for now as there is a bug in the API
+      .then(data => [...new Set(data.data.suggestions)])
       .then(data => data.map(x => ({ pathLabel: x, itemLabel: x })))
       .then(data => appendUniqueId(data, 'autocomplete'))
-      .then((data) => {
-        this.setState({ data });
-      })
+      .then(data => this.setState({ data }))
       .catch(e => console.error(e));
   }
 

--- a/src/ui/search/AutocompleteWrapper.jsx
+++ b/src/ui/search/AutocompleteWrapper.jsx
@@ -23,21 +23,25 @@ type State = {
   data: Array<Suggestions>,
 };
 
+type Chosen = {
+  id: string,
+  itemLabel: string,
+  pathLabel: string,
+}
+
 class AutocompleteWrapper extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { data: [] };
-    this.handleSelect = this.handleSelect.bind(this);
-    this.handleChange = this.handleChange.bind(this);
   }
 
-  handleChange(textInputValue) {
+  handleChange = (textInputValue: string) => {
     const { url } = this.props;
     const assembledUrl = urljoin(SERVER, url.replace(RE_QUERY, textInputValue));
     this.fetchOptions(assembledUrl);
   }
 
-  fetchOptions(url) {
+  fetchOptions = (url: string) => {
     fetchData(url)
       // Remove duplicates for now as there is a bug in the API
       .then(data => [...new Set(data.data.suggestions)])
@@ -47,7 +51,7 @@ class AutocompleteWrapper extends Component<Props, State> {
       .catch(e => console.error(e));
   }
 
-  handleSelect(chosen) {
+  handleSelect = (chosen: Chosen) => {
     const { onSelect } = this.props;
     onSelect(chosen.pathLabel);
   }

--- a/src/ui/search/AutocompleteWrapper.jsx
+++ b/src/ui/search/AutocompleteWrapper.jsx
@@ -1,0 +1,28 @@
+import React, { Component, Fragment } from 'react';
+import { Autocomplete } from 'franklin-sites';
+// import withData from '../hoc/withData';
+
+class AutocompleteWrapper extends Component {
+  constructor(props) {
+    super(props);
+    // this.handleSelect = this.handleSelect.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange = (value) => {
+    console.log(value);
+  }
+
+  render() {
+    return (
+      <Autocomplete
+        data={[]}
+        // onSelect={e => this.handleSelect(e)}
+        onChange={v => this.handleChange(v)}
+      />
+    );
+  }
+}
+
+export default AutocompleteWrapper;
+// export default withData(url, appendUniqueValue)(EvidenceField);

--- a/src/ui/search/EvidenceField.jsx
+++ b/src/ui/search/EvidenceField.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import withData from '../hoc/withData';
-import appendUniqueValue from '../hoc/prepareData';
+import appendUniqueId from '../hoc/prepareData';
 type Props = {
   updateEvidence: Function,
   selectedEvidence?: string,
@@ -41,4 +41,4 @@ class EvidenceField extends Component<Props> {
 }
 
 const url = props => props.url;
-export default withData(url, appendUniqueValue)(EvidenceField);
+export default withData(url, appendUniqueId)(EvidenceField);

--- a/src/ui/search/EvidenceField.jsx
+++ b/src/ui/search/EvidenceField.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import withData from '../hoc/withData';
 import appendUniqueId from '../hoc/prepareData';
+
 type Props = {
   updateEvidence: Function,
   selectedEvidence?: string,

--- a/src/ui/search/EvidenceField.jsx
+++ b/src/ui/search/EvidenceField.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import withData from '../hoc/withData';
-
+import appendUniqueValue from '../hoc/prepareData';
 type Props = {
   updateEvidence: Function,
   selectedEvidence?: string,
@@ -40,4 +40,5 @@ class EvidenceField extends Component<Props> {
   }
 }
 
-export default withData(props => props.url)(EvidenceField);
+const url = props => props.url;
+export default withData(url, appendUniqueValue)(EvidenceField);


### PR DESCRIPTION
Incorporates franklin-sites `0.0.3-dev.9`'s Autocomplete component by using an AutocompleteWrapper component to feed in the data from API requests.

* Assumes the API request for search-terms will have unique IDs
* For suggester API requests it appends unique IDs with:
    * a provided prefix
    * the index within the items array
    * for items with sub-items recurses with a new prefix: `${prefix}_${parentIndex}_${childIndex}`