### PR TITLE
2020 15 side panel query builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "classnames": "2.2.6",
     "core-js": "3.8.1",
     "d3": "5.16.0",
-    "franklin-sites": "0.0.94",
+    "franklin-sites": "0.0.96",
     "history": "4.10.1",
     "idb": "5.0.8",
     "interaction-viewer": "3.1.2",

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -3,6 +3,7 @@ import { Router, Route, Switch } from 'react-router-dom';
 import { FranklinSite, Loader } from 'franklin-sites';
 
 import BaseLayout from '../../shared/components/layouts/BaseLayout';
+import SingleColumnLayout from '../../shared/components/layouts/SingleColumnLayout';
 import ErrorBoundary from '../../shared/components/error-component/ErrorBoundary';
 import GDPR from '../../shared/components/gdpr/GDPR';
 
@@ -11,7 +12,6 @@ import history from '../../shared/utils/browserHistory';
 import { Location, LocationToPath } from '../config/urls';
 
 import './styles/app.scss';
-import SingleColumnLayout from '../../shared/components/layouts/SingleColumnLayout';
 
 if (process.env.NODE_ENV !== 'development') {
   import(/* webpackChunkName: "sentry" */ '@sentry/browser').then((module) => {
@@ -35,12 +35,6 @@ const UniProtKBEntryPage = lazy(
   () =>
     import(
       /* webpackChunkName: "uniprotkb-entry" */ '../../uniprotkb/components/entry/Entry'
-    )
-);
-const QueryBuilderPage = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "query-builder" */ '../../query-builder/components/QueryBuilder'
     )
 );
 const UniRefEntryPage = lazy(
@@ -202,15 +196,6 @@ const App = () => (
               render={() => (
                 <SingleColumnLayout>
                   <Dashboard />
-                </SingleColumnLayout>
-              )}
-            />
-            {/* Query builder */}
-            <Route
-              path={LocationToPath[Location.QueryBuilder]}
-              render={() => (
-                <SingleColumnLayout>
-                  <QueryBuilderPage />
                 </SingleColumnLayout>
               )}
             />

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -31,8 +31,6 @@ export enum Location {
   UploadListResult = 'UploadListResult',
   PeptideSearch = 'PeptideSearch',
   PeptideSearchResult = 'PeptideSearchResult',
-  // Other
-  QueryBuilder = 'QueryBuilder',
 }
 
 export const LocationToPath = {
@@ -63,8 +61,6 @@ export const LocationToPath = {
   [Location.UploadList]: '/uploadlists',
   [Location.PeptideSearchResult]: '/peptide-search/:id/:subPage?',
   [Location.PeptideSearch]: '/peptide-search',
-  // Other
-  [Location.QueryBuilder]: '/query-builder/:namespace?',
 };
 
 export const SearchResultsLocations = {

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -1,19 +1,15 @@
 import { FC, FormEvent, useState, useEffect } from 'react';
-import {
-  useHistory,
-  useRouteMatch,
-  generatePath,
-  useLocation,
-} from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import qs from 'query-string';
 import { v1 } from 'uuid';
 import { frame } from 'timing-functions';
-import { PageIntro, Loader } from 'franklin-sites';
+import { PageIntro, Loader, Button } from 'franklin-sites';
 
 import ClauseList from './ClauseList';
 
 import useDataApi from '../../shared/hooks/useDataApi';
+import useNS from '../../shared/hooks/useNS';
 
 import { createEmptyClause, defaultQueryFor } from '../utils/clause';
 import { stringify } from '../utils/queryStringProcessor';
@@ -23,11 +19,7 @@ import { addMessage } from '../../messages/state/messagesActions';
 
 import apiUrls from '../../shared/config/apiUrls';
 import { Namespace, NamespaceLabels } from '../../shared/types/namespaces';
-import {
-  LocationToPath,
-  Location,
-  SearchResultsLocations,
-} from '../../app/config/urls';
+import { SearchResultsLocations } from '../../app/config/urls';
 
 import {
   MessageFormat,
@@ -38,18 +30,20 @@ import { Clause, SearchTermType } from '../types/searchTypes';
 import '../../uniprotkb/components/search/styles/search-container.scss';
 import './styles/query-builder.scss';
 
-const QueryBuilder: FC = () => {
+type Props = {
+  onCancel: () => void;
+};
+
+const QueryBuilder: FC<Props> = ({ onCancel }) => {
   const history = useHistory();
   const location = useLocation();
-  const match = useRouteMatch<{ namespace?: Namespace }>(
-    LocationToPath[Location.QueryBuilder]
-  );
   const dispatch = useDispatch();
 
-  // To be replaced by getting it from url
   const [clauses, setClauses] = useState<Clause[]>([]);
 
-  const namespace = match?.params?.namespace || Namespace.uniprotkb;
+  const urlNamespace = useNS() || Namespace.uniprotkb;
+
+  const [namespace, setNamespace] = useState(urlNamespace);
 
   const { loading, data: searchTermsData } = useDataApi<SearchTermType[]>(
     namespace && apiUrls.queryBuilderTerms(namespace)
@@ -58,18 +52,6 @@ const QueryBuilder: FC = () => {
   useEffect(() => {
     setClauses([]);
   }, [namespace]);
-
-  // if URL doesn't finish with a namespace redirect to "uniprotkb" by default
-  // useEffect(() => {
-  //   if (!namespace) {
-  //     history.replace({
-  //       ...history.location,
-  //       pathname: generatePath(LocationToPath[Location.QueryBuilder], {
-  //         namespace: Namespace.uniprotkb,
-  //       }),
-  //     });
-  //   }
-  // }, [history, namespace]);
 
   useEffect(() => {
     if (!(searchTermsData && namespace) || loading) {
@@ -163,14 +145,7 @@ const QueryBuilder: FC = () => {
             Searching in
             <select
               id="namespace-select"
-              onChange={(e) => {
-                history.replace({
-                  pathname: generatePath(
-                    LocationToPath[Location.QueryBuilder],
-                    { namespace: e.target.value }
-                  ),
-                });
-              }}
+              onChange={(e) => setNamespace(e.target.value as Namespace)}
               value={namespace}
             >
               {Object.keys(NamespaceLabels).map((key) => (
@@ -189,19 +164,19 @@ const QueryBuilder: FC = () => {
             searchTerms={searchTermsData}
           />
         </fieldset>
-        <div className="query-builder__actions">
-          <button
-            type="button"
-            id="add-field"
-            className="button tertiary"
+        <div className="query-builder__actions button-group sliding-panel__button-row">
+          <Button
+            variant="tertiary"
+            className="query-builder__add-field"
             data-testid="query-builder-add-field"
             onClick={addClause}
           >
             Add Field
-          </button>
-          <button type="submit" id="submit-query" className="button">
-            Search
-          </button>
+          </Button>
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit">Search</Button>
         </div>
       </form>
     </>

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -129,6 +129,7 @@ const QueryBuilder: FC<Props> = ({ onCancel }) => {
       pathname: SearchResultsLocations[namespace],
       search: `query=${queryString}`,
     });
+    onCancel();
   };
 
   return (

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -49,7 +49,7 @@ const QueryBuilder: FC = () => {
   // To be replaced by getting it from url
   const [clauses, setClauses] = useState<Clause[]>([]);
 
-  const namespace = match?.params?.namespace;
+  const namespace = match?.params?.namespace || Namespace.uniprotkb;
 
   const { loading, data: searchTermsData } = useDataApi<SearchTermType[]>(
     namespace && apiUrls.queryBuilderTerms(namespace)
@@ -60,16 +60,16 @@ const QueryBuilder: FC = () => {
   }, [namespace]);
 
   // if URL doesn't finish with a namespace redirect to "uniprotkb" by default
-  useEffect(() => {
-    if (!namespace) {
-      history.replace({
-        ...history.location,
-        pathname: generatePath(LocationToPath[Location.QueryBuilder], {
-          namespace: Namespace.uniprotkb,
-        }),
-      });
-    }
-  }, [history, namespace]);
+  // useEffect(() => {
+  //   if (!namespace) {
+  //     history.replace({
+  //       ...history.location,
+  //       pathname: generatePath(LocationToPath[Location.QueryBuilder], {
+  //         namespace: Namespace.uniprotkb,
+  //       }),
+  //     });
+  //   }
+  // }, [history, namespace]);
 
   useEffect(() => {
     if (!(searchTermsData && namespace) || loading) {

--- a/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
+++ b/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
@@ -1,43 +1,36 @@
 import { createMemoryHistory } from 'history';
-import { act, fireEvent, screen, getByText } from '@testing-library/react';
+import { fireEvent, screen, getByText, waitFor } from '@testing-library/react';
 
 import QueryBuilder from '../QueryBuilder';
 
 import { resetUuidV1 } from '../../../../__mocks__/uuid';
 import renderWithRedux from '../../../shared/__test-helpers__/RenderWithRedux';
-import apiUrls from '../../../shared/config/apiUrls';
-import { Namespace } from '../../../shared/types/namespaces';
 import searchTermData from './__mocks__/configure_search-term.json';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 jest.mock('../../../shared/hooks/useDataApi');
 
-// const mock = useDataApi;
-// mock
-//   .onGet(apiUrls.queryBuilderTerms(Namespace.uniprotkb))
-//   .reply(200, searchTermData);
-
 let rendered;
 
 const history = createMemoryHistory();
+let onCancel;
 
 describe('QueryBuilder', () => {
   beforeEach(async () => {
+    onCancel = jest.fn();
     resetUuidV1();
-    useDataApi.mockReturnValue({ data: searchTermData });
+    (useDataApi as jest.Mock).mockReturnValue({ data: searchTermData });
 
-    await act(async () => {
-      rendered = renderWithRedux(<QueryBuilder />, { history });
+    rendered = renderWithRedux(<QueryBuilder onCancel={onCancel} />, {
+      history,
     });
   });
 
   // only exception where we want different payload
   test('should render loading', async () => {
-    useDataApi.mockReturnValue({ loading: true });
+    (useDataApi as jest.Mock).mockReturnValue({ loading: true });
 
-    await act(async () => {
-      rendered = renderWithRedux(<QueryBuilder />, { history });
-    });
+    rendered = renderWithRedux(<QueryBuilder onCancel={onCancel} />);
 
     expect(rendered.asFragment()).toMatchSnapshot();
   });
@@ -54,11 +47,22 @@ describe('QueryBuilder', () => {
     expect(clauses.length).toBe(5);
   });
 
-  test('should remove a clause', () => {
-    const { getAllByTestId } = rendered;
-    fireEvent.click(getAllByTestId('clause-list-button-remove')[1]);
-    const clauses = getAllByTestId('search__clause');
+  test('should remove clauses', () => {
+    // Go through all the default clauses one by one and remove them
+    fireEvent.click(screen.getAllByTestId('clause-list-button-remove')[0]);
+    let clauses = screen.getAllByTestId('search__clause');
     expect(clauses.length).toBe(3);
+    fireEvent.click(screen.getAllByTestId('clause-list-button-remove')[0]);
+    clauses = screen.getAllByTestId('search__clause');
+    expect(clauses.length).toBe(2);
+    fireEvent.click(screen.getAllByTestId('clause-list-button-remove')[0]);
+    clauses = screen.getAllByTestId('search__clause');
+    expect(clauses.length).toBe(1);
+    // Check special case where only one clause left,
+    // a new empty clause should be added
+    fireEvent.click(screen.getAllByTestId('clause-list-button-remove')[0]);
+    clauses = screen.getAllByTestId('search__clause');
+    expect(clauses.length).toBe(1);
   });
 
   test('should select field', () => {
@@ -69,26 +73,28 @@ describe('QueryBuilder', () => {
     });
     const clause = dropdownButton.closest('[data-testid="search__clause"]');
     fireEvent.click(dropdownButton);
-    let entryNameFieldOption = getByText(clause, /Entry Name \[ID\]/);
+    let entryNameFieldOption = getByText(
+      clause as HTMLElement,
+      /Entry Name \[ID\]/
+    );
     fireEvent.click(entryNameFieldOption);
     entryNameField = screen.queryByPlaceholderText('P53_HUMAN');
     expect(entryNameField).toBeTruthy();
   });
 
-  test('should submit a simple query', () => {
-    const { getByTestId, getAllByTestId, getByPlaceholderText } = rendered;
-    const input = getByPlaceholderText(/ydj1/);
+  test('should submit a simple query', async () => {
+    const input = screen.getByPlaceholderText(/ydj1/);
     fireEvent.change(input, { target: { value: 'zen' } });
-    const all = getByPlaceholderText(/a4_human/);
+    const all = screen.getByPlaceholderText(/a4_human/);
     fireEvent.change(all, { target: { value: 'eve' } });
-    const reviewedLogic = getAllByTestId('query-builder-logic-select');
+    const reviewedLogic = screen.getAllByTestId('query-builder-logic-select');
     // Note this should be 1 as the first line shouldn't have one
     fireEvent.change(reviewedLogic[3], { target: { value: 'OR' } });
-    // FIXME: These next lines are the ones triggering the warning even though
-    // FIXME: we are indeed using act...
-    act(() => {
-      fireEvent.submit(getByTestId('query-builder-form'));
-    });
+    const search = screen.getByRole('button', { name: 'Search' });
+    fireEvent.click(search);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(history.location.pathname).toBe('/uniprotkb');
     expect(history.location.search).toBe('?query=(gene:zen) OR eve');
   });
 });

--- a/src/query-builder/components/__tests__/__snapshots__/QueryBuilder.spec.tsx.snap
+++ b/src/query-builder/components/__tests__/__snapshots__/QueryBuilder.spec.tsx.snap
@@ -368,19 +368,23 @@ exports[`QueryBuilder should render 1`] = `
       </div>
     </fieldset>
     <div
-      class="query-builder__actions"
+      class="query-builder__actions button-group sliding-panel__button-row"
     >
       <button
-        class="button tertiary"
+        class="button tertiary query-builder__add-field"
         data-testid="query-builder-add-field"
-        id="add-field"
         type="button"
       >
         Add Field
       </button>
       <button
-        class="button"
-        id="submit-query"
+        class="button secondary"
+        type="button"
+      >
+        Cancel
+      </button>
+      <button
+        class="button primary"
         type="submit"
       >
         Search

--- a/src/query-builder/components/styles/query-builder.scss
+++ b/src/query-builder/components/styles/query-builder.scss
@@ -49,9 +49,9 @@
 
   &__actions {
     margin-top: 1em;
+  }
 
-    [type='submit'] {
-      float: right;
-    }
+  &__add-field.button {
+    margin-right: auto;
   }
 }

--- a/src/shared/__test-helpers__/RenderWithRedux.tsx
+++ b/src/shared/__test-helpers__/RenderWithRedux.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { Component } from 'react';
+import { ReactElement } from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import { render } from '@testing-library/react';
 import thunk from 'redux-thunk';
@@ -18,7 +18,7 @@ type RenderOptions = {
 };
 
 const renderWithRedux = (
-  ui: Component,
+  ui: ReactElement,
   {
     route = '',
     history = createMemoryHistory({ initialEntries: [route] }),

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,28 +1,29 @@
 import { useCallback, useState, FC, ChangeEvent } from 'react';
 import { Loader, CodeBlock, Button, LongNumber } from 'franklin-sites';
 
+import ColumnSelect from '../column-select/ColumnSelect';
+
 import { urlsAreEqual } from '../../utils/url';
 import fetchData from '../../utils/fetchData';
-import ColumnSelect from '../column-select/ColumnSelect';
 import useNS from '../../hooks/useNS';
 
 import { getDownloadUrl } from '../../config/apiUrls';
 import { Column, nsToPrimaryKeyColumn } from '../../config/columns';
-
-import { SortableColumn } from '../../../uniprotkb/types/columnTypes';
-import {
-  SelectedFacet,
-  SortDirection,
-} from '../../../uniprotkb/types/resultsTypes';
 import {
   fileFormatsWithColumns,
   fileFormatToContentType,
   nsToFileFormatsResultsDownload,
 } from '../../config/resultsDownload';
 
+import {
+  SelectedFacet,
+  SortDirection,
+} from '../../../uniprotkb/types/resultsTypes';
+import { ContentType, FileFormat } from '../../types/resultsDownload';
+import { SortableColumn } from '../../../uniprotkb/types/columnTypes';
+
 import './styles/download.scss';
 import '../../styles/sticky.scss';
-import { ContentType, FileFormat } from '../../types/resultsDownload';
 
 export const getPreviewFileFormat = (fileFormat: FileFormat) =>
   fileFormat === FileFormat.excel ? FileFormat.tsv : fileFormat;
@@ -232,10 +233,10 @@ const Download: FC<DownloadProps> = ({
         </>
       )}
       <section className="button-group sliding-panel__button-row sticky-bottom-right">
-        <Button variant="secondary" type="button" onClick={() => onClose()}>
+        <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>
-        <Button variant="secondary" type="button" onClick={handlePreview}>
+        <Button variant="secondary" onClick={handlePreview}>
           Preview {nPreview}
         </Button>
         <a

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -1,12 +1,5 @@
-import {
-  useMemo,
-  useState,
-  SetStateAction,
-  Dispatch,
-  Suspense,
-  lazy,
-} from 'react';
-import { useRouteMatch, useLocation } from 'react-router-dom';
+import { useMemo, useState, Suspense, lazy } from 'react';
+import { useRouteMatch } from 'react-router-dom';
 import { Header } from 'franklin-sites';
 
 import SlidingPanel, { Position } from './SlidingPanel';
@@ -19,8 +12,6 @@ import { LocationToPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../types/namespaces';
 
 import Logo from './svgs/uniprot-logo.svg';
-
-type QBMatch = { namespace?: Namespace };
 
 // NOTE: all of those paths should eventually come from the Location config object
 const tools = [
@@ -46,11 +37,7 @@ const tools = [
   },
 ];
 
-const items = (setDisplaySidePanel: Dispatch<SetStateAction<boolean>>) => [
-  {
-    label: 'Query Builder',
-    onClick: () => setDisplaySidePanel((flag) => !flag),
-  },
+const restOfItems = [
   {
     label: 'API',
     items: [
@@ -91,32 +78,26 @@ const QueryBuilder = lazy(
 );
 
 const UniProtHeader = () => {
-  const { search } = useLocation();
-
   const homeMatch = useRouteMatch(LocationToPath[Location.Home]);
-  const queryBuilderMatch = useRouteMatch<QBMatch>(
-    LocationToPath[Location.QueryBuilder]
-  );
 
   const namespace = useNS();
 
   const [selectedNamespace, setSelectedNamespace] = useState(
     namespace || Namespace.uniprotkb
   );
-  const [displaySidePanel, setDisplaySidePanel] = useState(false);
+  const [displayQueryBuilder, setDisplayQueryBuilder] = useState(false);
 
   const isHomePage = Boolean(homeMatch?.isExact);
 
-  // only show search if not on home page, or not on query builder page
-  const shouldShowSearch = !(isHomePage || queryBuilderMatch);
-
-  const displayedLinks = useMemo(
-    () =>
-      isHomePage
-        ? [...tools, ...items(setDisplaySidePanel)]
-        : [{ label: 'Tools', items: tools }, ...items(setDisplaySidePanel)],
-    [isHomePage, namespace, search, queryBuilderMatch]
-  );
+  const displayedLinks = useMemo(() => {
+    const queryBuilderButton = {
+      label: 'Query Builder',
+      onClick: () => setDisplayQueryBuilder((flag) => !flag),
+    };
+    return isHomePage
+      ? [...tools, queryBuilderButton, ...restOfItems]
+      : [{ label: 'Tools', items: tools }, queryBuilderButton, ...restOfItems];
+  }, [isHomePage]);
 
   return (
     <>
@@ -124,21 +105,21 @@ const UniProtHeader = () => {
         items={displayedLinks}
         isNegative={isHomePage}
         search={
-          shouldShowSearch ? (
+          isHomePage ? undefined : (
             <SearchContainer
               namespace={selectedNamespace}
               onNamespaceChange={(namespace: Namespace) =>
                 setSelectedNamespace(namespace)
               }
             />
-          ) : undefined
+          )
         }
         logo={<Logo width={120} height={50} />}
       />
-      {displaySidePanel && (
+      {displayQueryBuilder && (
         <Suspense fallback={null}>
           <SlidingPanel position={Position.left} yScrollable>
-            <QueryBuilder />
+            <QueryBuilder onCancel={() => setDisplayQueryBuilder(false)} />
           </SlidingPanel>
         </Suspense>
       )}

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -21,6 +21,16 @@ import { SortableColumn } from '../../../uniprotkb/types/columnTypes';
 import { ViewMode } from './ResultsContainer';
 import { Column } from '../../config/columns';
 
+const DownloadComponent = lazy(
+  () => import(/* webpackChunkName: "download" */ '../download/Download')
+);
+const CustomiseComponent = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "customise" */ '../customise-table/CustomiseTable'
+    )
+);
+
 const ResultsButtons: FC<{
   viewMode: ViewMode;
   setViewMode: (viewMode: ViewMode) => void;
@@ -44,23 +54,13 @@ const ResultsButtons: FC<{
   tableColumns,
   onTableColumnsChange,
 }) => {
-  const DownloadComponent = lazy(
-    () => import(/* webpackChunkName: "download" */ '../download/Download')
-  );
-  const CustomiseComponent = lazy(
-    () =>
-      import(
-        /* webpackChunkName: "customise" */ '../customise-table/CustomiseTable'
-      )
-  );
-
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const [displayCustomisePanel, setDisplayCustomisePanel] = useState(false);
 
   return (
     <>
       {displayDownloadPanel && (
-        <Suspense fallback>
+        <Suspense fallback={null}>
           <SlidingPanel position={Position.left} yScrollable>
             <DownloadComponent
               query={query}
@@ -76,7 +76,7 @@ const ResultsButtons: FC<{
         </Suspense>
       )}
       {displayCustomisePanel && (
-        <Suspense fallback>
+        <Suspense fallback={null}>
           <SlidingPanel position={Position.left} yScrollable>
             <CustomiseComponent
               selectedColumns={tableColumns}

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -106,6 +106,10 @@ type ResultButtonsProps<T extends JobTypes> = {
   isTableResultsFiltered?: boolean;
 };
 
+const ResultDownload = lazy(
+  () => import(/* webpackChunkName: "result-download" */ './ResultDownload')
+);
+
 const ResultButtons: FC<ResultButtonsProps<JobTypes>> = ({
   jobType,
   jobId,
@@ -114,10 +118,6 @@ const ResultButtons: FC<ResultButtonsProps<JobTypes>> = ({
   nHits,
   isTableResultsFiltered,
 }) => {
-  const ResultDownload = lazy(
-    () => import(/* webpackChunkName: "result-download" */ './ResultDownload')
-  );
-
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5604,10 +5604,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-franklin-sites@0.0.94:
-  version "0.0.94"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.94.tgz#202ba2368aded6f74f6f1cc298d3ba32683960b3"
-  integrity sha512-JOc5GtokWfwGHXP07Kg5qV/POGujZ4ZHXa7VMwLQBOcRJ/S1lV5yFmUePDq41AcpiOiYWq9TnON4XBrjPd/aLg==
+franklin-sites@0.0.96:
+  version "0.0.96"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.96.tgz#cb81bf7a12ffc516d8db86baadccbf3808cae039"
+  integrity sha512-5v3WEk2+gIIvK5vzJGx3ItQHFcjMWPb9Wr8QAjcqzWxnS10y2G7BnoD0oMW1ySMMOKsWqvsR+Fv/VZPmE5QcvA==
   dependencies:
     classnames "2.2.6"
     d3 "5.16.0"


### PR DESCRIPTION
## Purpose
Put the query builder in a side panel. See [TRM-25301](https://www.ebi.ac.uk/panda/jira/browse/TRM-25301).

## Approach
Remove location for query builder, initialise given the current namespace or UniProtKB by default

## Testing
Updated existing test snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
