### PR TITLE
add card renderer for UniParc and generalise card code

### DIFF
--- a/src/shared/components/results/ResultsView.tsx
+++ b/src/shared/components/results/ResultsView.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useRef, useMemo, FC } from 'react';
 import { DataTable, DataList, Loader } from 'franklin-sites';
 import { useHistory, useLocation, generatePath } from 'react-router-dom';
 
+// card renderers for card views
 import UniProtKBCard from '../../../uniprotkb/components/results/UniProtKBCard';
 import UniRefCard from '../../../uniref/components/results/UniRefCard';
+import UniParcCard from '../../../uniparc/components/results/UniParcCard';
 
 import uniProtKbConverter, {
   UniProtkbAPIModel,
@@ -12,6 +14,7 @@ import { UniRefLiteAPIModel } from '../../../uniref/adapters/uniRefConverter';
 import { UniParcAPIModel } from '../../../uniparc/adapters/uniParcConverter';
 
 import { getAPIQueryUrl } from '../../config/apiUrls';
+// columns for table views
 import UniProtKBColumnConfiguration from '../../../uniprotkb/config/UniProtKBColumnConfiguration';
 import UniRefColumnConfiguration from '../../../uniref/config/UniRefColumnConfiguration';
 import UniParcColumnConfiguration from '../../../uniparc/config/UniParcColumnConfiguration';
@@ -103,15 +106,15 @@ const cardRenderer = (
         />
       );
     }
