### PR TITLE
2020 14 uniparc results inactive

### DIFF
--- a/src/uniprotkb/adapters/uniProtkbConverter.ts
+++ b/src/uniprotkb/adapters/uniProtkbConverter.ts
@@ -63,6 +63,7 @@ export type UniProtkbAPIModel = {
   uniProtkbId: string;
   proteinExistence: string;
   entryType: string;
+  inactiveReason?: InactiveEntryReason;
   comments?: Comment[];
   keywords?: Keyword[];
   features?: FeatureData;
@@ -81,6 +82,7 @@ export type UniProtkbUIModel = {
   uniProtkbId: string;
   proteinExistence: string;
   entryType?: EntryType;
+  inactiveReason?: InactiveEntryReason;
   annotationScore: number;
   [EntrySection.Function]: UIModel;
   [EntrySection.NamesAndTaxonomy]: NamesAndTaxonomyUIModel;
@@ -109,14 +111,6 @@ export type InactiveEntryReason = {
   mergeDemergeTo: string[] | [];
 };
 
-export type UniProtkbInactiveEntryModel = {
-  annotationScore: number;
-  entryType: EntryType.INACTIVE;
-  inactiveReason: InactiveEntryReason;
-  primaryAccession: string;
-  uniProtkbId: string;
-};
-
 export const convertXrefProperties = (xrefs: Xref[]) =>
   xrefs.map((xref) => ({
     ...xref,
@@ -139,6 +133,7 @@ const uniProtKbConverter = (data: UniProtkbAPIModel): UniProtkbUIModel => {
     proteinExistence: dataCopy.proteinExistence,
     entryType: getEntryTypeFromString(dataCopy.entryType),
     annotationScore: dataCopy.annotationScore,
+    inactiveReason: dataCopy.inactiveReason,
     [EntrySection.Function]: convertFunction(dataCopy),
     [EntrySection.NamesAndTaxonomy]: convertNamesAndTaxonomy(dataCopy),
     [EntrySection.SubCellularLocation]: convertSubcellularLocation(dataCopy),

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -55,7 +55,6 @@ import useDataApi from '../../../shared/hooks/useDataApi';
 
 import uniProtKbConverter, {
   EntryType,
-  UniProtkbInactiveEntryModel,
   UniProtkbAPIModel,
 } from '../../adapters/uniProtkbConverter';
 
@@ -89,15 +88,19 @@ const Entry: FC = () => {
     }
   }, [match, history]);
 
-  const { loading, data, status, error, redirectedTo } = useDataApi<
-    UniProtkbAPIModel | UniProtkbInactiveEntryModel
-  >(apiUrls.entry(match?.params.accession || ''));
-
-  const transformedData = useMemo(
-    () =>
-      data && data.entryType !== EntryType.INACTIVE && uniProtKbConverter(data),
-    [data]
+  const {
+    loading,
+    data,
+    status,
+    error,
+    redirectedTo,
+  } = useDataApi<UniProtkbAPIModel>(
+    apiUrls.entry(match?.params.accession || '')
   );
+
+  const transformedData = useMemo(() => data && uniProtKbConverter(data), [
+    data,
+  ]);
 
   const sections = useMemo(() => {
     if (transformedData) {
@@ -134,7 +137,11 @@ const Entry: FC = () => {
     return <Loader />;
   }
 
-  if (data && data.entryType === EntryType.INACTIVE) {
+  if (
+    transformedData &&
+    transformedData.entryType === EntryType.INACTIVE &&
+    transformedData.inactiveReason
+  ) {
     if (!match) {
       return <ErrorHandler />;
     }
@@ -142,7 +149,7 @@ const Entry: FC = () => {
     return (
       <ObsoleteEntryPage
         accession={match.params.accession}
-        details={data.inactiveReason}
+        details={transformedData.inactiveReason}
       />
     );
   }

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -1,7 +1,6 @@
 import UniProtKBEntryConfig from '../config/UniProtEntryConfig';
 
 import {
-  UniProtkbInactiveEntryModel,
   UniProtkbUIModel,
   UniProtkbAPIModel,
 } from '../adapters/uniProtkbConverter';
@@ -33,9 +32,7 @@ export const flattenGeneNameData = (geneNamesData: GeneNamesData) => {
   return Array.from(geneNames);
 };
 
-export const getListOfIsoformAccessions = (
-  data?: UniProtkbAPIModel | UniProtkbInactiveEntryModel
-) => {
+export const getListOfIsoformAccessions = (data?: UniProtkbAPIModel) => {
   // will push all isoform accessions in this variable
   const out: string[] = [];
   if (!(data && 'comments' in data && data.comments)) {


### PR DESCRIPTION
## Purpose
Noticed that obsolete entries were displaying an error page instead of the obsolete page

## Approach
The issue was to do with the fact the model for obsolete entries was separate from the one used for the transformed data and therefore the `entryType` wasn't converted to an enum as it should have been. I've simplified the type definition by adding `inactiveReason` as an optional attribute to the main model so that it can run through the converter. As a result the entry type is now identified correctly and the relevant page displayed (B9U1N9 for instance).

## Testing
No new tests added or updated.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
