### PR TITLE
use getEntryPath() everywhere possible

### DIFF
--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState, FC } from 'react';
-import { InfoList, Sequence, ExternalLink } from 'franklin-sites';
-import { Link, useHistory, generatePath } from 'react-router-dom';
+import { InfoList, Sequence, ExternalLink, Button } from 'franklin-sites';
+import { Link, useHistory } from 'react-router-dom';
 
 import UniProtKBEvidenceTag from '../../../uniprotkb/components/protein-data-views/UniProtKBEvidenceTag';
 import numberView, {
@@ -25,11 +25,16 @@ import {
   AlternativeProductsComment,
 } from '../../../uniprotkb/types/commentTypes';
 import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
-import { Location, LocationToPath } from '../../../app/config/urls';
+import {
+  Location,
+  LocationToPath,
+  getEntryPath,
+} from '../../../app/config/urls';
 import {
   IsoformNotes,
   SequenceUIModel,
 } from '../../../uniprotkb/adapters/sequenceConverter';
+import { Namespace } from '../../types/namespaces';
 
 export type SequenceData = {
   value: string;
@@ -185,17 +190,19 @@ export const IsoformInfo: FC<{
           </p>
           {/* TODO: this is hacky and temporary until we sort out
           external isoforms */}
-          <Link
-            className="button secondary"
-            to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-              accession: isoformData.isoformIds[0].substring(
+          <Button
+            element={Link}
+            variant="secondary"
+            to={getEntryPath(
+              Namespace.uniprotkb,
+              isoformData.isoformIds[0].substring(
                 0,
                 isoformData.isoformIds[0].length - 2
-              ),
-            })}
+              )
+            )}
           >
             View isoform
-          </Link>
+          </Button>
         </section>
       )}
       <InfoList infoData={infoListData} columns isCompact />

