### PR TITLE
2020 11 uniref  better compat

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,19 +2,28 @@
 module.exports = function (api) {
   api.cache(true);
 
-  const presets = [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ];
-  const plugins = [
-    '@babel/plugin-transform-runtime',
-    '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-object-rest-spread',
-  ];
-
   return {
-    presets,
-    plugins,
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: {
+            chrome: '80',
+            edge: '18',
+            firefox: '68',
+            safari: '13',
+          },
+          useBuiltIns: 'usage',
+          corejs: { version: 3 },
+        },
+      ],
+      '@babel/preset-react',
+      '@babel/preset-typescript',
+    ],
+    plugins: [
+      '@babel/plugin-transform-runtime',
+      '@babel/plugin-proposal-class-properties',
+      '@babel/plugin-proposal-object-rest-spread',
+    ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@swissprot/rhea-reaction-visualizer": "0.0.16",
     "axios": "0.20.0",
     "classnames": "2.2.6",
+    "core-js": "3.6.5",
     "d3": "5.16.0",
     "file-type": "15.0.0",
     "franklin-sites": "0.0.72",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
+      "^/(.*)$": "<rootDir>/src/$1",
       "^react$": "<rootDir>/node_modules/react/",
       "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/",
       "^lodash-es$": "lodash"

--- a/setupJest.js
+++ b/setupJest.js
@@ -6,7 +6,7 @@ global.crypto = {
   },
 };
 
