### PR TITLE
use automatic bin size, connect hit distribution page to facet filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "classnames": "2.2.6",
     "d3": "5.16.0",
     "d3-scale": "3.2.1",
-    "franklin-sites": "0.0.65",
+    "franklin-sites": "0.0.66",
     "history": "4.10.1",
     "idb": "5.0.4",
     "idx": "2.5.6",

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -1,13 +1,7 @@
 /**
  * @jest-environment node
  */
-import {
-  removeProperty,
-  formatLargeNumber,
-  getBEMClassName,
-  getSmallerMultiple,
-  getLargerMultiple,
-} from '../utils';
+import { removeProperty, formatLargeNumber, getBEMClassName } from '../utils';
 
 test('removeProperty removes only specified property and returns a deep copy of object ', () => {
   const obj = { foo: { bar: [1] }, baz: -1 };
@@ -73,25 +67,5 @@ describe('getBEMClassName', () => {
         m: [true && 'modifier_1'],
       })
     ).toEqual('block block--modifier_1');
-  });
-});
-
-describe('getSmallerMultiple', () => {
-  it('should return a multiple of a factor < number', () => {
-    expect(getSmallerMultiple(91, 10)).toEqual(90);
-  });
-
-  it('should return the number if number is alread a multiple of the factor ', () => {
-    expect(getSmallerMultiple(90, 10)).toEqual(90);
-  });
-});
-
-describe('getLargerMultiple', () => {
-  it('should return a multiple of a factor > number', () => {
-    expect(getLargerMultiple(91, 10)).toEqual(100);
-  });
-
-  it('should return the number if number is alread a multiple of the factor ', () => {
-    expect(getSmallerMultiple(90, 10)).toEqual(90);
   });
 });

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -70,9 +70,3 @@ export const getBEMClassName = ({
   }
   return className;
 };
-
-export const getSmallerMultiple = (n: number, factor: number) =>
-  Math.floor(n / factor) * factor;
-
-export const getLargerMultiple = (n: number, factor: number) =>
-  Math.ceil(n / factor) * factor;

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -356,7 +356,11 @@ const BlastResult = () => {
           }
         >
           {actionBar}
-          <BlastResultHitDistribution hits={blastData.hits} />
+          <BlastResultHitDistribution
+            loading={blastLoading || accessionsLoading}
+            allHits={blastData?.hits || []}
+            filteredHits={hitsFiltered}
+          />
         </Tab>
         <Tab
           id="text-output"

--- a/src/tools/blast/components/results/BlastResultHitDistribution.tsx
+++ b/src/tools/blast/components/results/BlastResultHitDistribution.tsx
@@ -72,19 +72,26 @@ const BlastResultHitDistribution: FC<BlastResultHitDistributionProps> = ({
           </select>
         </label>
       </fieldset>
-      {Object.entries(valuesRef.current).map(([name, values]) => (
-        <div className="blast-result-hit-distribution" key={name}>
-          <Histogram
-            values={values}
-            unfilteredValues={unfilteredValues[name]}
-            nBins={nBinsValue === 'auto' ? optimisedBinNumber : nBinsValue}
-            min={bounds[name].min}
-            max={bounds[name].max}
-            xLabel={name}
-            yLabel="hits"
-          />
-        </div>
-      ))}
+      {Object.entries(valuesRef.current).map(([name, values]) => {
+        const { min, max } = bounds[name];
+        if (min === max) {
+          // If all values are the same then don't render the histogram
+          return null;
+        }
+        return (
+          <div className="blast-result-hit-distribution" key={name}>
+            <Histogram
+              values={values}
+              unfilteredValues={unfilteredValues[name]}
+              nBins={nBinsValue === 'auto' ? optimisedBinNumber : nBinsValue}
+              min={min}
+              max={max}
+              xLabel={name}
+              yLabel="hits"
+            />
+          </div>
+        );
+      })}
     </>
   );
 };

