### PR TITLE
useLocalStorage

### DIFF
--- a/src/hooks/__tests__/useLocalStorage.spec.ts
+++ b/src/hooks/__tests__/useLocalStorage.spec.ts
@@ -1,0 +1,75 @@
+import { renderHook, cleanup, act } from '@testing-library/react-hooks';
+
+import useLocalStorage from '../useLocalStorage';
+
+const url = '/some/path';
+const url2 = '/some/other/path';
+
+describe('useLocalStorage hook', () => {
+  test('get value, basic', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('key', 'default value')
+    );
+
+    expect(result.current[0]).toEqual('default value');
+  });
+
+  test('set value, basic', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('key', 'default value')
+    );
+
+    act(() => result.current[1]('other value'));
+
+    expect(result.current[0]).toEqual('other value');
+  });
+
+  test('set value, types', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('key', 'default value')
+    );
+
+    act(() => result.current[1](0));
+
+    expect(result.current[0]).toEqual(0);
+
+    act(() => result.current[1]([1]));
+
+    expect(result.current[0]).toEqual([1]);
+
+    act(() => result.current[1]({ complex: 'object', ok: true }));
+
+    expect(result.current[0]).toEqual({ complex: 'object', ok: true });
+  });
+
+  test('set/get value, accross instances', async () => {
+    const { result: instance1 } = renderHook(() =>
+      useLocalStorage('key', 'default value')
+    );
+
+    act(() => instance1.current[1]([1, 2, 3, 4]));
+
+    expect(localStorage.getItem('key')).toBe(JSON.stringify([1, 2, 3, 4]));
+
+    const { result: instance2 } = renderHook(() =>
+      useLocalStorage('key', 'other default value')
+    );
+
+    expect(instance2.current[0]).toEqual([1, 2, 3, 4]);
+  });
+
+  test('unset value, reset to default', async () => {
+    const { result } = renderHook(() =>
+      useLocalStorage('key', 'default value')
+    );
+
+    act(() => result.current[1]('value'));
+
+    expect(result.current[0]).toEqual('value');
+
+    act(() => result.current[2]());
+
+    expect(result.current[0]).toEqual(null);
+    expect(localStorage.getItem('key')).toBe(null);
+  });
+});

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,57 @@
+import { useState, useRef } from 'react';
+
+declare global {
+  interface Window {
+    requestIdleCallback: (callback: () => void) => any;
+    cancelIdleCallback: (handle: any) => void;
+  }
+}
+
+// fallback: noop
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const cancelIdleCallback = window.cancelIdleCallback || (() => {});
+// fallback: execute rightaway
+const requestIdleCallback =
+  window.requestIdleCallback || ((fn: () => any) => fn());
+
+const useLocalStorage = (key: string, initialValue: any = null) => {
+  const handle = useRef();
+
+  const [state, setState] = useState(() => {
+    const stored = window.localStorage.getItem(key);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(stored || '');
+      return parsed;
+    } catch {
+      window.localStorage.setItem(key, JSON.stringify(initialValue));
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: any) => {
+    const valueToStore = typeof value === 'function' ? value(state) : value;
+    setState(valueToStore);
+
+    cancelIdleCallback(handle.current);
+    handle.current = requestIdleCallback(() => {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+        /* if it's not stringifiable, can't save it */
+      }
+    });
+  };
+
+  const deleteValue = () => {
+    setValue(null);
+    cancelIdleCallback(handle.current);
+    handle.current = requestIdleCallback(() => {
+      window.localStorage.removeItem('key');
+    });
+  };
+
+  return [state, setValue, deleteValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
- [ ] What is the link to the Jira that this PR is for? none
- [x] Have you written tests and do these have >= 75% coverage of the code that you are contributing? yes
- [ ] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)? no
- [ ] Are there any linting errors that required you to add exceptions? yes (no-empty-function)
- [ ] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access? NA

added a new custom hook to access localStorage through react hooks logic like this:
```js
const [value, setValue, deleteValue] = useLocalStorage('key', 'default value');
```

It will *eventually* persist to localStorage. `value` is updated right away though.
This should be usable the same way than react's `useState` (compatible API).
One limitation is that values need to be JSON-serialisable.
As localStorage and JSON.parse and JSON.stringify are blocking operation, we try to execute as much of it as we can whenever the browser has time to do so through `requestIdleCallback`.
