### PR TITLE
MSA PR in the PR

### DIFF
--- a/src/tools/align/components/results/AlignLabel.tsx
+++ b/src/tools/align/components/results/AlignLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, CSSProperties, useCallback } from 'react';
+import React, { FC, CSSProperties, useCallback, MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
 import { noop } from 'lodash-es';
@@ -51,6 +51,10 @@ const AlignLabel: FC<AlignLabelProps> = ({
     [onSequenceChecked, accession]
   );
 
+  const handleClick = useCallback((event: MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
   if (!accession || loading || invalid) {
     return (
       <span className={className} title={title}>
@@ -82,8 +86,13 @@ const AlignLabel: FC<AlignLabelProps> = ({
       onClick={onIdClick || noop}
       tabIndex={onIdClick ? 0 : -1}
     >
-      {onSequenceChecked && (
-        <input type="checkbox" onChange={handleChange} checked={checked} />
+      {onSequenceChecked && accession && (
+        <input
+          type="checkbox"
+          onChange={handleChange}
+          onClick={handleClick}
+          checked={checked}
+        />
       )}
       {reviewImg}
       {before}

--- a/src/tools/align/components/results/AlignLabel.tsx
+++ b/src/tools/align/components/results/AlignLabel.tsx
@@ -1,15 +1,16 @@
-import React, { FC, CSSProperties } from 'react';
+import React, { FC, CSSProperties, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
+import { noop } from 'lodash-es';
 
+import { MSAInput } from '../../../components/AlignmentView';
+import { Sequence } from '../../../components/Wrapped';
 import { ReviewedUnreviewed } from '../../../../uniprotkb/components/protein-data-views/UniProtKBTitle';
 
 import { EntryType } from '../../../../uniprotkb/adapters/uniProtkbConverter';
 import { ParsedSequenceAndFeatures } from '../../utils/useSequenceInfo';
 
 import './styles/AlignLabel.scss';
-import { MSAInput } from '../../../components/AlignmentView';
-import { Sequence } from '../../../components/Wrapped';
 
 type AlignLabelProps = {
   accession?: string;
@@ -17,6 +18,7 @@ type AlignLabelProps = {
   info?: ParsedSequenceAndFeatures | MSAInput | Sequence;
   loading: boolean;
   style?: CSSProperties;
+  checked?: boolean;
   onSequenceChecked?: (id: string) => void;
   onIdClick?: () => void;
   active?: boolean;
@@ -28,6 +30,7 @@ const AlignLabel: FC<AlignLabelProps> = ({
   loading,
   children,
   style,
+  checked,
   onSequenceChecked,
   onIdClick,
   active = false,
@@ -40,7 +43,13 @@ const AlignLabel: FC<AlignLabelProps> = ({
     'align-label--invalid': invalid,
     'align-label--loading': loading,
     'align-label--active': active,
+    'align-label--selectable': onIdClick,
   });
+
+  const handleChange = useCallback(
+    () => accession && onSequenceChecked?.(accession),
+    [onSequenceChecked, accession]
+  );
 
   if (!accession || loading || invalid) {
     return (
@@ -66,20 +75,22 @@ const AlignLabel: FC<AlignLabelProps> = ({
   }
 
   return (
-    <span className={className} style={style}>
-      {onSequenceChecked && <input type="checkbox" />}
+    <button
+      type="button"
+      className={className}
+      style={style}
+      onClick={onIdClick || noop}
+      tabIndex={onIdClick ? 0 : -1}
+    >
+      {onSequenceChecked && (
+        <input type="checkbox" onChange={handleChange} checked={checked} />
+      )}
       {reviewImg}
       {before}
       {/* inject a link to the entry page */}
       <Link to={`/uniprotkb/${accession}`}>{accession}</Link>
-      {onIdClick ? (
-        <button type="button" className="button tertiary" onClick={onIdClick}>
-          {after.join(',')}
-        </button>
-      ) : (
-        after.join(',')
-      )}
-    </span>
+      {after.join(',')}
+    </button>
   );
 };
 

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -27,30 +27,38 @@ const jobType = JobTypes.ALIGN;
 const urls = toolsURLs(jobType);
 
 // overview
-const AlignResultOverview = lazy(() =>
-  import(/* webpackChunkName: "align-overview" */ './AlignResultOverview')
+const AlignResultOverview = lazy(
+  () => import(/* webpackChunkName: "align-overview" */ './AlignResultOverview')
 );
 // phylogenetic-tree
-const AlignResultPhyloTree = lazy(() =>
-  import(/* webpackChunkName: "align-phylotree" */ './AlignResultPhyloTree')
+const AlignResultPhyloTree = lazy(
+  () =>
+    import(/* webpackChunkName: "align-phylotree" */ './AlignResultPhyloTree')
 );
 // percent-identity-matrix
-const AlignResultPIM = lazy(() =>
-  import(/* webpackChunkName: "align-pim" */ './AlignResultPIM')
+const AlignResultPIM = lazy(
+  () => import(/* webpackChunkName: "align-pim" */ './AlignResultPIM')
 );
 // text-output
-const TextOutput = lazy(() =>
-  import(/* webpackChunkName: "text-output" */ '../../../components/TextOutput')
+const TextOutput = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "text-output" */ '../../../components/TextOutput'
+    )
 );
 // input-parameters
-const InputParameters = lazy(() =>
-  import(
-    /* webpackChunkName: "input-parameters" */ '../../../components/InputParameters'
-  )
+const InputParameters = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "input-parameters" */ '../../../components/InputParameters'
+    )
 );
 // input-parameters
-const APIRequest = lazy(() =>
-  import(/* webpackChunkName: "api-request" */ '../../../components/APIRequest')
+const APIRequest = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
+    )
 );
 
 enum TabLocation {
@@ -203,6 +211,8 @@ const AlignResult = () => {
               <AlignResultPhyloTree
                 id={match.params.id}
                 sequenceInfo={sequenceInfo}
+                selectedEntries={selectedEntries}
+                handleSelectedEntries={handleSelectedEntries}
               />
             </Suspense>
           </ErrorBoundary>
@@ -226,6 +236,8 @@ const AlignResult = () => {
               <AlignResultPIM
                 id={match.params.id}
                 sequenceInfo={sequenceInfo}
+                selectedEntries={selectedEntries}
+                handleSelectedEntries={handleSelectedEntries}
               />
             </Suspense>
           </ErrorBoundary>

--- a/src/tools/align/components/results/AlignResultOverview.tsx
+++ b/src/tools/align/components/results/AlignResultOverview.tsx
@@ -69,6 +69,8 @@ const enrichParsed = (
 const AlignResultOverview: FC<AlignResultOverviewProps> = ({
   data,
   sequenceInfo,
+  selectedEntries,
+  handleSelectedEntries,
 }) => {
   const clustalParsed = useMemo(() => alnClustalNum(data), [data]);
 
@@ -91,6 +93,8 @@ const AlignResultOverview: FC<AlignResultOverviewProps> = ({
       alignmentLength={parsedAndEnriched.sequences[0].sequence.length}
       defaultView={View.wrapped}
       tool={Tool.align}
+      selectedEntries={selectedEntries}
+      handleSelectedEntries={handleSelectedEntries}
     />
   );
 };

--- a/src/tools/align/components/results/AlignResultPIM.tsx
+++ b/src/tools/align/components/results/AlignResultPIM.tsx
@@ -25,9 +25,16 @@ const WAVE_EFFECT_TIME = 250; // in ms
 type AlignResultPIMProps = {
   id: string;
   sequenceInfo: SequenceInfo;
+  selectedEntries: string[];
+  handleSelectedEntries: (rowId: string) => void;
 };
 
-const AlignResultPIM: FC<AlignResultPIMProps> = ({ id, sequenceInfo }) => {
+const AlignResultPIM: FC<AlignResultPIMProps> = ({
+  id,
+  sequenceInfo,
+  selectedEntries,
+  handleSelectedEntries,
+}) => {
   const [hovered, setHovered] = useState<number[]>([]);
   const [contrast, setContrast] = useState(DEFAULT_CONTRAST);
 
@@ -73,6 +80,10 @@ const AlignResultPIM: FC<AlignResultPIMProps> = ({ id, sequenceInfo }) => {
                 accession={accession}
                 info={sequenceInfo.data.get(accession || '')}
                 loading={sequenceInfo.loading}
+                checked={Boolean(
+                  accession && selectedEntries?.includes(accession)
+                )}
+                onSequenceChecked={handleSelectedEntries}
               >
                 {name}
               </AlignLabel>

--- a/src/tools/align/components/results/AlignResultPhyloTree.tsx
+++ b/src/tools/align/components/results/AlignResultPhyloTree.tsx
@@ -18,11 +18,15 @@ const alignURLs = toolsURLs(JobTypes.ALIGN);
 type AlignResultPhyloTreeProps = {
   id: string;
   sequenceInfo: SequenceInfo;
+  selectedEntries: string[];
+  handleSelectedEntries: (rowId: string) => void;
 };
 
 const AlignResultPhyloTree: FC<AlignResultPhyloTreeProps> = ({
   id,
   sequenceInfo,
+  selectedEntries,
+  handleSelectedEntries,
 }) => {
   const [showDistance, setShowDistance] = useState(true);
   const [alignLabels, setAlignLabels] = useState(true);
@@ -112,6 +116,8 @@ const AlignResultPhyloTree: FC<AlignResultPhyloTreeProps> = ({
           alignLabels={alignLabels}
           circularLayout={circularLayout}
           sequenceInfo={sequenceInfo}
+          selectedEntries={selectedEntries}
+          handleSelectedEntries={handleSelectedEntries}
         />
       )}
     </section>

--- a/src/tools/align/components/results/PhyloTree.tsx
+++ b/src/tools/align/components/results/PhyloTree.tsx
@@ -52,6 +52,8 @@ type PhyloTreeProps = {
   alignLabels: boolean;
   circularLayout: boolean;
   sequenceInfo: SequenceInfo;
+  selectedEntries: string[];
+  handleSelectedEntries: (rowId: string) => void;
 };
 
 const PhyloTree: FC<PhyloTreeProps> = ({
@@ -60,6 +62,8 @@ const PhyloTree: FC<PhyloTreeProps> = ({
   alignLabels,
   circularLayout,
   sequenceInfo,
+  selectedEntries,
+  handleSelectedEntries,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const redrawRef = useRef<Redraw & Cancelable>();
@@ -352,6 +356,10 @@ const PhyloTree: FC<PhyloTreeProps> = ({
                     accession={accession}
                     info={sequenceInfo.data.get(accession || '')}
                     loading={sequenceInfo.loading}
+                    checked={Boolean(
+                      accession && selectedEntries?.includes(accession)
+                    )}
+                    onSequenceChecked={handleSelectedEntries}
                   >
                     {name || ''}
                   </AlignLabel>

--- a/src/tools/align/components/results/styles/AlignLabel.scss
+++ b/src/tools/align/components/results/styles/AlignLabel.scss
@@ -12,6 +12,8 @@
 .align-label {
   white-space: nowrap;
   opacity: 1;
+  margin: 0;
+  outline: none;
 
   &--invalid {
     cursor: not-allowed;
@@ -23,6 +25,11 @@
 
   &--active {
     background-color: $colour-gainsborough;
+  }
+
+  &--selectable {
+    cursor: pointer;
+    outline: initial;
   }
 
   input[type='checkbox'] {

--- a/src/tools/blast/components/results/HSPDetailPanel.tsx
+++ b/src/tools/blast/components/results/HSPDetailPanel.tsx
@@ -8,12 +8,13 @@ import useDataApi from '../../../../shared/hooks/useDataApi';
 import { UniProtkbAPIModel } from '../../../../uniprotkb/adapters/uniProtkbConverter';
 import { getAccessionsURL } from '../../../../shared/config/apiUrls';
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
-import './styles/HSPDetailPanel.scss';
 import AlignmentView, {
   MSAInput,
   View,
   Tool,
 } from '../../../components/AlignmentView';
+
+import './styles/HSPDetailPanel.scss';
 
 type UniProtkbAccessionsAPI = {
   results: UniProtkbAPIModel[];
@@ -53,7 +54,7 @@ export const convertHSPtoMSAInputs = (
       length: queryLength,
     },
     {
-      name: 'Match',
+      name: 'Match:',
       sequence: hsp_hseq,
       from: hsp_hit_from,
       to: hsp_hit_to,

--- a/src/tools/blast/components/results/__tests__/HSPDetailPanel.spec.tsx
+++ b/src/tools/blast/components/results/__tests__/HSPDetailPanel.spec.tsx
@@ -47,7 +47,7 @@ describe('HSPDetailPanel', () => {
     const msa = container.querySelector('protvista-msa');
     expect(msa.data).toEqual([
       { name: 'Query', sequence: hsp.hsp_qseq },
-      { name: 'Match', sequence: hsp.hsp_hseq },
+      { name: 'Match:', sequence: hsp.hsp_hseq },
     ]);
   });
 

--- a/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
+++ b/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
@@ -277,74 +277,64 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
     <div>
       <div>
         <section
-          class="alignment-grid"
+          class="alignment-grid alignment-wrapped"
           data-testid="alignment-wrapped-view"
         >
-          <section
-            class="alignment-grid__row alignment-grid__row--msa-track"
-          >
-            <div
-              class="track-label track-label--align-labels"
-            >
-              <span
-                class="align-label"
-              >
-                Query
-              </span>
-              <span
-                class="align-label"
-                style="height: 20px;"
-              >
-                Match
-                <a
-                  href="/uniprotkb/U6MKN0"
-                >
-                  U6MKN0
-                </a>
-                <button
-                  class="button tertiary"
-                  type="button"
-                />
-              </span>
-            </div>
-            <div
-              class="track"
-            >
-              <protvista-msa
-                colorscheme="clustal"
-                height="40"
-                length="45"
-              />
-            </div>
-            <span
-              class="right-coord"
-            >
-              <div
-                style="height: 20px; margin-top: 0px;"
-              >
-                47
-              </div>
-              <div
-                style="height: 20px;"
-              >
-                462
-              </div>
-            </span>
-          </section>
-          <section
-            class="alignment-grid__row"
+          <div
+            class="row-1 track-label track-label--align-labels"
           >
             <span
-              class="track-label"
+              class="align-label align-label--selectable"
             >
-              chain
+              Query
             </span>
-            <div
-              class="track"
+            <button
+              class="align-label align-label--selectable"
+              style="height: 20px;"
+              tabindex="0"
+              type="button"
             >
-              <protvista-track />
+              Match:
+              <a
+                href="/uniprotkb/U6MKN0"
+              >
+                U6MKN0
+              </a>
+            </button>
+          </div>
+          <div
+            class="row-1 track"
+          >
+            <protvista-msa
+              colorscheme="clustal"
+              height="40"
+              length="45"
+            />
+          </div>
+          <span
+            class="row-1 right-coord"
+          >
+            <div
+              style="height: 20px;"
+            >
+              47
             </div>
-          </section>
+            <div
+              style="height: 20px;"
+            >
+              462
+            </div>
+          </span>
+          <span
+            class="row-2 track-label"
+          >
+            chain
+          </span>
+          <div
+            class="row-2 track"
+          >
+            <protvista-track />
+          </div>
         </section>
       </div>
     </div>
@@ -636,111 +626,97 @@ exports[`HSPDetailPanel should initially render overview 1`] = `
             class="alignment-grid"
             data-testid="alignment-view"
           >
-            <section
-              class="alignment-grid__row"
+            <span
+              class="row-1 track-label"
             >
-              <span
-                class="track-label"
-              >
-                Overview
-              </span>
-              <div
-                class="track"
-              >
-                <div>
-                  <protvista-track
-                    height="15"
-                    highlight="418:446"
-                    layout="non-overlapping"
-                    length="486"
-                  />
-                  <protvista-track
-                    height="15"
-                    highlight="418:446"
-                    layout="non-overlapping"
-                    length="486"
-                  />
-                </div>
-              </div>
-            </section>
-            <section
-              class="alignment-grid__row"
+              Overview
+            </span>
+            <div
+              class="row-1 track"
             >
-              <span
-                class="track-label"
-              >
-                chain
-              </span>
-              <div
-                class="track"
-              >
+              <div>
                 <protvista-track
+                  height="15"
+                  highlight="418:446"
+                  layout="non-overlapping"
+                  length="486"
+                />
+                <protvista-track
+                  height="15"
                   highlight="418:446"
                   layout="non-overlapping"
                   length="486"
                 />
               </div>
-            </section>
-            <section
-              class="alignment-grid__row alignment-grid__row--msa-track"
+            </div>
+            <span
+              class="row-2 track-label"
+            >
+              chain
+            </span>
+            <div
+              class="row-2 track"
+            >
+              <protvista-track
+                highlight="418:446"
+                layout="non-overlapping"
+                length="486"
+              />
+            </div>
+            <div
+              class="row-3 track-label track-label--align-labels"
+            >
+              <span
+                class="align-label align-label--selectable"
+              >
+                Query
+              </span>
+              <button
+                class="align-label align-label--selectable"
+                style="height: 20px;"
+                tabindex="0"
+                type="button"
+              >
+                Match:
+                <a
+                  href="/uniprotkb/U6MKN0"
+                >
+                  U6MKN0
+                </a>
+              </button>
+            </div>
+            <div
+              class="row-3 track"
+            >
+              <protvista-manager
+                attributes="displaystart displayend"
+                displayend="28"
+                displaystart="1"
+              >
+                <protvista-navigation
+                  length="28"
+                />
+                <protvista-msa
+                  colorscheme="clustal"
+                  height="40"
+                  length="28"
+                />
+              </protvista-manager>
+            </div>
+            <span
+              class="row-3 right-coord"
             >
               <div
-                class="track-label track-label--align-labels"
+                style="height: 20px;"
               >
-                <span
-                  class="align-label"
-                >
-                  Query
-                </span>
-                <span
-                  class="align-label"
-                  style="height: 20px;"
-                >
-                  Match
-                  <a
-                    href="/uniprotkb/U6MKN0"
-                  >
-                    U6MKN0
-                  </a>
-                  <button
-                    class="button tertiary"
-                    type="button"
-                  />
-                </span>
+                28
               </div>
               <div
-                class="track"
+                style="height: 20px;"
               >
-                <protvista-manager
-                  attributes="displaystart displayend"
-                  displayend="28"
-                  displaystart="1"
-                >
-                  <protvista-navigation
-                    length="28"
-                  />
-                  <protvista-msa
-                    colorscheme="clustal"
-                    height="40"
-                    length="28"
-                  />
-                </protvista-manager>
+                28
               </div>
-              <span
-                class="right-coord"
-              >
-                <div
-                  style="height: 20px; margin-top: 0px;"
-                >
-                  28
-                </div>
-                <div
-                  style="height: 20px;"
-                >
-                  28
-                </div>
-              </span>
-            </section>
+            </span>
           </section>
         </div>
       </div>

--- a/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
+++ b/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
@@ -330,7 +330,7 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
           chain
         </span>
         <div
-          class="track"
+          class="track annotation-track"
         >
           <protvista-track />
         </div>

--- a/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
+++ b/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
@@ -275,67 +275,65 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
       </fieldset>
     </div>
     <div>
-      <div>
-        <section
-          class="alignment-grid alignment-wrapped"
-          data-testid="alignment-wrapped-view"
+      <div
+        class="alignment-grid alignment-wrapped"
+        data-testid="alignment-wrapped-view"
+      >
+        <div
+          class="track-label track-label--align-labels"
+        >
+          <span
+            class="align-label align-label--selectable"
+          >
+            Query
+          </span>
+          <button
+            class="align-label align-label--selectable"
+            style="height: 20px;"
+            tabindex="0"
+            type="button"
+          >
+            Match:
+            <a
+              href="/uniprotkb/U6MKN0"
+            >
+              U6MKN0
+            </a>
+          </button>
+        </div>
+        <div
+          class="track"
+        >
+          <protvista-msa
+            colorscheme="clustal"
+            height="40"
+            length="45"
+          />
+        </div>
+        <span
+          class="right-coord"
         >
           <div
-            class="row-1 track-label track-label--align-labels"
+            style="height: 20px;"
           >
-            <span
-              class="align-label align-label--selectable"
-            >
-              Query
-            </span>
-            <button
-              class="align-label align-label--selectable"
-              style="height: 20px;"
-              tabindex="0"
-              type="button"
-            >
-              Match:
-              <a
-                href="/uniprotkb/U6MKN0"
-              >
-                U6MKN0
-              </a>
-            </button>
+            47
           </div>
           <div
-            class="row-1 track"
+            style="height: 20px;"
           >
-            <protvista-msa
-              colorscheme="clustal"
-              height="40"
-              length="45"
-            />
+            462
           </div>
-          <span
-            class="row-1 right-coord"
-          >
-            <div
-              style="height: 20px;"
-            >
-              47
-            </div>
-            <div
-              style="height: 20px;"
-            >
-              462
-            </div>
-          </span>
-          <span
-            class="row-2 track-label"
-          >
-            chain
-          </span>
-          <div
-            class="row-2 track"
-          >
-            <protvista-track />
-          </div>
-        </section>
+        </span>
+        <span
+          class="track-label annotation-label"
+        >
+          chain
+        </span>
+        <div
+          class="track"
+        >
+          <protvista-track />
+        </div>
       </div>
     </div>
   </div>

--- a/src/tools/components/AlignmentView.tsx
+++ b/src/tools/components/AlignmentView.tsx
@@ -73,7 +73,16 @@ const AlignmentView: React.FC<{
   alignmentLength: number;
   defaultView?: View;
   tool: Tool;
-}> = ({ alignment, alignmentLength, defaultView, tool }) => {
+  selectedEntries?: string[];
+  handleSelectedEntries?: (rowId: string) => void;
+}> = ({
+  alignment,
+  alignmentLength,
+  defaultView,
+  tool,
+  selectedEntries,
+  handleSelectedEntries,
+}) => {
   const annotationChoices = useMemo(() => {
     const features = alignment
       .map(({ features }) => features)
@@ -98,8 +107,6 @@ const AlignmentView: React.FC<{
       .map(({ accession }) => accession)[0]
   );
 
-  const [checkedIds, setCheckedIds] = useState<{ [id: string]: boolean }>({});
-
   useEffect(() => {
     // if no default value was available on first render, set it now
     if (!annotation && annotationChoices.length) {
@@ -117,10 +124,6 @@ const AlignmentView: React.FC<{
         }
       : {};
 
-  const handleSequenceChecked = (id: string) => {
-    setCheckedIds({ ...checkedIds, [id]: !checkedIds[id] });
-  };
-
   const AlignmentComponent = activeView === View.overview ? Overview : Wrapped;
   const additionalAlignProps =
     tool === Tool.align
@@ -128,7 +131,8 @@ const AlignmentView: React.FC<{
           activeId,
           setActiveId,
           omitInsertionsInCoords: true,
-          onSequenceChecked: handleSequenceChecked,
+          selectedEntries,
+          handleSelectedEntries,
         }
       : {};
 

--- a/src/tools/components/Overview.tsx
+++ b/src/tools/components/Overview.tsx
@@ -53,7 +53,8 @@ export type BlastOverviewProps = {
 };
 
 // NOTE: hardcoded for now, might need to change that in the future if need be
-const heightStyle = { height: '20px' };
+const sequenceHeight = 20;
+const heightStyle = { height: `${sequenceHeight}px` };
 
 const AlignOverview: FC<BlastOverviewProps> = ({
   alignment,
@@ -204,7 +205,7 @@ const AlignOverview: FC<BlastOverviewProps> = ({
           <protvista-msa
             ref={setMSAAttributes}
             length={alignmentLength}
-            height={alignment.length * 20}
+            height={alignment.length * sequenceHeight}
             colorscheme={highlightProperty}
             {...conservationOptions}
           />

--- a/src/tools/components/Overview.tsx
+++ b/src/tools/components/Overview.tsx
@@ -47,9 +47,13 @@ export type BlastOverviewProps = {
   annotation: FeatureType | undefined;
   activeId?: string;
   setActiveId?: Dispatch<SetStateAction<string | undefined>>;
-  onSequenceChecked?: (id: string) => void;
   omitInsertionsInCoords?: boolean;
+  selectedEntries?: string[];
+  handleSelectedEntries?: (rowId: string) => void;
 };
+
+// NOTE: hardcoded for now, might need to change that in the future if need be
+const heightStyle = { height: '20px' };
 
 const AlignOverview: FC<BlastOverviewProps> = ({
   alignment,
@@ -60,15 +64,15 @@ const AlignOverview: FC<BlastOverviewProps> = ({
   annotation,
   activeId,
   setActiveId = () => null,
-  onSequenceChecked,
   omitInsertionsInCoords,
+  selectedEntries,
+  handleSelectedEntries,
 }) => {
   const [highlightPosition, setHighlighPosition] = useState('');
   const [initialDisplayEnd, setInitialDisplayEnd] = useState<
     number | undefined
   >();
   const [displayEnd, setDisplayEnd] = useState<number>();
-  const [msaOffsetTop, setMsaOffsetTop] = useState<number | undefined>();
 
   const tracksOffset = Math.max(...alignment.map(({ from }) => from));
 
@@ -105,7 +109,6 @@ const AlignOverview: FC<BlastOverviewProps> = ({
       if (!node) {
         return;
       }
-      setMsaOffsetTop(node.offsetTop);
 
       const displayEndValue =
         alignmentLength / (15 / node.getSingleBaseWidth());
@@ -150,84 +153,77 @@ const AlignOverview: FC<BlastOverviewProps> = ({
       {/* Query track */}
       {/* NOTE: both tracks currently merged into one - new Nightingale component needed */}
 
-      <section className="alignment-grid__row">
-        <span className="track-label">Overview</span>
-        <div className="track">
-          <AlignmentOverview
-            height={overviewHeight}
-            length={totalLength}
-            highlight={highlightPosition}
-            data={alignment ? getFullAlignmentSegments(alignment) : []}
-          />
-        </div>
-      </section>
+      {/* first row */}
+      <span className="row-1 track-label">Overview</span>
+      <div className="row-1 track">
+        <AlignmentOverview
+          height={overviewHeight}
+          length={totalLength}
+          highlight={highlightPosition}
+          data={alignment ? getFullAlignmentSegments(alignment) : []}
+        />
+      </div>
 
-      <section className="alignment-grid__row">
-        <span className="track-label">{annotation}</span>
-        <div className="track">
-          <protvista-track
-            ref={setFeatureTrackData}
-            length={totalLength}
-            layout="non-overlapping"
-            highlight={highlightPosition}
-          />
-        </div>
-      </section>
+      {/* second row */}
+      <span className="row-2 track-label">{annotation}</span>
+      <div className="row-2 track">
+        <protvista-track
+          ref={setFeatureTrackData}
+          length={totalLength}
+          layout="non-overlapping"
+          highlight={highlightPosition}
+        />
+      </div>
 
-      <section className="alignment-grid__row alignment-grid__row--msa-track">
-        <div className="track-label track-label--align-labels">
-          {alignment.map((s, index) => (
-            <AlignLabel
-              accession={s.accession}
-              info={s}
-              loading={false}
-              key={s.name}
-              style={{
-                height: 20,
-                marginTop: index === 0 ? msaOffsetTop : undefined,
-              }}
-              onSequenceChecked={onSequenceChecked}
-              onIdClick={() => setActiveId(s.accession)}
-              active={!!activeId && activeId === s.accession}
-            >
-              {s.name || ''}
-            </AlignLabel>
-          ))}
-        </div>
-        <div className="track">
-          <protvista-manager
-            ref={managerRef}
-            attributes="displaystart displayend"
+      {/* third row */}
+      <div className="row-3 track-label track-label--align-labels">
+        {alignment.map((s) => (
+          <AlignLabel
+            accession={s.accession}
+            info={s}
+            loading={false}
+            key={s.name}
+            style={heightStyle}
+            checked={Boolean(
+              s.accession && selectedEntries?.includes(s.accession)
+            )}
+            onSequenceChecked={handleSelectedEntries}
+            onIdClick={() => setActiveId(s.accession)}
+            active={!!activeId && activeId === s.accession}
           >
-            <protvista-navigation length={alignmentLength} />
-            <protvista-msa
-              ref={setMSAAttributes}
-              length={alignmentLength}
-              height={alignment.length * 20}
-              colorscheme={highlightProperty}
-              {...conservationOptions}
-            />
-          </protvista-manager>
-        </div>
-        <span className="right-coord">
-          {alignment.map((s, index) => (
-            <div
-              style={{
-                height: 20,
-                marginTop: index === 0 ? msaOffsetTop : undefined,
-              }}
-              key={s.name}
-            >
-              {omitInsertionsInCoords
+            {s.name || ''}
+          </AlignLabel>
+        ))}
+      </div>
+      <div className="row-3 track">
+        <protvista-manager
+          ref={managerRef}
+          attributes="displaystart displayend"
+        >
+          <protvista-navigation length={alignmentLength} />
+          <protvista-msa
+            ref={setMSAAttributes}
+            length={alignmentLength}
+            height={alignment.length * 20}
+            colorscheme={highlightProperty}
+            {...conservationOptions}
+          />
+        </protvista-manager>
+      </div>
+      <span className="row-3 right-coord">
+        {alignment.map((s) => (
+          <div style={heightStyle} key={s.name}>
+            {Math.floor(
+              omitInsertionsInCoords
                 ? getEndCoordinate(
                     s.sequence,
                     displayEnd ?? initialDisplayEnd ?? 0
                   )
-                : displayEnd ?? initialDisplayEnd ?? 0}
-            </div>
-          ))}
-        </span>
-      </section>
+                : displayEnd ?? initialDisplayEnd ?? 0
+            )}
+          </div>
+        ))}
+      </span>
     </section>
   );
 };

--- a/src/tools/components/Wrapped.tsx
+++ b/src/tools/components/Wrapped.tsx
@@ -116,11 +116,8 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
   // TODO: replace this with fragments to have one big grid
   // -> to keep the right column of the right size to fit all possible values
   return (
-    <section
-      data-testid="alignment-wrapped-view"
-      className="alignment-grid alignment-wrapped"
-    >
-      <div className="row-1 track-label track-label--align-labels">
+    <>
+      <div className="track-label track-label--align-labels">
         {sequences.map((s) => (
           <AlignLabel
             accession={s.accession}
@@ -139,7 +136,7 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
           </AlignLabel>
         ))}
       </div>
-      <div className="row-1 track">
+      <div className="track">
         <protvista-msa
           ref={setMSAAttributes}
           length={rowLength}
@@ -148,7 +145,7 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
           {...conservationOptions}
         />
       </div>
-      <span className="row-1 right-coord">
+      <span className="right-coord">
         {sequences.map((s) => (
           <div style={heightStyle} key={s.name}>
             {omitInsertionsInCoords
@@ -157,11 +154,11 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
           </div>
         ))}
       </span>
-      <span className="row-2 track-label">{annotation}</span>
-      <div className="row-2 track">
+      <span className="track-label annotation-label">{annotation}</span>
+      <div className="track">
         <protvista-track ref={setFeatureTrackData} />
       </div>
-    </section>
+    </>
   );
 };
 
@@ -252,7 +249,11 @@ const Wrapped: FC<MSAViewProps> = ({
   }, [alignment, alignmentLength, rowLength]);
 
   return (
-    <div ref={containerRef}>
+    <div
+      ref={containerRef}
+      className="alignment-grid alignment-wrapped"
+      data-testid="alignment-wrapped-view"
+    >
       {sequenceChunks.map(({ sequences, id }, index) => {
         if (index < nItemsToRender) {
           return (
@@ -271,7 +272,7 @@ const Wrapped: FC<MSAViewProps> = ({
             />
           );
         }
-        return <section key={id} className="alignment-grid__placeholder" />;
+        return <div key={id} className="alignment-grid__placeholder" />;
       })}
     </div>
   );

--- a/src/tools/components/Wrapped.tsx
+++ b/src/tools/components/Wrapped.tsx
@@ -67,7 +67,8 @@ export type MSAWrappedRowProps = {
 };
 
 // NOTE: hardcoded for now, might need to change that in the future if need be
-const heightStyle = { height: '20px' };
+const sequenceHeight = 20;
+const heightStyle = { height: `${sequenceHeight}px` };
 
 const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
   rowLength,
@@ -140,7 +141,7 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
         <protvista-msa
           ref={setMSAAttributes}
           length={rowLength}
-          height={sequences.length * 20}
+          height={sequences.length * sequenceHeight}
           colorscheme={highlightProperty}
           {...conservationOptions}
         />

--- a/src/tools/components/Wrapped.tsx
+++ b/src/tools/components/Wrapped.tsx
@@ -155,7 +155,7 @@ const MSAWrappedRow: FC<MSAWrappedRowProps> = ({
         ))}
       </span>
       <span className="track-label annotation-label">{annotation}</span>
-      <div className="track">
+      <div className="track annotation-track">
         <protvista-track ref={setFeatureTrackData} />
       </div>
     </>

--- a/src/tools/components/styles/alignment-view.scss
+++ b/src/tools/components/styles/alignment-view.scss
@@ -10,56 +10,87 @@
     height: 80px;
   }
 
-  &__row {
-    display: grid;
-    grid-template-columns: 16vw auto 4vw;
-    grid-template-areas: 'label track .';
-    align-items: center;
+  display: grid;
+  grid-template-columns: fit-content(10px) 1fr fit-content(10px);
+  grid-template-areas:
+    'label-1 track-1 .'
+    'label-2 track-2 .'
+    'label-3 track-3 right-coord';
+  align-items: end;
 
-    &--msa-track {
-      grid-template-areas: 'label track right-coord';
+  &.alignment-wrapped {
+    grid-template-areas:
+      'label-1 track-1 right-coord'
+      'label-2 track-2 .';
+  }
+
+  .track-label {
+    text-align: right;
+    padding-right: 0.5rem;
+    font-weight: 800;
+    white-space: nowrap;
+
+    &:first-letter {
+      text-transform: uppercase;
     }
 
-    .track-label {
-      grid-area: label;
-      text-align: right;
-      padding-right: 0.5rem;
-      font-weight: 800;
-      &:first-letter {
-        text-transform: uppercase;
-      }
+    &.row-1 {
+      grid-area: label-1;
+    }
 
-      &--align-labels {
-        align-self: flex-end;
-        margin: 0;
-        list-style: none;
+    &.row-2 {
+      grid-area: label-2;
+    }
 
-        .align-label {
+    &.row-3 {
+      grid-area: label-3;
+    }
+
+    &--align-labels {
+      align-self: flex-end;
+      margin: 0;
+      list-style: none;
+
+      .align-label {
+        font-size: 0.75rem;
+        border-top: 1px solid $colour-gainsborough;
+        display: flex;
+        align-items: center;
+
+        &:last-child {
+          border-bottom: 1px solid $colour-gainsborough;
+        }
+
+        button {
+          margin: 0;
           font-size: 0.75rem;
-          border-top: 1px solid $colour-gainsborough;
-          display: flex;
-          align-items: center;
-
-          &:last-child {
-            border-bottom: 1px solid $colour-gainsborough;
-          }
-
-          button {
-            margin: 0;
-            font-size: 0.75rem;
-          }
         }
       }
     }
 
-    .track {
-      grid-area: track;
-      position: relative;
+    & > * {
+      width: 100%;
+    }
+  }
+
+  .track {
+    position: relative;
+
+    &.row-1 {
+      grid-area: track-1;
     }
 
-    .right-coord {
-      padding-left: 0.1rem;
-      grid-area: right-coord;
+    &.row-2 {
+      grid-area: track-2;
     }
+
+    &.row-3 {
+      grid-area: track-3;
+    }
+  }
+
+  .right-coord {
+    padding-left: 0.1rem;
+    grid-area: right-coord;
   }
 }

--- a/src/tools/components/styles/alignment-view.scss
+++ b/src/tools/components/styles/alignment-view.scss
@@ -6,15 +6,14 @@
   height: auto;
   max-height: 50%;
 
-  &__placeholder {
-    height: 80px;
-    grid-column: span 3;
-    background: red;
-  }
-
   display: grid;
   grid-template-columns: fit-content(auto) 1fr fit-content(auto);
   align-items: end;
+
+  &__placeholder {
+    height: 80px;
+    grid-column: span 3;
+  }
 
   &.alignment-wrapped {
     align-items: start;
@@ -24,7 +23,7 @@
       margin-bottom: 1em; // hacky: fake gap between groups of cells ("rows")
     }
 
-    .track:nth-of-type(odd) {
+    .annotation-track {
       margin-bottom: 1em; // hacky: fake gap between groups of cells ("rows")
     }
   }

--- a/src/tools/components/styles/alignment-view.scss
+++ b/src/tools/components/styles/alignment-view.scss
@@ -8,20 +8,25 @@
 
   &__placeholder {
     height: 80px;
+    grid-column: span 3;
+    background: red;
   }
 
   display: grid;
-  grid-template-columns: fit-content(10px) 1fr fit-content(10px);
-  grid-template-areas:
-    'label-1 track-1 .'
-    'label-2 track-2 .'
-    'label-3 track-3 right-coord';
+  grid-template-columns: fit-content(auto) 1fr fit-content(auto);
   align-items: end;
 
   &.alignment-wrapped {
-    grid-template-areas:
-      'label-1 track-1 right-coord'
-      'label-2 track-2 .';
+    align-items: start;
+
+    .annotation-label {
+      align-self: center;
+      margin-bottom: 1em; // hacky: fake gap between groups of cells ("rows")
+    }
+
+    .track:nth-of-type(odd) {
+      margin-bottom: 1em; // hacky: fake gap between groups of cells ("rows")
+    }
   }
 
   .track-label {
@@ -29,21 +34,10 @@
     padding-right: 0.5rem;
     font-weight: 800;
     white-space: nowrap;
+    grid-column: 1;
 
     &:first-letter {
       text-transform: uppercase;
-    }
-
-    &.row-1 {
-      grid-area: label-1;
-    }
-
-    &.row-2 {
-      grid-area: label-2;
-    }
-
-    &.row-3 {
-      grid-area: label-3;
     }
 
     &--align-labels {
@@ -75,22 +69,12 @@
 
   .track {
     position: relative;
-
-    &.row-1 {
-      grid-area: track-1;
-    }
-
-    &.row-2 {
-      grid-area: track-2;
-    }
-
-    &.row-3 {
-      grid-area: track-3;
-    }
+    grid-column: 2;
   }
 
   .right-coord {
     padding-left: 0.1rem;
-    grid-area: right-coord;
+    grid-column: 3;
+    grid-row: span 2;
   }
 }


### PR DESCRIPTION
PR inside the PR

handles:
 - connect align label checkboxes to blast and align action buttons
   - add checkboxes and connect to action buttons in phylotree ad pim components
   - in wrapped view, toggle all checkboxes corresponding to the same sequence
 - floor the coordinate number that was appearing as a decimal when first switching to overview
 - make whole align label clickable as way to select one of the alignments
 - optimise use of grid and cell positionning
   - push the cells to the bottom to keep alignment without injecting dynamic style depending on track information
   - merge "rows" into one big section and handle grids as grids (stuff all the cells in one grid, and assign areas to those cells)
   - define size of side columns depending on content and not based on fixed sizing anymore -> better use of space

Notes and rough edges:
 - ~in wrapped view, the right column gets a different size based on the size of number displayed~
   - -> ~fixable by defining a huge grid with repeated grid-area patterns~ -> done (and it even simplifies the code)
 - in overview, the zoom of the nightingale components jumps every time the checkbox is selected