### PR TITLE
2020 15 side panel click outside

### DIFF
--- a/src/shared/components/layouts/SlidingPanel.tsx
+++ b/src/shared/components/layouts/SlidingPanel.tsx
@@ -38,7 +38,7 @@ const SlidingPanel: FC<{
   useEffect(() => {
     if (onClickOutside) {
       const handleClickOutside = (e: MouseEvent) => {
-        if (!node?.current?.contains(e.target as Node)) {
+        if (node?.current && !node.current.contains(e.target as Node)) {
           onClickOutside();
         }
       };

--- a/src/shared/components/layouts/SlidingPanel.tsx
+++ b/src/shared/components/layouts/SlidingPanel.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useRef, useEffect } from 'react';
 import { useSpring, animated } from 'react-spring';
 import cn from 'classnames';
 import { upperFirst } from 'lodash-es';
@@ -18,7 +18,15 @@ const SlidingPanel: FC<{
   position: Position;
   className?: string;
   yScrollable?: boolean;
-}> = ({ children, position, className, yScrollable = false }) => {
+  onClickOutside?: (arg: void) => void;
+}> = ({
+  children,
+  position,
+  className,
+  onClickOutside,
+  yScrollable = false,
+}) => {
+  const node = useRef<HTMLDivElement>(null);
   const margin = `margin${upperFirst(position)}`;
   const [props] = useSpring(() => ({
     opacity: 1,
@@ -26,10 +34,27 @@ const SlidingPanel: FC<{
     from: { opacity: 0, [margin]: -1000 },
   }));
 
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (onClickOutside) {
+      const handleClickOutside = (e: MouseEvent) => {
+        if (!node?.current?.contains(e.target as Node)) {
+          onClickOutside();
+        }
+      };
+
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [onClickOutside]);
+
   return (
     <animated.div
       className={cn(`sliding-panel sliding-panel--${position}`, className)}
       style={{ ...props, overflowY: yScrollable ? 'auto' : 'initial' }}
+      ref={node}
     >
       <ErrorBoundary>
         <div>{children}</div>

--- a/src/shared/components/layouts/SlidingPanel.tsx
+++ b/src/shared/components/layouts/SlidingPanel.tsx
@@ -18,14 +18,8 @@ const SlidingPanel: FC<{
   position: Position;
   className?: string;
   yScrollable?: boolean;
-  onClickOutside?: (arg: void) => void;
-}> = ({
-  children,
-  position,
-  className,
-  onClickOutside,
-  yScrollable = false,
-}) => {
+  onClose: (arg: void) => void;
+}> = ({ children, position, className, onClose, yScrollable = false }) => {
   const node = useRef<HTMLDivElement>(null);
   const margin = `margin${upperFirst(position)}`;
   const [props] = useSpring(() => ({
@@ -34,21 +28,23 @@ const SlidingPanel: FC<{
     from: { opacity: 0, [margin]: -1000 },
   }));
 
-  // eslint-disable-next-line consistent-return
-  useEffect(() => {
-    if (onClickOutside) {
-      const handleClickOutside = (e: MouseEvent) => {
-        if (node?.current && !node.current.contains(e.target as Node)) {
-          onClickOutside();
-        }
-      };
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-      };
-    }
-  }, [onClickOutside]);
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (node?.current && !node.current.contains(e.target as Node)) {
+        e.stopPropagation();
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside, true);
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, []);
 
   return (
     <animated.div

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, Suspense, lazy } from 'react';
+import { useMemo, useState, Suspense, lazy, useCallback } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { Header } from 'franklin-sites';
 
@@ -99,6 +99,8 @@ const UniProtHeader = () => {
       : [{ label: 'Tools', items: tools }, queryBuilderButton, ...restOfItems];
   }, [isHomePage]);
 
+  const handleClose = useCallback(() => setDisplayQueryBuilder(false), []);
+
   return (
     <>
       <Header
@@ -118,8 +120,12 @@ const UniProtHeader = () => {
       />
       {displayQueryBuilder && (
         <Suspense fallback={null}>
-          <SlidingPanel position={Position.left} yScrollable>
-            <QueryBuilder onCancel={() => setDisplayQueryBuilder(false)} />
+          <SlidingPanel
+            position={Position.left}
+            yScrollable
+            onClose={handleClose}
+          >
+            <QueryBuilder onCancel={handleClose} />
           </SlidingPanel>
         </Suspense>
       )}

--- a/src/shared/components/layouts/__tests__/SlidingPanel.spec.tsx
+++ b/src/shared/components/layouts/__tests__/SlidingPanel.spec.tsx
@@ -1,0 +1,34 @@
+import { fireEvent } from '@testing-library/react';
+import renderWithRouter from '../../../__test-helpers__/RenderWithRouter';
+import SlidingPanel, { Position } from '../SlidingPanel';
+
+describe('SlidingPanel', () => {
+  const onClickOutside = jest.fn();
+  let rendered;
+
+  beforeEach(() => {
+    rendered = renderWithRouter(
+      <>
+        <div>outside</div>
+        <SlidingPanel position={Position.right} onClickOutside={onClickOutside}>
+          inside
+        </SlidingPanel>
+      </>
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call onClickOutside when mouse clicks outside', async () => {
+    const outside = rendered.getByText('outside');
+    fireEvent.mouseDown(outside);
+    expect(onClickOutside).toHaveBeenCalled();
+  });
+  test('should not call onClickOutside when mouse clicks inside', async () => {
+    const inside = rendered.getByText('inside');
+    fireEvent.mouseDown(inside);
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/components/layouts/__tests__/SlidingPanel.spec.tsx
+++ b/src/shared/components/layouts/__tests__/SlidingPanel.spec.tsx
@@ -1,34 +1,34 @@
-import { fireEvent } from '@testing-library/react';
-import renderWithRouter from '../../../__test-helpers__/RenderWithRouter';
+import { screen, fireEvent, render, act } from '@testing-library/react';
+
 import SlidingPanel, { Position } from '../SlidingPanel';
 
+import renderWithRouter from '../../../__test-helpers__/RenderWithRouter';
+
 describe('SlidingPanel', () => {
-  const onClickOutside = jest.fn();
-  let rendered;
+  const onClose = jest.fn();
 
   beforeEach(() => {
-    rendered = renderWithRouter(
+    renderWithRouter(
       <>
         <div>outside</div>
-        <SlidingPanel position={Position.right} onClickOutside={onClickOutside}>
+        <SlidingPanel position={Position.right} onClose={onClose}>
           inside
         </SlidingPanel>
       </>
     );
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  afterEach(jest.clearAllMocks);
+
+  test('should call onClose when mouse clicks outside', async () => {
+    const outside = screen.getByText('outside');
+    fireEvent.click(outside);
+    expect(onClose).toHaveBeenCalled();
   });
 
-  test('should call onClickOutside when mouse clicks outside', async () => {
-    const outside = rendered.getByText('outside');
-    fireEvent.mouseDown(outside);
-    expect(onClickOutside).toHaveBeenCalled();
-  });
-  test('should not call onClickOutside when mouse clicks inside', async () => {
-    const inside = rendered.getByText('inside');
-    fireEvent.mouseDown(inside);
-    expect(onClickOutside).not.toHaveBeenCalled();
+  test('should not call onClose when mouse clicks inside', async () => {
+    const inside = screen.getByText('inside');
+    fireEvent.click(inside);
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -64,7 +64,7 @@ const ResultsButtons: FC<{
           <SlidingPanel
             position={Position.left}
             yScrollable
-            onClickOutside={() => setDisplayDownloadPanel(false)}
+            onClose={() => setDisplayDownloadPanel(false)}
           >
             <DownloadComponent
               query={query}
@@ -84,7 +84,7 @@ const ResultsButtons: FC<{
           <SlidingPanel
             position={Position.left}
             yScrollable
-            onClickOutside={() => setDisplayCustomisePanel(false)}
+            onClose={() => setDisplayCustomisePanel(false)}
           >
             <CustomiseComponent
               selectedColumns={tableColumns}

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -61,7 +61,11 @@ const ResultsButtons: FC<{
     <>
       {displayDownloadPanel && (
         <Suspense fallback>
-          <SlidingPanel position={Position.left} yScrollable>
+          <SlidingPanel
+            position={Position.left}
+            yScrollable
+            onClickOutside={() => setDisplayDownloadPanel(false)}
+          >
             <DownloadComponent
               query={query}
               selectedFacets={selectedFacets}
@@ -77,7 +81,11 @@ const ResultsButtons: FC<{
       )}
       {displayCustomisePanel && (
         <Suspense fallback>
-          <SlidingPanel position={Position.left} yScrollable>
+          <SlidingPanel
+            position={Position.left}
+            yScrollable
+            onClickOutside={() => setDisplayCustomisePanel(false)}
+          >
             <CustomiseComponent
               selectedColumns={tableColumns}
               onSave={(columns: Column[]) => {

--- a/src/tools/blast/components/results/HSPDetailPanel.tsx
+++ b/src/tools/blast/components/results/HSPDetailPanel.tsx
@@ -136,7 +136,7 @@ const HSPDetailPanel: FC<HSPDetailPanelProps> = ({
     <SlidingPanel
       position={Position.bottom}
       className={containerClass}
-      onClickOutside={onClose}
+      onClose={onClose}
     >
       {content}
     </SlidingPanel>

--- a/src/tools/blast/components/results/HSPDetailPanel.tsx
+++ b/src/tools/blast/components/results/HSPDetailPanel.tsx
@@ -133,7 +133,11 @@ const HSPDetailPanel: FC<HSPDetailPanelProps> = ({
   }
 
   return (
-    <SlidingPanel position={Position.bottom} className={containerClass}>
+    <SlidingPanel
+      position={Position.bottom}
+      className={containerClass}
+      onClickOutside={onClose}
+    >
       {content}
     </SlidingPanel>
   );

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -126,7 +126,7 @@ const ResultButtons: FC<ResultButtonsProps<JobTypes>> = ({
         <Suspense fallback={null}>
           <SlidingPanel
             position={Position.left}
-            onClickOutside={() => setDisplayDownloadPanel(false)}
+            onClose={() => setDisplayDownloadPanel(false)}
           >
             <ResultDownload
               jobType={jobType}

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -124,7 +124,10 @@ const ResultButtons: FC<ResultButtonsProps<JobTypes>> = ({
     <>
       {displayDownloadPanel && (
         <Suspense fallback={null}>
-          <SlidingPanel position={Position.left}>
+          <SlidingPanel
+            position={Position.left}
+            onClickOutside={() => setDisplayDownloadPanel(false)}
+          >
             <ResultDownload
               jobType={jobType}
               id={jobId}


### PR DESCRIPTION
## Purpose
[Close sliding panel when user clicks outside.](https://www.ebi.ac.uk/panda/jira/browse/TRM-25265)


## Approach
* Inside of SlidingPanel added a listener to the body for mouse down events and calls the prop onClickOutside if the target is outside.
* Updated instances of SlidingPanel in the codebase to use this behaviour.

## Testing
* Click outside of the component
* Click inside of the component

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
