### PR TITLE
Add caution comment

### DIFF
--- a/src/uniprotkb/adapters/functionConverter.ts
+++ b/src/uniprotkb/adapters/functionConverter.ts
@@ -106,6 +106,7 @@ const commentsCategories = [
   CommentType.ACTIVITY_REGULATION,
   CommentType.BIOPHYSICOCHEMICAL_PROPERTIES,
   CommentType.PATHWAY,
+  CommentType.CAUTION,
   CommentType.MISCELLANEOUS,
 ];
 

--- a/src/uniprotkb/components/entry/FunctionSection.tsx
+++ b/src/uniprotkb/components/entry/FunctionSection.tsx
@@ -1,5 +1,5 @@
 import React, { FC, lazy, Suspense } from 'react';
-import { Card, Loader } from 'franklin-sites';
+import { Card, Loader, Message } from 'franklin-sites';
 
 import ErrorBoundary from '../../../shared/components/error-component/ErrorBoundary';
 
@@ -151,6 +151,16 @@ const FunctionSection: FC<{
   return (
     <div id={EntrySectionIDs[EntrySection.Function]} data-entry-section>
       <Card title={EntrySection.Function}>
+        {data.commentsData.get(CommentType.CAUTION) && (
+          <Message level="warning">
+            <h4>Caution</h4>
+            <FreeTextView
+              comments={
+                data.commentsData.get(CommentType.CAUTION) as FreeTextComment[]
+              }
+            />
+          </Message>
+        )}
         <FreeTextView
           comments={
             data.commentsData.get(CommentType.FUNCTION) as FreeTextComment[]

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -397,6 +397,34 @@ exports[`Entry view should render 1`] = `
         <div
           class="card__content"
         >
+          <div
+            class="message message--warning"
+            role="status"
+          >
+            <div
+              class="message__side-border"
+            />
+            <svg
+              fill="currentColor"
+              height="1.125em"
+              viewBox="0 0 16 14"
+              width="1.125em"
+            >
+              <path
+                d="M9.54.87a1.8 1.8 0 00-3.08 0L.24 11.37A1.75 1.75 0 001.78 14h12.44a1.75 1.75 0 001.54-2.63L9.54.87zM7 4a1 1 0 112 0v4a1 1 0 11-2 0V4zm1 8a1 1 0 100-2 1 1 0 000 2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <section
+              class="message__content"
+            >
+              <small>
+                <h4>
+                  Caution
+                </h4>
+              </small>
+            </section>
+          </div>
           <h3>
             catalytic activity
           </h3>


### PR DESCRIPTION
During Preethi’s presentation, I noticed we were missing a comment type in the new website: Caution.
See https://www.uniprot.org/uniprot/P14210#miscellaneous for an example. As it’s highlighted in the old website, I take it it has to be highlighted for the user too so thought of using a message component of status “warning”.