### PR TITLE
switch default highlight to conservation

### DIFF
--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -9,3 +9,9 @@
   margin-inline-start: 0;
   margin-inline-end: 0;
 }
+
+// only show the first loader component when 2 or more are direct siblings
+// useful for lists of potentially loading components
+.loader-container + .loader-container {
+  display: none;
+}

--- a/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
+++ b/src/tools/blast/components/results/__tests__/__snapshots__/HSPDetailPanel.spec.tsx.snap
@@ -91,7 +91,7 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
                   class="active"
                   type="button"
                 >
-                  Clustal
+                  Similarity
                 </button>
               </li>
               <li
@@ -101,7 +101,7 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
                   class=""
                   type="button"
                 >
-                  Similarity
+                  Clustal
                 </button>
               </li>
               <li
@@ -465,10 +465,12 @@ exports[`HSPDetailPanel should change to wrapped and render when wrapped view is
           class="track"
         >
           <protvista-msa
-            colorscheme="clustal"
+            calculate-conservation="true"
+            colorscheme="conservation"
             height="40"
             hidelabel="true"
             length="45"
+            overlay-conservation="true"
           />
         </div>
         <span
@@ -601,7 +603,7 @@ exports[`HSPDetailPanel should initially render overview 1`] = `
                       class="active"
                       type="button"
                     >
-                      Clustal
+                      Similarity
                     </button>
                   </li>
                   <li
@@ -611,7 +613,7 @@ exports[`HSPDetailPanel should initially render overview 1`] = `
                       class=""
                       type="button"
                     >
-                      Similarity
+                      Clustal
                     </button>
                   </li>
                   <li
@@ -1020,10 +1022,12 @@ exports[`HSPDetailPanel should initially render overview 1`] = `
                   length="28"
                 />
                 <protvista-msa
-                  colorscheme="clustal"
+                  calculate-conservation="true"
+                  colorscheme="conservation"
                   height="40"
                   hidelabel="true"
                   length="28"
+                  overlay-conservation="true"
                 />
               </protvista-manager>
             </div>

--- a/src/tools/components/AlignmentView.tsx
+++ b/src/tools/components/AlignmentView.tsx
@@ -143,7 +143,7 @@ const AlignmentView: React.FC<{
   );
   const annotationChanged = useRef(false);
   const [highlightProperty, setHighlightProperty] = useState<MsaColorScheme>(
-    MsaColorScheme.CLUSTAL
+    MsaColorScheme.CONSERVATION
   );
   const highlightChanged = useRef(false);
   const [activeId, setActiveId] = useState<string | undefined>(
@@ -211,7 +211,7 @@ const AlignmentView: React.FC<{
               ? `"${msaColorSchemeToString[highlightProperty]}" highlight`
               : 'Highlight properties'
           }
-          defaultActiveNodes={useMemo(() => [MsaColorScheme.CLUSTAL], [])}
+          defaultActiveNodes={useMemo(() => [MsaColorScheme.CONSERVATION], [])}
           className="tertiary"
         />
         {annotationsPerEntry.length && (

--- a/src/tools/components/Wrapped.tsx
+++ b/src/tools/components/Wrapped.tsx
@@ -13,7 +13,6 @@ import { Loader } from 'franklin-sites';
 
 import useSize from '../../shared/hooks/useSize';
 import useSafeState from '../../shared/hooks/useSafeState';
-import useStaggeredRenderingHelper from '../../shared/hooks/useStaggeredRenderingHelper';
 import useCustomElement from '../../shared/hooks/useCustomElement';
 
 import { MsaColorScheme } from '../config/msaColorSchemes';
@@ -205,12 +204,6 @@ const Wrapped: FC<MSAViewProps> = ({
   const [size] = useSize(containerRef);
 
   const [rowLength, setRowLength] = useSafeState(0);
-  const nItemsToRender = useStaggeredRenderingHelper({
-    first: 4,
-    increment: +Infinity,
-    max: +Infinity,
-    delay: 500,
-  });
   const debouncedSetRowLength = useMemo(
     () =>
       debounce((width: number) => {
@@ -271,25 +264,20 @@ const Wrapped: FC<MSAViewProps> = ({
       className="alignment-grid alignment-wrapped"
       data-testid="alignment-wrapped-view"
     >
-      {sequenceChunks.map(({ sequences, id }, index) => {
-        if (index < nItemsToRender) {
-          return (
-            <MSAWrappedRow
-              key={id}
-              rowLength={rowLength}
-              sequences={sequences}
-              annotation={annotation}
-              highlightProperty={highlightProperty}
-              conservationOptions={conservationOptions}
-              activeId={activeId}
-              setActiveId={setActiveId}
-              selectedEntries={selectedEntries}
-              handleSelectedEntries={handleSelectedEntries}
-            />
-          );
-        }
-        return <div key={id} className="alignment-grid__placeholder" />;
-      })}
+      {sequenceChunks.map(({ sequences, id }) => (
+        <MSAWrappedRow
+          key={id}
+          rowLength={rowLength}
+          sequences={sequences}
+          annotation={annotation}
+          highlightProperty={highlightProperty}
+          conservationOptions={conservationOptions}
+          activeId={activeId}
+          setActiveId={setActiveId}
+          selectedEntries={selectedEntries}
+          handleSelectedEntries={handleSelectedEntries}
+        />
+      ))}
     </div>
   );
 };

--- a/src/tools/components/styles/alignment-view.scss
+++ b/src/tools/components/styles/alignment-view.scss
@@ -11,9 +11,8 @@
   grid-template-columns: min-content minmax(0, 1fr) min-content;
   align-items: end;
 
-  &__placeholder {
-    height: 80px;
-    grid-column: span 3;
+  .loader-container {
+    grid-column: 1 / 4;
   }
 
   &.alignment-wrapped {
@@ -70,6 +69,7 @@
   .track {
     position: relative;
     grid-column: 2;
+    content-visibility: auto;
   }
 
   .right-coord {

--- a/src/tools/config/msaColorSchemes.ts
+++ b/src/tools/config/msaColorSchemes.ts
@@ -62,12 +62,12 @@ export const msaColorSchemeToString = {
 
 export const colorSchemeTree = [
   {
-    label: msaColorSchemeToString[MsaColorScheme.CLUSTAL],
-    id: MsaColorScheme.CLUSTAL,
-  },
-  {
     label: msaColorSchemeToString[MsaColorScheme.CONSERVATION],
     id: MsaColorScheme.CONSERVATION,
+  },
+  {
+    label: msaColorSchemeToString[MsaColorScheme.CLUSTAL],
+    id: MsaColorScheme.CLUSTAL,
   },
   {
     label: 'Physical properties',


### PR DESCRIPTION
- [x] What is the link to the Jira that this PR is for? [TRM-24991](https://www.ebi.ac.uk/panda/jira/browse/TRM-24991)
- [ ] Have you written tests and do these have >= 75% coverage of the code that you are contributing?
- [x] Is it possible to visually evaluate this PR in the browser? If so, what are the steps to do this (eg specific URLs or sections)? anywhere where we have a MSA viewer
- [ ] Are there any linting errors that required you to add exceptions?
- [ ] If there are backend requests, have you checked for the existence of the resource's attributes before attempting access?

Not as simple as expected:
Had to de-optimise the staggered rendering in wrapped view as the conservation highlight was disappearing when lower instances get added and the numbers on the right get longer and so push the grid's middle column to be smaller without the component detecting that it got resized. So, one way to solve that was to render everything in one go.
As an other way to optimise the page, I applied [this approach](https://web.dev/content-visibility/) to the MSA viewer as the space for the MSA viewer will be fixed once all the elements are rendered once.