### PR TITLE
Handle multiple fasta

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "jsx-no-lambda": "off",
     "jsx-no-multiline-js": "off",
     "no-restricted-syntax": "off",
+    "no-shadow": "off",
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react/destructuring-assignment": "off",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "axios": "0.19.2",
     "d3": "5.16.0",
     "d3-scale": "3.2.1",
-    "franklin-sites": "0.0.62",
+    "franklin-sites": "0.0.64",
     "history": "4.10.1",
     "idb": "5.0.4",
     "idx": "2.5.6",

--- a/src/shared/components/error-component/__tests__/__snapshots__/ErrorComponent.spec.tsx.snap
+++ b/src/shared/components/error-component/__tests__/__snapshots__/ErrorComponent.spec.tsx.snap
@@ -15,13 +15,13 @@ exports[`ErrorComponent should render 1`] = `
       <svg
         fill="currentColor"
         height="1.125em"
-        viewBox="0 0 18 18"
+        stroke="currentColor"
+        viewBox="0 0 19 18"
         width="1.125em"
       >
         <path
-          clip-rule="evenodd"
-          d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-          fill-rule="evenodd"
+          d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+          stroke-width="2"
         />
       </svg>
       <section

--- a/src/shared/components/error-pages/__tests__/__snapshots__/JobErrorPage.spec.tsx.snap
+++ b/src/shared/components/error-pages/__tests__/__snapshots__/JobErrorPage.spec.tsx.snap
@@ -19,13 +19,13 @@ exports[`JobErrorPage component should render 1`] = `
       <svg
         fill="currentColor"
         height="1.125em"
-        viewBox="0 0 18 18"
+        stroke="currentColor"
+        viewBox="0 0 19 18"
         width="1.125em"
       >
         <path
-          clip-rule="evenodd"
-          d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-          fill-rule="evenodd"
+          d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+          stroke-width="2"
         />
       </svg>
       <section

--- a/src/shared/components/error-pages/__tests__/__snapshots__/ResourceNotFoundPage.spec.tsx.snap
+++ b/src/shared/components/error-pages/__tests__/__snapshots__/ResourceNotFoundPage.spec.tsx.snap
@@ -19,13 +19,13 @@ exports[`ResourceNotFoundPage component should render 1`] = `
       <svg
         fill="currentColor"
         height="1.125em"
-        viewBox="0 0 18 18"
+        stroke="currentColor"
+        viewBox="0 0 19 18"
         width="1.125em"
       >
         <path
-          clip-rule="evenodd"
-          d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-          fill-rule="evenodd"
+          d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+          stroke-width="2"
         />
       </svg>
       <section

--- a/src/shared/components/error-pages/__tests__/__snapshots__/ServiceUnavailablePage.spec.tsx.snap
+++ b/src/shared/components/error-pages/__tests__/__snapshots__/ServiceUnavailablePage.spec.tsx.snap
@@ -19,13 +19,13 @@ exports[`ServiceUnavailablePage component should render 1`] = `
       <svg
         fill="currentColor"
         height="1.125em"
-        viewBox="0 0 18 18"
+        stroke="currentColor"
+        viewBox="0 0 19 18"
         width="1.125em"
       >
         <path
-          clip-rule="evenodd"
-          d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-          fill-rule="evenodd"
+          d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+          stroke-width="2"
         />
       </svg>
       <section

