### PR TITLE
Trm 21704 autocomplete show id in options (MERGE THIS ONE SECOND PLZ)

### DIFF
--- a/src/components/AutocompleteWrapper.tsx
+++ b/src/components/AutocompleteWrapper.tsx
@@ -52,7 +52,7 @@ class AutocompleteWrapper extends Component<Props, State> {
     fetchData(url)
       .then(data =>
         data.data.suggestions.map((suggestion: Suggestion) => ({
-          pathLabel: suggestion.value,
+          pathLabel: `${suggestion.value} [${suggestion.id}]`,
           itemLabel: suggestion.value,
           apiId: suggestion.id,
           id: v1(),

--- a/src/search/Field.tsx
+++ b/src/search/Field.tsx
@@ -49,11 +49,7 @@ const Field = ({
               url={field.autoComplete}
               onSelect={handleInputChange}
               title={field.label}
-              value={
-                queryInput.id
-                  ? `${queryInput.stringValue} [${queryInput.id}]`
-                  : queryInput.stringValue
-              }
+              value={queryInput.stringValue}
             />
           ) : (
             <TextField


### PR DESCRIPTION
Fields with a suggester API should display options in `Value [ID]` format and also use the same format once selected. 