-    // case Namespace.uniparc: {
-    //   return (cardData: UniParcAPIModel) => (
-    //     <UniParcCard
-    //       data={cardData}
-    //       selected={selectedEntries.includes(getIdKey(cardData))}
-    //       handleEntrySelection={handleEntrySelection}
-    //     />
-    //   );
-    // }
+    case Namespace.uniparc: {
+      return (cardData: UniParcAPIModel) => (
+        <UniParcCard
+          data={cardData}
+          selected={selectedEntries.includes(getIdKey(cardData))}
+          handleEntrySelection={handleEntrySelection}
+        />
+      );
+    }
     default:
       return () => (
         <div className="warning">{`${namespace} has no card renderer yet`}</div>

--- a/src/shared/components/results/__tests__/__snapshots__/ResultsView.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsView.spec.tsx.snap
@@ -18,10 +18,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -29,7 +29,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -160,10 +160,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -171,7 +171,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -302,10 +302,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -313,7 +313,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -460,10 +460,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -471,7 +471,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -602,10 +602,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -613,7 +613,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -724,10 +724,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -735,7 +735,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -866,10 +866,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -877,7 +877,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -996,10 +996,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1007,7 +1007,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1105,10 +1105,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1116,7 +1116,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1214,10 +1214,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1225,7 +1225,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1316,10 +1316,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1327,7 +1327,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1470,10 +1470,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1481,7 +1481,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1580,10 +1580,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1591,7 +1591,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1750,10 +1750,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1761,7 +1761,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1884,10 +1884,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -1895,7 +1895,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -1994,10 +1994,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2005,7 +2005,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2152,10 +2152,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2163,7 +2163,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2294,10 +2294,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2305,7 +2305,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2452,10 +2452,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2463,7 +2463,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2594,10 +2594,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2605,7 +2605,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2712,10 +2712,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2723,7 +2723,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -2854,10 +2854,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -2865,7 +2865,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -3012,10 +3012,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -3023,7 +3023,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -3102,10 +3102,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -3113,7 +3113,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span
@@ -3244,10 +3244,10 @@ exports[`ResultsView component should render cards 1`] = `
             class="card__content"
           >
             <section
-              class="uniprot-card"
+              class="result-card"
             >
               <section
-                class="uniprot-card__left"
+                class="result-card__left"
               >
                 <input
                   data-testid="up-card-checkbox"
@@ -3255,7 +3255,7 @@ exports[`ResultsView component should render cards 1`] = `
                 />
               </section>
               <section
-                class="uniprot-card__right"
+                class="result-card__right"
               >
                 <h5>
                   <span

--- a/src/shared/components/results/styles/result-card.scss
+++ b/src/shared/components/results/styles/result-card.scss
@@ -1,11 +1,17 @@
-.uniprot-card {
+.result-card {
   display: flex;
+
   &__left {
     padding: 0.2rem;
   }
+
   &__right {
     h5 {
       margin: 0;
     }
+  }
+
+  &__info-bit {
+    white-space: nowrap;
   }
 }

--- a/src/uniparc/components/results/UniParcCard.tsx
+++ b/src/uniparc/components/results/UniParcCard.tsx
@@ -1,0 +1,102 @@
+import { FC, useCallback, useMemo } from 'react';
+import { Card, LongNumber } from 'franklin-sites';
+import { useHistory, generatePath } from 'react-router-dom';
+
+import EntryTitle from '../../../shared/components/entry/EntryTitle';
+
+import UniParcColumnConfiguration, {
+  UniParcColumn,
+} from '../../config/UniParcColumnConfiguration';
+
+import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
+import { Location, LocationToPath } from '../../../app/config/urls';
+
+import { UniParcAPIModel } from '../../adapters/uniParcConverter';
+
+import '../../../shared/components/results/styles/result-card.scss';
+
+const firstSeen = UniParcColumnConfiguration.get(UniParcColumn.firstSeen)
+  ?.render;
+const lastSeen = UniParcColumnConfiguration.get(UniParcColumn.lastSeen)?.render;
+
+const uniProtKBCounter = (data: UniParcAPIModel) => {
+  let reviewed = 0;
+  let unreviewed = 0;
+  for (const xref of data.uniParcCrossReferences || []) {
+    if (xref.database.includes('UniProtKB/Swiss-Prot')) {
+      reviewed += 1;
+    } else if (xref.database.includes('UniProtKB/TrEMBL')) {
+      unreviewed += 1;
+    }
+  }
+  return { reviewed, unreviewed };
+};
+
+const UniRefCard: FC<{
+  data: UniParcAPIModel;
+  selected?: boolean;
+  handleEntrySelection: (rowId: string) => void;
+}> = ({ data, selected, handleEntrySelection }): JSX.Element => {
+  const history = useHistory();
+
+  const handleCardClick = useCallback(() => {
+    history.push(
+      generatePath(LocationToPath[Location.UniParcEntry], {
+        accession: data.uniParcId,
+      })
+    );
+  }, [history, data.uniParcId]);
+
+  const organismCount = data.taxonomies.length;
+  const uniProtKBCount = useMemo(() => uniProtKBCounter(data), [data]);
+
+  return (
+    <Card onClick={handleCardClick}>
+      <section className="result-card">
+        <section className="result-card__left">
+          <input
+            type="checkbox"
+            checked={selected}
+            onClick={(e) => e.stopPropagation()}
+            onChange={() => handleEntrySelection(data.uniParcId)}
+            data-testid="up-card-checkbox"
+          />
+        </section>
+        <section className="result-card__right">
+          <h5>
+            <EntryTitle
+              mainTitle={data.uniParcId}
+              entryType={EntryType.UNIPARC}
+            />
+          </h5>
+          <section>
+            <span className="result-card__info-bit">
+              Organism{organismCount === 1 ? '' : 's'}:{' '}
+              <LongNumber>{organismCount}</LongNumber>
+            </span>
+            {' · '}
+            <span className="result-card__info-bit">
+              UniprotKB entries: {uniProtKBCount.reviewed} reviewed and{' '}
+              <LongNumber>{uniProtKBCount.unreviewed}</LongNumber> unreviewed
+            </span>
+          </section>
+          <section>
+            <span className="result-card__info-bit">
+              First seen: {firstSeen?.(data)}
+            </span>
+            {' · '}
+            <span className="result-card__info-bit">
+              Last seen: {lastSeen?.(data)}
+            </span>
+            {' · '}
+            <span className="result-card__info-bit">
+              Sequence length: <LongNumber>{data.sequence.length}</LongNumber>
+            </span>
+          </section>
+        </section>
+      </section>
+    </Card>
+  );
+};
+
+export default UniRefCard;

--- a/src/uniparc/components/results/__tests__/UniParcCard.spec.tsx
+++ b/src/uniparc/components/results/__tests__/UniParcCard.spec.tsx
@@ -1,0 +1,16 @@
+import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
+import UniParcCard from '../UniParcCard';
+import data from '../../../__mocks__/entryModelData.json';
+import { UniParcAPIModel } from '../../../adapters/uniParcConverter';
+
+describe('UniRefCard tests', () => {
+  it('should render and match snapshot', () => {
+    const { asFragment } = renderWithRouter(
+      <UniParcCard
+        data={data as UniParcAPIModel}
+        handleEntrySelection={() => {}}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/uniparc/components/results/__tests__/__snapshots__/UniParcCard.spec.tsx.snap
+++ b/src/uniparc/components/results/__tests__/__snapshots__/UniParcCard.spec.tsx.snap
@@ -32,34 +32,54 @@ exports[`UniRefCard tests should render and match snapshot 1`] = `
                 class="entry-title"
               >
                 <span
-                  class="entry-title__status icon--unreviewed"
-                  title="This marks an unreviewed UniProtKB entry"
+                  class="entry-title__status icon--uniparc"
+                  title="This marks a UniParc entry"
                 >
                   <test-file-stub />
                 </span>
-                UniRef100_B2R6V2
+                UPI0000000001
               </span>
             </h5>
             <section>
-              Cluster: cDNA, FLJ93132, highly similar to Homo sapiens CDC7 cell division cycle 7 (S. cerevisiae) (CDC7), mRNA
-            </section>
-            <section>
-              <strong
-                class="result-card__info-bit"
-              >
-                Members: 1
-              </strong>
-               · 
               <span
                 class="result-card__info-bit"
               >
-                Sequence length: 574
+                Organisms: 6
               </span>
                · 
               <span
                 class="result-card__info-bit"
               >
-                Identity: UniRef100
+                UniprotKB entries: 2 reviewed and 6 unreviewed
+              </span>
+            </section>
+            <section>
+              <span
+                class="result-card__info-bit"
+              >
+                First seen: 
+                <time
+                  datetime="1988-11-01T00:00:00.000Z"
+                >
+                  1988-11-01
+                </time>
+              </span>
+               · 
+              <span
+                class="result-card__info-bit"
+              >
+                Last seen: 
+                <time
+                  datetime="2020-12-02T00:00:00.000Z"
+                >
+                  2020-12-02
+                </time>
+              </span>
+               · 
+              <span
+                class="result-card__info-bit"
+              >
+                Sequence length: 250
               </span>
             </section>
           </section>

--- a/src/uniprotkb/components/results/UniProtKBCard.tsx
+++ b/src/uniprotkb/components/results/UniProtKBCard.tsx
@@ -13,11 +13,11 @@ import KeywordCategory from '../../types/keywordCategory';
 
 import { UniProtkbAPIModel } from '../../adapters/uniProtkbConverter';
 
-import './styles/uniprot-card.scss';
+import '../../../shared/components/results/styles/result-card.scss';
 
 const UniProtKBCard: FC<{
   data: UniProtkbAPIModel;
-  selected: boolean;
+  selected?: boolean;
   handleEntrySelection: (rowId: string) => void;
 }> = ({ data, selected, handleEntrySelection }): JSX.Element => {
   const history = useHistory();
@@ -52,8 +52,8 @@ const UniProtKBCard: FC<{
 
   return (
     <Card links={highlights} onClick={handleCardClick}>
-      <section className="uniprot-card">
-        <section className="uniprot-card__left">
+      <section className="result-card">
+        <section className="result-card__left">
           <input
             type="checkbox"
             checked={selected}
@@ -62,7 +62,7 @@ const UniProtKBCard: FC<{
             data-testid="up-card-checkbox"
           />
         </section>
-        <section className="uniprot-card__right">
+        <section className="result-card__right">
           <h5>
             <EntryTitle
               mainTitle={data.primaryAccession}

--- a/src/uniprotkb/components/results/__tests__/UniProtKBCard.spec.tsx
+++ b/src/uniprotkb/components/results/__tests__/UniProtKBCard.spec.tsx
@@ -1,33 +1,35 @@
-import { render, fireEvent } from '@testing-library/react';
-import { MemoryRouter as Router } from 'react-router-dom';
+import { screen, fireEvent } from '@testing-library/react';
+
 import UniProtKBCard from '../UniProtKBCard';
+
+import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
+
+import { UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
+
 import data from '../../../__mocks__/entryModelData.json';
 
 const handleEntrySelection = jest.fn();
 
-let item;
+let rendered;
 
 describe('UniProtKBCard component', () => {
   beforeEach(() => {
-    item = render(
-      <Router>
-        <UniProtKBCard
-          data={data}
-          selectedEntries={{}}
-          handleEntrySelection={handleEntrySelection}
-        />
-      </Router>
+    rendered = renderWithRouter(
+      <UniProtKBCard
+        // TODO: check mock data to see if it fits model, something's off...
+        data={data as UniProtkbAPIModel}
+        handleEntrySelection={handleEntrySelection}
+      />
     );
   });
 
   test('should render', () => {
-    const { asFragment } = item;
+    const { asFragment } = rendered;
     expect(asFragment()).toMatchSnapshot();
   });
 
   test('should select a row', () => {
-    const { getByTestId } = item;
-    const checkbox = getByTestId('up-card-checkbox');
+    const checkbox = screen.getByTestId('up-card-checkbox');
     fireEvent.click(checkbox);
     expect(handleEntrySelection).toHaveBeenCalled();
   });

--- a/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
+++ b/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
@@ -14,10 +14,10 @@ exports[`UniProtKBCard component should render 1`] = `
         class="card__content"
       >
         <section
-          class="uniprot-card"
+          class="result-card"
         >
           <section
-            class="uniprot-card__left"
+            class="result-card__left"
           >
             <input
               data-testid="up-card-checkbox"
@@ -25,7 +25,7 @@ exports[`UniProtKBCard component should render 1`] = `
             />
           </section>
           <section
-            class="uniprot-card__right"
+            class="result-card__right"
           >
             <h5>
               <span

--- a/src/uniref/components/results/UniRefCard.tsx
+++ b/src/uniref/components/results/UniRefCard.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback } from 'react';
-import { Card } from 'franklin-sites';
+import { Card, LongNumber } from 'franklin-sites';
 import { useHistory, generatePath } from 'react-router-dom';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
@@ -8,11 +8,11 @@ import { Location, LocationToPath } from '../../../app/config/urls';
 
 import { UniRefLiteAPIModel } from '../../adapters/uniRefConverter';
 
-import '../../../uniprotkb/components/results/styles/uniprot-card.scss';
+import '../../../shared/components/results/styles/result-card.scss';
 
 const UniRefCard: FC<{
   data: UniRefLiteAPIModel;
-  selected: boolean;
+  selected?: boolean;
   handleEntrySelection: (rowId: string) => void;
 }> = ({ data, selected, handleEntrySelection }): JSX.Element => {
   const history = useHistory();
@@ -25,8 +25,8 @@ const UniRefCard: FC<{
 
   return (
     <Card onClick={handleCardClick}>
-      <section className="uniprot-card">
-        <section className="uniprot-card__left">
+      <section className="result-card">
+        <section className="result-card__left">
           <input
             type="checkbox"
             checked={selected}
@@ -35,15 +35,23 @@ const UniRefCard: FC<{
             data-testid="up-card-checkbox"
           />
         </section>
-        <section className="uniprot-card__right">
+        <section className="result-card__right">
           <h5>
             <EntryTitle mainTitle={data.id} entryType={data.memberIdTypes} />
           </h5>
           <section>{data.name}</section>
           <section>
-            <strong>Members: {data.memberCount}</strong>
-            {' · '} Sequence length: {data.sequenceLength} {' · '} Identity:{' '}
-            {data.entryType}
+            <strong className="result-card__info-bit">
+              Members: {data.memberCount}
+            </strong>
+            {' · '}
+            <span className="result-card__info-bit">
+              Sequence length: <LongNumber>{data.sequenceLength}</LongNumber>
+            </span>
+            {' · '}
+            <span className="result-card__info-bit">
+              Identity: {data.entryType}
+            </span>
           </section>
         </section>
       </section>

--- a/src/uniref/components/results/__tests__/UniRefCard.spec.tsx
+++ b/src/uniref/components/results/__tests__/UniRefCard.spec.tsx
@@ -1,11 +1,21 @@
 import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
+
 import UniRefCard from '../UniRefCard';
+
+import { UniRefLiteAPIModel } from '../../../adapters/uniRefConverter';
+
 import data from '../../../__mocks__/UniRefResultsData.json';
 
 describe('UniRefCard tests', () => {
   it('should render and match snapshot', () => {
     const row = data.results[0];
-    const { asFragment } = renderWithRouter(<UniRefCard data={row} />);
+    const { asFragment } = renderWithRouter(
+      <UniRefCard
+        // TODO: check mock data to see if it fits model, something's off...
+        data={row as UniRefLiteAPIModel}
+        handleEntrySelection={() => {}}
+      />
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Purpose
Create a UniParc card renderer for the result page

## Approach
New renderer code, and generalise code for other namespace card renderers

## Testing
Updated tests for generalised code, and added specific snapshot testing for UniParc card renderer

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
