### PR TITLE
hacky fix to force rerendering of results view with new data when changing columns

### DIFF
--- a/src/shared/components/results/ResultsView.tsx
+++ b/src/shared/components/results/ResultsView.tsx
@@ -194,10 +194,15 @@ const ResultsView: FC<ResultsTableProps> = ({
   sortableColumnToSortColumn,
 }) => {
   const namespace = useNS() || Namespace.uniprotkb;
-  const prevNamespace = useRef<Namespace>();
+  const prevNamespace = useRef<Namespace>(namespace);
   useEffect(() => {
     // will set it *after* the current render
     prevNamespace.current = namespace;
+  });
+  const prevColumns = useRef<Column[]>(columns);
+  useEffect(() => {
+    // will set it *after* the current render
+    prevColumns.current = columns;
   });
 
   const history = useHistory();
@@ -240,7 +245,7 @@ const ResultsView: FC<ResultsTableProps> = ({
     results: APIModel[];
   }>(url);
 
-  const prevViewMode = useRef<ViewMode>();
+  const prevViewMode = useRef<ViewMode>(viewMode);
   useEffect(() => {
     prevViewMode.current = viewMode;
   });
@@ -277,7 +282,9 @@ const ResultsView: FC<ResultsTableProps> = ({
     // or we just switched namespace (a bit hacky workaround to force unmount)
     prevNamespace.current !== namespace ||
     // or we just switched view mode (hacky too)
-    prevViewMode.current !== viewMode
+    prevViewMode.current !== viewMode ||
+    // or we just changed the displayed columns (hacky too...)
+    prevColumns.current !== columns
   ) {
     return <Loader />;
   }


### PR DESCRIPTION
## Purpose
Force unmount/remount of results view when changing the selected columns.

## Approach
Same hacky approach that we currently do when switching view mode (card/table) or namespace.

## Testing
Manual testing and switching views, columns, and namespaces

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Tackle issue raised to @dlrice that I saw when the Proteomes lineage renderer would be be asked to render data without the lineage data when switching the columns to display