### PR TITLE
Add root reducer to reset state when results component is unmounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "axios-mock-adapter": "^1.15.0",
-    "franklin-sites": "0.0.3-dev.24",
+    "franklin-sites": "0.0.3-dev.25",
     "idx": "^2.5.2",
     "npm-run-all": "^4.1.2",
     "path": "^0.12.7",

--- a/src/results/ResultsContainer.tsx
+++ b/src/results/ResultsContainer.tsx
@@ -32,6 +32,7 @@ interface IResultsProps extends RouteComponentProps {
   dispatchUpdateColumnSort: (column: SortableColumns) => void;
   dispatchAddFacet: (facetName: string, facetValue: string) => void;
   dispatchRemoveFacet: (facetName: string, facetValue: string) => void;
+  dispatchReset: () => void;
   clauses?: Array<Clause>;
   columns: Array<string>;
   sort: SortType;
@@ -97,6 +98,11 @@ export class Results extends Component<IResultsProps, ResultsContainerState> {
         direction
       );
     }
+  }
+
+  componentWillUnmount() {
+    const { dispatchReset } = this.props;
+    dispatchReset();
   }
 
   handleRowSelect(rowId: string) {
@@ -186,6 +192,7 @@ const mapDispatchToProps = (dispatch: Dispatch<RootAction>) =>
         searchActions.updateQueryString(queryString),
       dispatchUpdateColumnSort: (column: SortableColumns) =>
         resultsActions.updateColumnSort(column),
+      dispatchReset: () => searchActions.reset(),
     },
     dispatch
   );

--- a/src/results/__tests__/__snapshots__/ResultsTable.spec.tsx.snap
+++ b/src/results/__tests__/__snapshots__/ResultsTable.spec.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResultsTable component should render 1`] = `"<e columns={{...}} data={{...}} selectable={true} selected={{...}} onSelect={[Function: onSelect]} onHeaderClick={[Function: onHeaderClick]} />"`;
+exports[`ResultsTable component should render 1`] = `"<e columns={{...}} data={{...}} selectable={true} selected={{...}} onSelect={[Function: onSelect]} onHeaderClick={[Function: onHeaderClick]} idKey=\\"id\\" />"`;

--- a/src/search/state/actions.ts
+++ b/src/search/state/actions.ts
@@ -26,6 +26,7 @@ export const REQUEST_EVIDENCES = 'REQUEST_EVIDENCES';
 export const RECEIVE_EVIDENCES = 'RECEIVE_EVIDENCES';
 export const UPDATE_CLAUSES = 'UPDATE_CLAUSES';
 export const UPDATE_QUERY_STRING = 'UPDATE_QUERY_STRING';
+export const RESET = 'RESET';
 
 export const selectSearchTerm = (
   clauseId: string,
@@ -156,3 +157,5 @@ export const updateQueryString = (queryString: string) =>
   action(UPDATE_QUERY_STRING, {
     queryString,
   });
+
+export const reset = () => action(RESET);

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -1,10 +1,27 @@
-import {
-  combineReducers, Action, Reducer, ReducersMapObject,
-} from 'redux';
-import query from '../search/state/reducers';
-import results from '../results/state/reducers';
+import { combineReducers, Action, Reducer, ReducersMapObject } from 'redux';
+import query, { SearchAction } from '../search/state/reducers';
+import results, { ResultAction } from '../results/state/reducers';
+import { SearchState } from '../search/state/initialState';
+import { ResultsState } from '../results/state/initialState';
 
-export default combineReducers({
+type RootState =
+  | {
+      query: SearchState;
+      results: ResultsState;
+    }
+  | undefined;
+
+const appReducer = combineReducers({
   query,
   results,
 });
+
+const rootReducer = (state: RootState, action: SearchAction | ResultAction) => {
+  if (action.type === 'RESET') {
+    state = undefined;
+  }
+
+  return appReducer(state, action);
+};
+
+export default rootReducer;

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -4,19 +4,20 @@ import results, { ResultAction } from '../results/state/reducers';
 import { SearchState } from '../search/state/initialState';
 import { ResultsState } from '../results/state/initialState';
 
-type RootState =
-  | {
-      query: SearchState;
-      results: ResultsState;
-    }
-  | undefined;
+type RootState = {
+  query: SearchState;
+  results: ResultsState;
+};
 
 const appReducer = combineReducers({
   query,
   results,
 });
 
-const rootReducer = (state: RootState, action: SearchAction | ResultAction) => {
+const rootReducer = (
+  state: RootState | undefined,
+  action: SearchAction | ResultAction
+) => {
   if (action.type === 'RESET') {
     state = undefined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3400,10 +3400,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-franklin-sites@0.0.3-dev.24:
-  version "0.0.3-dev.24"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.3-dev.24.tgz#f7a3e315e9eab6a7e5e0a581c8e1f29c70ab6870"
-  integrity sha512-Mjmgv8hZ3O9BEiNjxkOK5W5nz9GCDmMkBePzuH2AJSsO/4VkukPF3DTe0kVC24SUAGM4JwdgAVxW6HriubVf9A==
+franklin-sites@0.0.3-dev.25:
+  version "0.0.3-dev.25"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.3-dev.25.tgz#8e1f99597241329a368df4945f56817fdd82fd04"
+  integrity sha512-iSUgJDRKZ8JkHAo2j9GYzbbTD2wXo2HAgsKBvd/x78tfCPCJi9fZ8cGgll0E7PRzmTWdLsuHkZbDOBaTX606Wg==
   dependencies:
     file-loader "^2.0.0"
     foundation-sites "^6.5.0-rc.3"


### PR DESCRIPTION
Reset the query (actually the whole state at the moment) when the user navigates away from the results page (unmount)