--- a/src/tools/blast/components/results/BlastResultHitDistribution.tsx
+++ b/src/tools/blast/components/results/BlastResultHitDistribution.tsx
@@ -33,16 +33,16 @@ const BlastResultHitDistribution: FC<BlastResultHitDistributionProps> = ({
     valuesRef.current = values;
   }
 
-  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(
-    () => [
-      getDataPoints(allHits),
+  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(() => {
+    const dataPoints = getDataPoints(allHits);
+    return [
+      dataPoints,
       getBounds(allHits),
       // see: https://en.wikipedia.org/wiki/Histogram#Square-root_choice
       // We chose the simplest implementation, 𝐤=⌈√𝐧⌉
-      Math.ceil(Math.sqrt(allHits.length)),
-    ],
-    [allHits]
-  );
+      Math.ceil(Math.sqrt(dataPoints.score.length)),
+    ];
+  }, [allHits]);
 
   if (loading && !valuesRef.current.score.length) {
     return <Loader />;

--- a/src/tools/blast/components/results/BlastResultHitDistribution.tsx
+++ b/src/tools/blast/components/results/BlastResultHitDistribution.tsx
@@ -1,30 +1,91 @@
-import React, { FC } from 'react';
-import { Histogram } from 'franklin-sites';
+import React, { FC, useRef, useMemo, useState } from 'react';
+import { Histogram, Loader } from 'franklin-sites';
+
+import { getDataPoints, getBounds } from '../../utils/blastFacetDataUtils';
+
 import { BlastHit } from '../../types/blastResults';
-import {
-  getSmallerMultiple,
-  getLargerMultiple,
-} from '../../../../shared/utils/utils';
+
 import '../styles/BlastResultHitDistribution.scss';
 
-const BlastResultHitDistribution: FC<{ hits: BlastHit[] }> = ({ hits }) => {
-  const scores = hits
-    .map((hit) => hit.hit_hsps.map((hsp) => hsp.hsp_score))
-    .flat();
-  const binSize = 100;
-  const min = getSmallerMultiple(Math.min(...scores), binSize);
-  const max = getLargerMultiple(Math.max(...scores), binSize);
+const nBinOptions = ['auto', 5, 10, 25, 50, 100] as const;
+
+type BlastResultHitDistributionProps = {
+  loading: boolean;
+  allHits: BlastHit[];
+  filteredHits: BlastHit[];
+};
+
+const BlastResultHitDistribution: FC<BlastResultHitDistributionProps> = ({
+  loading,
+  allHits,
+  filteredHits,
+}) => {
+  const [nBinsValue, setNBinsValue] = useState<typeof nBinOptions[number]>(
+    'auto'
+  );
+
+  const values = useMemo(() => getDataPoints(filteredHits || []), [
+    filteredHits,
+  ]);
+  // logic to keep stale data available
+  const valuesRef = useRef(values);
+  if (values.score.length || !loading) {
+    valuesRef.current = values;
+  }
+
+  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(
+    () => [
+      getDataPoints(allHits),
+      getBounds(allHits),
+      // see: https://en.wikipedia.org/wiki/Histogram#Square-root_choice
+      // We chose the simplest implementation, 𝐤=⌈√𝐧⌉
+      Math.ceil(Math.sqrt(allHits.length)),
+    ],
+    [allHits]
+  );
+
+  if (loading && !valuesRef.current.score.length) {
+    return <Loader />;
+  }
+
   return (
-    <div className="blast-result-hit-distribution">
-      <Histogram
-        values={scores}
-        binSize={binSize}
-        min={min}
-        max={max}
-        xLabel="Score"
-        yLabel="Hits"
-      />
-    </div>
+    <>
+      <fieldset>
+        <label>
+          Number of bins:{' '}
+          <select
+            value={nBinsValue}
+            onChange={(event) =>
+              setNBinsValue(
+                event.target.value === 'auto'
+                  ? event.target.value
+                  : (+event.target.value as typeof nBinOptions[number])
+              )
+            }
+          >
+            {nBinOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+                {option === 'auto' && ` (${optimisedBinNumber})`}
+              </option>
+            ))}
+          </select>
+        </label>
+      </fieldset>
+      {Object.entries(valuesRef.current).map(([name, values]) => (
+        <div className="blast-result-hit-distribution" key={name}>
+          <Histogram
+            values={values}
+            unfilteredValues={unfilteredValues[name]}
+            nBins={nBinsValue === 'auto' ? optimisedBinNumber : nBinsValue}
+            min={bounds[name].min}
+            max={bounds[name].max}
+            xLabel={name}
+            yLabel="hits"
+          />
+        </div>
+      ))}
+    </>
   );
 };
 

--- a/src/tools/blast/components/results/BlastResultHitDistribution.tsx
+++ b/src/tools/blast/components/results/BlastResultHitDistribution.tsx
@@ -50,7 +50,7 @@ const BlastResultHitDistribution: FC<BlastResultHitDistributionProps> = ({
 
   return (
     <>
-      <fieldset>
+      <fieldset className="nbin-selection">
         <label>
           Number of bins:{' '}
           <select
@@ -88,6 +88,7 @@ const BlastResultHitDistribution: FC<BlastResultHitDistributionProps> = ({
               max={max}
               xLabel={name}
               yLabel="hits"
+              unfilteredValuesShadow={0.2}
             />
           </div>
         );

--- a/src/tools/blast/components/results/BlastResultLocalFacets.tsx
+++ b/src/tools/blast/components/results/BlastResultLocalFacets.tsx
@@ -31,6 +31,7 @@ type LocalFacetProps = {
   hitsFilteredByServer: BlastHit[];
   selectedFacets: SelectedFacet[];
   unfilteredValues: number[];
+  optimisedBinNumber: number;
 };
 const LocalFacet: FC<LocalFacetProps> = ({
   facet,
@@ -39,6 +40,7 @@ const LocalFacet: FC<LocalFacetProps> = ({
   hitsFilteredByServer,
   selectedFacets,
   unfilteredValues,
+  optimisedBinNumber,
 }) => {
   const history = useHistory();
 
@@ -95,7 +97,7 @@ const LocalFacet: FC<LocalFacetProps> = ({
         height={50}
         min={bounds.min}
         max={bounds.max}
-        nBins={30}
+        nBins={optimisedBinNumber}
         onChange={handleChange}
         selectedRange={selectedRange}
         values={values[facet]}
@@ -137,13 +139,20 @@ const BlastResultLocalFacets: FC<{
     return allHits.filter((hit) => filteredAccessions.has(hit.hit_acc));
   }, [data, allHits]);
 
-  const bounds = useMemo(() => getBounds(allHits), [allHits]);
-
   const facetBounds = useMemo(() => getFacetBounds(selectedFacets), [
     selectedFacets,
   ]);
 
-  const unfilteredValues = useMemo(() => getDataPoints(allHits), [allHits]);
+  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(
+    () => [
+      getDataPoints(allHits),
+      getBounds(allHits),
+      // see: https://en.wikipedia.org/wiki/Histogram#Square-root_choice
+      // We chose the simplest implementation, 𝐤=⌈√𝐧⌉
+      Math.ceil(Math.sqrt(allHits.length)),
+    ],
+    [allHits]
+  );
 
   if (loading && !isStale) {
     return <Loader />;
@@ -168,6 +177,7 @@ const BlastResultLocalFacets: FC<{
                 hitsFilteredByServer={hitsFilteredByServer}
                 selectedFacets={selectedFacets}
                 unfilteredValues={unfilteredValues[facet]}
+                optimisedBinNumber={optimisedBinNumber}
               />
             ))}
           </ul>

--- a/src/tools/blast/components/results/BlastResultLocalFacets.tsx
+++ b/src/tools/blast/components/results/BlastResultLocalFacets.tsx
@@ -143,16 +143,16 @@ const BlastResultLocalFacets: FC<{
     selectedFacets,
   ]);
 
-  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(
-    () => [
-      getDataPoints(allHits),
+  const [unfilteredValues, bounds, optimisedBinNumber] = useMemo(() => {
+    const dataPoints = getDataPoints(allHits);
+    return [
+      dataPoints,
       getBounds(allHits),
       // see: https://en.wikipedia.org/wiki/Histogram#Square-root_choice
       // We chose the simplest implementation, 𝐤=⌈√𝐧⌉
-      Math.ceil(Math.sqrt(allHits.length)),
-    ],
-    [allHits]
-  );
+      Math.ceil(Math.sqrt(dataPoints.score.length)),
+    ];
+  }, [allHits]);
 
   if (loading && !isStale) {
     return <Loader />;

--- a/src/tools/blast/components/styles/BlastResultHitDistribution.scss
+++ b/src/tools/blast/components/styles/BlastResultHitDistribution.scss
@@ -4,3 +4,11 @@
   padding-right: 1rem;
   max-width: 60rem;
 }
+
+.nbin-selection {
+  float: right;
+
+  & select {
+    width: auto;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5681,10 +5681,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-franklin-sites@0.0.65:
-  version "0.0.65"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.65.tgz#57117cff124e3e6e973e8fa01ff913bd90253e1e"
-  integrity sha512-dc56nzTBeeKRhdDPaQFXgLqKg15Y3EBei6OED1zZ2vBpG33DEG3vLnzHvwb7p3FmDOD6hbiioArXYCd1qS9Mvw==
+franklin-sites@0.0.66:
+  version "0.0.66"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.66.tgz#5fbdc7496b78c9f6212ac0ce7345c588fb28c69a"
+  integrity sha512-1lEz7WgMESufMtdXNPimNa9b1hzvJIm4O2iVeLnSz1nnaOkemE6ien+5v7MOyqYprbaPNJdfrbf7xM6rqaklBQ==
   dependencies:
     classnames "^2.2.6"
     d3-array "^2.4.0"


### PR DESCRIPTION
- [ ] What is the link to the Jira that this PR is for?
- [ ] Have you written tests and do these have >= 75% coverage of the code that you are contributing?
- [x] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)?
- [ ] Are there any linting errors that required you to add exceptions?
- [x] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?

 - Modify Histogram filters to use an automatically calculated number of bins depending on number of items in original dataset (number of hsp across all hits)
 - Modify hit distribution tab:
   - Connect to filtered data
   - Display all value types
   - Let user change number of bins (defaults to auto)