--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -56,26 +56,23 @@ const AlignForm = () => {
     if (parametersFromHistoryState) {
       // if we get here, we got parameters passed with the location update to
       // use as pre-filled fields
-      // yes, I'm doing that in one go to avoid having typescript complain about
-      // the object not being of the right shape even though I want to construct
-      // it in multiple steps 🙄
-      // TODO: Try to use TypeScript Partial<>
-      return Object.freeze(
-        Object.fromEntries(
-          Object.entries(defaultFormValues as AlignFormValues).map(
-            ([key, field]) => [
-              key,
-              Object.freeze({
-                ...field,
-                selected:
-                  parametersFromHistoryState[
-                    field.fieldName as keyof FormParameters
-                  ] || field.selected,
-              }) as Readonly<AlignFormValue>,
-            ]
-          )
-        )
-      ) as Readonly<AlignFormValues>;
+      const formValues: Partial<AlignFormValues> = {};
+      const defaultValuesEntries = Object.entries(defaultFormValues) as [
+        AlignFields,
+        AlignFormValue
+      ][];
+      // for every field of the form, get its value from the history state if
+      // present, otherwise go for the default one
+      for (const [key, field] of defaultValuesEntries) {
+        formValues[key] = Object.freeze({
+          ...field,
+          selected:
+            parametersFromHistoryState[
+              field.fieldName as keyof FormParameters
+            ] || field.selected,
+        }) as Readonly<AlignFormValue>;
+      }
+      return Object.freeze(formValues) as Readonly<AlignFormValues>;
     }
     // otherwise, pass the default values
     return defaultFormValues;

--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -118,7 +118,7 @@ const AlignForm = () => {
   const submitAlignJob = (event: FormEvent | MouseEvent) => {
     event.preventDefault();
 
-    if (!sequence) {
+    if (!sequence.selected) {
       return;
     }
 
@@ -135,7 +135,9 @@ const AlignForm = () => {
     // navigate to the dashboard, not immediately, to give the impression that
     // something is happening
     sleep(1000).then(() => {
-      history.push(LocationToPath[Location.Dashboard], { parameters });
+      history.push(LocationToPath[Location.Dashboard], {
+        parameters: [parameters],
+      });
       // We emit an action containing only the parameters and the type of job
       // the reducer will be in charge of generating a proper job object for
       // internal state. Dispatching after history.push so that pop-up messages (as a
@@ -179,7 +181,8 @@ const AlignForm = () => {
           .join('\n'),
       }));
       setSubmitDisabled(
-        parsedSequences.some((parsedSequence) => !parsedSequence.valid)
+        parsedSequences.some((parsedSequence) => !parsedSequence.valid) ||
+          parsedSequences.length === 1
       );
     },
     [jobNameEdited]
@@ -194,6 +197,14 @@ const AlignForm = () => {
   );
 
   const { name, links, info } = infoMappings[JobTypes.ALIGN];
+
+  let submitButtonContent: string | JSX.Element = 'Run Align';
+  if (parsedSequences.length > 1) {
+    submitButtonContent = `Align ${parsedSequences.length} sequences`;
+  }
+  if (sending) {
+    submitButtonContent = <SpinnerIcon />;
+  }
 
   return (
     <>
@@ -257,7 +268,7 @@ const AlignForm = () => {
                 disabled={submitDisabled}
                 onClick={submitAlignJob}
               >
-                {sending ? <SpinnerIcon /> : 'Run Align'}
+                {submitButtonContent}
               </button>
             </section>
           </section>

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -120,26 +120,23 @@ const BlastForm = () => {
     if (parametersFromHistoryState) {
       // if we get here, we got parameters passed with the location update to
       // use as pre-filled fields
-      // yes, I'm doing that in one go to avoid having typescript complain about
-      // the object not being of the right shape even though I want to construct
-      // it in multiple steps 🙄
-      // TODO: Try to use TypeScript Partial<>
-      return Object.freeze(
-        Object.fromEntries(
-          Object.entries(defaultFormValues as BlastFormValues).map(
-            ([key, field]) => [
-              key,
-              Object.freeze({
-                ...field,
-                selected:
-                  parametersFromHistoryState[
-                    field.fieldName as keyof FormParameters
-                  ] || field.selected,
-              }) as Readonly<BlastFormValue>,
-            ]
-          )
-        )
-      ) as Readonly<BlastFormValues>;
+      const formValues: Partial<BlastFormValues> = {};
+      const defaultValuesEntries = Object.entries(defaultFormValues) as [
+        BlastFields,
+        BlastFormValue
+      ][];
+      // for every field of the form, get its value from the history state if
+      // present, otherwise go for the default one
+      for (const [key, field] of defaultValuesEntries) {
+        formValues[key] = Object.freeze({
+          ...field,
+          selected:
+            parametersFromHistoryState[
+              field.fieldName as keyof FormParameters
+            ] || field.selected,
+        }) as Readonly<BlastFormValue>;
+      }
+      return Object.freeze(formValues) as Readonly<BlastFormValues>;
     }
     // otherwise, pass the default values
     return defaultFormValues;

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -21,7 +21,7 @@ import { sleep } from 'timing-functions';
 
 import AutocompleteWrapper from '../../../uniprotkb/components/query-builder/AutocompleteWrapper';
 import SequenceSearchLoader, {
-  SequenceSubmissionOnChangeEvent,
+  ParsedSequence,
 } from '../../components/SequenceSearchLoader';
 
 import { JobTypes } from '../../types/toolsJobTypes';
@@ -296,7 +296,7 @@ const BlastForm = () => {
   const { name, links, info } = infoMappings[JobTypes.BLAST];
 
   const onSequenceChange = useCallback(
-    (event: SequenceSubmissionOnChangeEvent) => {
+    (event: ParsedSequence[]) => {
       if (event.sequence === sequence.selected) {
         return;
       }

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -545,7 +545,7 @@ exports[`BlastForm test Renders the form 1`] = `
             class="button primary"
             type="submit"
           >
-            Run Blast
+            Run BLAST
           </button>
         </section>
       </section>

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -124,6 +124,7 @@ exports[`BlastForm test Renders the form 1`] = `
           class="sequence-submission-input"
           data-testid="sequence-submission-input"
           placeholder="MLPGLALLLL or AGTTTCCTCGGCAGCGGTAGGC"
+          spellcheck="false"
         />
       </section>
       <section

--- a/src/tools/blast/components/results/BlastResultTaxonomy.tsx
+++ b/src/tools/blast/components/results/BlastResultTaxonomy.tsx
@@ -24,7 +24,6 @@ const TaxItem: FC<TaxItemProps> = ({ taxNode, ratio }) => {
     );
   }
 
-  // eslint-disable-next-line no-shadow
   const handleClick = () => setOpen((open) => !open);
 
   return (

--- a/src/tools/blast/types/apiSequenceData.ts
+++ b/src/tools/blast/types/apiSequenceData.ts
@@ -1,3 +1,5 @@
+import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
+
 type Name = {
   value: string;
 };
@@ -8,9 +10,7 @@ type ProteinName = {
 };
 
 export type APISequenceData = {
-  entryType:
-    | 'UniProtKB reviewed (Swiss-Prot)'
-    | 'UniProtKB unreviewed (TrEMBL)';
+  entryType: EntryType;
   primaryAccession: string;
   uniProtkbId: string;
   entryAudit: {

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -83,7 +83,7 @@ const SequenceSearchLoader = forwardRef<
 >(({ onLoad }, ref) => {
   const [accessionOrID, setAccessionOrID] = useState('');
   // flag, abused to store previous value of the field
-  const [pasteLoading, setPasteLoading] = useState<null | string>(null);
+  const [pasteLoading, setPasteLoading] = useState(false);
   const dispatch = useDispatch();
 
   useImperativeHandle(ref, () => ({
@@ -175,7 +175,7 @@ const SequenceSearchLoader = forwardRef<
       // prevent displaying the content of the clipboard and empty the input
       event.preventDefault();
       setAccessionOrID('');
-      setPasteLoading(accessionOrID);
+      setPasteLoading(true);
 
       try {
         const parsedSequences = [];
@@ -226,27 +226,27 @@ const SequenceSearchLoader = forwardRef<
       } catch (error) {
         console.error(error); // eslint-disable-line no-console
       } finally {
-        setAccessionOrID(pasteLoading || '');
-        setPasteLoading(null);
+        setAccessionOrID(accessionOrID); // reset to previous value
+        setPasteLoading(false);
       }
     },
-    [onLoad, dispatch, accessionOrID, setAccessionOrID, pasteLoading]
+    [onLoad, dispatch, accessionOrID, setAccessionOrID]
   );
 
   return (
     <SearchInput
-      isLoading={loading || typeof pasteLoading === 'string'}
+      isLoading={loading || pasteLoading}
       onChange={(event: ChangeEvent<HTMLInputElement>) =>
         setAccessionOrID(event.target.value)
       }
       onPaste={handlePaste}
       placeholder={
-        typeof pasteLoading === 'string'
+        pasteLoading
           ? 'loading from pasted text'
           : 'P05067, A4_HUMAN, UPI0000000001'
       }
       value={accessionOrID}
-      disabled={typeof pasteLoading === 'string'}
+      disabled={pasteLoading}
     />
   );
 });

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -216,7 +216,7 @@ const SequenceSearchLoader = forwardRef<
           );
         }
       } catch (error) {
-        /**/
+        console.error(error); // eslint-disable-line no-console
       } finally {
         setPasteLoading(false);
       }

--- a/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
+++ b/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import SequenceSearchLoader from '../SequenceSearchLoader';
-import entryModelData from '../../../../uniprotkb/__mocks__/entryModelData.json';
+import entryModelData from '../../../uniprotkb/__mocks__/entryModelData.json';
 
 jest.mock('../../../../shared/hooks/useDataApi', () => jest.fn());
-import useDataApi from '../../../../shared/hooks/useDataApi';
+import useDataApi from '../../../shared/hooks/useDataApi';
 
 describe('SequenceSearchLoader tests', () => {
   it('Should load a sequence', () => {
@@ -26,9 +26,9 @@ describe('SequenceSearchLoader tests', () => {
     expect(onLoadMock).toBeCalledWith({
       likelyType: null,
       message: null,
-      name: 'P21802',
+      name: 'sp|P21802|uniprot_id',
       sequence:
-        '>sp|P21802|uniprot id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF',
+        '>sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF',
       valid: true,
     });
   });

--- a/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
+++ b/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+
 import SequenceSearchLoader from '../SequenceSearchLoader';
+
+import renderWithRedux from '../../../shared/__test-helpers__/RenderWithRedux';
+
 import entryModelData from '../../../uniprotkb/__mocks__/entryModelData.json';
 
-jest.mock('../../../../shared/hooks/useDataApi', () => jest.fn());
+jest.mock('../../../shared/hooks/useDataApi', () => jest.fn());
 import useDataApi from '../../../shared/hooks/useDataApi';
 
 describe('SequenceSearchLoader tests', () => {
@@ -18,19 +22,23 @@ describe('SequenceSearchLoader tests', () => {
     });
 
     const onLoadMock = jest.fn();
-    const component = render(<SequenceSearchLoader onLoad={onLoadMock} />);
+    const component = renderWithRedux(
+      <SequenceSearchLoader onLoad={onLoadMock} />
+    );
     const { getByPlaceholderText } = component;
     const input = getByPlaceholderText('P05067, A4_HUMAN, UPI0000000001');
     fireEvent.change(input, { target: { value: 'P05' } });
     expect(input.value).toEqual('P05');
-    expect(onLoadMock).toBeCalledWith({
-      likelyType: null,
-      message: null,
-      name: 'sp|P21802|uniprot_id',
-      sequence:
-        '>sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF',
-      valid: true,
-    });
+    expect(onLoadMock).toBeCalledWith([
+      {
+        likelyType: null,
+        message: null,
+        name: 'sp|P21802|uniprot_id',
+        sequence:
+          '>sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF',
+        valid: true,
+      },
+    ]);
   });
 
   it.skip('Should reset the sequence when no results are found', () => {
@@ -44,16 +52,20 @@ describe('SequenceSearchLoader tests', () => {
     });
 
     const onLoadMock = jest.fn();
-    const component = render(<SequenceSearchLoader onLoad={onLoadMock} />);
+    const component = renderWithRedux(
+      <SequenceSearchLoader onLoad={onLoadMock} />
+    );
     const { getByPlaceholderText } = component;
     const input = getByPlaceholderText('P05067, A4_HUMAN, UPI0000000001');
     fireEvent.change(input, { target: { value: 'P05' } });
     expect(input.value).toEqual('P05');
-    expect(onLoadMock).toBeCalledWith({
-      sequence: '',
-      valid: false,
-      likelyType: null,
-      message: null,
-    });
+    expect(onLoadMock).toBeCalledWith([
+      {
+        sequence: '',
+        valid: false,
+        likelyType: null,
+        message: null,
+      },
+    ]);
   });
 });

--- a/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
+++ b/src/tools/components/__tests__/SequenceSearchLoader.spec.tsx
@@ -34,8 +34,10 @@ describe('SequenceSearchLoader tests', () => {
         likelyType: null,
         message: null,
         name: 'sp|P21802|uniprot_id',
-        sequence:
-          '>sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF',
+        sequence: '',
+        header: '',
+        raw:
+          '>sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5\nSAPSQDFMRF\n',
         valid: true,
       },
     ]);

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -239,7 +239,7 @@ interface RowProps {
 }
 
 interface CustomLocationState {
-  parameters?: Job['parameters'];
+  parameters?: Job['parameters'][];
 }
 
 const Row: FC<RowProps> = memo(({ job, hasExpired }) => {
@@ -275,10 +275,13 @@ const Row: FC<RowProps> = memo(({ job, hasExpired }) => {
   // it means we just arrived from a submission form page and this is the job
   // that was just added, animate it to have it visually represented as "new"
   useLayoutEffect(() => {
+    if (!(ref.current && 'animate' in ref.current)) {
+      return;
+    }
     if (
-      job.parameters !==
-        (history.location?.state as CustomLocationState)?.parameters ||
-      !(ref.current && 'animate' in ref.current)
+      !(history.location?.state as CustomLocationState)?.parameters?.includes(
+        job.parameters
+      )
     ) {
       return;
     }

--- a/src/tools/styles/ToolsForm.scss
+++ b/src/tools/styles/ToolsForm.scss
@@ -12,6 +12,10 @@
     &--selected-taxon {
       margin-top: 1.5rem;
     }
+
+    & [name='title'] {
+      width: 22ch; /* match the max number of characters allowed in the field */
+    }
   }
 
   &__main_actions {

--- a/src/uniparc/config/apiUrls.ts
+++ b/src/uniparc/config/apiUrls.ts
@@ -1,0 +1,11 @@
+import joinUrl from 'url-join';
+
+export const devPrefix = 'https://wwwdev.ebi.ac.uk';
+
+// NOTE: isn't working/deployed yet
+const apiUrls = {
+  entry: (accession: string) =>
+    joinUrl(devPrefix, '/uniprot/api/uniparc', accession),
+};
+
+export default apiUrls;

--- a/src/uniprotkb/__mocks__/entryModelData.json
+++ b/src/uniprotkb/__mocks__/entryModelData.json
@@ -2,7 +2,7 @@
   "entryType": "UniProtKB reviewed (Swiss-Prot)",
   "primaryAccession": "P21802",
   "secondaryAccessions": ["P21802"],
-  "uniProtkbId": "uniprot id",
+  "uniProtkbId": "uniprot_id",
   "entryAudit": {
     "firstPublicDate": "2015-08-02",
     "lastAnnotationUpdateDate": "2016-04-24",

--- a/src/uniprotkb/adapters/__tests__/__snapshots__/entryToFASTAWithHeaders.spec.ts.snap
+++ b/src/uniprotkb/adapters/__tests__/__snapshots__/entryToFASTAWithHeaders.spec.ts.snap
@@ -6,6 +6,6 @@ SAPSQDFMRF"
 `;
 
 exports[`entryToFASTAWithHeaders should output a FASTA with subset 1`] = `
-">sp|P21802|1-1,3-5|uniprot id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5
+">sp|P21802|uniprot_id|1-1,3-5 rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5
 SPSQ"
 `;

--- a/src/uniprotkb/adapters/__tests__/__snapshots__/entryToFASTAWithHeaders.spec.ts.snap
+++ b/src/uniprotkb/adapters/__tests__/__snapshots__/entryToFASTAWithHeaders.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`entryToFASTAWithHeaders should output a FASTA string with UniProt-style headers 1`] = `
-">sp|P21802|uniprot id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5
+">sp|P21802|uniprot_id rec full Name OS=scientific name OX=9606 GN=some Gene PE=1 SV=5
 SAPSQDFMRF"
 `;
 

--- a/src/uniprotkb/adapters/entryToFASTAWithHeaders.ts
+++ b/src/uniprotkb/adapters/entryToFASTAWithHeaders.ts
@@ -1,3 +1,5 @@
+import { formatFASTA } from 'franklin-sites';
+
 import { UniProtkbAPIModel, EntryType } from './uniProtkbConverter';
 import { APISequenceData } from '../../tools/blast/types/apiSequenceData';
 
@@ -71,13 +73,13 @@ const entryToFASTAWithHeaders = (
     }
     let optionalSubset = '';
     if (subsets.length) {
-      optionalSubset = `${subsets.join(',')}|`;
+      optionalSubset = `|${subsets.join(',')}`;
     }
-    sequence = `>${db}|${entry.primaryAccession}|${optionalSubset}${entry.uniProtkbId} ${optionalProteinName}${optionalOS}${optionalOX}${optionalGN}PE=${pe} ${optionalSV}\n${sequence}`;
+    sequence = `>${db}|${entry.primaryAccession}|${entry.uniProtkbId}${optionalSubset} ${optionalProteinName}${optionalOS}${optionalOX}${optionalGN}PE=${pe} ${optionalSV}\n${sequence}`;
   } catch {
     /* */
   }
-  return sequence;
+  return formatFASTA(sequence);
 };
 
 export default entryToFASTAWithHeaders;

--- a/src/uniprotkb/adapters/entryToFASTAWithHeaders.ts
+++ b/src/uniprotkb/adapters/entryToFASTAWithHeaders.ts
@@ -7,16 +7,6 @@ type Subset = { start: number; end: number };
 
 type Modifications = { subsets: Subset[] }; // keep open for variant for example?
 
-// const CHUNK_OF_TEXT_OF_SIXTY_CHARACTERS = /(.{1,60})/g;
-// const CHUNK_OF_TEXT_OF_TEN_CHARACTERS = /(.{1,10})/g;
-
-// NOTE: if we decide to do formatting here, use formatting logic from franklin
-// .split(CHUNK_OF_TEXT_OF_SIXTY_CHARACTERS)
-// .filter(Boolean)
-// .map((line) =>
-//   line.replace(CHUNK_OF_TEXT_OF_TEN_CHARACTERS, '$1 ').trim()
-// )
-// .join('\n');
 // build a "nicely"-formatted FASTA string
 // See https://www.uniprot.org/help/fasta-headers for current headers
 const entryToFASTAWithHeaders = (
@@ -77,7 +67,13 @@ const entryToFASTAWithHeaders = (
     }
     sequence = `>${db}|${entry.primaryAccession}|${entry.uniProtkbId}${optionalSubset} ${optionalProteinName}${optionalOS}${optionalOX}${optionalGN}PE=${pe} ${optionalSV}\n${sequence}`;
   } catch {
-    /* */
+    // temporary catch for uniParc entry
+    if ((entry as any).uniParcId) {
+      sequence = `>${(entry as any).uniParcId}\n${sequence}`;
+    } else {
+      // empty header 🤷🏽‍♂️
+      sequence = `>\n${sequence}`;
+    }
   }
   return formatFASTA(sequence);
 };

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`Entry view should render 1`] = `
                 />
               </svg>
             </span>
-            P21802 · uniprot id
+            P21802 · uniprot_id
           </span>
         </h2>
       </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryPublications.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryPublications.spec.tsx.snap
@@ -19,13 +19,13 @@ exports[`EntryPublications tests should render the error 1`] = `
       <svg
         fill="currentColor"
         height="1.125em"
-        viewBox="0 0 18 18"
+        stroke="currentColor"
+        viewBox="0 0 19 18"
         width="1.125em"
       >
         <path
-          clip-rule="evenodd"
-          d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-          fill-rule="evenodd"
+          d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+          stroke-width="2"
         />
       </svg>
       <section

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtKBEntryPublications.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtKBEntryPublications.spec.tsx.snap
@@ -12,13 +12,13 @@ exports[`UniProtKBEntryPublications Should make a call with pubmed ids 1`] = `
     <svg
       fill="currentColor"
       height="1.125em"
-      viewBox="0 0 18 18"
+      stroke="currentColor"
+      viewBox="0 0 19 18"
       width="1.125em"
     >
       <path
-        clip-rule="evenodd"
-        d="M18 9A9 9 0 110 9a9 9 0 0118 0zM8 4a1 1 0 112 0v6a1 1 0 11-2 0V4zm1 9a1 1 0 100 2 1 1 0 000-2z"
-        fill-rule="evenodd"
+        d="M14.93 11.14h0L12.8 9l2.13-2.14a1.9 1.9 0 000-2.67h0l-.63-.64a1.9 1.9 0 00-2.68 0h0L9.5 5.7 7.35 3.55a1.9 1.9 0 00-2.68 0h0l-.63.64a1.9 1.9 0 000 2.67h0L6.18 9l-2.14 2.14a1.9 1.9 0 000 2.67h0l.63.64a1.9 1.9 0 002.68 0L9.5 12.3l2.13 2.14a1.9 1.9 0 002.68 0l.63-.64a1.9 1.9 0 000-2.67zM17.5 9a8 8 0 11-16 0 8 8 0 0116 0z"
+        stroke-width="2"
       />
     </svg>
     <section

--- a/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
+++ b/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`UniProtKBCard component should render 1`] = `
                     />
                   </svg>
                 </span>
-                P21802 · uniprot id
+                P21802 · uniprot_id
               </span>
             </h5>
             <section>
@@ -95,7 +95,7 @@ exports[`UniProtKBCard component should render 1`] = `
       class="card__actions"
     >
       <span
-        class="card__link false"
+        class="card__link"
       >
         <a
           href="/uniprotkb/P21802#Sequence"

--- a/src/uniprotkb/config/__tests__/__snapshots__/ColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/ColumnConfiguration.spec.tsx.snap
@@ -581,7 +581,7 @@ exports[`ColumnConfiguration component should render all columns: Entry 1`] = `
 exports[`ColumnConfiguration component should render all columns: Entry Name 1`] = `
 <DocumentFragment>
   <span>
-    uniprot id
+    uniprot_id
   </span>
 </DocumentFragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5676,10 +5676,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-franklin-sites@0.0.62:
-  version "0.0.62"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.62.tgz#85b157af00edf42c125d02c6910f702adce18b53"
-  integrity sha512-SNfOgVWKmD/bhYS+ZySkSbEZLmi3nF+q3CHKNYRE/e1eD0J4ngG/Q1zHlyqxDLWRG9LzHtYhx19JHBH7+eSaLw==
+franklin-sites@0.0.64:
+  version "0.0.64"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.64.tgz#b14b3fbcde58a46151f5b048b5cf73b6a4592b5b"
+  integrity sha512-WTE69Qaw4hUXwWGT4QB97q/E/ZyrGJxGhBeYvhMGZ2pE+cfJYSUxNvc5GyJJY/PrVqLRijng7dJvHJc2zyWpAQ==
   dependencies:
     classnames "^2.2.6"
     d3-array "^2.4.0"


### PR DESCRIPTION
- [x] What is the link to the Jira that this PR is for? [TRM-24451](https://www.ebi.ac.uk/panda/jira/browse/TRM-24451)
- [ ] Have you written tests and do these have >= 75% coverage of the code that you are contributing? pending
- [x] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)? Align form and Blast form
- [x] Are there any linting errors that required you to add exceptions? `no-shadow`
- [x] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?

Group of changes mainly aimed at handling better multiple sequences FASTAs
See [corresponding PR](https://github.com/ebi-uniprot/franklin-sites/pull/97) in franklin-sites

 - Add ProcessedSequence object state to the forms to handle validation, name extraction, and prepending of new sequences
   - Seems a bit redundant with the `sequence` state holding the raw sequence text and the form input config though
 - Better handling of job name autofill
   - If user modifies, don't autofill anymore
   - use NCBI identifier extracted from FASTA header of available
   - use '<first found identifier> + 2' in case of 3 sequences
   - use '3 sequences' if no identifier found
 - Auto load from accession or identifier
   - in case of align form:
     - prepend new sequence to already provided ones
     - handle pasting of multiple identifier in the search field
   - added logic to load from UniParc accession (even if endpoint not available yet)
   - use `formatFASTA` to nicely format imported sequences
