### PR TITLE
make responsive dashboard, avoid action buttons escaping

### DIFF
--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -248,7 +248,10 @@ const AlignForm = () => {
                   name="title"
                   type="text"
                   autoComplete="off"
-                  maxLength={22}
+                  maxLength={100}
+                  style={{
+                    width: `${(jobName.selected as string).length + 2}ch`,
+                  }}
                   placeholder="my job title"
                   value={jobName.selected as string}
                   onChange={(event) => {

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -461,7 +461,10 @@ const BlastForm = () => {
                   name="title"
                   type="text"
                   autoComplete="off"
-                  maxLength={22}
+                  maxLength={100}
+                  style={{
+                    width: `${(jobName.selected as string).length + 2}ch`,
+                  }}
                   placeholder="my job title"
                   value={jobName.selected as string}
                   onChange={(event) => {

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -522,9 +522,10 @@ exports[`BlastForm test Renders the form 1`] = `
             Name your BLAST job
             <input
               autocomplete="off"
-              maxlength="22"
+              maxlength="100"
               name="title"
               placeholder="my job title"
+              style="width: 2ch;"
               type="text"
               value=""
             />

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -64,7 +64,7 @@ const Name: FC<NameProps> = ({ children, id }: NameProps) => {
         autoComplete="off"
         type="text"
         value={text}
-        maxLength={22}
+        maxLength={100}
       />
       <EditIcon width="2ch" />
     </label>
@@ -316,10 +316,10 @@ const Row: FC<RowProps> = memo(({ job, hasExpired }) => {
         ],
       })}
     >
+      <span className="dashboard__body__type">{job.type}</span>
       <span className="dashboard__body__name">
         <Name id={job.internalID}>{job.title}</Name>
       </span>
-      <span className="dashboard__body__type">{job.type}</span>
       <span
         className="dashboard__body__time"
         title={

--- a/src/tools/dashboard/components/styles/Dashboard.scss
+++ b/src/tools/dashboard/components/styles/Dashboard.scss
@@ -5,11 +5,13 @@
     font-weight: bold;
     display: grid;
     /* this needs to be the same as below to keep visual alignment */
-    grid-template-columns: 10ch 27ch 18ch 20ch 1fr;
+    grid-template-columns: 10ch 27ch 12ch 1fr;
     grid-gap: 1ch;
   }
 
   &__body {
+    min-width: fit-content;
+
     & .card--failure {
       border: 1px solid $colour-failure;
       border-left: 0.25rem solid $colour-failure;
@@ -59,6 +61,10 @@
         & .dashboard__body__actions {
           opacity: 1;
         }
+
+        & input[type='text'] {
+          background: rgba(255, 255, 255, 0.25);
+        }
       }
     }
 
@@ -68,7 +74,7 @@
       grid-template-areas:
         'type name time status actions'
         'id   id   time status actions';
-      grid-template-columns: 10ch 27ch 18ch 20ch 1fr;
+      grid-template-columns: 10ch 27ch 12ch 1fr max-content;
       grid-gap: 1ch;
       grid-template-rows: 1fr 1fr;
     }
@@ -77,10 +83,9 @@
     &__name {
       grid-area: name;
       font-weight: bold;
-      width: 25ch;
-      display: flex;
 
       & label {
+        width: 90%;
         display: inline-flex;
       }
 
@@ -88,6 +93,7 @@
         background: transparent;
         box-shadow: none;
         border: none;
+        border-radius: 0.25em;
         height: 1.5em;
         padding: 0;
         margin: 0;
@@ -179,6 +185,33 @@
     &__actions {
       opacity: 0.5;
       transition: opacity ease-in-out 100ms;
+    }
+  }
+}
+
+// switch to narrow view before content starts escaping the cards
+@media only screen and (max-width: 50em) {
+  .dashboard {
+    &__header {
+      display: none;
+    }
+
+    &__body {
+      & .card__content {
+        grid-template-areas:
+          'type name   time'
+          '.    status time'
+          'id   id     actions';
+        grid-template-columns: 10ch minmax(27ch, auto) 12ch;
+        grid-gap: 0;
+        grid-template-rows: 1fr 1fr 1fr;
+      }
+
+      &__time {
+        text-align: end;
+        flex-direction: row-reverse;
+        justify-content: flex-start;
+      }
     }
   }
 }

--- a/src/tools/styles/ToolsForm.scss
+++ b/src/tools/styles/ToolsForm.scss
@@ -14,7 +14,9 @@
     }
 
     & [name='title'] {
-      width: 22ch; /* match the max number of characters allowed in the field */
+      // so that we have a calculable size in ch units
+      font-family: monospace;
+      min-width: 25ch;
     }
   }
 


### PR DESCRIPTION
Change Dashboard style to:
 - avoid having the action buttons escape when the screen starts to get narrower
 - give more space to the title
   - related to that, made title monospace on Align and BLAST forms to dinamically set the needed width for the input (no way to style an input[type="text"] relative to the size of its content 🤷🏽‍♂️)
 - implement the alternative grid for small screens according to mockup