-// mock
+// useCustomElement always says that the component is defined for tests
 jest.mock('/shared/hooks/useCustomElement', () => ({
   __esModule: true,
   default: () => true,

--- a/setupJest.js
+++ b/setupJest.js
@@ -5,3 +5,9 @@ global.crypto = {
     return nodeCrypto.randomFillSync(buffer);
   },
 };
+
+// mock
+jest.mock('/shared/hooks/useCustomElement', () => ({
+  __esModule: true,
+  default: () => true,
+}));

--- a/src/shared/hooks/useCustomElement.ts
+++ b/src/shared/hooks/useCustomElement.ts
@@ -27,12 +27,7 @@ const useCustomElement = (
     CEgetter.current()
       .then((module) => {
         if (!window.customElements.get(name)) {
-          try {
-            window.customElements.define(name, module.default);
-          } catch (err) {
-            console.error(err);
-            console.log(module, name);
-          }
+          window.customElements.define(name, module.default);
         }
         setDefined(true);
       })

--- a/src/shared/hooks/useCustomElement.ts
+++ b/src/shared/hooks/useCustomElement.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+import useSafeState from './useSafeState';
+
+const useCustomElement = (
+  customElementGetter: () => Promise<{ default: CustomElementConstructor }>,
+  name: string
+) => {
+  const [defined, setDefined] = useSafeState(
+    Boolean(window.customElements && window.customElements.get(name))
+  );
+
+  // as it's a function, it might have been redefined through a rerender pass,
+  // so keep that in a ref to avoid the useEffect to rerun needlessly
+  const CEgetter = useRef(customElementGetter);
+
+  useEffect(() => {
+    // customElements not supported, bail
+    if (!window.customElements) {
+      return;
+    }
+    // already instantiated, update state and bail
+    if (window.customElements.get(name)) {
+      setDefined(true);
+      return;
+    }
+    CEgetter.current()
+      .then((module) => {
+        if (!window.customElements.get(name)) {
+          try {
+            window.customElements.define(name, module.default);
+          } catch (err) {
+            console.error(err);
+            console.log(module, name);
+          }
+        }
+        setDefined(true);
+      })
+      // eslint-disable-next-line no-console
+      .catch((error) => console.error(error));
+  }, [name, setDefined]);
+
+  return defined;
+};
+
+export default useCustomElement;

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -12,19 +12,6 @@ export const formatLargeNumber = (x: number) => {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };
 
-interface WebComponentConstructor {
-  new (): HTMLElement;
-}
-
-export const loadWebComponent = (
-  name: string,
-  className: WebComponentConstructor
-) => {
-  if (window.customElements && !window.customElements.get(name)) {
-    window.customElements.define(name, className);
-  }
-};
-
 export function moveItemInList<T>(
   list: T[],
   srcIndex: number,

--- a/src/tools/blast/components/results/__tests__/BlastResultTable.spec.tsx
+++ b/src/tools/blast/components/results/__tests__/BlastResultTable.spec.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+
 import BlastResultTable from '../BlastResultTable';
+
 import blastResultsMockData from '../../../../__mocks__/server-jobs/example-truncated.json';
 import renderWithRedux from '../../../../../shared/__test-helpers__/RenderWithRedux';
+
 import { fireEvent } from '@testing-library/react';
+
+// import useCustomElement from '../../../../../shared/hooks/useCustomElement';
+// jest.mock('/shared/hooks/useCustomElement', () => ({
+//   __esModule: true,
+//   default: () => true,
+// }));
 
 let component;
 

--- a/src/tools/components/AlignmentOverview.tsx
+++ b/src/tools/components/AlignmentOverview.tsx
@@ -1,10 +1,7 @@
 import React, { FC, useCallback } from 'react';
-import ProtvistaTrack from 'protvista-track';
 
-import { loadWebComponent } from '../../shared/utils/utils';
+import useCustomElement from '../../shared/hooks/useCustomElement';
 import { FullAlignmentSegments, SegmentTrackData } from '../utils/sequences';
-
-loadWebComponent('protvista-track', ProtvistaTrack);
 
 type AlignmentOverviewProps = {
   height: string;
@@ -26,14 +23,19 @@ const AlignmentOverviewTrack: FC<AlignmentOverviewTrackProps> = ({
   length,
   height,
 }) => {
+  const ceDefined = useCustomElement(
+    () => import(/* webpackChunkName: "protvista-track" */ 'protvista-track'),
+    'protvista-track'
+  );
+
   const setTrackData = useCallback(
     (node): void => {
-      if (node) {
+      if (node && ceDefined) {
         // eslint-disable-next-line no-param-reassign
         node.data = data;
       }
     },
-    [data]
+    [data, ceDefined]
   );
 
   return (

--- a/src/tools/components/MSAView.tsx
+++ b/src/tools/components/MSAView.tsx
@@ -80,19 +80,20 @@ const MSAView: FC<MSAViewProps> = ({
     [initialDisplayEnd, findHighlighPositions, tracksOffset]
   );
 
-  const trackDefined = useCustomElement(
-    () => import(/* webpackChunkName: "protvista-track" */ 'protvista-track'),
-    'protvista-track'
+  const msaDefined = useCustomElement(
+    () => import(/* webpackChunkName: "protvista-msa" */ 'protvista-msa'),
+    'protvista-msa'
   );
 
   const setMSAAttributes = useCallback(
     (node): void => {
-      if (!node) {
+      if (!(node && msaDefined)) {
         return;
       }
 
-      const displayEndValue =
-        alignmentLength / (15 / node.getSingleBaseWidth());
+      const singleBaseWidth =
+        'getSingleBaseWidth' in node ? node.getSingleBaseWidth() : 15;
+      const displayEndValue = alignmentLength / (15 / singleBaseWidth);
 
       const maxSequenceLength = Math.max(
         ...alignment.map((al) => al.sequence.length)
@@ -105,19 +106,19 @@ const MSAView: FC<MSAViewProps> = ({
 
       node.data = alignment.map(({ name, sequence }) => ({ name, sequence }));
     },
-    [alignment, alignmentLength]
+    [msaDefined, alignment, alignmentLength]
   );
 
+  const trackDefined = useCustomElement(
+    () => import(/* webpackChunkName: "protvista-track" */ 'protvista-track'),
+    'protvista-track'
+  );
   const navigationDefined = useCustomElement(
     () =>
       import(
         /* webpackChunkName: "protvista-navigation" */ 'protvista-navigation'
       ),
     'protvista-navigation'
-  );
-  const msaDefined = useCustomElement(
-    () => import(/* webpackChunkName: "protvista-msa" */ 'protvista-msa'),
-    'protvista-msa'
   );
   const managerDefined = useCustomElement(
     () =>

--- a/src/tools/components/MSAWrappedView.tsx
+++ b/src/tools/components/MSAWrappedView.tsx
@@ -9,7 +9,7 @@ import React, {
   Dispatch,
 } from 'react';
 import { debounce } from 'lodash-es';
-import { Loading } from 'franklin-sites';
+import { Loader } from 'franklin-sites';
 
 import useSize from '../../shared/hooks/useSize';
 import useSafeState from '../../shared/hooks/useSafeState';
@@ -103,7 +103,7 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
   );
 
   if (!(msaDefined && trackDefined)) {
-    return <Loading />;
+    return <Loader />;
   }
 
   return (

--- a/src/uniprotkb/components/entry/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/FeatureViewer.tsx
@@ -1,20 +1,22 @@
 import React, { FC } from 'react';
-import ProtvistaUniprot from 'protvista-uniprot';
 import { Loader } from 'franklin-sites';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
-
-import { loadWebComponent } from '../../../shared/utils/utils';
+import useCustomElement from '../../../shared/hooks/useCustomElement';
 
 import { UniProtkbAPIModel } from '../../adapters/uniProtkbConverter';
 import { getProteinsApiUrl } from '../../../shared/config/apiUrls';
-
-loadWebComponent('protvista-uniprot', ProtvistaUniprot);
 
 const FeatureViewer: FC<{ accession: string }> = ({ accession }) => {
   // just to make sure not to render protvista-uniprot if we won't get any data
   const { loading, data } = useDataApi<UniProtkbAPIModel>(
     getProteinsApiUrl(accession)
+  );
+
+  useCustomElement(
+    () =>
+      import(/* webpackChunkName: "protvista-uniprot" */ 'protvista-uniprot'),
+    'protvista-uniprot'
   );
 
   if (loading) return <Loader />;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2122,7 +2122,6 @@ exports[`Entry view should render 1`] = `
         >
           <interaction-viewer
             accession="P21802"
-            style="display: block; min-height: 6em;"
           />
           <protvista-datatable
             filter-scroll="true"

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,12 +1,22 @@
-import React, { Fragment, useState, useCallback, useRef } from 'react';
-import '@swissprot/rhea-reaction-visualizer';
+import React, {
+  Fragment,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+} from 'react';
 import { useModal, ModalBackdrop, Window, Loader } from 'franklin-sites';
+
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
+
+import useSafeState from '../../../shared/hooks/useSafeState';
+
 import {
   CatalyticActivityComment,
   PhysiologicalReactionDirection,
   PhysiologicalReaction,
 } from '../../types/commentTypes';
+
 import './styles/catalytic-activity-view.scss';
 
 // example accession to view this component: P31937
@@ -66,6 +76,7 @@ export const RheaReactionVisualizer: React.FC<RheaReactionVisualizerProps> = ({
   show: initialShow,
 }) => {
   const [show, setShow] = useState(initialShow);
+  const [wcLoaded, setWCLoaded] = useSafeState(false);
   const [zoomImageData, setZoomImageData] = useState<ChebiImageData>();
   const { displayModal, setDisplayModal, Modal } = useModal(
     ModalBackdrop,
@@ -86,8 +97,20 @@ export const RheaReactionVisualizer: React.FC<RheaReactionVisualizerProps> = ({
     [setDisplayModal]
   );
 
+  useEffect(() => {
+    import('@swissprot/rhea-reaction-visualizer').then(
+      () => setWCLoaded(true),
+      // eslint-disable-next-line no-console
+      (error) => console.error(error)
+    );
+  }, [setWCLoaded]);
+
+  if (!wcLoaded) {
+    return null;
+  }
+
   return (
-    <Fragment>
+    <>
       <button
         type="button"
         className="button tertiary rhea-reaction-visualizer__button"
@@ -96,7 +119,7 @@ export const RheaReactionVisualizer: React.FC<RheaReactionVisualizerProps> = ({
         {`${show ? 'Hide' : 'View'} Rhea reaction`}
       </button>
       {show && (
-        <Fragment>
+        <>
           <div className="rhea-reaction-visualizer__component">
             <rhea-reaction
               rheaid={rheaId}
@@ -118,9 +141,9 @@ export const RheaReactionVisualizer: React.FC<RheaReactionVisualizerProps> = ({
               />
             </Modal>
           )}
-        </Fragment>
+        </>
       )}
-    </Fragment>
+    </>
   );
 };
 
@@ -156,7 +179,7 @@ export const ReactionDirection: React.FC<ReactionDirectionProps> = ({
     return null;
   }
   return (
-    <Fragment>
+    <>
       {`This reaction proceeds in `}
       {physiologicalReactions
         // Ensure that left-to-right/forward comes before right-to-left/backward
@@ -175,7 +198,7 @@ export const ReactionDirection: React.FC<ReactionDirectionProps> = ({
               ' directions '}
           </Fragment>
         ))}
-    </Fragment>
+    </>
   );
 };
 
@@ -193,7 +216,7 @@ const CatalyticActivityView: React.FC<CatalyticActivityProps> = ({
   }
   let firstRheaId: number | null = null;
   return (
-    <Fragment>
+    <>
       {title && <h3>{title}</h3>}
       {comments.map(({ reaction, physiologicalReactions }) => {
         if (!reaction) {
@@ -233,7 +256,7 @@ const CatalyticActivityView: React.FC<CatalyticActivityProps> = ({
           </span>
         );
       })}
-    </Fragment>
+    </>
   );
 };
 

--- a/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
@@ -65,7 +65,7 @@ const FeaturesTableView: FC<{
         node.columns = getColumnConfig(evidenceTagCallback);
       }
     },
-    [data, getColumnConfig]
+    [datatableDefined, data, getColumnConfig]
   );
 
   return (

--- a/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FeaturesTableView.tsx
@@ -1,14 +1,14 @@
-import React, { Fragment, useCallback, useState, FC } from 'react';
+import React, { useCallback, useState, FC } from 'react';
 import { TemplateResult } from 'lit-html';
-import ProtvistaDatatable from 'protvista-datatable';
+
 import { UniProtEvidenceTagContent } from './UniProtKBEvidenceTag';
-import { loadWebComponent } from '../../../shared/utils/utils';
 import { ProtvistaFeature, ProcessedFeature } from './FeaturesView';
 import { ProtvistaVariant } from './VariationView';
+
+import useCustomElement from '../../../shared/hooks/useCustomElement';
+
 import { EvidenceData } from '../../config/evidenceCodes';
 import { Evidence } from '../../types/modelTypes';
-
-loadWebComponent('protvista-datatable', ProtvistaDatatable);
 
 type FeatureColumns = {
   [name: string]: {
@@ -48,9 +48,17 @@ const FeaturesTableView: FC<{
     setShowEvidenceTagData(true);
   };
 
+  const datatableDefined = useCustomElement(
+    () =>
+      import(
+        /* webpackChunkName: "protvista-datatable" */ 'protvista-datatable'
+      ),
+    'protvista-datatable'
+  );
+
   const setTableData = useCallback(
     (node): void => {
-      if (node) {
+      if (node && datatableDefined) {
         // eslint-disable-next-line no-param-reassign
         node.data = data;
         // eslint-disable-next-line no-param-reassign
@@ -61,7 +69,7 @@ const FeaturesTableView: FC<{
   );
 
   return (
-    <Fragment>
+    <>
       <protvista-datatable ref={setTableData} filter-scroll />
       <div
         className={`evidence-tag-content ${
@@ -75,7 +83,7 @@ const FeaturesTableView: FC<{
           />
         )}
       </div>
-    </Fragment>
+    </>
   );
 };
 

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -3,19 +3,13 @@ import { Loader } from 'franklin-sites';
 import { html } from 'lit-html';
 import joinUrl from 'url-join';
 
-import ProtvistaManager from 'protvista-manager';
-import ProtvistaSequence from 'protvista-sequence';
-import ProtvistaNavigation from 'protvista-navigation';
-import ProtvistaVariation from 'protvista-variation';
 import { transformData } from 'protvista-variation-adapter';
-import ProtvistaFilter from 'protvista-filter';
 
 import { UniProtProtvistaEvidenceTag } from './UniProtKBEvidenceTag';
 import FeaturesTableView, { FeaturesTableCallback } from './FeaturesTableView';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
-
-import { loadWebComponent } from '../../../shared/utils/utils';
+import useCustomElement from '../../../shared/hooks/useCustomElement';
 
 import { UniProtkbAPIModel } from '../../adapters/uniProtkbConverter';
 
@@ -73,12 +67,6 @@ export type TransformedVariantsResponse = {
   sequence: string;
   variants: TransformedProtvistaVariant[];
 };
-
-loadWebComponent('protvista-variation', ProtvistaVariation);
-loadWebComponent('protvista-navigation', ProtvistaNavigation);
-loadWebComponent('protvista-sequence', ProtvistaSequence);
-loadWebComponent('protvista-manager', ProtvistaManager);
-loadWebComponent('protvista-filter', ProtvistaFilter);
 
 const formatVariantDescription = (description: string) => {
   /* eslint-disable no-useless-escape */
@@ -181,16 +169,32 @@ const VariationView: FC<{
     joinUrl(apiUrls.variation, primaryAccession)
   );
 
-  const protvistaFilterRef = useCallback((node) => {
-    if (node !== null) {
-      // eslint-disable-next-line no-param-reassign
-      node.filters = filterConfig;
-    }
-  }, []);
+  const filterDefined = useCustomElement(
+    () => import(/* webpackChunkName: "protvista-filter" */ 'protvista-filter'),
+    'protvista-filter'
+  );
+
+  const protvistaFilterRef = useCallback(
+    (node) => {
+      if (node && filterDefined) {
+        // eslint-disable-next-line no-param-reassign
+        node.filters = filterConfig;
+      }
+    },
+    [filterDefined]
+  );
+
+  const variationDefined = useCustomElement(
+    () =>
+      import(
+        /* webpackChunkName: "protvista-variation" */ 'protvista-variation'
+      ),
+    'protvista-variation'
+  );
 
   const protvistaVariationRef = useCallback(
     (node) => {
-      if (node !== null && data && data.features) {
+      if (node && variationDefined && data && data.features) {
         const transformedData: TransformedVariantsResponse = transformData(
           data
         );
@@ -202,10 +206,34 @@ const VariationView: FC<{
         node.length = transformedData.sequence.length;
       }
     },
-    [data]
+    [variationDefined, data]
   );
 
-  if (loading) return <Loader />;
+  const navigationDefined = useCustomElement(
+    () =>
+      import(
+        /* webpackChunkName: "protvista-navigation" */ 'protvista-navigation'
+      ),
+    'protvista-navigation'
+  );
+  const sequenceDefined = useCustomElement(
+    () =>
+      import(/* webpackChunkName: "protvista-sequence" */ 'protvista-sequence'),
+    'protvista-sequence'
+  );
+  const managerDefined = useCustomElement(
+    () =>
+      import(/* webpackChunkName: "protvista-manager" */ 'protvista-manager'),
+    'protvista-manager'
+  );
+  const ceDefined =
+    filterDefined &&
+    variationDefined &&
+    navigationDefined &&
+    sequenceDefined &&
+    managerDefined;
+
+  if (loading || !ceDefined) return <Loader />;
 
   if (error && status !== 404) {
     // TODO: use in-page error message

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
@@ -286,16 +286,7 @@ exports[`ReactionDirection component should render ReactionDirection when two ph
 </DocumentFragment>
 `;
 
-exports[`RheaReactionVisualizer component should render RheaReactionVisualizer 1`] = `
-<DocumentFragment>
-  <button
-    class="button tertiary rhea-reaction-visualizer__button"
-    type="button"
-  >
-    View Rhea reaction
-  </button>
-</DocumentFragment>
-`;
+exports[`RheaReactionVisualizer component should render RheaReactionVisualizer 1`] = `<DocumentFragment />`;
 
 exports[`ZoomModalContent component should render 1`] = `
 <DocumentFragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,6 +4781,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
+core-js@3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
 core-js@^2.4.0, core-js@^2.5.3:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"


### PR DESCRIPTION
Handle issues seen during user testing where some error would make whole chunks of the website (even seemingly unrelated to where the error is) fail to the user. Those errors would be due to compatibility issues

 - Dynamically load rhea component (uses webcomponent, and auto declares it to the customElementRegistry):
    - Now, if something fails (most likely, web components not supported) -> just show the reaction, but no visuals
 - Change the way the custom elements are defined and registered. Now uses custom hook, and have a returned flag when the components are indeed defined, which gives us:
    - Errors contained
    - Only load custom element logic on render
    - Better handling of race conditions through the returned flag (wait for definition before doing something)
 - Tweak the config of babel-preset-env to clearly define our support targets, and add babel transformations and polyfills accordingly.