### PR TITLE
2021 01 similar proteins

### DIFF
--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -328,3 +328,11 @@ export const getPublicationsURL = (ids: string[]) =>
 
 export const getProteinsApiUrl = (accession: string) =>
   `https://www.ebi.ac.uk/proteins/api/proteins/${accession}`;
+
+export const getClustersForProteins = (accessions: string[]) =>
+  joinUrl(
+    devPrefix,
+    `/uniprot/api/uniref/search?query=(${accessions
+      .map((accession) => `uniprot_id:${accession}`)
+      .join(' OR ')})`
+  );

--- a/src/uniprotkb/adapters/__tests__/extractIsoformsConverter.spec.ts
+++ b/src/uniprotkb/adapters/__tests__/extractIsoformsConverter.spec.ts
@@ -1,0 +1,9 @@
+import modelData from '../../__mocks__/entryModelData.json';
+import extractIsoforms from '../extractIsoformsConverter';
+
+describe('Accessions data converter', () => {
+  test('should extract all accessions', () => {
+    const isoformData = extractIsoforms(modelData);
+    expect(isoformData).toStrictEqual({ isoforms: ['isoID1'] });
+  });
+});

--- a/src/uniprotkb/adapters/allAccessionsConverter.ts
+++ b/src/uniprotkb/adapters/allAccessionsConverter.ts
@@ -1,0 +1,14 @@
+import { AlternativeProductsComment, CommentType } from '../types/commentTypes';
+import { UniProtkbAPIModel } from './uniProtkbConverter';
+
+const convertAllAccessions = (data: UniProtkbAPIModel) => {
+  const alternativeProducts = data.comments?.find(
+    (comment) => comment.commentType === CommentType.ALTERNATIVE_PRODUCTS
+  ) as AlternativeProductsComment;
+  const isoforms = alternativeProducts.isoforms
+    .map((isoform) => isoform.isoformIds.map((isoformId) => isoformId))
+    .flat();
+  return { isoforms };
+};
+
+export default convertAllAccessions;

--- a/src/uniprotkb/adapters/allAccessionsConverter.ts
+++ b/src/uniprotkb/adapters/allAccessionsConverter.ts
@@ -5,10 +5,10 @@ const convertAllAccessions = (data: UniProtkbAPIModel) => {
   const alternativeProducts = data.comments?.find(
     (comment) => comment.commentType === CommentType.ALTERNATIVE_PRODUCTS
   ) as AlternativeProductsComment;
-  const isoforms = alternativeProducts.isoforms
+  const isoforms = alternativeProducts?.isoforms
     .map((isoform) => isoform.isoformIds.map((isoformId) => isoformId))
     .flat();
-  return { isoforms };
+  return { isoforms: isoforms || [] };
 };
 
 export default convertAllAccessions;

--- a/src/uniprotkb/adapters/extractIsoformsConverter.ts
+++ b/src/uniprotkb/adapters/extractIsoformsConverter.ts
@@ -1,7 +1,7 @@
 import { AlternativeProductsComment, CommentType } from '../types/commentTypes';
 import { UniProtkbAPIModel } from './uniProtkbConverter';
 
