### PR TITLE
Fix result view switching

### DIFF
--- a/src/shared/hooks/__tests__/useLocalStorage.spec.ts
+++ b/src/shared/hooks/__tests__/useLocalStorage.spec.ts
@@ -1,13 +1,6 @@
-import { renderHook, cleanup, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import useLocalStorage from '../useLocalStorage';
-
-const url = '/some/path';
-const url2 = '/some/other/path';
-
-afterAll(() => {
-  cleanup();
-});
 
 describe('useLocalStorage hook', () => {
   test('get value, basic', () => {
@@ -20,7 +13,7 @@ describe('useLocalStorage hook', () => {
 
   test('set value, basic', () => {
     const { result } = renderHook(() =>
-      useLocalStorage('key', 'default value')
+      useLocalStorage<string>('key', 'default value')
     );
 
     act(() => result.current[1]('other value'));
@@ -28,9 +21,21 @@ describe('useLocalStorage hook', () => {
     expect(result.current[0]).toEqual('other value');
   });
 
+  test('set value, through function of current value', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage<string>('key', 'default value')
+    );
+
+    act(() =>
+      result.current[1]((currentValue) => `"${currentValue.toUpperCase()}!"`)
+    );
+
+    expect(result.current[0]).toEqual('"OTHER VALUE!"');
+  });
+
   test('set value, types', () => {
     const { result } = renderHook(() =>
-      useLocalStorage('key', 'default value')
+      useLocalStorage<any>('key', 'default value')
     );
 
     act(() => result.current[1](0));
@@ -48,7 +53,7 @@ describe('useLocalStorage hook', () => {
 
   test('set/get value, accross instances', async () => {
     const { result: instance1 } = renderHook(() =>
-      useLocalStorage('key', 'default value')
+      useLocalStorage<any>('key', 'default value')
     );
 
     act(() => instance1.current[1]([1, 2, 3, 4]));
@@ -56,7 +61,7 @@ describe('useLocalStorage hook', () => {
     expect(localStorage.getItem('key')).toBe(JSON.stringify([1, 2, 3, 4]));
 
     const { result: instance2 } = renderHook(() =>
-      useLocalStorage('key', 'other default value')
+      useLocalStorage<any>('key', 'other default value')
     );
 
     expect(instance2.current[0]).toEqual([1, 2, 3, 4]);
@@ -64,7 +69,7 @@ describe('useLocalStorage hook', () => {
 
   test('unset value, reset to default', async () => {
     const { result } = renderHook(() =>
-      useLocalStorage('key', 'default value')
+      useLocalStorage<any>('key', 'default value')
     );
 
     act(() => result.current[1]('value'));
@@ -75,5 +80,20 @@ describe('useLocalStorage hook', () => {
 
     expect(result.current[0]).toEqual(null);
     expect(localStorage.getItem('key')).toBe(null);
+  });
+
+  test('get value, change key for same hook', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useLocalStorage(props.key, props.initialValue),
+      {
+        initialProps: { key: 'key-1', initialValue: 'default value for key 1' },
+      }
+    );
+
+    expect(result.current[0]).toEqual('default value for key 1');
+
+    rerender({ key: 'key-2', initialValue: 'default value for key 2' });
+
+    expect(result.current[0]).toBe('default value for key 2');
   });
 });


### PR DESCRIPTION
## Purpose
Fix different issues when, in a search page, switching the namespace and doing a new search

## Approach
Fix `useLocalStorage` to change the returned value when the key is changed

## Testing
Updated existing tests and added new test for `useLocalStorage`

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