--- a/src/shared/components/entry/TaxonomyView.tsx
+++ b/src/shared/components/entry/TaxonomyView.tsx
@@ -41,7 +41,7 @@ const TaxonomyView: FC<TaxonomyDataProps> = ({ data }) => {
 
   const termValue = `${data.scientificName}${
     data.commonName ? ` (${data.commonName})` : ''
-  } ${data.synonyms && data.synonyms.length > 0 ? ` (${data.synonyms})` : ''}`;
+  } ${data.synonyms?.length ? ` (${data.synonyms.join(', ')})` : ''}`;
 
   return (
     <SimpleView
@@ -67,9 +67,9 @@ export const TaxonomyListView: FC<{
           <Link to={getEntryPath(Namespace.taxonomy, data.taxonId)}>
             {`${data.scientificName} (${data.commonName})`}
           </Link>
-          {data.evidences && data.evidences.length && (
+          {data.evidences?.length ? (
             <UniProtKBEvidenceTag evidences={data.evidences} />
-          )}
+          ) : null}
         </>
       ),
     });

--- a/src/shared/components/entry/TaxonomyView.tsx
+++ b/src/shared/components/entry/TaxonomyView.tsx
@@ -1,11 +1,13 @@
 import { FC } from 'react';
 import { InfoList, ExternalLink } from 'franklin-sites';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import SimpleView from '../../../uniprotkb/components/protein-data-views/SimpleView';
 
 import externalUrls from '../../config/externalUrls';
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../types/namespaces';
 
 import { OrganismData } from '../../../uniprotkb/adapters/namesAndTaxonomyConverter';
 import UniProtKBEvidenceTag from '../../../uniprotkb/components/protein-data-views/UniProtKBEvidenceTag';
@@ -25,9 +27,7 @@ export const TaxonomyId: FC<{ taxonId?: number }> = ({ taxonId }) => {
   return (
     <>
       <Link
-        to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-          accession: `${taxonId}`,
-        })}
+        to={getEntryPath(Namespace.taxonomy, taxonId)}
       >{`${taxonId} `}</Link>
       <ExternalLink url={externalUrls.NCBI(taxonId)}>NCBI</ExternalLink>
     </>
@@ -35,7 +35,7 @@ export const TaxonomyId: FC<{ taxonId?: number }> = ({ taxonId }) => {
 };
 
 const TaxonomyView: FC<TaxonomyDataProps> = ({ data }) => {
-  if (!data) {
+  if (!data?.taxonId) {
     return null;
   }
 
@@ -44,28 +44,27 @@ const TaxonomyView: FC<TaxonomyDataProps> = ({ data }) => {
   } ${data.synonyms && data.synonyms.length > 0 ? ` (${data.synonyms})` : ''}`;
 
   return (
-    <SimpleView termValue={termValue} linkTo={`/taxonomy/${data.taxonId}`} />
+    <SimpleView
+      termValue={termValue}
+      linkTo={getEntryPath(Namespace.taxonomy, data.taxonId)}
+    />
   );
 };
 
 export const TaxonomyListView: FC<{
   data?: OrganismData;
   hosts?: OrganismData[];
-}> = ({ data, hosts }): JSX.Element | null => {
+}> = ({ data, hosts }) => {
   if (!data) {
     return null;
   }
   const infoListData: { title: string; content: JSX.Element | string }[] = [];
-  if (data.scientificName) {
+  if (data.scientificName && data.taxonId) {
     infoListData.push({
       title: 'Organism',
       content: (
         <>
-          <Link
-            to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-              accession: `${data.taxonId}`,
-            })}
-          >
+          <Link to={getEntryPath(Namespace.taxonomy, data.taxonId)}>
             {`${data.scientificName} (${data.commonName})`}
           </Link>
           {data.evidences && data.evidences.length && (

--- a/src/shared/components/entry/__tests__/__snapshots__/TaxonomyView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/TaxonomyView.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Organism should render organism 1`] = `
   <a
     href="/taxonomy/12344"
   >
-    Cheeky monkey (Really cheeky little monkey)  (Monkey 1,Monkey 2)
+    Cheeky monkey (Really cheeky little monkey)  (Monkey 1, Monkey 2)
   </a>
 </DocumentFragment>
 `;

--- a/src/shared/components/error-pages/ObsoleteEntryPage.tsx
+++ b/src/shared/components/error-pages/ObsoleteEntryPage.tsx
@@ -1,10 +1,15 @@
 import { FC, Fragment } from 'react';
 import { Message } from 'franklin-sites';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import listFormat from '../../utils/listFormat';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import {
+  Location,
+  LocationToPath,
+  getEntryPath,
+} from '../../../app/config/urls';
+import { Namespace } from '../../types/namespaces';
 
 import {
   InactiveEntryReason,
@@ -31,9 +36,8 @@ const DeletedEntryMessage: FC<{ accession: string }> = ({ accession }) => (
       . For previous versions of this entry, please look at its{' '}
       <Link
         to={{
-          pathname: generatePath(LocationToPath[Location.UniProtKBEntry], {
-            accession,
-          }),
+          pathname: getEntryPath(Namespace.uniprotkb, accession),
+          // TODO: actually implement this in the website
           search: 'version=*',
         }}
       >
@@ -56,11 +60,7 @@ const DemergedEntryMessage: FC<{
         {demergedTo.map((newEntry, index) => (
           <Fragment key={newEntry}>
             {listFormat(index, demergedTo)}
-            <Link
-              to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-                accession: newEntry,
-              })}
-            >
+            <Link to={getEntryPath(Namespace.uniprotkb, newEntry)}>
               {newEntry}
             </Link>
           </Fragment>
@@ -90,9 +90,7 @@ const DemergedEntryMessage: FC<{
       . For previous versions of this entry, please look at its{' '}
       <Link
         to={{
-          pathname: generatePath(LocationToPath[Location.UniProtKBEntry], {
-            accession,
-          }),
+          pathname: getEntryPath(Namespace.uniprotkb, accession),
           // TODO: actually implement this in the website
           search: `version=*`,
         }}

--- a/src/tools/align/components/results/AlignLabel.tsx
+++ b/src/tools/align/components/results/AlignLabel.tsx
@@ -1,13 +1,14 @@
 import { FC, CSSProperties, useCallback, MouseEvent } from 'react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import cn from 'classnames';
 import { noop } from 'lodash-es';
 
 import { MSAInput } from '../../../components/AlignmentView';
 import EntryTypeIcon from '../../../../shared/components/entry/EntryTypeIcon';
 
-import { Location, LocationToPath } from '../../../../app/config/urls';
+import { getEntryPath } from '../../../../app/config/urls';
 
+import { Namespace } from '../../../../shared/types/namespaces';
 import { ParsedSequenceAndFeatures } from '../../utils/useSequenceInfo';
 
 import './styles/AlignLabel.scss';
@@ -85,13 +86,7 @@ const AlignLabel: FC<AlignLabelProps> = ({
       <EntryTypeIcon entryType={before} />
       {before}
       {/* inject a link to the entry page */}
-      <Link
-        to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-          accession,
-        })}
-      >
-        {accession}
-      </Link>
+      <Link to={getEntryPath(Namespace.uniprotkb, accession)}>{accession}</Link>
       {after.join(accession)}
     </button>
   );

--- a/src/tools/blast/components/results/BlastResultTable.tsx
+++ b/src/tools/blast/components/results/BlastResultTable.tsx
@@ -10,7 +10,7 @@ import {
   ReactNode,
 } from 'react';
 import { DataTable, Chip, Loader } from 'franklin-sites';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import cn from 'classnames';
 
 import { HSPDetailPanelProps } from './HSPDetailPanel';
@@ -19,7 +19,9 @@ import EntryTypeIcon from '../../../../shared/components/entry/EntryTypeIcon';
 import useStaggeredRenderingHelper from '../../../../shared/hooks/useStaggeredRenderingHelper';
 import useCustomElement from '../../../../shared/hooks/useCustomElement';
 
-import { Location, LocationToPath } from '../../../../app/config/urls';
+import { getEntryPath } from '../../../../app/config/urls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
 
 import { EnrichedBlastHit } from './BlastResult';
 import { BlastResults, BlastHsp, BlastHit } from '../../types/blastResults';
@@ -329,11 +331,7 @@ const BlastResultTable: FC<{
         label: 'Accession',
         name: 'accession',
         render: ({ hit_acc, hit_db }) => (
-          <Link
-            to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-              accession: hit_acc,
-            })}
-          >
+          <Link to={getEntryPath(Namespace.uniprotkb, hit_acc)}>
             <EntryTypeIcon entryType={hit_db} />
             {hit_acc}
           </Link>
@@ -356,11 +354,7 @@ const BlastResultTable: FC<{
         label: 'Organism',
         name: 'organism',
         render: ({ hit_uni_ox, hit_uni_os }) => (
-          <Link
-            to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-              accession: hit_uni_ox,
-            })}
-          >
+          <Link to={getEntryPath(Namespace.taxonomy, hit_uni_ox)}>
             {hit_uni_os}
           </Link>
         ),

--- a/src/uniparc/components/results/UniParcCard.tsx
+++ b/src/uniparc/components/results/UniParcCard.tsx
@@ -1,15 +1,17 @@
 import { FC, useCallback, useMemo } from 'react';
 import { Card, LongNumber } from 'franklin-sites';
-import { useHistory, generatePath } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
+
+import { getEntryPath } from '../../../app/config/urls';
 
 import UniParcColumnConfiguration, {
   UniParcColumn,
 } from '../../config/UniParcColumnConfiguration';
 
 import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { UniParcAPIModel } from '../../adapters/uniParcConverter';
 
@@ -40,11 +42,7 @@ const UniRefCard: FC<{
   const history = useHistory();
 
   const handleCardClick = useCallback(() => {
-    history.push(
-      generatePath(LocationToPath[Location.UniParcEntry], {
-        accession: data.uniParcId,
-      })
-    );
+    history.push(getEntryPath(Namespace.uniparc, data.uniParcId));
   }, [history, data.uniParcId]);
 
   const organismCount = data.taxonomies.length;

--- a/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
+++ b/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 import { useCallback, useMemo, useState, FC, ReactNode } from 'react';
 import { DataTable, Message, Button } from 'franklin-sites';
-import { Link, generatePath, useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 import AddToBasket from '../../../shared/components/action-buttons/AddToBasket';
 import AlignButton from '../../../shared/components/action-buttons/Align';
@@ -12,7 +12,12 @@ import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 import useDataApi from '../../../shared/hooks/useDataApi';
 import apiUrls from '../../../shared/config/apiUrls';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import {
+  getEntryPath,
+  Location,
+  LocationToPath,
+} from '../../../app/config/urls';
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { MessageLevel } from '../../../messages/types/messagesTypes';
 import { Sequence } from '../../../shared/types/sequence';
@@ -54,11 +59,7 @@ const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
         label: 'Entry',
         name: 'accession',
         render: ({ id: accession, entryType }) => (
-          <Link
-            to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-              accession,
-            })}
-          >
+          <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
             <EntryTypeIcon entryType={entryType} />
             {accession}
           </Link>

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
@@ -1,19 +1,29 @@
 import { Loader, Message, Tabs, Tab, Card, Button } from 'franklin-sites';
 import { FC, useMemo } from 'react';
 import { groupBy } from 'lodash-es';
-import { generatePath, Link } from 'react-router-dom';
-import { getClustersForProteins } from '../../../../shared/config/apiUrls';
+import { Link } from 'react-router-dom';
+
+import SimilarProteinsTable from './SimilarProteinsTable';
+
 import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import { getClustersForProteins } from '../../../../shared/config/apiUrls';
+
+import {
+  getEntryPath,
+  Location,
+  LocationToPath,
+} from '../../../../app/config/urls';
+import { Namespace } from '../../../../shared/types/namespaces';
+import EntrySection, {
+  getEntrySectionNameAndId,
+} from '../../../types/entrySection';
+
 import {
   UniRefEntryType,
   UniRefEntryTypeToPercent,
   UniRefLiteAPIModel,
 } from '../../../../uniref/adapters/uniRefConverter';
-import EntrySection, {
-  getEntrySectionNameAndId,
-} from '../../../types/entrySection';
-import { Location, LocationToPath } from '../../../../app/config/urls';
-import SimilarProteinsTable from './SimilarProteinsTable';
 
 const SimilarProteins: FC<{
   isoforms: { isoforms: string[] };
@@ -95,11 +105,9 @@ const SimilarProteins: FC<{
                         <h4>{representativeId}</h4>
                         {clusterData[clusterType][representativeId].map(
                           (row) => {
-                            const unirefEntryUrl = generatePath(
-                              LocationToPath[Location.UniRefEntry],
-                              {
-                                accession: row.id,
-                              }
+                            const unirefEntryUrl = getEntryPath(
+                              Namespace.uniref,
+                              row.id
                             );
                             return (
                               <section key={row.id}>
@@ -107,9 +115,11 @@ const SimilarProteins: FC<{
                                   <Link to={unirefEntryUrl}>{row.id}</Link>
                                 </h5>
                                 <SimilarProteinsTable members={row.members} />
-                                {row.memberCount - row.members.length - 1 > 0 && (
+                                {row.memberCount - row.members.length - 1 >
+                                  0 && (
                                   <Link to={unirefEntryUrl}>
-                                    {row.memberCount - row.members.length - 1} more
+                                    {row.memberCount - row.members.length - 1}{' '}
+                                    more
                                   </Link>
                                 )}
                               </section>

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
@@ -1,13 +1,19 @@
 import { FC } from 'react';
 import { DataTable, Loader, Message } from 'franklin-sites';
-import { generatePath, Link } from 'react-router-dom';
-import { getAccessionsURL } from '../../../../shared/config/apiUrls';
-import useDataApi from '../../../../shared/hooks/useDataApi';
-import { UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
-import { UniProtKBColumn } from '../../../types/columnTypes';
+import { Link } from 'react-router-dom';
+
 import EntryTypeIcon from '../../../../shared/components/entry/EntryTypeIcon';
 import TaxonomyView from '../../../../shared/components/entry/TaxonomyView';
-import { Location, LocationToPath } from '../../../../app/config/urls';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import { getAccessionsURL } from '../../../../shared/config/apiUrls';
+import { getEntryPath } from '../../../../app/config/urls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+
+import { UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
+import { UniProtKBColumn } from '../../../types/columnTypes';
 
 const columns = [
   UniProtKBColumn.accession,
@@ -25,11 +31,7 @@ const columnConfig = [
     render: (row: UniProtkbAPIModel) => (
       <>
         <EntryTypeIcon entryType={row.entryType} />
-        <Link
-          to={generatePath(LocationToPath[Location.UniProtKBEntry], {
-            accession: row.primaryAccession,
-          })}
-        >
+        <Link to={getEntryPath(Namespace.uniprotkb, row.primaryAccession)}>
           {row.primaryAccession}
         </Link>
       </>

--- a/src/uniprotkb/components/protein-data-views/KeywordView.tsx
+++ b/src/uniprotkb/components/protein-data-views/KeywordView.tsx
@@ -1,9 +1,11 @@
 import { Fragment, FC } from 'react';
 import { InfoList, ExpandableList } from 'franklin-sites';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import cn from 'classnames';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { Keyword, KeywordUIModel } from '../../utils/KeywordsUtil';
 
@@ -24,13 +26,7 @@ export const KeywordItem: FC<KeywordItempProps> = ({ id, value }) => {
   if (!id || !value) {
     return null;
   }
-  return (
-    <Link
-      to={generatePath(LocationToPath[Location.KeywordsEntry], {
-        accession: id,
-      })}
-    >{` #${value}`}</Link>
-  );
+  return <Link to={getEntryPath(Namespace.keywords, id)}>{` #${value}`}</Link>;
 };
 
 export const KeywordList: FC<KeywordListProps> = ({

--- a/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
@@ -1,11 +1,13 @@
 import { FC, ReactNode } from 'react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import AnnotationScoreDoughnutChart, {
   DoughnutChartSize,
 } from './AnnotationScoreDoughnutChart';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { UniProtkbAPIModel } from '../../adapters/uniProtkbConverter';
 
@@ -37,11 +39,7 @@ const ProteinOverview: FC<{
     organismNameNode = (
       <>
         {data.organism.taxonId ? (
-          <Link
-            to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-              accession: `${data.organism.taxonId}`,
-            })}
-          >
+          <Link to={getEntryPath(Namespace.taxonomy, data.organism.taxonId)}>
             {data.organism.scientificName || data.organism.taxonId}
           </Link>
         ) : (

--- a/src/uniprotkb/components/protein-data-views/ProteomesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteomesView.tsx
@@ -1,20 +1,15 @@
 import { FC } from 'react';
 import { InfoList, ExpandableList } from 'franklin-sites';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../../shared/types/namespaces';
+
 import { Xref } from '../../../shared/types/apiModel';
 
 const ProteomesId: FC<{ id?: string }> = ({ id }) =>
-  id ? (
-    <Link
-      to={generatePath(LocationToPath[Location.ProteomesEntry], {
-        accession: id,
-      })}
-    >
-      {id}
-    </Link>
-  ) : null;
+  id ? <Link to={getEntryPath(Namespace.proteomes, id)}>{id}</Link> : null;
 
 const ProteomesComponents: FC<{
   components?: { [key: string]: string };

--- a/src/uniprotkb/components/results/UniProtKBCard.tsx
+++ b/src/uniprotkb/components/results/UniProtKBCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback, Fragment, FC, MouseEvent } from 'react';
 import { Card } from 'franklin-sites';
-import { useHistory, generatePath } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
 import { KeywordList } from '../protein-data-views/KeywordView';
@@ -8,8 +8,10 @@ import ProteinOverview from '../protein-data-views/ProteinOverviewView';
 
 import getProteinHighlights from '../../adapters/proteinHighlights';
 import { getKeywordsForCategories } from '../../utils/KeywordsUtil';
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
 import KeywordCategory from '../../types/keywordCategory';
+
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { UniProtkbAPIModel } from '../../adapters/uniProtkbConverter';
 
@@ -31,11 +33,7 @@ const UniProtKBCard: FC<Props> = ({ data, selected, handleEntrySelection }) => {
       if (BLOCK_CLICK_ON_CARD.has((event.target as HTMLElement).tagName)) {
         return;
       }
-      history.push(
-        generatePath(LocationToPath[Location.UniProtKBEntry], {
-          accession: data.primaryAccession,
-        })
-      );
+      history.push(getEntryPath(Namespace.uniprotkb, data.primaryAccession));
     },
     [history, data.primaryAccession]
   );

--- a/src/uniref/components/data-views/Overview.tsx
+++ b/src/uniref/components/data-views/Overview.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   SpinnerIcon,
   TremblIcon,
@@ -12,7 +12,9 @@ import MemberLink from '../entry/MemberLink';
 import { UseDataAPIState } from '../../../shared/hooks/useDataApi';
 
 import { getBEMClassName } from '../../../shared/utils/utils';
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { UniRefUIModel } from '../../adapters/uniRefConverter';
 import { FacetObject } from '../../../uniprotkb/types/responseTypes';
@@ -50,9 +52,7 @@ export const MemberIcons: FC<MemberIconsProps> = ({ facetData, id }) => {
     ?.find((f) => f?.name === 'member_id_type')
     ?.values.find((fv) => fv.value === MemberTypes.UniParc)?.count;
 
-  const pathname = generatePath(LocationToPath[Location.UniRefEntry], {
-    accession: id,
-  });
+  const pathname = getEntryPath(Namespace.uniref, id);
 
   return (
     <>

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useState, useEffect, FC } from 'react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Card, DataTableWithLoader, Loader } from 'franklin-sites';
 
 import AddToBasket from '../../../shared/components/action-buttons/AddToBasket';
@@ -9,21 +9,26 @@ import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 import MemberLink from './MemberLink';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
+import usePrefetch from '../../../shared/hooks/usePrefetch';
 
 import getNextURLFromHeaders from '../../../shared/utils/getNextURLFromHeaders';
+import {
+  Location,
+  LocationToPath,
+  getEntryPathFor,
+} from '../../../app/config/urls';
 
 import EntrySection, {
   getEntrySectionNameAndId,
 } from '../../types/entrySection';
+import { Namespace } from '../../../shared/types/namespaces';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
 import {
   Identity,
   UniRefMember,
   UniRefAPIModel,
   RepresentativeMember,
 } from '../../adapters/uniRefConverter';
-import usePrefetch from '../../../shared/hooks/usePrefetch';
 
 // OK so, if it's UniProt KB, use first accession as unique key and as first
 // column, if it's UniParc use ID (see entryname renderer lower for counterpart)
@@ -39,6 +44,9 @@ type ColumDescriptor = {
     datum: UniRefMember
   ) => undefined | string | number | boolean | JSX.Element;
 };
+
+const getEntryPathForTaxonomy = getEntryPathFor(Namespace.taxonomy);
+const getEntryPathForUniRef = getEntryPathFor(Namespace.uniref);
 
 const columns: ColumDescriptor[] = [
   {
@@ -75,26 +83,14 @@ const columns: ColumDescriptor[] = [
     name: 'organisms',
     label: 'Organisms',
     render: ({ organismName, organismTaxId }) => (
-      <Link
-        to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-          accession: `${organismTaxId}`,
-        })}
-      >
-        {organismName}
-      </Link>
+      <Link to={getEntryPathForTaxonomy(organismTaxId)}>{organismName}</Link>
     ),
   },
   {
     name: 'organismIDs',
     label: 'Organism IDs',
     render: ({ organismTaxId }) => (
-      <Link
-        to={generatePath(LocationToPath[Location.TaxonomyEntry], {
-          accession: `${organismTaxId}`,
-        })}
-      >
-        {organismTaxId}
-      </Link>
+      <Link to={getEntryPathForTaxonomy(organismTaxId)}>{organismTaxId}</Link>
     ),
   },
   {
@@ -104,32 +100,20 @@ const columns: ColumDescriptor[] = [
       <>
         {member.uniref50Id && (
           <>
-            <Link
-              to={generatePath(LocationToPath[Location.UniRefEntry], {
-                accession: member.uniref50Id,
-              })}
-            >
+            <Link to={getEntryPathForUniRef(member.uniref50Id)}>
               {member.uniref50Id}
             </Link>{' '}
           </>
         )}
         {member.uniref90Id && (
           <>
-            <Link
-              to={generatePath(LocationToPath[Location.UniRefEntry], {
-                accession: member.uniref90Id,
-              })}
-            >
+            <Link to={getEntryPathForUniRef(member.uniref90Id)}>
               {member.uniref90Id}
             </Link>{' '}
           </>
         )}
         {member.uniref100Id && (
-          <Link
-            to={generatePath(LocationToPath[Location.UniRefEntry], {
-              accession: member.uniref100Id,
-            })}
-          >
+          <Link to={getEntryPathForUniRef(member.uniref100Id)}>
             {member.uniref100Id}
           </Link>
         )}

--- a/src/uniref/components/results/UniRefCard.tsx
+++ b/src/uniref/components/results/UniRefCard.tsx
@@ -1,10 +1,12 @@
 import { FC, useCallback } from 'react';
 import { Card, LongNumber } from 'franklin-sites';
-import { useHistory, generatePath } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
 
-import { Location, LocationToPath } from '../../../app/config/urls';
+import { getEntryPath } from '../../../app/config/urls';
+
+import { Namespace } from '../../../shared/types/namespaces';
 
 import { UniRefLiteAPIModel } from '../../adapters/uniRefConverter';
 
@@ -26,11 +28,7 @@ const UniRefCard: FC<Props> = ({ data, selected, handleEntrySelection }) => {
       if (BLOCK_CLICK_ON_CARD.has((event.target as HTMLElement).tagName)) {
         return;
       }
-      history.push(
-        generatePath(LocationToPath[Location.UniRefEntry], {
-          accession: data.id,
-        })
-      );
+      history.push(getEntryPath(Namespace.uniref, data.id));
     },
     [history, data.id]
   );


### PR DESCRIPTION
## Purpose
Use helper function to create paths to entry pages

## Approach
Replace everywhere we were using the generatePath function with the different location objects with this helper function

## Testing
All the tests still pass (generated URLs should stay the same)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