-const convertAllAccessions = (data: UniProtkbAPIModel) => {
+const extractIsoforms = (data: UniProtkbAPIModel) => {
   const alternativeProducts = data.comments?.find(
     (comment) => comment.commentType === CommentType.ALTERNATIVE_PRODUCTS
   ) as AlternativeProductsComment;
@@ -11,4 +11,4 @@ const convertAllAccessions = (data: UniProtkbAPIModel) => {
   return { isoforms: isoforms || [] };
 };
 
-export default convertAllAccessions;
+export default extractIsoforms;

--- a/src/uniprotkb/adapters/uniProtkbConverter.ts
+++ b/src/uniprotkb/adapters/uniProtkbConverter.ts
@@ -29,6 +29,8 @@ import Comment, { Xref } from '../types/commentTypes';
 import { transfromProperties } from '../utils';
 import { Property } from '../types/modelTypes';
 import { Reference } from '../types/literatureTypes';
+import convertAllAccessions from './allAccessionsConverter';
+import { XrefUIModel } from '../utils/xrefUtils';
 
 export enum EntryType {
   REVIEWED,
@@ -96,6 +98,10 @@ export type UniProtkbUIModel = {
   [EntrySection.Structure]: UIModel;
   [EntrySection.FamilyAndDomains]: UIModel;
   [EntrySection.ExternalLinks]: UIModel;
+  [EntrySection.SimilarProteins]: {
+    isoforms: string[];
+    xrefData?: XrefUIModel[]; // Dummy, not used
+  };
   references?: Reference[];
   extraAttributes: UniProtkbAPIModel['extraAttributes'];
 };
@@ -146,6 +152,7 @@ const uniProtKbConverter = (data: UniProtkbAPIModel): UniProtkbUIModel => {
     [EntrySection.Sequence]: convertSequence(dataCopy),
     [EntrySection.FamilyAndDomains]: convertFamilyAndDomains(dataCopy),
     [EntrySection.ExternalLinks]: convertExternalLinks(dataCopy),
+    [EntrySection.SimilarProteins]: convertAllAccessions(dataCopy),
     references: dataCopy.references || [],
     extraAttributes: data.extraAttributes,
   };

--- a/src/uniprotkb/adapters/uniProtkbConverter.ts
+++ b/src/uniprotkb/adapters/uniProtkbConverter.ts
@@ -29,7 +29,7 @@ import Comment, { Xref } from '../types/commentTypes';
 import { transfromProperties } from '../utils';
 import { Property } from '../types/modelTypes';
 import { Reference } from '../types/literatureTypes';
-import convertAllAccessions from './allAccessionsConverter';
+import extractIsoforms from './extractIsoformsConverter';
 import { XrefUIModel } from '../utils/xrefUtils';
 
 export enum EntryType {
@@ -152,7 +152,7 @@ const uniProtKbConverter = (data: UniProtkbAPIModel): UniProtkbUIModel => {
     [EntrySection.Sequence]: convertSequence(dataCopy),
     [EntrySection.FamilyAndDomains]: convertFamilyAndDomains(dataCopy),
     [EntrySection.ExternalLinks]: convertExternalLinks(dataCopy),
-    [EntrySection.SimilarProteins]: convertAllAccessions(dataCopy),
+    [EntrySection.SimilarProteins]: extractIsoforms(dataCopy),
     references: dataCopy.references || [],
     extraAttributes: data.extraAttributes,
   };

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -115,13 +115,21 @@ const Entry: FC = () => {
           taxId,
           numberOfIsoforms
         );
+        let disabled = true;
+        switch (nameAndId.id) {
+          case EntrySection.ExternalLinks:
+            disabled = !hasExternalLinks(transformedData);
+            break;
+          case EntrySection.SimilarProteins:
+            disabled = false;
+            break;
+          default:
+            disabled = !hasContent(transformedData[nameAndId.id]);
+        }
         return {
           label: nameAndId.name,
           id: nameAndId.id,
-          disabled:
-            nameAndId.id === EntrySection.ExternalLinks
-              ? !hasExternalLinks(transformedData)
-              : !hasContent(transformedData[nameAndId.id]),
+          disabled,
         };
       });
     }

--- a/src/uniprotkb/components/entry/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/SimilarProteins.tsx
@@ -1,10 +1,14 @@
 import { Loader, Message, Tabs, Tab, Card, Button } from 'franklin-sites';
 import { FC, useMemo } from 'react';
-import { groupBy } from 'lodash-es';
+import { groupBy, sortBy } from 'lodash-es';
 import { generatePath, Link } from 'react-router-dom';
 import { getClustersForProteins } from '../../../shared/config/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
-import { UniRefLiteAPIModel } from '../../../uniref/adapters/uniRefConverter';
+import {
+  UniRefEntryType,
+  UniRefEntryTypeToPercent,
+  UniRefLiteAPIModel,
+} from '../../../uniref/adapters/uniRefConverter';
 import EntrySection, {
   getEntrySectionNameAndId,
 } from '../../types/entrySection';
@@ -27,8 +31,9 @@ const SimilarProteins: FC<{
       const { results } = data;
       // Remove all items with only 1 member as it will be canonical/isoform
       const filtered = results.filter((item) => item.members.length > 1);
+      const ordered = sortBy(filtered, 'entryType');
 
-      const clusterTypeGroups = groupBy(filtered, 'entryType');
+      const clusterTypeGroups = groupBy(ordered, 'entryType');
       // Note: thought we could use Dictionary<T> here but lodash doesn't
       // seem to export it
       const allClusterTypesGroups: {
@@ -64,7 +69,13 @@ const SimilarProteins: FC<{
       <Card title={nameAndId.name}>
         <Tabs>
           {Object.keys(clusterData).map((clusterType) => (
-            <Tab id={clusterType} title={clusterType} key={clusterType}>
+            <Tab
+              id={clusterType}
+              title={`${
+                UniRefEntryTypeToPercent[clusterType as UniRefEntryType]
+              } identity`}
+              key={clusterType}
+            >
               {Object.keys(clusterData[clusterType]).map((representativeId) => (
                 <section key={representativeId} className="text-block">
                   <h4>{representativeId}</h4>

--- a/src/uniprotkb/components/entry/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/SimilarProteins.tsx
@@ -1,6 +1,6 @@
 import { Loader, Message, Tabs, Tab, Card, Button } from 'franklin-sites';
 import { FC, useMemo } from 'react';
-import { groupBy, sortBy } from 'lodash-es';
+import { groupBy } from 'lodash-es';
 import { generatePath, Link } from 'react-router-dom';
 import { getClustersForProteins } from '../../../shared/config/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
@@ -31,9 +31,8 @@ const SimilarProteins: FC<{
       const { results } = data;
       // Remove all items with only 1 member as it will be canonical/isoform
       const filtered = results.filter((item) => item.members.length > 1);
-      const ordered = sortBy(filtered, 'entryType');
 
-      const clusterTypeGroups = groupBy(ordered, 'entryType');
+      const clusterTypeGroups = groupBy(filtered, 'entryType');
       // Note: thought we could use Dictionary<T> here but lodash doesn't
       // seem to export it
       const allClusterTypesGroups: {
@@ -68,7 +67,7 @@ const SimilarProteins: FC<{
     <div id={EntrySection.SimilarProteins}>
       <Card title={nameAndId.name}>
         <Tabs>
-          {Object.keys(clusterData).map((clusterType) => (
+          {Object.values(UniRefEntryType).map((clusterType) => (
             <Tab
               id={clusterType}
               title={`${

--- a/src/uniprotkb/components/entry/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/SimilarProteins.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+// import { Tabs } from 'franklin-sites';
+import { getClustersForProteins } from '../../../shared/config/apiUrls';
+import useDataApi from '../../../shared/hooks/useDataApi';
+
+const SimilarProteins: FC<{
+  isoforms: { isoforms: string[] };
+  primaryAccession: string;
+}> = ({ isoforms, primaryAccession }) => {
+  const searchUrl = getClustersForProteins([
+    primaryAccession,
+    ...isoforms.isoforms,
+  ]);
+  const { loading, data, error } = useDataApi(searchUrl);
+  console.log(data);
+
+  return <></>;
+};
+
+export default SimilarProteins;

--- a/src/uniprotkb/components/entry/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/SimilarProteins.tsx
@@ -26,6 +26,7 @@ const SimilarProteins: FC<{
   const { loading, data, error } = useDataApi<{
     results: UniRefLiteAPIModel[];
   }>(searchUrl);
+
   const clusterData = useMemo(() => {
     if (data) {
       const { results } = data;
@@ -67,63 +68,74 @@ const SimilarProteins: FC<{
     <div id={EntrySection.SimilarProteins}>
       <Card title={nameAndId.name}>
         <Tabs>
-          {Object.values(UniRefEntryType).map((clusterType) => (
-            <Tab
-              id={clusterType}
-              title={`${
-                UniRefEntryTypeToPercent[clusterType as UniRefEntryType]
-              } identity`}
-              key={clusterType}
-            >
-              {Object.keys(clusterData[clusterType]).map((representativeId) => (
-                <section key={representativeId} className="text-block">
-                  <h4>{representativeId}</h4>
-                  {clusterData[clusterType][representativeId].map((row) => (
-                    <section key={row.id}>
-                      <h5>
-                        <Link
-                          to={generatePath(
-                            LocationToPath[Location.UniRefEntry],
-                            {
-                              accession: row.id,
-                            }
-                          )}
-                        >
-                          {row.id}
-                        </Link>
-                      </h5>
-                      <ul className="no-bullet">
-                        {/* Note: move following to its own component  */}
-                        {row.members
-                          ?.filter((member) => member !== representativeId)
-                          .map((member) => (
-                            <li key={member}>
-                              <Link
-                                to={generatePath(
-                                  LocationToPath[Location.UniProtKBEntry],
-                                  {
-                                    accession: member,
-                                  }
-                                )}
-                              >
-                                {member}
-                              </Link>
-                            </li>
-                          ))}
-                        {row.members &&
-                          row.memberCount > row.members?.length && (
-                            <li>{row.memberCount} more</li>
-                          )}
-                      </ul>
-                    </section>
-                  ))}
-                  <hr />
-                </section>
-              ))}
-              {/* TODO: check with backend what query should be generated here */}
-              <Button>View all</Button>
-            </Tab>
-          ))}
+          {Object.values(UniRefEntryType).map(
+            (clusterType) =>
+              clusterData[clusterType] && (
+                <Tab
+                  id={clusterType}
+                  title={`${
+                    UniRefEntryTypeToPercent[clusterType as UniRefEntryType]
+                  } identity`}
+                  key={clusterType}
+                >
+                  {Object.keys(clusterData[clusterType]).map(
+                    (representativeId) => (
+                      <section key={representativeId} className="text-block">
+                        <h4>{representativeId}</h4>
+                        {clusterData[clusterType][representativeId].map(
+                          (row) => (
+                            <section key={row.id}>
+                              <h5>
+                                <Link
+                                  to={generatePath(
+                                    LocationToPath[Location.UniRefEntry],
+                                    {
+                                      accession: row.id,
+                                    }
+                                  )}
+                                >
+                                  {row.id}
+                                </Link>
+                              </h5>
+                              <ul className="no-bullet">
+                                {/* Note: move following to its own component  */}
+                                {row.members
+                                  ?.filter(
+                                    (member) => member !== representativeId
+                                  )
+                                  .map((member) => (
+                                    <li key={member}>
+                                      <Link
+                                        to={generatePath(
+                                          LocationToPath[
+                                            Location.UniProtKBEntry
+                                          ],
+                                          {
+                                            accession: member,
+                                          }
+                                        )}
+                                      >
+                                        {member}
+                                      </Link>
+                                    </li>
+                                  ))}
+                                {row.members &&
+                                  row.memberCount > row.members?.length && (
+                                    <li>{row.memberCount} more</li>
+                                  )}
+                              </ul>
+                            </section>
+                          )
+                        )}
+                        <hr />
+                      </section>
+                    )
+                  )}
+                  {/* TODO: check with backend what query should be generated here */}
+                  <Button>View all</Button>
+                </Tab>
+              )
+          )}
         </Tabs>
       </Card>
     </div>

--- a/src/uniprotkb/components/entry/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/SimilarProteins.tsx
@@ -1,7 +1,14 @@
-import { FC } from 'react';
-// import { Tabs } from 'franklin-sites';
+import { Loader, Message, Tabs, Tab, Card, Button } from 'franklin-sites';
+import { FC, useMemo } from 'react';
+import { groupBy } from 'lodash-es';
+import { generatePath, Link } from 'react-router-dom';
 import { getClustersForProteins } from '../../../shared/config/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
+import { UniRefLiteAPIModel } from '../../../uniref/adapters/uniRefConverter';
+import EntrySection, {
+  getEntrySectionNameAndId,
+} from '../../types/entrySection';
+import { Location, LocationToPath } from '../../../app/config/urls';
 
 const SimilarProteins: FC<{
   isoforms: { isoforms: string[] };
@@ -11,10 +18,106 @@ const SimilarProteins: FC<{
     primaryAccession,
     ...isoforms.isoforms,
   ]);
-  const { loading, data, error } = useDataApi(searchUrl);
-  console.log(data);
+  // Get the clusters in which the canonical and isoforms are found
+  const { loading, data, error } = useDataApi<{
+    results: UniRefLiteAPIModel[];
+  }>(searchUrl);
+  const clusterData = useMemo(() => {
+    if (data) {
+      const { results } = data;
+      // Remove all items with only 1 member as it will be canonical/isoform
+      const filtered = results.filter((item) => item.members.length > 1);
 
-  return <></>;
+      const clusterTypeGroups = groupBy(filtered, 'entryType');
+      // Note: thought we could use Dictionary<T> here but lodash doesn't
+      // seem to export it
+      const allClusterTypesGroups: {
+        [key: string]: { [key: string]: UniRefLiteAPIModel[] };
+      } = {};
+      Object.keys(clusterTypeGroups).forEach((key) => {
+        allClusterTypesGroups[key] = groupBy(
+          clusterTypeGroups[key],
+          'representativeId'
+        );
+      });
+      return allClusterTypesGroups;
+    }
+    return null;
+  }, [data]);
+
+  if (loading) {
+    return <Loader />;
+  }
+  if (error) {
+    return <Message level="failure">{error.message}</Message>;
+  }
+  if (!clusterData) {
+    return null;
+  }
+
+  const nameAndId = getEntrySectionNameAndId(EntrySection.SimilarProteins);
+
+  // TODO get extra columns about the cluster members
+
+  return (
+    <div id={EntrySection.SimilarProteins}>
+      <Card title={nameAndId.name}>
+        <Tabs>
+          {Object.keys(clusterData).map((clusterType) => (
+            <Tab id={clusterType} title={clusterType} key={clusterType}>
+              {Object.keys(clusterData[clusterType]).map((representativeId) => (
+                <section key={representativeId} className="text-block">
+                  <h4>{representativeId}</h4>
+                  {clusterData[clusterType][representativeId].map((row) => (
+                    <section key={row.id}>
+                      <h5>
+                        <Link
+                          to={generatePath(
+                            LocationToPath[Location.UniRefEntry],
+                            {
+                              accession: row.id,
+                            }
+                          )}
+                        >
+                          {row.id}
+                        </Link>
+                      </h5>
+                      <ul className="no-bullet">
+                        {/* Note: move following to its own component  */}
+                        {row.members
+                          ?.filter((member) => member !== representativeId)
+                          .map((member) => (
+                            <li key={member}>
+                              <Link
+                                to={generatePath(
+                                  LocationToPath[Location.UniProtKBEntry],
+                                  {
+                                    accession: member,
+                                  }
+                                )}
+                              >
+                                {member}
+                              </Link>
+                            </li>
+                          ))}
+                        {row.members &&
+                          row.memberCount > row.members?.length && (
+                            <li>{row.memberCount} more</li>
+                          )}
+                      </ul>
+                    </section>
+                  ))}
+                  <hr />
+                </section>
+              ))}
+              {/* TODO: check with backend what query should be generated here */}
+              <Button>View all</Button>
+            </Tab>
+          ))}
+        </Tabs>
+      </Card>
+    </div>
+  );
 };
 
 export default SimilarProteins;

--- a/src/uniprotkb/components/entry/__tests__/SimilarProteins.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/SimilarProteins.spec.tsx
@@ -26,12 +26,12 @@ describe('SimilarProteins tests', () => {
   it('should call useDataApi and render', async () => {
     const { findByText } = getRendered();
     expect(useDataApi).toHaveBeenCalled();
-    expect(await findByText(/P12023/)).toBeTruthy();
+    expect(await findByText(/0FGN2/)).toBeTruthy();
   });
 
   it('should change tabs', async () => {
     const { getByText, findByText } = getRendered();
-    fireEvent.click(getByText('UniRef100'));
-    expect(await findByText(/I0FGN2/)).toBeTruthy();
+    fireEvent.click(getByText('50% identity'));
+    expect(await findByText(/P12023/)).toBeTruthy();
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/SimilarProteins.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/SimilarProteins.spec.tsx
@@ -1,0 +1,37 @@
+import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
+import SimilarProteins from '../SimilarProteins';
+import similarProteinsData from './__mocks__/similarProteinsData.json';
+
+jest.mock('../../../../shared/hooks/useDataApi', () => jest.fn());
+import useDataApi from '../../../../shared/hooks/useDataApi';
+import { fireEvent } from '@testing-library/react';
+
+const dataMock = {
+  loading: false,
+  data: similarProteinsData,
+};
+
+const getRendered = () =>
+  renderWithRouter(
+    <SimilarProteins
+      primaryAccession="P05067"
+      isoforms={{ isoforms: ['P05067-4'] }}
+    />
+  );
+describe('SimilarProteins tests', () => {
+  beforeEach(() => {
+    useDataApi.mockImplementation(() => dataMock);
+  });
+
+  it('should call useDataApi and render', async () => {
+    const { findByText } = getRendered();
+    expect(useDataApi).toHaveBeenCalled();
+    expect(await findByText(/P12023/)).toBeTruthy();
+  });
+
+  it('should change tabs', async () => {
+    const { getByText, findByText } = getRendered();
+    fireEvent.click(getByText('UniRef100'));
+    expect(await findByText(/I0FGN2/)).toBeTruthy();
+  });
+});

--- a/src/uniprotkb/components/entry/__tests__/__mocks__/similarProteinsData.json
+++ b/src/uniprotkb/components/entry/__tests__/__mocks__/similarProteinsData.json
@@ -1,0 +1,267 @@
+{
+  "results": [
+    {
+      "id": "UniRef50_P05067",
+      "name": "Cluster: Amyloid-beta precursor protein",
+      "updated": "2020-12-02",
+      "entryType": "UniRef50",
+      "commonTaxonId": 131567,
+      "commonTaxon": "cellular organisms",
+      "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+      "sequenceLength": 770,
+      "memberCount": 1276,
+      "organismCount": 423,
+      "representativeId": "P05067",
+      "seedId": "UPI001386A8D7",
+      "memberIdTypes": [
+        "UniParc",
+        "UniProtKB Reviewed (Swiss-Prot)",
+        "UniProtKB Unreviewed (TrEMBL)"
+      ],
+      "members": [
+        "P05067",
+        "P12023",
+        "Q5IS80",
+        "P08592",
+        "P79307",
+        "Q28053",
+        "Q29149",
+        "Q28748",
+        "Q28757",
+        "Q28280"
+      ],
+      "organismIds": [
+        9606,
+        10090,
+        9598,
+        10116,
+        9823,
+        9913,
+        29073,
+        9986,
+        9940,
+        9615
+      ],
+      "organisms": [
+        "Homo sapiens (Human)",
+        "Mus musculus (Mouse)",
+        "Pan troglodytes (Chimpanzee)",
+        "Rattus norvegicus (Rat)",
+        "Sus scrofa (Pig)",
+        "Bos taurus (Bovine)",
+        "Ursus maritimus (Polar bear) (Thalarctos maritimus)",
+        "Oryctolagus cuniculus (Rabbit)",
+        "Ovis aries (Sheep)",
+        "Canis lupus familiaris (Dog) (Canis familiaris)"
+      ]
+    },
+    {
+      "id": "UniRef100_P05067-4",
+      "name": "Cluster: Isoform APP695 of Amyloid-beta precursor protein",
+      "updated": "2020-08-12",
+      "entryType": "UniRef100",
+      "commonTaxonId": 9526,
+      "commonTaxon": "Catarrhini",
+      "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVRVPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+      "sequenceLength": 695,
+      "memberCount": 17,
+      "organismCount": 12,
+      "representativeId": "P05067-4",
+      "seedId": "I0FGN2",
+      "memberIdTypes": [
+        "UniProtKB Unreviewed (TrEMBL)",
+        "UniProtKB Reviewed (Swiss-Prot)"
+      ],
+      "members": [
+        "P05067-4",
+        "I0FGN2",
+        "A0A2K6QWS0",
+        "A0A2J8UKM8",
+        "A0A2I3SHN1",
+        "A0A6D2X899",
+        "A0A2K5NR37",
+        "A0A2I3MTM7",
+        "A0A2R8ZFN4",
+        "A0A2K5U6B3"
+      ],
+      "organismIds": [
+        9606,
+        9544,
+        61622,
+        9601,
+        9598,
+        9531,
+        9555,
+        9597,
+        9541,
+        61621
+      ],
+      "organisms": [
+        "Homo sapiens (Human)",
+        "Macaca mulatta (Rhesus macaque)",
+        "Rhinopithecus roxellana (Golden snub-nosed monkey) (Pygathrix roxellana)",
+        "Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)",
+        "Pan troglodytes (Chimpanzee)",
+        "Cercocebus atys (Sooty mangabey) (Cercocebus torquatus atys)",
+        "Papio anubis (Olive baboon)",
+        "Pan paniscus (Pygmy chimpanzee) (Bonobo)",
+        "Macaca fascicularis (Crab-eating macaque) (Cynomolgus monkey)",
+        "Rhinopithecus bieti (Black snub-nosed monkey) (Pygathrix bieti)"
+      ]
+    },
+    {
+      "id": "UniRef90_P05067-4",
+      "name": "Cluster: Isoform APP695 of Amyloid-beta precursor protein",
+      "updated": "2020-12-02",
+      "entryType": "UniRef90",
+      "commonTaxonId": 32524,
+      "commonTaxon": "Amniota",
+      "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVRVPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+      "sequenceLength": 695,
+      "memberCount": 129,
+      "organismCount": 111,
+      "representativeId": "P05067-4",
+      "seedId": "UPI001386654F",
+      "memberIdTypes": [
+        "UniParc",
+        "UniProtKB Unreviewed (TrEMBL)",
+        "UniProtKB Reviewed (Swiss-Prot)"
+      ],
+      "members": [
+        "P05067-4",
+        "I0FGN2",
+        "A0A2K6QWS0",
+        "A0A2J8UKM8",
+        "A0A2I3SHN1",
+        "A0A6D2X899",
+        "A0A2K5NR37",
+        "A0A2I3MTM7",
+        "A0A2R8ZFN4",
+        "A0A2K5U6B3"
+      ],
+      "organismIds": [
+        9606,
+        9544,
+        61622,
+        9601,
+        9598,
+        9531,
+        9555,
+        9597,
+        9541,
+        61621
+      ],
+      "organisms": [
+        "Homo sapiens (Human)",
+        "Macaca mulatta (Rhesus macaque)",
+        "Rhinopithecus roxellana (Golden snub-nosed monkey) (Pygathrix roxellana)",
+        "Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)",
+        "Pan troglodytes (Chimpanzee)",
+        "Cercocebus atys (Sooty mangabey) (Cercocebus torquatus atys)",
+        "Papio anubis (Olive baboon)",
+        "Pan paniscus (Pygmy chimpanzee) (Bonobo)",
+        "Macaca fascicularis (Crab-eating macaque) (Cynomolgus monkey)",
+        "Rhinopithecus bieti (Black snub-nosed monkey) (Pygathrix bieti)"
+      ],
+      "goTerms": [
+        {
+          "goId": "GO:0004867",
+          "aspect": "GO Molecular Function"
+        },
+        {
+          "goId": "GO:0008201",
+          "aspect": "GO Molecular Function"
+        },
+        {
+          "goId": "GO:0046914",
+          "aspect": "GO Molecular Function"
+        },
+        {
+          "goId": "GO:0016021",
+          "aspect": "GO Cellular Component"
+        },
+        {
+          "goId": "GO:0048856",
+          "aspect": "GO Biological Process"
+        }
+      ]
+    },
+    {
+      "id": "UniRef100_P05067",
+      "name": "Cluster: Amyloid-beta precursor protein",
+      "updated": "2020-08-12",
+      "entryType": "UniRef100",
+      "commonTaxonId": 9526,
+      "commonTaxon": "Catarrhini",
+      "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+      "sequenceLength": 770,
+      "memberCount": 4,
+      "organismCount": 2,
+      "representativeId": "P05067",
+      "seedId": "P05067",
+      "memberIdTypes": [
+        "UniParc",
+        "UniProtKB Unreviewed (TrEMBL)",
+        "UniProtKB Reviewed (Swiss-Prot)"
+      ],
+      "members": ["P05067", "A0A140VJC8", "O97584", "UPI0000110448"],
+      "organismIds": [9606, 9544],
+      "organisms": ["Homo sapiens (Human)", "Macaca mulatta (Rhesus macaque)"]
+    },
+    {
+      "id": "UniRef90_P05067",
+      "name": "Cluster: Amyloid-beta precursor protein",
+      "updated": "2020-12-02",
+      "entryType": "UniRef90",
+      "commonTaxonId": 131567,
+      "commonTaxon": "cellular organisms",
+      "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+      "sequenceLength": 770,
+      "memberCount": 371,
+      "organismCount": 268,
+      "representativeId": "P05067",
+      "seedId": "UPI001386A8D7",
+      "memberIdTypes": [
+        "UniParc",
+        "UniProtKB Reviewed (Swiss-Prot)",
+        "UniProtKB Unreviewed (TrEMBL)"
+      ],
+      "members": [
+        "P05067",
+        "P79307",
+        "P08592",
+        "P12023",
+        "Q5IS80",
+        "Q28053",
+        "Q29149",
+        "Q28748",
+        "Q28757",
+        "Q28280"
+      ],
+      "organismIds": [
+        9606,
+        9823,
+        10116,
+        10090,
+        9598,
+        9913,
+        29073,
+        9986,
+        9940,
+        9615
+      ],
+      "organisms": [
+        "Homo sapiens (Human)",
+        "Sus scrofa (Pig)",
+        "Rattus norvegicus (Rat)",
+        "Mus musculus (Mouse)",
+        "Pan troglodytes (Chimpanzee)",
+        "Bos taurus (Bovine)",
+        "Ursus maritimus (Polar bear) (Thalarctos maritimus)",
+        "Oryctolagus cuniculus (Rabbit)",
+        "Ovis aries (Sheep)",
+        "Canis lupus familiaris (Dog) (Canis familiaris)"
+      ]
+    }
+  ]
+}

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2189,6 +2189,15 @@ exports[`Entry view should render 1`] = `
     </div>
   </div>
   <div
+    class="loader-container"
+  >
+    <test-file-stub
+      classname="loader"
+      height="100"
+      width="100"
+    />
+  </div>
+  <div
     class="hero-container hero-container--side-padding"
   >
     <em>
@@ -4072,6 +4081,15 @@ exports[`Entry view should render for non-human entry 1`] = `
         </div>
       </section>
     </div>
+  </div>
+  <div
+    class="loader-container"
+  >
+    <test-file-stub
+      classname="loader"
+      height="100"
+      width="100"
+    />
   </div>
   <div
     class="hero-container hero-container--side-padding"

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
@@ -900,6 +900,96 @@ exports[`XRefView should render for Sequence section 1`] = `
 </DocumentFragment>
 `;
 
+exports[`XRefView should render for SimilarProteins section 1`] = `
+<DocumentFragment>
+  <h3 />
+  <ul
+    class="info-list info-list--columns"
+  >
+    <li>
+      <div
+        class="decorated-list-item"
+      >
+        <div
+          class="decorated-list-item__title"
+        >
+          <h5
+            class="bold"
+          >
+            EMBL
+          </h5>
+        </div>
+        <div
+          class="decorated-list-item__content"
+        >
+          <ul
+            class="expandable-list no-bullet"
+          >
+            <li>
+              (
+              <a
+                class="external-link"
+                href="https://www.ebi.ac.uk/ena/data/view/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                EMBL
+                <test-file-stub
+                  width="12.5"
+                />
+              </a>
+               | 
+              <a
+                class="external-link"
+                href="https://www.ncbi.nlm.nih.gov/protein/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                GenBank
+                <test-file-stub
+                  width="12.5"
+                />
+              </a>
+               | 
+              <a
+                class="external-link"
+                href="http://getentry.ddbj.nig.ac.jp/getentry/dad/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                DDBJ
+                <test-file-stub
+                  width="12.5"
+                />
+              </a>
+              ) 
+              <a
+                class="external-link"
+                href="//www.ebi.ac.uk/ena/data/view/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                1234
+                <test-file-stub
+                  width="12.5"
+                />
+              </a>
+              [
+              <a
+                href="#ABCD"
+              >
+                ABCD
+              </a>
+              ]
+            </li>
+          </ul>
+        </div>
+      </div>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`XRefView should render for Structure section 1`] = `
 <DocumentFragment>
   <h3 />

--- a/src/uniprotkb/config/UniProtEntryConfig.tsx
+++ b/src/uniprotkb/config/UniProtEntryConfig.tsx
@@ -12,6 +12,7 @@ import StructureSection from '../components/entry/StructureSection';
 import { UniProtkbUIModel } from '../adapters/uniProtkbConverter';
 import { FunctionUIModel } from '../adapters/functionConverter';
 import EntrySection from '../types/entrySection';
+import SimilarProteins from '../components/entry/SimilarProteins';
 
 const UniProtKBEntryConfig: {
   id: EntrySection;
@@ -121,6 +122,16 @@ const UniProtKBEntryConfig: {
         data={data[EntrySection.Sequence]}
         primaryAccession={data.primaryAccession}
         key={EntrySection.Sequence}
+      />
+    ),
+  },
+  {
+    id: EntrySection.SimilarProteins,
+    sectionContent: (data) => (
+      <SimilarProteins
+        isoforms={data[EntrySection.SimilarProteins]}
+        primaryAccession={data.primaryAccession}
+        key={EntrySection.SimilarProteins}
       />
     ),
   },

--- a/src/uniprotkb/types/entrySection.ts
+++ b/src/uniprotkb/types/entrySection.ts
@@ -11,6 +11,7 @@ export enum EntrySection {
   Structure = 'structure',
   SubCellularLocation = 'subcellular-location',
   ExternalLinks = 'external-links',
+  SimilarProteins = 'similar-proteins',
 }
 
 export type EntrySectionNameAndId = {
@@ -95,6 +96,12 @@ export const getEntrySectionNameAndId = (
       }
 
       return { name, id: EntrySection.Sequence };
+    }
+    case EntrySection.SimilarProteins: {
+      return {
+        name: 'Similar Proteins',
+        id: EntrySection.Sequence,
+      };
     }
   }
 };

--- a/src/uniprotkb/types/entrySection.ts
+++ b/src/uniprotkb/types/entrySection.ts
@@ -100,7 +100,7 @@ export const getEntrySectionNameAndId = (
     case EntrySection.SimilarProteins: {
       return {
         name: 'Similar Proteins',
-        id: EntrySection.Sequence,
+        id: EntrySection.SimilarProteins,
       };
     }
   }

--- a/src/uniref/adapters/uniRefConverter.ts
+++ b/src/uniref/adapters/uniRefConverter.ts
@@ -8,11 +8,17 @@ enum GeneOntologyAspect {
   COMPONENT = 'GO Cellular Component',
 }
 
-enum UniRefEntryType {
+export enum UniRefEntryType {
   UniRef100 = 'UniRef100',
   UniRef90 = 'UniRef90',
   UniRef50 = 'UniRef50',
 }
+
+export const UniRefEntryTypeToPercent = {
+  UniRef100: '100%',
+  UniRef90: '90%',
+  UniRef50: '50%',
+};
 
 type GeneOntologyEntry = {
   aspect: GeneOntologyAspect;


### PR DESCRIPTION
## Purpose
Adding the "Similar Proteins" section to the UniProtKB entry.
This is the first part of the work required, retrieving the UniRef data, organising it in tabs and displaying the basics. Next step will be to retrieve additional data about the "members" and deciding on the best way to display it based on input from UX.

## Approach
- Add a data "converter" to extract the list of isoforms and add it to the UI model object
- Create a new component which uses the list of isoforms and canonical accessions to query the UniRef endpoint
- Filter out unwanted data (canonical and isoform accessions from results) and group both by Identity level and by UniProtKB accession
- Display the results in tabs based on groups defined above.

## Testing
Add a test for the data converter as well as the new `SimilarProteins` component, mocking data retrieval and checking that tabs work properly.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
