### PR TITLE
fixes the re-rendering issue with the in-page navigation

### DIFF
--- a/src/entry/Entry.tsx
+++ b/src/entry/Entry.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, memo } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Card, InPageNav, DownloadIcon, Loader } from 'franklin-sites';
 import useDataApi from '../utils/useDataApi';
@@ -17,6 +17,11 @@ type MatchParams = {
 };
 
 type EntryProps = RouteComponentProps<MatchParams>;
+
+function arePropsEqual(prevProps: EntryProps, nextProps: EntryProps) {
+  // Do NOT re-render the page, as long as the 'accession' value is the same.
+  return prevProps.match.params.accession === nextProps.match.params.accession;
+}
 
 const Entry: React.FC<EntryProps> = ({ match }) => {
   const url = apiUrls.entry(match.params.accession);
@@ -85,4 +90,4 @@ const Entry: React.FC<EntryProps> = ({ match }) => {
   );
 };
 
-export default withRouter(Entry);
+export default withRouter(memo(Entry, arePropsEqual));


### PR DESCRIPTION
- [x] What is the link to the Jira that this PR is for?
[TRM-22525](https://www.ebi.ac.uk/panda/jira/browse/TRM-22525)
- [ ] Have you written tests and do these have >= 75% coverage of the code that you are contributing?
*Was not needed.*
- [ ] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)?
*This only prevents re-rendering of the page. At the moment there are a few console logs -- from other pieces of code, when the page or `Entry` component renders. If you clean the console and click on the in-page navigation links, you should not those console logs to re-appear. This is the simplest way to visually verify this PR is working.*
- [ ] Are there any linting errors that required you to add exceptions?
*No.*
- [ ] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?
*No.*