### PR TITLE
Add logic for examples and text

### DIFF
--- a/src/app/components/HomePage.tsx
+++ b/src/app/components/HomePage.tsx
@@ -22,11 +22,15 @@ const UniProtFooter = lazy(
 const mission =
   'UniProt is the world’s leading high-quality, comprehensive and freely accessible resource of protein sequence and functional information.';
 
+// TODO remove "Partial" once all namespaces are added
 const namespaceFindYour: Partial<Record<Namespace, string>> = {
   [Namespace.uniprotkb]: 'protein',
   [Namespace.uniref]: 'protein cluster',
   [Namespace.uniparc]: 'protein sequence',
   [Namespace.proteomes]: 'proteome',
+  [Namespace.taxonomy]: 'taxon',
+  [Namespace.publications]: 'publication',
+  [Namespace.keywords]: 'keyword',
 };
 
 const HomePage = () => {

--- a/src/app/components/HomePage.tsx
+++ b/src/app/components/HomePage.tsx
@@ -22,8 +22,7 @@ const UniProtFooter = lazy(
 const mission =
   'UniProt is the world’s leading high-quality, comprehensive and freely accessible resource of protein sequence and functional information.';
 
-// TODO remove "Partial" once all namespaces are added
-const namespaceFindYour: Partial<Record<Namespace, string>> = {
+const namespaceFindYour: Record<Namespace, string> = {
   [Namespace.uniprotkb]: 'protein',
   [Namespace.uniref]: 'protein cluster',
   [Namespace.uniparc]: 'protein sequence',

--- a/src/app/components/HomePage.tsx
+++ b/src/app/components/HomePage.tsx
@@ -1,8 +1,10 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { HeroHeader, Loader } from 'franklin-sites';
 
 import SearchContainer from '../../uniprotkb/components/search/SearchContainer';
 import ErrorBoundary from '../../shared/components/error-component/ErrorBoundary';
+import useNS from '../../shared/hooks/useNS';
+import { Namespace } from '../../shared/types/namespaces';
 
 const HomePageNonCritical = lazy(
   () =>
@@ -20,29 +22,54 @@ const UniProtFooter = lazy(
 const mission =
   'UniProt is the world’s leading high-quality, comprehensive and freely accessible resource of protein sequence and functional information.';
 
-const HomePage = () => (
-  <>
-    <main>
-      <ErrorBoundary>
-        <HeroHeader title="Find your protein" footer={mission}>
-          <section className="uniprot-grid uniprot-grid--centered">
-            <SearchContainer className="uniprot-grid-cell--span-12" />
-          </section>
-        </HeroHeader>
-      </ErrorBoundary>
+const namespaceFindYour: Partial<Record<Namespace, string>> = {
+  [Namespace.uniprotkb]: 'protein',
+  [Namespace.uniref]: 'protein cluster',
+  [Namespace.uniparc]: 'protein sequence',
+  [Namespace.proteomes]: 'proteome',
+};
 
-      <ErrorBoundary>
-        <Suspense fallback={<Loader />}>
-          <HomePageNonCritical />
-        </Suspense>
-      </ErrorBoundary>
-    </main>
-    <Suspense fallback={null}>
-      <ErrorBoundary>
-        <UniProtFooter />
-      </ErrorBoundary>
-    </Suspense>
-  </>
-);
+const HomePage = () => {
+  const namespace = useNS();
+
+  const [selectedNamespace, setSelectedNamespace] = useState(
+    namespace || Namespace.uniprotkb
+  );
+
+  return (
+    <>
+      <main>
+        <ErrorBoundary>
+          <HeroHeader
+            title={`Find your ${namespaceFindYour[selectedNamespace]}`}
+            footer={mission}
+          >
+            <section className="uniprot-grid uniprot-grid--centered">
+              <SearchContainer
+                namespace={selectedNamespace}
+                onNamespaceChange={(namespace) =>
+                  setSelectedNamespace(namespace)
+                }
+                className="uniprot-grid-cell--span-12"
+                includeFooter
+              />
+            </section>
+          </HeroHeader>
+        </ErrorBoundary>
+
+        <ErrorBoundary>
+          <Suspense fallback={<Loader />}>
+            <HomePageNonCritical />
+          </Suspense>
+        </ErrorBoundary>
+      </main>
+      <Suspense fallback={null}>
+        <ErrorBoundary>
+          <UniProtFooter />
+        </ErrorBoundary>
+      </Suspense>
+    </>
+  );
+};
 
 export default HomePage;

--- a/src/app/components/HomePageNonCritical.tsx
+++ b/src/app/components/HomePageNonCritical.tsx
@@ -11,7 +11,7 @@ import ArchiveIllustration from '../../svg/archive_illustration.svg';
 // Tools
 import BlastIllustration from '../../svg/blast_illustration.svg';
 import AlignIllustration from '../../svg/align_illustration.svg';
-import IDMappingIllustration from '../../svg/id-mapping_illustration.svg';
+import UploadListIllustration from '../../svg/id-mapping_illustration.svg';
 import PeptideSearchIllustration from '../../svg/peptide_search_illustration.svg';
 
 // Technical corner
@@ -123,7 +123,7 @@ const HomePageNonCritical = () => (
         title="Search with Lists / Map IDs"
         className="uniprot-grid-cell--span-3"
         description="Find proteins with lists of UniProt IDs or convert from/to other database IDs."
-        backgroundImage={<IDMappingIllustration />}
+        backgroundImage={<UploadListIllustration />}
         backgroundColor={colors.idMapping}
         gradient
       />

--- a/src/app/components/__tests__/HomePage.spec.tsx
+++ b/src/app/components/__tests__/HomePage.spec.tsx
@@ -1,10 +1,30 @@
+import { cleanup, fireEvent, getAllByText } from '@testing-library/react';
+import { after } from 'lodash';
 import renderWithRedux from '../../../shared/__test-helpers__/RenderWithRedux';
 
 import HomePage from '../HomePage';
 
+let component;
+
 describe('HomePage component', () => {
+  beforeEach(() => {
+    component = renderWithRedux(<HomePage />);
+  });
+
   test('should render', () => {
-    const { asFragment } = renderWithRedux(<HomePage />);
+    const { asFragment } = component;
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('should change the text when selecting a different namespace', async () => {
+    const { getByText, getAllByText } = component;
+    expect(getByText('Find your protein')).toBeTruthy();
+    fireEvent.click(getByText('UniProtKB'));
+    const matches = getAllByText('UniRef');
+    fireEvent.click(matches.find(({ type }) => type === 'button'));
+    const newTagLine = await getByText('Find your protein cluster');
+    expect(newTagLine).toBeTruthy();
+  });
+
+  afterEach(cleanup);
 });

--- a/src/app/components/__tests__/__snapshots__/HomePage.spec.tsx.snap
+++ b/src/app/components/__tests__/__snapshots__/HomePage.spec.tsx.snap
@@ -49,6 +49,37 @@ exports[`HomePage component should render 1`] = `
                 Search
               </button>
             </form>
+            <section
+              class="search-container-footer"
+            >
+              <section>
+                Examples: 
+                <button
+                  type="button"
+                >
+                  p53
+                </button>
+                , 
+                <button
+                  type="button"
+                >
+                  Human EGFR
+                </button>
+                , 
+                <button
+                  type="button"
+                >
+                  Albumin
+                </button>
+              </section>
+              <section>
+                <a
+                  href="/uploadlists"
+                >
+                  Search with a list of IDs
+                </a>
+              </section>
+            </section>
           </section>
         </section>
       </div>

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -19,8 +19,8 @@ export enum Location {
   AlignResult = 'AlignResult',
   Blast = 'Blast',
   BlastResult = 'BlastResult',
-  IDMap = 'IDMap',
-  IDMapResult = 'IDMapResult',
+  UploadList = 'UploadList',
+  UploadListResult = 'UploadListResult',
   PeptideSearch = 'PeptideSearch',
   PeptideSearchResult = 'PeptideSearchResult',
   QueryBuilder = 'QueryBuilder',
@@ -35,8 +35,8 @@ export const LocationToPath = {
   [Location.Align]: '/align',
   [Location.BlastResult]: '/blast/:id/:subPage?',
   [Location.Blast]: '/blast',
-  [Location.IDMapResult]: '/idmap/:id/:subPage?',
-  [Location.IDMap]: '/idmap',
+  [Location.UploadListResult]: '/uploadlists/:id/:subPage?',
+  [Location.UploadList]: '/uploadlists',
   [Location.PeptideSearchResult]: '/peptide-search/:id/:subPage?',
   [Location.PeptideSearch]: '/peptide-search',
   [Location.QueryBuilder]: '/query-builder/:namespace?',
@@ -80,7 +80,9 @@ export const jobTypeToPath = (type: JobTypes, result?: boolean) => {
     case JobTypes.BLAST:
       return LocationToPath[result ? Location.BlastResult : Location.Blast];
     case JobTypes.IDMAP:
-      return LocationToPath[result ? Location.IDMapResult : Location.IDMap];
+      return LocationToPath[
+        result ? Location.UploadListResult : Location.UploadList
+      ];
     case JobTypes.PEPTIDE_SEARCH:
       return LocationToPath[
         result ? Location.PeptideSearchResult : Location.PeptideSearch

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -79,7 +79,7 @@ export const jobTypeToPath = (type: JobTypes, result?: boolean) => {
       return LocationToPath[result ? Location.AlignResult : Location.Align];
     case JobTypes.BLAST:
       return LocationToPath[result ? Location.BlastResult : Location.Blast];
-    case JobTypes.IDMAP:
+    case JobTypes.UPLOAD_LIST:
       return LocationToPath[
         result ? Location.UploadListResult : Location.UploadList
       ];

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   useRouteMatch,
   generatePath,
@@ -121,6 +121,10 @@ const UniProtHeader = () => {
 
   const namespace = useNS();
 
+  const [selectedNamespace, setSelectedNamespace] = useState(
+    namespace || Namespace.uniprotkb
+  );
+
   const isHomePage = Boolean(homeMatch?.isExact);
 
   // only show search if not on home page, or not on query builder page
@@ -141,7 +145,16 @@ const UniProtHeader = () => {
     <Header
       links={displayedLinks}
       isNegative={isHomePage}
-      search={shouldShowSearch ? <SearchContainer /> : undefined}
+      search={
+        shouldShowSearch ? (
+          <SearchContainer
+            namespace={selectedNamespace}
+            onNamespaceChange={(namespace: Namespace) =>
+              setSelectedNamespace(namespace)
+            }
+          />
+        ) : undefined
+      }
       logo={<Logo width={120} height={50} />}
     />
   );

--- a/src/shared/config/InfoMappings.tsx
+++ b/src/shared/config/InfoMappings.tsx
@@ -84,8 +84,8 @@ const infoMappings: {
       { title: 'Video', destination: '' },
     ],
   },
-  [JobTypes.IDMAP]: {
-    name: 'ID mapping',
+  [JobTypes.UPLOAD_LIST]: {
+    name: 'Upload list',
     info: null,
     links: [
       { title: 'Help', destination: '' },

--- a/src/tools/adapters/parameters.ts
+++ b/src/tools/adapters/parameters.ts
@@ -83,7 +83,7 @@ export function formParametersToServerParameters<T extends JobTypes>(
         } as ServerParameters[T];
       }
       break;
-    case JobTypes.IDMAP:
+    case JobTypes.UPLOAD_LIST:
       //
       break;
     case JobTypes.PEPTIDE_SEARCH:
@@ -174,7 +174,7 @@ export function serverParametersToFormParameters<T extends JobTypes>(
         } as FormParameters[T];
       }
       break;
-    case JobTypes.IDMAP:
+    case JobTypes.UPLOAD_LIST:
       //
       break;
     case JobTypes.PEPTIDE_SEARCH:

--- a/src/tools/components/ResultDownload.tsx
+++ b/src/tools/components/ResultDownload.tsx
@@ -73,14 +73,14 @@ const options: Record<JobTypes, DownloadOptions<JobTypes>[]> = {
       ext: 'jpg',
     },
   ] as DownloadOptions<JobTypes.BLAST>[],
-  [JobTypes.IDMAP]: [],
+  [JobTypes.UPLOAD_LIST]: [],
   [JobTypes.PEPTIDE_SEARCH]: [],
 };
 
 const defaultFormat: Record<JobTypes, ResultFormat[JobTypes]> = {
   [JobTypes.ALIGN]: 'aln-clustal_num',
   [JobTypes.BLAST]: 'out',
-  [JobTypes.IDMAP]: 'out', // TODO: check after implementing
+  [JobTypes.UPLOAD_LIST]: 'out', // TODO: check after implementing
   [JobTypes.PEPTIDE_SEARCH]: 'out', // TODO: check after implementing
 };
 

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -30,7 +30,7 @@ export type ResultFormat = {
     | 'ffdp-subject-jpeg'
     | 'parameters' // in XML
     | 'json';
-  [JobTypes.IDMAP]: never; // TODO
+  [JobTypes.UPLOAD_LIST]: never; // TODO
   [JobTypes.PEPTIDE_SEARCH]: never; // TODO
 };
 
@@ -43,7 +43,7 @@ function urlObjectCreator<T extends JobTypes>(type: T) {
     case JobTypes.BLAST:
       baseURL = 'https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast';
       break;
-    case JobTypes.IDMAP:
+    case JobTypes.UPLOAD_LIST:
       baseURL = ''; // TODO
       break;
     case JobTypes.PEPTIDE_SEARCH:

--- a/src/tools/dashboard/components/Dashboard.tsx
+++ b/src/tools/dashboard/components/Dashboard.tsx
@@ -39,7 +39,10 @@ const Dashboard = () => {
       <div>
         Try using <Link to={LocationToPath[Location.Blast]}>BLAST</Link>,{' '}
         <Link to={LocationToPath[Location.Align]}>Align</Link>,{' '}
-        <Link to={LocationToPath[Location.IDMap]}>ID Mapping/Retrieve</Link> or{' '}
+        <Link to={LocationToPath[Location.UploadList]}>
+          ID Mapping/Retrieve
+        </Link>{' '}
+        or{' '}
         <Link to={LocationToPath[Location.PeptideSearch]}>Peptide Search</Link>{' '}
         to begin
       </div>

--- a/src/tools/types/toolsFormParameters.ts
+++ b/src/tools/types/toolsFormParameters.ts
@@ -6,6 +6,6 @@ import { FormParameters as BlastFP } from '../blast/types/blastFormParameters';
 export type FormParameters = {
   [JobTypes.ALIGN]: AlignFP;
   [JobTypes.BLAST]: BlastFP;
-  [JobTypes.IDMAP]: never; // TODO
+  [JobTypes.UPLOAD_LIST]: never; // TODO
   [JobTypes.PEPTIDE_SEARCH]: never; // TODO
 };

--- a/src/tools/types/toolsJob.ts
+++ b/src/tools/types/toolsJob.ts
@@ -34,7 +34,7 @@ export interface RunningJob extends BaseJob<JobTypes> {
 type DataForDashboard = {
   [JobTypes.ALIGN]: never;
   [JobTypes.BLAST]: { hits: number };
-  [JobTypes.IDMAP]: never; // TODO
+  [JobTypes.UPLOAD_LIST]: never; // TODO
   [JobTypes.PEPTIDE_SEARCH]: never; // TODO
 };
 

--- a/src/tools/types/toolsJobTypes.ts
+++ b/src/tools/types/toolsJobTypes.ts
@@ -1,6 +1,6 @@
 export enum JobTypes {
   BLAST = 'blast',
   ALIGN = 'align',
-  IDMAP = 'ID mapping',
+  UPLOAD_LIST = 'upload list',
   PEPTIDE_SEARCH = 'peptide search',
 }

--- a/src/tools/types/toolsServerParameters.ts
+++ b/src/tools/types/toolsServerParameters.ts
@@ -6,13 +6,13 @@ import { ServerParameters as BlastSP } from '../blast/types/blastServerParameter
 export type ServerParameters = {
   [JobTypes.ALIGN]: AlignSP;
   [JobTypes.BLAST]: BlastSP;
-  [JobTypes.IDMAP]: never; // TODO
+  [JobTypes.UPLOAD_LIST]: never; // TODO
   [JobTypes.PEPTIDE_SEARCH]: never; // TODO
 };
 
 export type PublicServerParameters = {
   [JobTypes.ALIGN]: Omit<AlignSP, 'email'>;
   [JobTypes.BLAST]: Omit<BlastSP, 'email'>;
-  [JobTypes.IDMAP]: never; // TODO
+  [JobTypes.UPLOAD_LIST]: never; // TODO
   [JobTypes.PEPTIDE_SEARCH]: never; // TODO
 };

--- a/src/tools/utils/isValidServerID.ts
+++ b/src/tools/utils/isValidServerID.ts
@@ -4,7 +4,7 @@ import { JobTypes } from '../types/toolsJobTypes';
 const validServerID = {
   [JobTypes.ALIGN]: /^clustalo-R\d{8}(-\w+){4}$/,
   [JobTypes.BLAST]: /^ncbiblast-R\d{8}(-\w+){4}$/,
-  [JobTypes.IDMAP]: /./,
+  [JobTypes.UPLOAD_LIST]: /./,
   [JobTypes.PEPTIDE_SEARCH]: /./,
 };
 

--- a/src/uniprotkb/components/search/SearchContainer.tsx
+++ b/src/uniprotkb/components/search/SearchContainer.tsx
@@ -15,7 +15,6 @@ import './styles/search-container.scss';
 // Keep partial until all are added
 const examples: Partial<Record<Namespace, string[]>> = {
   [Namespace.uniprotkb]: ['p53', 'Human EGFR', 'Albumin'],
-  [Namespace.uniref]: [''],
 };
 
 const Search: FC<{
@@ -77,18 +76,22 @@ const Search: FC<{
       {includeFooter && (
         <section className="search-container-footer">
           <section>
-            Examples:{' '}
-            {examples[namespace]
-              ?.map<React.ReactNode>((example) => (
-                <button
-                  type="button"
-                  onClick={() => loadExample(example)}
-                  key={example}
-                >
-                  {example}
-                </button>
-              ))
-              .reduce((prev, curr) => [prev, ', ', curr])}
+            {examples[namespace] && (
+              <>
+                Examples:{' '}
+                {examples[namespace]
+                  ?.map<React.ReactNode>((example) => (
+                    <button
+                      type="button"
+                      onClick={() => loadExample(example)}
+                      key={example}
+                    >
+                      {example}
+                    </button>
+                  ))
+                  .reduce((prev, curr) => [prev, ', ', curr])}
+              </>
+            )}
           </section>
           <section>
             <Link to={LocationToPath[Location.UploadList]}>

--- a/src/uniprotkb/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/uniprotkb/components/search/__tests__/SearchContainer.spec.tsx
@@ -1,3 +1,5 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import { Namespace } from '../../../../shared/types/namespaces';
 import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
 import Search from '../SearchContainer';
 
@@ -12,9 +14,26 @@ const props = {
   },
 };
 
+let component;
+
 describe('Search shallow components', () => {
+  beforeEach(() => {
+    component = renderWithRouter(
+      <Search {...props} includeFooter namespace={Namespace.uniprotkb} />
+    );
+  });
+
   test('should render', () => {
-    const { asFragment } = renderWithRouter(<Search {...props} />);
+    const { asFragment } = component;
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('it should ', () => {
+    const { getByText, getByDisplayValue, queryByDisplayValue } = component;
+    expect(queryByDisplayValue('Albumin')).toBeNull();
+    fireEvent.click(getByText('Albumin'));
+    expect(getByDisplayValue('Albumin')).toBeTruthy();
+  });
+
+  afterAll(cleanup);
 });

--- a/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
+++ b/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
@@ -14,9 +14,7 @@ exports[`Search shallow components should render 1`] = `
         <button
           class="button primary dropdown"
           type="button"
-        >
-          UniProtKB
-        </button>
+        />
         <div
           class="dropdown-menu"
         />

--- a/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
+++ b/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
@@ -14,7 +14,9 @@ exports[`Search shallow components should render 1`] = `
         <button
           class="button primary dropdown"
           type="button"
-        />
+        >
+          UniProtKB
+        </button>
         <div
           class="dropdown-menu"
         />
@@ -32,6 +34,37 @@ exports[`Search shallow components should render 1`] = `
         Search
       </button>
     </form>
+    <section
+      class="search-container-footer"
+    >
+      <section>
+        Examples: 
+        <button
+          type="button"
+        >
+          p53
+        </button>
+        , 
+        <button
+          type="button"
+        >
+          Human EGFR
+        </button>
+        , 
+        <button
+          type="button"
+        >
+          Albumin
+        </button>
+      </section>
+      <section>
+        <a
+          href="/uploadlists"
+        >
+          Search with a list of IDs
+        </a>
+      </section>
+    </section>
   </section>
 </DocumentFragment>
 `;

--- a/src/uniprotkb/components/search/styles/search-container.scss
+++ b/src/uniprotkb/components/search/styles/search-container.scss
@@ -4,3 +4,21 @@
   margin-top: 0.2rem;
   font-size: 0.9rem;
 }
+
+.search-container-footer {
+  margin-top: 0.5rem;
+  button {
+    font-weight: bold;
+    cursor: pointer;
+  }
+  display: flex;
+  & > * {
+    flex: 1;
+  }
+  & > :first-child {
+    text-align: left;
+  }
+  & > :last-child {
+    text-align: right;
+  }
+}


### PR DESCRIPTION
## Purpose
Add search examples, upload lists link and update list of examples and search input header sentence when the namespace selector is used on the homepage.

## Approach
Hoisted the namespace state hook to the parent component so that the header sentence can be updated after selection. Added buttons to add examples to the search box but the behaviour of this is TBC.

## Testing
- Update snapshots
- Add a test for namespace selection
- Add a test for example selection

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
