### PR TITLE
Add scroll to view, add sequence to table

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2030,7 +2030,7 @@ exports[`Entry view should render 1`] = `
             Features
           </h3>
           <protvista-manager
-            attributes="highlight displaystart displayend"
+            attributes="highlight displaystart displayend selectedid"
           >
             <protvista-navigation
               length="10"

--- a/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
@@ -64,8 +64,9 @@ const FeaturesTableView: FC<{
     <Fragment>
       <protvista-datatable ref={setTableData} filter-scroll />
       <div
-        className={`evidence-tag-content ${showEvidenceTagData &&
-          'evidence-tag-content--visible'}`}
+        className={`evidence-tag-content ${
+          showEvidenceTagData && 'evidence-tag-content--visible'
+        }`}
       >
         {selectedEvidenceData && selectedReferences && (
           <UniProtEvidenceTagContent

--- a/src/uniprotkb/components/protein-data-views/FeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FeaturesView.tsx
@@ -4,6 +4,7 @@ import ProtvistaTrack from 'protvista-track';
 import ProtvistaManager from 'protvista-manager';
 import ProtvistaSequence from 'protvista-sequence';
 import ProtvistaNavigation from 'protvista-navigation';
+import { v1 } from 'uuid';
 import { loadWebComponent } from '../../../shared/utils/utils';
 import { Evidence } from '../../types/modelTypes';
 import FeatureType from '../../types/featureType';
@@ -56,20 +57,24 @@ type FeatureProps = {
 };
 
 export type ProcessedFeature = {
-  accession: string | undefined;
+  protvistaFeatureId?: string;
   start: number;
   end: number;
   startModifier: LocationModifier;
   endModifier: LocationModifier;
   type: FeatureType;
-  description: string | undefined;
-  evidences: Evidence[] | undefined;
+  description?: string;
+  evidences?: Evidence[];
+  sequence?: string;
 };
 
-const processData = (data: FeatureData): ProcessedFeature[] =>
+const processData = (
+  data: FeatureData,
+  sequence?: string
+): ProcessedFeature[] =>
   data.map(
     (feature): ProcessedFeature => ({
-      accession: feature.featureId,
+      protvistaFeatureId: feature.featureId ? feature.featureId : v1(),
       start: feature.location.start.value,
       end: feature.location.end.value,
       startModifier: feature.location.start.modifier,
@@ -77,6 +82,10 @@ const processData = (data: FeatureData): ProcessedFeature[] =>
       type: feature.type,
       description: feature.description,
       evidences: feature.evidences,
+      sequence: sequence?.substring(
+        feature.location.start.value - 1,
+        feature.location.end.value
+      ),
     })
   );
 
@@ -89,28 +98,35 @@ const FeaturesView: React.FC<FeatureProps> = ({
   loadWebComponent('protvista-sequence', ProtvistaSequence);
   loadWebComponent('protvista-navigation', ProtvistaNavigation);
 
-  const processedData = processData(features);
+  const processedData = processData(features, sequence);
 
   const getColumnConfig = (evidenceTagCallback: FeaturesTableCallback) => ({
     type: {
       label: 'Type',
-      resolver: (d: ProtvistaFeature): string => d.type,
+      resolver: (d: ProcessedFeature): string => {
+        return d.type;
+      },
     },
     positions: {
       label: 'Positions',
-      resolver: (d: ProtvistaFeature): string =>
+      resolver: (d: ProcessedFeature): string =>
         `${d.startModifier === LocationModifier.UNKNOWN ? '?' : d.start}-${
           d.endModifier === LocationModifier.UNKNOWN ? '?' : d.end
         }`,
     },
     description: {
       label: 'Description',
-      resolver: (d: ProtvistaFeature): TemplateResult =>
+      resolver: (d: ProcessedFeature): TemplateResult =>
         html`
           ${d.description}
           ${d.evidences &&
-            UniProtProtvistaEvidenceTag(d.evidences, evidenceTagCallback)}
+          UniProtProtvistaEvidenceTag(d.evidences, evidenceTagCallback)}
         `,
+    },
+    sequence: {
+      label: 'Sequence',
+      child: true,
+      resolver: (d: ProcessedFeature) => (d.sequence ? d.sequence : ''),
     },
   });
 
@@ -131,7 +147,7 @@ const FeaturesView: React.FC<FeatureProps> = ({
   return (
     <Fragment>
       <h3>Features</h3>
-      <protvista-manager attributes="highlight displaystart displayend">
+      <protvista-manager attributes="highlight displaystart displayend selectedid">
         {sequence && (
           <Fragment>
             <protvista-navigation length={sequence.length} />

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`FeaturesView component it renders without crashing 1`] = `
     Features
   </h3>
   <protvista-manager
-    attributes="highlight displaystart displayend"
+    attributes="highlight displaystart displayend selectedid"
   >
     <protvista-navigation
       length="21"


### PR DESCRIPTION
This is a (yet to be created) subtask of https://www.ebi.ac.uk/panda/jira/browse/TRM-24238

There's been requests (on the covid platform) to show the sequence in some form as part of the `protvista-datatable`. This PR offers a simple solution "for now" while we decide how we want to integrate the rest of requirements, and has been discussed with @SangyaP 

Will cherry-pick the PR on covid-19 when approved.