### PR TITLE
Get sortable column name.

### DIFF
--- a/src/shared/components/results/ResultsView.tsx
+++ b/src/shared/components/results/ResultsView.tsx
@@ -287,6 +287,11 @@ const ResultsView: FC<ResultsTableProps> = ({
   const handleLoadMoreRows = () => nextUrl && setUrl(nextUrl);
 
   const updateColumnSort = (columnName: string) => {
+    const sortColumn = sortableColumnToSortColumn.get(columnName as Column);
+    if (!sortColumn) {
+      return;
+    }
+
     // Change sort direction
     const updatedSortDirection =
       !sortDirection || sortDirection === SortDirection.descend
@@ -298,7 +303,7 @@ const ResultsView: FC<ResultsTableProps> = ({
         pathname: SearchResultsLocations[namespace],
         query,
         selectedFacets,
-        sortColumn: columnName,
+        sortColumn,
         sortDirection: updatedSortDirection,
       })
     );


### PR DESCRIPTION
## Purpose
Some columns weren't sortable

## Approach
Get sortable column name before passing to getLocationObjForParams

## Testing
no change

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
