### PR TITLE
Size hook

### DIFF
--- a/src/shared/hooks/__tests__/useLocalStorage.spec.ts
+++ b/src/shared/hooks/__tests__/useLocalStorage.spec.ts
@@ -5,6 +5,10 @@ import useLocalStorage from '../useLocalStorage';
 const url = '/some/path';
 const url2 = '/some/other/path';
 
+afterAll(() => {
+  cleanup();
+});
+
 describe('useLocalStorage hook', () => {
   test('get value, basic', () => {
     const { result } = renderHook(() =>

--- a/src/shared/hooks/__tests__/useSafeState.spec.ts
+++ b/src/shared/hooks/__tests__/useSafeState.spec.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { renderHook, cleanup, act } from '@testing-library/react-hooks';
 
 import useSafeState from '../useSafeState';

--- a/src/shared/hooks/__tests__/useSafeState.spec.ts
+++ b/src/shared/hooks/__tests__/useSafeState.spec.ts
@@ -1,0 +1,57 @@
+import { renderHook, cleanup, act } from '@testing-library/react-hooks';
+
+import useSafeState from '../useSafeState';
+
+afterAll(() => {
+  cleanup();
+});
+
+describe('useSafeState hook', () => {
+  test('basic usage, value', () => {
+    const { result } = renderHook(() => useSafeState('value'));
+
+    expect(result.current[0]).toEqual('value');
+
+    act(() => result.current[1]('other value'));
+
+    expect(result.current[0]).toEqual('other value');
+  });
+
+  test('basic usage, setter', () => {
+    const { result } = renderHook(() => useSafeState('value'));
+
+    expect(result.current[0]).toEqual('value');
+
+    act(() => result.current[1]((state) => `other ${state}`));
+
+    expect(result.current[0]).toEqual('other value');
+  });
+
+  test('use after unmounting, value', () => {
+    const { result, unmount } = renderHook(() => useSafeState('value'));
+
+    expect(result.current[0]).toEqual('value');
+
+    unmount();
+
+    act(() => result.current[1](`other value`));
+
+    // expect to not have changed, even if in real life we won't have access to
+    // the state anymore
+    expect(result.current[0]).toEqual('value');
+  });
+
+  test('use after unmounting, setter', () => {
+    const { result, unmount } = renderHook(() => useSafeState('value'));
+
+    expect(result.current[0]).toEqual('value');
+
+    unmount();
+
+    act(() => result.current[1]((state) => `other ${state}`));
+
+    // expect to not have changed, even if in real life we won't have access to
+    // the state anymore
+    expect(result.current[0]).toEqual('value');
+  });
+});

--- a/src/shared/hooks/__tests__/useSize.spec.ts
+++ b/src/shared/hooks/__tests__/useSize.spec.ts
@@ -1,0 +1,43 @@
+import { renderHook, cleanup, act } from '@testing-library/react-hooks';
+
+import useSize from '../useSize';
+
+let element;
+
+beforeAll(() => {
+  element = document.createElement('p');
+});
+
+afterAll(() => {
+  element = null;
+  cleanup();
+});
+
+/**
+ * JSDOM doesn't render elements and gives them no size, so we're not going to
+ * be able to test everything, focus on what we know we are going to be using
+ */
+
+describe('useSize', () => {
+  test('basic usage', () => {
+    const ref = { current: element };
+    const { result, rerender } = renderHook(() => useSize(ref));
+
+    const firstSize = result.current[0];
+
+    expect(typeof firstSize).toBe('object');
+    // only testing this as this is what we'll need
+    expect(firstSize.width).toBe(0);
+
+    // rerender, as if for whatever reason, not resizing-related
+    rerender(ref);
+    // expect to get the exact same object
+    expect(result.current[0]).toBe(firstSize);
+
+    act(() => {
+      window.dispatchEvent(new window.Event('resize'));
+    });
+    // expect a brand new object after a resize event
+    expect(result.current[0]).not.toBe(firstSize);
+  });
+});

--- a/src/shared/hooks/useSafeState.ts
+++ b/src/shared/hooks/useSafeState.ts
@@ -1,0 +1,39 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  Dispatch,
+  SetStateAction,
+} from 'react';
+
+/**
+ * custom hook that avoids the issue of set state on an unmounted component\
+ * copy useState typescript function signature
+ * @param {S} initialState
+ */
+function useSafeState<S>(
+  initialState: S | (() => S)
+): [S, Dispatch<SetStateAction<S>>] {
+  const [state, setState] = useState<S>(initialState);
+  const isMounted = useRef<boolean>(true);
+
+  // keep track of mount/unmount
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // "fake" setState that we'll return to the user of the hook
+  // it will check if mounted before calling the actual setState
+  const customSetState = useCallback((newStateOrSetter) => {
+    if (!isMounted.current) return;
+    setState(newStateOrSetter);
+  }, []);
+
+  return [state, customSetState];
+}
+
+export default useSafeState;

--- a/src/shared/hooks/useSize.ts
+++ b/src/shared/hooks/useSize.ts
@@ -1,0 +1,41 @@
+import { MutableRefObject, useEffect, useState, useCallback } from 'react';
+
+/**
+ * given a reference to an actual HTML element, gives us access to its size
+ * even through resizes and zoom
+ * @param {MutableRefObject<HTMLElement>} ref
+ * @returns {Array} tuple - return tuple
+ * @returns {DOMRect | null} tuple[0]
+ *          DOMRect object with the sizes of the passed ref, or null if no ref
+ * @returns {() => void} tuple[1]
+ *          Manual refresh function, to call if the size needs to be recomputed
+ *          for whatever reason (e.g. content changed)
+ */
+function useSize<E extends HTMLElement = HTMLElement>(
+  ref: MutableRefObject<E | undefined>
+): [DOMRect | null, () => void] {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  const onResize = useCallback(() => {
+    if (!ref.current) {
+      return;
+    }
+    setRect(ref.current.getBoundingClientRect());
+  }, [ref]);
+
+  useEffect(() => {
+    if (!ref.current) {
+      setRect(null);
+      return;
+    }
+
+    onResize(); // first time
+    window.addEventListener('resize', onResize);
+    // eslint-disable-next-line consistent-return
+    return () => window.removeEventListener('resize', onResize);
+  }, [ref, onResize]);
+
+  return [rect, onResize];
+}
+
+export default useSize;


### PR DESCRIPTION
- [x] What is the link to the Jira that this PR is for? [TRM-24474](https://www.ebi.ac.uk/panda/jira/browse/TRM-24474)
- [x] Have you written tests and do these have >= 75% coverage of the code that you are contributing? (not really able to test everything in Jest/JSDOM)
- [ ] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)? not really out of the box, but you could do this:
```jsx
  const testRef = useRef<HTMLElement>();
  const [size] = useSize(testRef);
  // ... lower, in render
  <input
    type="text"
    ref={testRef}
    readOnly
    style={{ width: 'initial' }}
    value={`My width is ${size?.width}px`}
  />
```
- [x] Are there any linting errors that required you to add exceptions? `consistent-return`
- [ ] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?

added 2 custom hooks,
 - `useSafeState` (not really related to the Jira, but will be useful), that makes sure the component is still mounted before setting the state. Exact same API as react's `useState`. Useful when state depends from async logic
 - `useSize` which returns the size (DOMRect) of a specified referenced element. Returns new size in case of resizing the window (that is, actual resize, or zoom). Even if the element itself has not changed size, a new size object will be rendered (the values will be the same, as expected). At the moment (is that required?), doesn't trigger when the element reflows, or changes its size due to changes in the DOM.

Regarding detecting zoom, I guess there's no nice way right now to distinguish between a resize and a zoom, see [this text about it](https://github.com/tombigel/detect-zoom#read-this-detect-zoom-is-currently-unusable-for-desktop).
