### PR TITLE
Move url update from Search to Results

### DIFF
--- a/src/results/ResultsContainer.tsx
+++ b/src/results/ResultsContainer.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Dispatch, bindActionCreators } from 'redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Facets, PageIntro } from 'franklin-sites';
+import { default as queryStringModule } from 'query-string';
 import * as resultsActions from './state/actions';
 import * as searchActions from '../search/state/actions';
 import { Clause, Namespace } from '../search/types/searchTypes';
@@ -24,7 +25,7 @@ interface ResultsProps extends RouteComponentProps {
   selectedFacets: SelectedFacet[];
   dispatchFetchResults: (
     queryString: string,
-    columns: Array<string>,
+    columns: string[],
     selectedFacets: SelectedFacet[],
     sortBy: SortableColumns | undefined,
     sortDirection: keyof SortDirectionsType | undefined
@@ -34,8 +35,8 @@ interface ResultsProps extends RouteComponentProps {
   dispatchAddFacet: (facetName: string, facetValue: string) => void;
   dispatchRemoveFacet: (facetName: string, facetValue: string) => void;
   dispatchReset: () => void;
-  clauses?: Array<Clause>;
-  columns: Array<string>;
+  clauses?: Clause[];
+  columns: string[];
   sort: SortType;
   results: any[];
   facets: any[];
@@ -64,6 +65,15 @@ export class Results extends Component<ResultsProps, ResultsContainerState> {
       history,
       sort: { column, direction },
     } = this.props;
+    const queryFromUrl = queryStringModule.parse(queryParamFromUrl).query;
+    if (
+      queryFromUrl &&
+      queryFromUrl !== queryString &&
+      typeof queryFromUrl === 'string'
+    ) {
+      dispatchUpdateQueryString(queryFromUrl);
+      return;
+    }
     dispatchFetchResults(
       queryString,
       columns,
@@ -75,7 +85,6 @@ export class Results extends Component<ResultsProps, ResultsContainerState> {
 
   componentDidUpdate(prevProps: ResultsProps) {
     const {
-      location: { search: queryParamFromUrl },
       dispatchFetchResults,
       queryString,
       selectedFacets,

--- a/src/search/SearchContainer.tsx
+++ b/src/search/SearchContainer.tsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { Dispatch, bindActionCreators } from 'redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { MainSearch } from 'franklin-sites';
-import { default as queryStringModule } from 'query-string';
 import { RootState, RootAction } from '../state/state-types';
 import * as searchActions from './state/actions';
 import {
@@ -23,9 +22,9 @@ interface SearchProps extends RouteComponentProps {
   dispatchUpdateQueryString: (type: string) => void;
   searchTerms: [any];
   namespace: Namespace;
-  clauses: Array<Clause>;
+  clauses: Clause[];
   evidences: any;
-  dispatchUpdateClauses: (clauses: Array<Clause>) => void;
+  dispatchUpdateClauses: (clauses: Clause[]) => void;
   dispatchfetchEvidencesIfNeeded: (type: EvidenceType) => void;
   dispatchFetchSearchTermsIfNeeded: () => void;
   dispatchAddClause: () => void;
@@ -58,22 +57,6 @@ export class Search extends Component<SearchProps, SearchContainerState> {
     this.handleSubmitClick = this.handleSubmitClick.bind(this);
     this.handleAdvancedSubmitClick = this.handleAdvancedSubmitClick.bind(this);
     this.handleQueryStringChange = this.handleQueryStringChange.bind(this);
-  }
-
-  componentDidMount() {
-    const {
-      location: { search: queryParamFromUrl },
-      queryString,
-      dispatchUpdateQueryString,
-    } = this.props;
-    const queryFromUrl = queryStringModule.parse(queryParamFromUrl).query;
-    if (
-      queryFromUrl &&
-      queryFromUrl !== queryString &&
-      typeof queryFromUrl === 'string'
-    ) {
-      dispatchUpdateQueryString(queryFromUrl);
-    }
   }
 
   componentDidUpdate(prevProps: SearchProps) {


### PR DESCRIPTION
This solves the issue with back button from the entry page back to results. The issue was to do with the lifecycle of the components, and the fact the url was parsed and updated in a Search component rather than Results component.