### PR TITLE
hotfix for query builder when opened through the taxonomy fake facet

### DIFF
--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -1,4 +1,5 @@
 import { parse } from './queryStringProcessor';
+import { getNextId } from './clause';
 
 import { Clause, SearchTermType } from '../types/searchTypes';
 
@@ -33,7 +34,10 @@ const parseAndMatchQuery = (
     parsedQuery = (Array.isArray(query) ? query : [query]).flatMap(parse);
   }
   if (fieldToAdd) {
-    parsedQuery = [...parsedQuery, ...parse(`(${fieldToAdd}:)`)];
+    parsedQuery = [
+      ...parsedQuery,
+      ...parse(`(${fieldToAdd}:)`, getNextId(parsedQuery)),
+    ];
   }
   // for each parsed clause, try to find the corresponding endpoint-described
   // clause to merge its 'searchTerm' field

--- a/src/query-builder/utils/queryStringProcessor.ts
+++ b/src/query-builder/utils/queryStringProcessor.ts
@@ -82,11 +82,11 @@ const getEmptyClause = (id: number): Clause => ({
   logicOperator: Operator.AND,
 });
 
-export const parse = (queryString = ''): Clause[] => {
+export const parse = (queryString = '', startId = 0): Clause[] => {
   // split querystring on all the recognised operators
   const split = queryString.trim().split(clauseSplitter);
 
-  let id = 0;
+  let id = startId;
 
   const clauses: Clause[] = [];
   let currentClause = getEmptyClause(id);

--- a/src/query-builder/utils/queryStringProcessor.ts
+++ b/src/query-builder/utils/queryStringProcessor.ts
@@ -82,6 +82,13 @@ const getEmptyClause = (id: number): Clause => ({
   logicOperator: Operator.AND,
 });
 
+/**
+ * Function to parse a string corresponding to a query and return the
+ * corresponding parsed object. Each clause has a stable unique ID which is a
+ * number that will always keep growing clause after clause.
+ * @param {string} queryString - String to parse, corresponding to a query
+ * @param {number} [startId=0] - Optional starting ID to assign to 1st clause
+ */
 export const parse = (queryString = '', startId = 0): Clause[] => {
   // split querystring on all the recognised operators
   const split = queryString.trim().split(clauseSplitter);


### PR DESCRIPTION
## Purpose
Fix issue when injecting a new clause in the query builder via the fake taxonomy facet

## Approach


## Testing


## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
