### PR TITLE
Trm 22818/annotation score visualisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "d3": "^5.9.2",
     "eslint": "5.3.0",
     "eslint-config-prettier": "^6.0.0",
-    "franklin-sites": "0.0.14",
+    "franklin-sites": "0.0.15",
     "idx": "^2.5.2",
     "litemol": "^2.4.2",
     "npm-run-all": "^4.1.2",

--- a/src/components/__tests__/UniProtEvidenceTag.spec.tsx
+++ b/src/components/__tests__/UniProtEvidenceTag.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import UniProtEvidenceTag from '../UniProtEvidenceTag';
 import { render, cleanup } from '@testing-library/react';
+import UniProtEvidenceTag from '../UniProtEvidenceTag';
 
 describe('UniProtEvidenceTag components', () => {
   test('should render automatic annotation', () => {
@@ -25,7 +25,7 @@ describe('UniProtEvidenceTag components', () => {
       {
         evidenceCode: 'ECO:0000269',
         source: 'PubMed',
-        id: '12345',
+        id: '12346',
       },
     ];
     const { asFragment } = render(<UniProtEvidenceTag evidences={evidences} />);

--- a/src/components/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
+++ b/src/components/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
@@ -119,7 +119,7 @@ exports[`UniProtEvidenceTag components should render publications count 1`] = `
         PubMed:12345
       </div>
       <div>
-        PubMed:12345
+        PubMed:12346
       </div>
     </div>
   </div>

--- a/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -306,7 +306,7 @@ exports[`Entry should render 1`] = `
                   <span
                     class="doughnut-chart--medium__inner-circle"
                   >
-                    2
+                    1
                   </span>
                 </span>
               </div>

--- a/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -284,11 +284,33 @@ exports[`Entry should render 1`] = `
               <div
                 class="info-list__item__content"
               >
-                <span
-                  class="bubble--medium colour-uniprot-blue"
+                <div
+                  class="doughnut-chart--medium colour-light-grey"
                 >
-                  2
-                </span>
+                  <div
+                    class="doughnut-chart--medium__left-wrap"
+                  >
+                    <div
+                      class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+                      style="transform: rotate(0deg);"
+                    />
+                  </div>
+                  <div
+                    class="doughnut-chart--medium__right-wrap"
+                  >
+                    <div
+                      class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+                      style="transform: rotate(72deg);"
+                    />
+                  </div>
+                  <div
+                    class="doughnut-chart--medium__inner-circle"
+                  >
+                    <span>
+                      20%
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -284,33 +284,31 @@ exports[`Entry should render 1`] = `
               <div
                 class="info-list__item__content"
               >
-                <div
+                <span
                   class="doughnut-chart--medium colour-light-grey"
                 >
-                  <div
+                  <span
                     class="doughnut-chart--medium__left-wrap"
                   >
-                    <div
+                    <span
                       class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
                       style="transform: rotate(0deg);"
                     />
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="doughnut-chart--medium__right-wrap"
                   >
-                    <div
+                    <span
                       class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
                       style="transform: rotate(72deg);"
                     />
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="doughnut-chart--medium__inner-circle"
                   >
-                    <span>
-                      20%
-                    </span>
-                  </div>
-                </div>
+                    2
+                  </span>
+                </span>
               </div>
             </div>
           </div>

--- a/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -285,28 +285,32 @@ exports[`Entry should render 1`] = `
                 class="info-list__item__content"
               >
                 <span
-                  class="doughnut-chart--medium colour-light-grey"
+                  title="Annotation Score"
                 >
                   <span
-                    class="doughnut-chart--medium__left-wrap"
+                    class="doughnut-chart--medium colour-light-grey"
                   >
                     <span
-                      class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
-                      style="transform: rotate(0deg);"
-                    />
-                  </span>
-                  <span
-                    class="doughnut-chart--medium__right-wrap"
-                  >
+                      class="doughnut-chart--medium__left-wrap"
+                    >
+                      <span
+                        class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+                        style="transform: rotate(0deg);"
+                      />
+                    </span>
                     <span
-                      class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
-                      style="transform: rotate(72deg);"
-                    />
-                  </span>
-                  <span
-                    class="doughnut-chart--medium__inner-circle"
-                  >
-                    1
+                      class="doughnut-chart--medium__right-wrap"
+                    >
+                      <span
+                        class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+                        style="transform: rotate(72deg);"
+                      />
+                    </span>
+                    <span
+                      class="doughnut-chart--medium__inner-circle"
+                    >
+                      1/5
+                    </span>
                   </span>
                 </span>
               </div>

--- a/src/model/uniprotkb/ProteinNamesConverter.ts
+++ b/src/model/uniprotkb/ProteinNamesConverter.ts
@@ -13,17 +13,17 @@ const convertProteinNames = (data: ProteinNamesData) => {
     }
   }
   const alternativeNames: string[] = [];
-  const ecNumbers = idx(data, _ => _.recommendedName.ecNumbers);
+  const ecNumbers = idx(data, o => o.recommendedName.ecNumbers);
   if (ecNumbers && ecNumbers.length > 0) {
     alternativeNames.push(...ecNumbers.map(ec => ec.value));
   }
-  const submissionNames = idx(data, _ => _.submissionNames);
+  const submissionNames = idx(data, o => o.submissionNames);
   if (submissionNames && submissionNames.length > 0) {
     alternativeNames.push(
       ...submissionNames.map(submissionName => submissionName.fullName.value)
     );
   }
-  const alternativeNameArray = idx(data, _ => _.alternativeNames);
+  const alternativeNameArray = idx(data, o => o.alternativeNames);
   if (alternativeNameArray && alternativeNameArray.length > 0) {
     alternativeNames.push(
       ...alternativeNameArray.map(altName => altName.fullName.value)

--- a/src/results/state/resultsActions.ts
+++ b/src/results/state/resultsActions.ts
@@ -60,7 +60,7 @@ export const fetchBatchOfResults = (url: string, state: RootState) => async (
 ) => {
   dispatch(requestBatchOfResults(url));
   fetchData(url).then((response: Response) => {
-    const nextUrl = getNextUrlFromResponse(idx(response, _ => _.headers.link));
+    const nextUrl = getNextUrlFromResponse(idx(response, o => o.headers.link));
     dispatch(
       receiveBatchOfResults(
         url,

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { FC, Fragment } from 'react';
+import React, { FC } from 'react';
 import { DoughnutChart } from 'franklin-sites';
 
 export const annotationScoreToBin = (annotationScore: number) => {
@@ -31,9 +30,11 @@ const AnnotationScoreDoughnutChart: FC<AnnotationScoreDoughnutChartProps> = ({
 }) => {
   const annotationScoreBin = annotationScoreToBin(annotationScore);
   return (
-    <DoughnutChart percent={annotationScoreBin * 20} size={size}>
-      {`${annotationScoreBin}/5`}
-    </DoughnutChart>
+    <span title="Annotation Score">
+      <DoughnutChart percent={annotationScoreBin * 20} size={size}>
+        {`${annotationScoreBin}/5`}
+      </DoughnutChart>
+    </span>
   );
 };
 

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { FC } from 'react';
+import React, { FC, Fragment } from 'react';
 import { DoughnutChart } from 'franklin-sites';
 
 export const annotationScoreToBin = (annotationScore: number) => {
@@ -25,9 +25,10 @@ type AnnotationScoreDoughnutChartProps = {
   size?: DoughnutChartSize;
 };
 
-const AnnotationScoreDoughnutChart: React.FC<
-  AnnotationScoreDoughnutChartProps
-> = ({ children: annotationScore, size = DoughnutChartSize.medium }) => {
+const AnnotationScoreDoughnutChart: FC<AnnotationScoreDoughnutChartProps> = ({
+  children: annotationScore,
+  size = DoughnutChartSize.medium,
+}) => {
   const annotationScoreBin = annotationScoreToBin(annotationScore);
   return (
     <DoughnutChart percent={annotationScoreBin * 20} size={size}>

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -31,7 +31,7 @@ const AnnotationScoreDoughnutChart: React.FC<
   const annotationScoreBin = annotationScoreToBin(annotationScore);
   return (
     <DoughnutChart percent={annotationScoreBin * 20} size={size}>
-      {annotationScoreBin}
+      {`${annotationScoreBin}/5`}
     </DoughnutChart>
   );
 };

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { FC } from 'react';
+import { DoughnutChart } from 'franklin-sites';
+
+export const annotationScoreToBin = (annotationScore: number) => {
+  /*
+    0-19: bin 1
+    20-39: bin 2
+    40-59: bin 3
+    60-79: bin 4
+    80 and above bin 5.
+  */
+  const bin = Math.floor(annotationScore / 20) + 1;
+  return Math.min(bin, 5);
+};
+
+export enum DoughnutChartSize {
+  small = 'small',
+  medium = 'medium',
+  large = 'large',
+}
+
+type AnnotationScoreDoughnutChartProps = {
+  children: number;
+  size?: DoughnutChartSize;
+};
+
+const AnnotationScoreDoughnutChart: React.FC<
+  AnnotationScoreDoughnutChartProps
+> = ({ children: annotationScore, size = DoughnutChartSize.medium }) => {
+  const annotationScoreBin = annotationScoreToBin(annotationScore);
+  return (
+    <DoughnutChart percent={annotationScoreBin * 20} size={size}>
+      {annotationScoreBin}
+    </DoughnutChart>
+  );
+};
+
+export default AnnotationScoreDoughnutChart;

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -4,11 +4,11 @@ import { DoughnutChart } from 'franklin-sites';
 
 export const annotationScoreToBin = (annotationScore: number) => {
   /*
-    0-19: bin 1
-    20-39: bin 2
-    40-59: bin 3
-    60-79: bin 4
-    80 and above bin 5.
+    0-19  | bin 1
+    20-39 | bin 2
+    40-59 | bin 3
+    60-79 | bin 4
+    >=80  | bin 5
   */
   const bin = Math.floor(annotationScore / 20) + 1;
   return Math.min(bin, 5);

--- a/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
+++ b/src/view/uniprotkb/components/AnnotationScoreDoughnutChart.tsx
@@ -20,15 +20,15 @@ export enum DoughnutChartSize {
 }
 
 type AnnotationScoreDoughnutChartProps = {
-  children: number;
+  score: number;
   size?: DoughnutChartSize;
 };
 
 const AnnotationScoreDoughnutChart: FC<AnnotationScoreDoughnutChartProps> = ({
-  children: annotationScore,
+  score,
   size = DoughnutChartSize.medium,
 }) => {
-  const annotationScoreBin = annotationScoreToBin(annotationScore);
+  const annotationScoreBin = annotationScoreToBin(score);
   return (
     <span title="Annotation Score">
       <DoughnutChart percent={annotationScoreBin * 20} size={size}>

--- a/src/view/uniprotkb/components/ProteinOverviewView.tsx
+++ b/src/view/uniprotkb/components/ProteinOverviewView.tsx
@@ -44,11 +44,7 @@ export const ProteinOverview: FC<{
     },
     {
       title: 'Annotation score',
-      content: (
-        <AnnotationScoreDoughnutChart>
-          {annotationScore}
-        </AnnotationScoreDoughnutChart>
-      ),
+      content: <AnnotationScoreDoughnutChart score={annotationScore} />,
     },
   ];
 

--- a/src/view/uniprotkb/components/ProteinOverviewView.tsx
+++ b/src/view/uniprotkb/components/ProteinOverviewView.tsx
@@ -55,7 +55,9 @@ export const ProteinOverview: FC<{
     {
       title: 'Annotation score',
       content: (
-        <DoughnutChart percent={annotationScoreToPercentage(annotationScore)} />
+        <DoughnutChart percent={annotationScoreToPercentage(annotationScore)}>
+          {annotationScore > 99 ? '99+' : annotationScore}
+        </DoughnutChart>
       ),
     },
   ];

--- a/src/view/uniprotkb/components/ProteinOverviewView.tsx
+++ b/src/view/uniprotkb/components/ProteinOverviewView.tsx
@@ -16,9 +16,9 @@ export const ProteinOverview: FC<{
   ];
   const proteinName = idx(
     proteinNamesData,
-    _ => _.recommendedName.fullName.value
+    o => o.recommendedName.fullName.value
   );
-  const ECnumbers = idx(proteinNamesData, _ => _.recommendedName.ecNumbers);
+  const ECnumbers = idx(proteinNamesData, o => o.recommendedName.ecNumbers);
 
   const infoListData = [
     {

--- a/src/view/uniprotkb/components/ProteinOverviewView.tsx
+++ b/src/view/uniprotkb/components/ProteinOverviewView.tsx
@@ -1,22 +1,11 @@
 import React, { FC } from 'react';
-import { InfoList, DoughnutChart } from 'franklin-sites';
+import { InfoList } from 'franklin-sites';
 import idx from 'idx';
 import OrganismView from './OrganismView';
 import GeneNamesView from './GeneNamesView';
 import { UniProtkbUIModel } from '../../../model/uniprotkb/UniProtkbConverter';
 import EntrySection from '../../../model/types/EntrySection';
-
-export const annotationScoreToPercentage = (annotationScore: number) => {
-  /*
-    0-19: bin 1
-    20-39: bin 2
-    40-59: bin 3
-    60-79: bin 4
-    80 and above bin 5.
-  */
-  const bin = Math.floor(annotationScore / 20) + 1;
-  return Math.min(bin, 5) * 20;
-};
+import AnnotationScoreDoughnutChart from './AnnotationScoreDoughnutChart';
 
 export const ProteinOverview: FC<{
   transformedData: UniProtkbUIModel;
@@ -30,6 +19,7 @@ export const ProteinOverview: FC<{
     _ => _.recommendedName.fullName.value
   );
   const ECnumbers = idx(proteinNamesData, _ => _.recommendedName.ecNumbers);
+
   const infoListData = [
     {
       title: 'Name',
@@ -55,9 +45,9 @@ export const ProteinOverview: FC<{
     {
       title: 'Annotation score',
       content: (
-        <DoughnutChart percent={annotationScoreToPercentage(annotationScore)}>
-          {annotationScore > 99 ? '99+' : annotationScore}
-        </DoughnutChart>
+        <AnnotationScoreDoughnutChart>
+          {annotationScore}
+        </AnnotationScoreDoughnutChart>
       ),
     },
   ];

--- a/src/view/uniprotkb/components/ProteinOverviewView.tsx
+++ b/src/view/uniprotkb/components/ProteinOverviewView.tsx
@@ -1,10 +1,22 @@
 import React, { FC } from 'react';
-import { InfoList, Bubble } from 'franklin-sites';
+import { InfoList, DoughnutChart } from 'franklin-sites';
 import idx from 'idx';
 import OrganismView from './OrganismView';
 import GeneNamesView from './GeneNamesView';
 import { UniProtkbUIModel } from '../../../model/uniprotkb/UniProtkbConverter';
 import EntrySection from '../../../model/types/EntrySection';
+
+export const annotationScoreToPercentage = (annotationScore: number) => {
+  /*
+    0-19: bin 1
+    20-39: bin 2
+    40-59: bin 3
+    60-79: bin 4
+    80 and above bin 5.
+  */
+  const bin = Math.floor(annotationScore / 20) + 1;
+  return Math.min(bin, 5) * 20;
+};
 
 export const ProteinOverview: FC<{
   transformedData: UniProtkbUIModel;
@@ -42,7 +54,9 @@ export const ProteinOverview: FC<{
     },
     {
       title: 'Annotation score',
-      content: <Bubble value={annotationScore} />,
+      content: (
+        <DoughnutChart percent={annotationScoreToPercentage(annotationScore)} />
+      ),
     },
   ];
 

--- a/src/view/uniprotkb/components/SequenceView.tsx
+++ b/src/view/uniprotkb/components/SequenceView.tsx
@@ -105,7 +105,7 @@ export const IsoformInfo: React.FC<{ isoformData: Isoform }> = ({
     },
     {
       title: 'Synonyms',
-      content: (idx(isoformData, _ => _.synonyms) || [])
+      content: (idx(isoformData, o => o.synonyms) || [])
         .map(syn => syn.value)
         .join(', '),
     },
@@ -190,7 +190,7 @@ isoforms
   }
 
   let notesNode;
-  const texts = idx(data.alternativeProducts, _ => _.note.texts);
+  const texts = idx(data.alternativeProducts, o => o.note.texts);
   if (texts) {
     notesNode = <p>{texts.map(text => text.value).join(' ')}</p>;
   }

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { FC, Fragment } from 'react';
 import idx from 'idx';
-import { DoughnutChart } from 'franklin-sites';
 import { UniProtkbAPIModel } from '../../../model/uniprotkb/UniProtkbConverter';
 import { getKeywordsForCategories } from '../../../model/utils/KeywordsUtil';
 import { truncateStringWithEllipsis } from '../../../utils/utils';
@@ -10,7 +9,9 @@ import convertGeneNames from '../../../model/uniprotkb/GeneNamesConverter';
 import { GeneNamesViewFlat } from './GeneNamesView';
 import { KeywordList } from './KeywordView';
 import UniProtTitle from './UniProtTitle';
-import { annotationScoreToPercentage } from './ProteinOverviewView';
+import AnnotationScoreDoughnutChart, {
+  DoughnutChartSize,
+} from './AnnotationScoreDoughnutChart';
 import Comment from '../../../model/types/Comment';
 
 const CHAR_LENGTH_FUNCTION_SUMMARY = 150;
@@ -44,12 +45,9 @@ const UniProtCard: FC<{
 
   const { annotationScore } = data;
   const annotationScoreNode = (
-    <DoughnutChart
-      percent={annotationScoreToPercentage(annotationScore)}
-      size="small"
-    >
-      {annotationScore > 99 ? '99+' : annotationScore}
-    </DoughnutChart>
+    <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
+      {annotationScore}
+    </AnnotationScoreDoughnutChart>
   );
 
   let keywordsNode;

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -46,7 +46,10 @@ const UniProtCard: FC<{
 
   const { annotationScore } = data;
   const annotationScoreNode = (
-    <span className="uniprot-card__annotation-score-doughnut-chart">
+    <span
+      className="uniprot-card__annotation-score-doughnut-chart"
+      title="Annotation Score"
+    >
       <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
         {annotationScore}
       </AnnotationScoreDoughnutChart>

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -13,7 +13,6 @@ import AnnotationScoreDoughnutChart, {
   DoughnutChartSize,
 } from './AnnotationScoreDoughnutChart';
 import Comment from '../../../model/types/Comment';
-import './styles/UniProtCard.scss';
 
 const CHAR_LENGTH_FUNCTION_SUMMARY = 150;
 
@@ -46,14 +45,9 @@ const UniProtCard: FC<{
 
   const { annotationScore } = data;
   const annotationScoreNode = (
-    <span
-      className="uniprot-card__annotation-score-doughnut-chart"
-      title="Annotation Score"
-    >
-      <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
-        {annotationScore}
-      </AnnotationScoreDoughnutChart>
-    </span>
+    <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
+      {annotationScore}
+    </AnnotationScoreDoughnutChart>
   );
 
   let keywordsNode;

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { FC, Fragment } from 'react';
 import idx from 'idx';
-import { Bubble } from 'franklin-sites';
+import { DoughnutChart } from 'franklin-sites';
 import { UniProtkbAPIModel } from '../../../model/uniprotkb/UniProtkbConverter';
 import { getKeywordsForCategories } from '../../../model/utils/KeywordsUtil';
 import { truncateStringWithEllipsis } from '../../../utils/utils';
@@ -10,6 +10,7 @@ import convertGeneNames from '../../../model/uniprotkb/GeneNamesConverter';
 import { GeneNamesViewFlat } from './GeneNamesView';
 import { KeywordList } from './KeywordView';
 import UniProtTitle from './UniProtTitle';
+import { annotationScoreToPercentage } from './ProteinOverviewView';
 import Comment from '../../../model/types/Comment';
 
 const CHAR_LENGTH_FUNCTION_SUMMARY = 150;
@@ -41,12 +42,14 @@ const UniProtCard: FC<{
 
   const sequenceLengthNode = `${data.sequence.length} amino-acids · `;
 
+  const { annotationScore } = data;
   const annotationScoreNode = (
-    <Bubble
-      value={data.annotationScore}
+    <DoughnutChart
+      percent={annotationScoreToPercentage(annotationScore)}
       size="small"
-      title="Annotation score"
-    />
+    >
+      {annotationScore > 99 ? '99+' : annotationScore}
+    </DoughnutChart>
   );
 
   let keywordsNode;
@@ -83,7 +86,7 @@ const UniProtCard: FC<{
   }
 
   return (
-    <div className="uniprot-card">
+    <div>
       <h4>
         <UniProtTitle
           primaryAccession={data.primaryAccession}

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -13,6 +13,7 @@ import AnnotationScoreDoughnutChart, {
   DoughnutChartSize,
 } from './AnnotationScoreDoughnutChart';
 import Comment from '../../../model/types/Comment';
+import './styles/UniProtCard.scss';
 
 const CHAR_LENGTH_FUNCTION_SUMMARY = 150;
 
@@ -45,9 +46,11 @@ const UniProtCard: FC<{
 
   const { annotationScore } = data;
   const annotationScoreNode = (
-    <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
-      {annotationScore}
-    </AnnotationScoreDoughnutChart>
+    <span className="uniprot-card__annotation-score-doughnut-chart">
+      <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
+        {annotationScore}
+      </AnnotationScoreDoughnutChart>
+    </span>
   );
 
   let keywordsNode;

--- a/src/view/uniprotkb/components/UniProtCard.tsx
+++ b/src/view/uniprotkb/components/UniProtCard.tsx
@@ -45,9 +45,10 @@ const UniProtCard: FC<{
 
   const { annotationScore } = data;
   const annotationScoreNode = (
-    <AnnotationScoreDoughnutChart size={DoughnutChartSize.small}>
-      {annotationScore}
-    </AnnotationScoreDoughnutChart>
+    <AnnotationScoreDoughnutChart
+      score={annotationScore}
+      size={DoughnutChartSize.small}
+    />
   );
 
   let keywordsNode;

--- a/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
+++ b/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AnnotationScoreDoughnutChart, {
+  annotationScoreToBin,
+} from '../AnnotationScoreDoughnutChart';
+
+describe('AnnotationScoreDoughnutChart component', () => {
+  test('should render', () => {
+    const { asFragment } = render(
+      <AnnotationScoreDoughnutChart>{50}</AnnotationScoreDoughnutChart>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});
+
+describe('annotationScoreToBin function', () => {
+  /*
+    0-19  | bin 1
+    20-39 | bin 2
+    40-59 | bin 3
+    60-79 | bin 4
+    >=80  | bin 5
+  */
+  const annotationScoreToBinTestPoints = [
+    // [annotation score, percentage]
+    [0, 1],
+    [1, 1],
+    [19, 1],
+    [20, 2],
+    [39, 2],
+    [40, 3],
+    [59, 3],
+    [60, 4],
+    [79, 4],
+    [80, 5],
+    [81, 5],
+    [1000, 5],
+  ];
+  annotationScoreToBinTestPoints.forEach(([annotationScore, bin]) => {
+    test(`Should convert annotationScore of ${annotationScore} to bin ${bin}`, () => {
+      expect(annotationScoreToBin(annotationScore)).toEqual(bin);
+    });
+  });
+});

--- a/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
+++ b/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
@@ -6,9 +6,7 @@ import AnnotationScoreDoughnutChart, {
 
 describe('AnnotationScoreDoughnutChart component', () => {
   test('should render', () => {
-    const { asFragment } = render(
-      <AnnotationScoreDoughnutChart>{50}</AnnotationScoreDoughnutChart>
-    );
+    const { asFragment } = render(<AnnotationScoreDoughnutChart score={50} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
+++ b/src/view/uniprotkb/components/__tests__/AnnotationScoreDoughnutChart.spec.tsx
@@ -22,7 +22,7 @@ describe('annotationScoreToBin function', () => {
     >=80  | bin 5
   */
   const annotationScoreToBinTestPoints = [
-    // [annotation score, percentage]
+    // [annotation score, bin]
     [0, 1],
     [1, 1],
     [19, 1],

--- a/src/view/uniprotkb/components/__tests__/ProteinOverview.spec.tsx
+++ b/src/view/uniprotkb/components/__tests__/ProteinOverview.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import ProteinOverview from '../ProteinOverviewView';
+import ProteinOverview, {
+  annotationScoreToPercentage,
+} from '../ProteinOverviewView';
 import ProteinNamesUIDataJson from '../__mocks__/ProteinNamesUIData.json';
 import EntrySection from '../../../../model/types/EntrySection';
 
@@ -16,5 +18,35 @@ describe('ProteinOverview component', () => {
       <ProteinOverview transformedData={transformedData} />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+});
+
+describe('annotationScoreToPercentage function', () => {
+  /*
+    0-19  | bin 1 | 20%
+    20-39 | bin 2 | 40%
+    40-59 | bin 3 | 60%
+    60-79 | bin 4 | 80%
+    >=80  | bin 5 | 100%
+  */
+  const annotationScoreToPercentageTests = [
+    // [annotation score, percentage]
+    [0, 20],
+    [1, 20],
+    [19, 20],
+    [20, 40],
+    [39, 40],
+    [40, 60],
+    [59, 60],
+    [60, 80],
+    [79, 80],
+    [80, 100],
+    [81, 100],
+    [1000, 100],
+  ];
+  annotationScoreToPercentageTests.forEach(([annotationScore, percentage]) => {
+    test(`Should convert annotationScore of ${annotationScore} to ${percentage}%`, () => {
+      expect(annotationScoreToPercentage(annotationScore)).toEqual(percentage);
+    });
   });
 });

--- a/src/view/uniprotkb/components/__tests__/ProteinOverview.spec.tsx
+++ b/src/view/uniprotkb/components/__tests__/ProteinOverview.spec.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import ProteinOverview, {
-  annotationScoreToPercentage,
-} from '../ProteinOverviewView';
+import ProteinOverview from '../ProteinOverviewView';
 import ProteinNamesUIDataJson from '../__mocks__/ProteinNamesUIData.json';
 import EntrySection from '../../../../model/types/EntrySection';
 
@@ -13,40 +11,9 @@ describe('ProteinOverview component', () => {
       annotationScore: 12.4,
     };
     transformedData[EntrySection.NamesAndTaxonomy] = ProteinNamesUIDataJson;
-
     const { asFragment } = render(
       <ProteinOverview transformedData={transformedData} />
     );
     expect(asFragment()).toMatchSnapshot();
-  });
-});
-
-describe('annotationScoreToPercentage function', () => {
-  /*
-    0-19  | bin 1 | 20%
-    20-39 | bin 2 | 40%
-    40-59 | bin 3 | 60%
-    60-79 | bin 4 | 80%
-    >=80  | bin 5 | 100%
-  */
-  const annotationScoreToPercentageTests = [
-    // [annotation score, percentage]
-    [0, 20],
-    [1, 20],
-    [19, 20],
-    [20, 40],
-    [39, 40],
-    [40, 60],
-    [59, 60],
-    [60, 80],
-    [79, 80],
-    [80, 100],
-    [81, 100],
-    [1000, 100],
-  ];
-  annotationScoreToPercentageTests.forEach(([annotationScore, percentage]) => {
-    test(`Should convert annotationScore of ${annotationScore} to ${percentage}%`, () => {
-      expect(annotationScoreToPercentage(annotationScore)).toEqual(percentage);
-    });
   });
 });

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/AnnotationScoreDoughnutChart.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/AnnotationScoreDoughnutChart.spec.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AnnotationScoreDoughnutChart component should render 1`] = `
+<DocumentFragment>
+  <span
+    class="doughnut-chart--medium colour-light-grey"
+  >
+    <span
+      class="doughnut-chart--medium__left-wrap"
+    >
+      <span
+        class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+        style="transform: rotate(36deg);"
+      />
+    </span>
+    <span
+      class="doughnut-chart--medium__right-wrap"
+    >
+      <span
+        class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+        style="transform: rotate(180deg);"
+      />
+    </span>
+    <span
+      class="doughnut-chart--medium__inner-circle"
+    >
+      3
+    </span>
+  </span>
+</DocumentFragment>
+`;

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/AnnotationScoreDoughnutChart.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/AnnotationScoreDoughnutChart.spec.tsx.snap
@@ -3,28 +3,32 @@
 exports[`AnnotationScoreDoughnutChart component should render 1`] = `
 <DocumentFragment>
   <span
-    class="doughnut-chart--medium colour-light-grey"
+    title="Annotation Score"
   >
     <span
-      class="doughnut-chart--medium__left-wrap"
+      class="doughnut-chart--medium colour-light-grey"
     >
       <span
-        class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
-        style="transform: rotate(36deg);"
-      />
-    </span>
-    <span
-      class="doughnut-chart--medium__right-wrap"
-    >
+        class="doughnut-chart--medium__left-wrap"
+      >
+        <span
+          class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+          style="transform: rotate(36deg);"
+        />
+      </span>
       <span
-        class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
-        style="transform: rotate(180deg);"
-      />
-    </span>
-    <span
-      class="doughnut-chart--medium__inner-circle"
-    >
-      3
+        class="doughnut-chart--medium__right-wrap"
+      >
+        <span
+          class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+          style="transform: rotate(180deg);"
+        />
+      </span>
+      <span
+        class="doughnut-chart--medium__inner-circle"
+      >
+        3/5
+      </span>
     </span>
   </span>
 </DocumentFragment>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
@@ -31,28 +31,32 @@ exports[`ProteinOverview component should render 1`] = `
         class="info-list__item__content"
       >
         <span
-          class="doughnut-chart--medium colour-light-grey"
+          title="Annotation Score"
         >
           <span
-            class="doughnut-chart--medium__left-wrap"
+            class="doughnut-chart--medium colour-light-grey"
           >
             <span
-              class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
-              style="transform: rotate(0deg);"
-            />
-          </span>
-          <span
-            class="doughnut-chart--medium__right-wrap"
-          >
+              class="doughnut-chart--medium__left-wrap"
+            >
+              <span
+                class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+                style="transform: rotate(0deg);"
+              />
+            </span>
             <span
-              class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
-              style="transform: rotate(72deg);"
-            />
-          </span>
-          <span
-            class="doughnut-chart--medium__inner-circle"
-          >
-            1
+              class="doughnut-chart--medium__right-wrap"
+            >
+              <span
+                class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+                style="transform: rotate(72deg);"
+              />
+            </span>
+            <span
+              class="doughnut-chart--medium__inner-circle"
+            >
+              1/5
+            </span>
           </span>
         </span>
       </div>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
@@ -30,33 +30,31 @@ exports[`ProteinOverview component should render 1`] = `
       <div
         class="info-list__item__content"
       >
-        <div
+        <span
           class="doughnut-chart--medium colour-light-grey"
         >
-          <div
+          <span
             class="doughnut-chart--medium__left-wrap"
           >
-            <div
+            <span
               class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
               style="transform: rotate(0deg);"
             />
-          </div>
-          <div
+          </span>
+          <span
             class="doughnut-chart--medium__right-wrap"
           >
-            <div
+            <span
               class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
               style="transform: rotate(72deg);"
             />
-          </div>
-          <div
+          </span>
+          <span
             class="doughnut-chart--medium__inner-circle"
           >
-            <span>
-              20%
-            </span>
-          </div>
-        </div>
+            12.4
+          </span>
+        </span>
       </div>
     </div>
   </div>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
@@ -30,11 +30,33 @@ exports[`ProteinOverview component should render 1`] = `
       <div
         class="info-list__item__content"
       >
-        <span
-          class="bubble--medium colour-uniprot-blue"
+        <div
+          class="doughnut-chart--medium colour-light-grey"
         >
-          12.4
-        </span>
+          <div
+            class="doughnut-chart--medium__left-wrap"
+          >
+            <div
+              class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+              style="transform: rotate(0deg);"
+            />
+          </div>
+          <div
+            class="doughnut-chart--medium__right-wrap"
+          >
+            <div
+              class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+              style="transform: rotate(72deg);"
+            />
+          </div>
+          <div
+            class="doughnut-chart--medium__inner-circle"
+          >
+            <span>
+              20%
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/ProteinOverview.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`ProteinOverview component should render 1`] = `
           <span
             class="doughnut-chart--medium__inner-circle"
           >
-            12.4
+            1
           </span>
         </span>
       </div>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`UniProtCard component should render 1`] = `
 <DocumentFragment>
-  <div
-    class="uniprot-card"
-  >
+  <div>
     <h4>
       <div
         class="uniprot-title"
@@ -41,9 +39,29 @@ exports[`UniProtCard component should render 1`] = `
       </a>
        · Gene: some Gene, some Syn, some orf · 10 amino-acids · 
       <span
-        class="bubble--small colour-uniprot-blue"
+        class="doughnut-chart--small colour-light-grey"
       >
-        2
+        <span
+          class="doughnut-chart--small__left-wrap"
+        >
+          <span
+            class="doughnut-chart--small__left-wrap__loader colour-uniprot-blue"
+            style="transform: rotate(0deg);"
+          />
+        </span>
+        <span
+          class="doughnut-chart--small__right-wrap"
+        >
+          <span
+            class="doughnut-chart--small__right-wrap__loader colour-uniprot-blue"
+            style="transform: rotate(72deg);"
+          />
+        </span>
+        <span
+          class="doughnut-chart--small__inner-circle"
+        >
+          2
+        </span>
       </span>
     </p>
     <p />

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
@@ -60,7 +60,7 @@ exports[`UniProtCard component should render 1`] = `
         <span
           class="doughnut-chart--small__inner-circle"
         >
-          2
+          1
         </span>
       </span>
     </p>

--- a/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
+++ b/src/view/uniprotkb/components/__tests__/__snapshots__/UniProtCard.spec.tsx.snap
@@ -39,28 +39,32 @@ exports[`UniProtCard component should render 1`] = `
       </a>
        · Gene: some Gene, some Syn, some orf · 10 amino-acids · 
       <span
-        class="doughnut-chart--small colour-light-grey"
+        title="Annotation Score"
       >
         <span
-          class="doughnut-chart--small__left-wrap"
+          class="doughnut-chart--small colour-light-grey"
         >
           <span
-            class="doughnut-chart--small__left-wrap__loader colour-uniprot-blue"
-            style="transform: rotate(0deg);"
-          />
-        </span>
-        <span
-          class="doughnut-chart--small__right-wrap"
-        >
+            class="doughnut-chart--small__left-wrap"
+          >
+            <span
+              class="doughnut-chart--small__left-wrap__loader colour-uniprot-blue"
+              style="transform: rotate(0deg);"
+            />
+          </span>
           <span
-            class="doughnut-chart--small__right-wrap__loader colour-uniprot-blue"
-            style="transform: rotate(72deg);"
-          />
-        </span>
-        <span
-          class="doughnut-chart--small__inner-circle"
-        >
-          1
+            class="doughnut-chart--small__right-wrap"
+          >
+            <span
+              class="doughnut-chart--small__right-wrap__loader colour-uniprot-blue"
+              style="transform: rotate(72deg);"
+            />
+          </span>
+          <span
+            class="doughnut-chart--small__inner-circle"
+          >
+            1/5
+          </span>
         </span>
       </span>
     </p>

--- a/src/view/uniprotkb/components/styles/UniProtCard.scss
+++ b/src/view/uniprotkb/components/styles/UniProtCard.scss
@@ -1,0 +1,4 @@
+.uniprot-card__annotation-score-doughnut-chart {
+  top: 0.5rem;
+  position: relative;
+}

--- a/src/view/uniprotkb/components/styles/UniProtCard.scss
+++ b/src/view/uniprotkb/components/styles/UniProtCard.scss
@@ -1,4 +1,0 @@
-.uniprot-card__annotation-score-doughnut-chart {
-  top: 0.5rem;
-  position: relative;
-}

--- a/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
+++ b/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
@@ -137,33 +137,31 @@ exports[`ProteinSummary component it renders without crashing 1`] = `
           <div
             class="info-list__item__content"
           >
-            <div
+            <span
               class="doughnut-chart--medium colour-light-grey"
             >
-              <div
+              <span
                 class="doughnut-chart--medium__left-wrap"
               >
-                <div
+                <span
                   class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
                   style="transform: rotate(0deg);"
                 />
-              </div>
-              <div
+              </span>
+              <span
                 class="doughnut-chart--medium__right-wrap"
               >
-                <div
+                <span
                   class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
                   style="transform: rotate(72deg);"
                 />
-              </div>
-              <div
+              </span>
+              <span
                 class="doughnut-chart--medium__inner-circle"
               >
-                <span>
-                  20%
-                </span>
-              </div>
-            </div>
+                2
+              </span>
+            </span>
           </div>
         </div>
       </div>

--- a/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
+++ b/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
@@ -138,28 +138,32 @@ exports[`ProteinSummary component it renders without crashing 1`] = `
             class="info-list__item__content"
           >
             <span
-              class="doughnut-chart--medium colour-light-grey"
+              title="Annotation Score"
             >
               <span
-                class="doughnut-chart--medium__left-wrap"
+                class="doughnut-chart--medium colour-light-grey"
               >
                 <span
-                  class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
-                  style="transform: rotate(0deg);"
-                />
-              </span>
-              <span
-                class="doughnut-chart--medium__right-wrap"
-              >
+                  class="doughnut-chart--medium__left-wrap"
+                >
+                  <span
+                    class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+                    style="transform: rotate(0deg);"
+                  />
+                </span>
                 <span
-                  class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
-                  style="transform: rotate(72deg);"
-                />
-              </span>
-              <span
-                class="doughnut-chart--medium__inner-circle"
-              >
-                1
+                  class="doughnut-chart--medium__right-wrap"
+                >
+                  <span
+                    class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+                    style="transform: rotate(72deg);"
+                  />
+                </span>
+                <span
+                  class="doughnut-chart--medium__inner-circle"
+                >
+                  1/5
+                </span>
               </span>
             </span>
           </div>

--- a/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
+++ b/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
@@ -137,11 +137,33 @@ exports[`ProteinSummary component it renders without crashing 1`] = `
           <div
             class="info-list__item__content"
           >
-            <span
-              class="bubble--medium colour-uniprot-blue"
+            <div
+              class="doughnut-chart--medium colour-light-grey"
             >
-              2
-            </span>
+              <div
+                class="doughnut-chart--medium__left-wrap"
+              >
+                <div
+                  class="doughnut-chart--medium__left-wrap__loader colour-uniprot-blue"
+                  style="transform: rotate(0deg);"
+                />
+              </div>
+              <div
+                class="doughnut-chart--medium__right-wrap"
+              >
+                <div
+                  class="doughnut-chart--medium__right-wrap__loader colour-uniprot-blue"
+                  style="transform: rotate(72deg);"
+                />
+              </div>
+              <div
+                class="doughnut-chart--medium__inner-circle"
+              >
+                <span>
+                  20%
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
+++ b/src/view/uniprotkb/summary/__tests__/__snapshots__/ProteinSummary.spec.tsx.snap
@@ -159,7 +159,7 @@ exports[`ProteinSummary component it renders without crashing 1`] = `
               <span
                 class="doughnut-chart--medium__inner-circle"
               >
-                2
+                1
               </span>
             </span>
           </div>


### PR DESCRIPTION
# Notes

- This needs this Franklin PR https://github.com/ebi-uniprot/franklin-sites/pull/43 to be merged first as there is an error about `div`s being children of `p`s.
- Provided two different IDs to UniProtEvidenceTag to avoid encountering 'two children with the same key' warning during tests.

# Checklist
- [x] What is the link to the Jira that this PR is for?
https://www.ebi.ac.uk/panda/jira/browse/TRM-22818
- [x] Have you written tests and do these have >= 75% coverage of the code that you are contributing?
100%
- [x] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)?
In results and protein summary
- [x] Are there any linting errors that required you to add exceptions?
N/A
- [x] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?
N/A