### PR TITLE
2020 12 a few alignment fixes

### DIFF
--- a/src/tools/align/components/results/AlignResultOverview.tsx
+++ b/src/tools/align/components/results/AlignResultOverview.tsx
@@ -70,11 +70,11 @@ const enrichParsed = (
       features: features ?? [],
       ...sequence,
       // not sure yet if that is needed or not
-      ...getFromToLength(sequence.sequence),
+      // ...getFromToLength(sequence.sequence),
       // or if those values are enough
-      // from: 1,
-      // to: sequence.sequence?.length || 0,
-      // length: sequence.sequence?.length || 0,
+      from: 1,
+      to: sequence.sequence?.length || 0,
+      length: sequence.sequence?.length || 0,
     };
   }
   return { ...parsed, sequences } as ParsedAndEnriched;

--- a/src/tools/align/components/results/AlignResultOverview.tsx
+++ b/src/tools/align/components/results/AlignResultOverview.tsx
@@ -26,20 +26,6 @@ type ParsedAndEnriched = {
   sequences: EnrichedSequence[];
 };
 
-const dashesRE = {
-  start: /^-*/,
-  end: /-*$/,
-  any: /-*/g,
-};
-// calculate start and end of alignments without initial and final dashes
-const getFromToLength = (clustalSeq = '') => {
-  const trimmedStart = clustalSeq.replace(dashesRE.start, '');
-  const from = clustalSeq.length - trimmedStart.length + 1;
-  const trimmed = trimmedStart.replace(dashesRE.end, '');
-  const { length } = trimmed.replace(dashesRE.any, '');
-  return { from, to: from + trimmed.length, length };
-};
-
 const enrichParsed = (
   parsed: AlnClustalNum | null,
   sequenceInfo: SequenceInfo
@@ -69,12 +55,12 @@ const enrichParsed = (
       ...info,
       features: features ?? [],
       ...sequence,
-      // not sure yet if that is needed or not
-      ...getFromToLength(sequence.sequence),
-      // or if those values are enough
+      length: sequence.sequence?.length || 0,
+      // The following are really BLAST specific (corresponding to hsp_query_from, hsp_query_to
+      // and likewise for hit) but as we want the  alignment visualisation components to be
+      // generic for both BLAST and Align output we set these values.
       from: 1,
       to: sequence.sequence?.length || 0,
-      length: sequence.sequence?.length || 0,
     };
   }
   return { ...parsed, sequences } as ParsedAndEnriched;

--- a/src/tools/align/components/results/AlignResultOverview.tsx
+++ b/src/tools/align/components/results/AlignResultOverview.tsx
@@ -70,7 +70,7 @@ const enrichParsed = (
       features: features ?? [],
       ...sequence,
       // not sure yet if that is needed or not
-      // ...getFromToLength(sequence.sequence),
+      ...getFromToLength(sequence.sequence),
       // or if those values are enough
       from: 1,
       to: sequence.sequence?.length || 0,

--- a/src/tools/components/Overview.tsx
+++ b/src/tools/components/Overview.tsx
@@ -126,7 +126,7 @@ const AlignOverview: FC<BlastOverviewProps> = ({
 
       node.data = alignment.map(({ name, sequence }) => ({ name, sequence }));
     },
-    [msaDefined, alignment, alignmentLength]
+    [msaDefined, alignmentLength, alignment, displayEnd]
   );
 
   const trackDefined = useCustomElement(
@@ -181,6 +181,7 @@ const AlignOverview: FC<BlastOverviewProps> = ({
   if (!ceDefined) {
     return <Loader />;
   }
+
   return (
     <section data-testid="alignment-view" className="alignment-grid">
       {/* first row */}

--- a/src/tools/components/Overview.tsx
+++ b/src/tools/components/Overview.tsx
@@ -119,11 +119,11 @@ const AlignOverview: FC<BlastOverviewProps> = ({
       const maxSequenceLength = Math.max(
         ...alignment.map((al) => al.sequence.length)
       );
-      if (displayEndValue < maxSequenceLength) {
-        setInitialDisplayEnd(displayEndValue);
-      } else {
-        setInitialDisplayEnd(maxSequenceLength);
+
+      if (typeof displayEnd === 'undefined') {
+        setInitialDisplayEnd(Math.min(displayEndValue, maxSequenceLength));
       }
+
       node.data = alignment.map(({ name, sequence }) => ({ name, sequence }));
     },
     [msaDefined, alignment, alignmentLength]


### PR DESCRIPTION
A few bug fixes for align:

1. When a user provides a sequence that isn't in UniProtKB we now set `from`, `to`, `length`. Without these we were getting some negative value errors in protvista's SVGs.
2. Don't set `initialDisplayEnd` if `displayEnd` is already defined as this was causing the navigation to alternate between `initialDisplayEnd` and `displayEnd` during scrolling.