### PR TITLE
2021 02 BLAST form taxonomy filtering

### DIFF
--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -81,6 +81,7 @@ const apiUrls = {
       accession,
       '/publications'
     ),
+  taxonomySuggester: '/uniprot/api/suggester?dict=taxonomy&query=?',
   organismSuggester: '/uniprot/api/suggester?dict=organism&query=?',
 
   // TODO: move that to UniRef-specific file?

--- a/src/shared/hooks/useDragNDropFile.ts
+++ b/src/shared/hooks/useDragNDropFile.ts
@@ -85,6 +85,7 @@ const useDragNDropFile = ({
     overlayRef.current = document.createElement('div');
 
     overlayRef.current.style.pointerEvents = 'none';
+    overlayRef.current.style.visibility = 'hidden';
     overlayRef.current.style.position = 'absolute';
     overlayRef.current.style.display = 'flex';
     overlayRef.current.style.alignItems = 'center';

--- a/src/tools/__mocks__/internal-jobs/created.ts
+++ b/src/tools/__mocks__/internal-jobs/created.ts
@@ -15,6 +15,7 @@ const created: CreatedJob = {
     program: 'blastp',
     database: 'uniprotkb_refprotswissprot',
     taxIDs: [],
+    negativeTaxIDs: [],
     threshold: '1e-2',
     matrix: 'BLOSUM62',
     filter: 'T',

--- a/src/tools/__mocks__/internal-jobs/failed-after-submission.ts
+++ b/src/tools/__mocks__/internal-jobs/failed-after-submission.ts
@@ -17,6 +17,7 @@ const failedBeforeSubmission: FailedJob = {
     program: 'blastp',
     database: 'uniprotkb_refprotswissprot',
     taxIDs: [{ id: '9606', label: 'Homo sapiens' }],
+    negativeTaxIDs: [],
     threshold: '10',
     matrix: 'BLOSUM62',
     filter: 'F',

--- a/src/tools/__mocks__/internal-jobs/failed-before-submission.ts
+++ b/src/tools/__mocks__/internal-jobs/failed-before-submission.ts
@@ -19,6 +19,7 @@ const failedAfterSubmission: FailedJob = {
     sequence: 'MLPGLALLLL',
     database: 'uniprotkb_refprotswissprot',
     taxIDs: [{ id: '9606', label: 'Homo sapiens' }],
+    negativeTaxIDs: [],
     threshold: '10',
     matrix: 'BLOSUM62',
     filter: 'F',

--- a/src/tools/__mocks__/internal-jobs/finished.ts
+++ b/src/tools/__mocks__/internal-jobs/finished.ts
@@ -22,6 +22,7 @@ const finished: FinishedJob<JobTypes.BLAST> = {
     sequence: 'MLPGLALLLL',
     database: 'uniprotkb_refprotswissprot',
     taxIDs: [{ id: '9606', label: 'Homo sapiens' }],
+    negativeTaxIDs: [],
     threshold: '10',
     matrix: 'BLOSUM62',
     filter: 'F',

--- a/src/tools/__mocks__/internal-jobs/running.ts
+++ b/src/tools/__mocks__/internal-jobs/running.ts
@@ -19,6 +19,7 @@ const running: RunningJob = {
     sequence: 'MLPGLALLLL',
     database: 'uniprotkb_refprotswissprot',
     taxIDs: [],
+    negativeTaxIDs: [],
     threshold: '1.0',
     matrix: 'BLOSUM50',
     filter: 'T',

--- a/src/tools/adapters/__tests__/parameters.spec.ts
+++ b/src/tools/adapters/__tests__/parameters.spec.ts
@@ -59,7 +59,7 @@ describe('tools adapter tests', () => {
   describe('BLAST', () => {
     describe('formParametersToServerParameters', () => {
       it('should translate BLAST parameters accurately', () => {
-        const formParams: FormParameters = {
+        const formParams: FormParameters[JobTypes.BLAST] = {
           program: 'blastp',
           matrix: 'PAM30',
           hits: 250,
@@ -70,6 +70,7 @@ describe('tools adapter tests', () => {
             { id: '1234', label: 'some species' },
             { id: '4321', label: 'some other species' },
           ],
+          negativeTaxIDs: [],
           stype: 'protein',
           sequence: 'ATGC',
           database: 'UniProt',
@@ -90,6 +91,7 @@ describe('tools adapter tests', () => {
           ['filter', 'F'],
           ['gapalign', 'false'],
           ['taxids', '1234,4321'],
+          ['negative_taxids', ''],
           ['stype', 'protein'],
           ['sequence', 'ATGC'],
           ['database', 'UniProt'],
@@ -134,12 +136,13 @@ describe('tools adapter tests', () => {
             '>sp|P06787|CALM_YEAST Calmodulin OS=Saccharomyces cerevisiae (strain ATCC 204508 / S288c) OX=559292 PE=1 SV=1↵MSSNLTEEQIAEFKEAFALFDKDNNGSISSSELATVMRSLGLSPSEAEVNDLMNEIDVDG↵NHQIEFSEFLALMSRQLKSNDSEQELLEAFKVFDKNGDGLISAAELKHVLTSIGEKLTDA↵EVDDMLREVSDGSGEINIQQFAALLSK↵',
           stype: 'protein',
           taxIDs: [{ id: '9606', label: 'Homo Sapiens [9606]' }],
+          negativeTaxIDs: [],
           threshold: '1e-1',
         });
       });
 
       it('should translate blast parameters event without taxon info', () => {
-        const serverParams: PublicServerParameters = {
+        const serverParams: PublicServerParameters[JobTypes.BLAST] = {
           alignments: 250,
           compstats: 'F',
           database: 'uniprotkb_refprotswissprot',
@@ -169,6 +172,7 @@ describe('tools adapter tests', () => {
             '>sp|P06787|CALM_YEAST Calmodulin OS=Saccharomyces cerevisiae (strain ATCC 204508 / S288c) OX=559292 PE=1 SV=1↵MSSNLTEEQIAEFKEAFALFDKDNNGSISSSELATVMRSLGLSPSEAEVNDLMNEIDVDG↵NHQIEFSEFLALMSRQLKSNDSEQELLEAFKVFDKNGDGLISAAELKHVLTSIGEKLTDA↵EVDDMLREVSDGSGEINIQQFAALLSK↵',
           stype: 'protein',
           taxIDs: [],
+          negativeTaxIDs: [],
           threshold: '1e-1',
         });
       });

--- a/src/tools/align/config/AlignFormData.ts
+++ b/src/tools/align/config/AlignFormData.ts
@@ -9,7 +9,9 @@ export type AlignFormValue = {
   fieldName: string;
   selected?: string | boolean | number;
   type?: AlignFieldTypes;
-  values?: { label?: string; value?: string | boolean | number }[];
+  values?: Readonly<
+    Array<{ label?: string; value?: string | boolean | number }>
+  >;
 };
 
 export enum AlignFields {
@@ -19,9 +21,9 @@ export enum AlignFields {
   iterations = 'Iterations',
 }
 
-export type AlignFormValues = { [x in AlignFields]: AlignFormValue };
+export type AlignFormValues = Record<AlignFields, Readonly<AlignFormValue>>;
 
-export default Object.freeze({
+const formData: Readonly<AlignFormValues> = Object.freeze({
   [AlignFields.sequence]: Object.freeze({
     fieldName: 'sequence',
     type: AlignFieldTypes.textarea,
@@ -54,4 +56,6 @@ export default Object.freeze({
     ] as Array<{ value: FormParameters['iterations'] }>),
     selected: 0,
   }),
-}) as Readonly<AlignFormValues>;
+});
+
+export default formData;

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -186,6 +186,9 @@ const BlastForm = () => {
   const [taxIDs, setTaxIDs] = useState<BlastFormValues[BlastFields.taxons]>(
     initialFormValues[BlastFields.taxons]
   );
+  const [negativeTaxIDs, setNegativeTaxIDs] = useState<
+    BlastFormValues[BlastFields.excludedtaxons]
+  >(initialFormValues[BlastFields.excludedtaxons]);
   const [threshold, setThreshold] = useState<
     BlastFormValues[BlastFields.threshold]
   >(initialFormValues[BlastFields.threshold]);
@@ -248,6 +251,7 @@ const BlastForm = () => {
     setSequence(defaultFormValues[BlastFields.sequence]);
     setDatabase(defaultFormValues[BlastFields.database]);
     setTaxIDs(defaultFormValues[BlastFields.taxons]);
+    setNegativeTaxIDs(defaultFormValues[BlastFields.excludedtaxons]);
     setThreshold(defaultFormValues[BlastFields.threshold]);
     setMatrix(defaultFormValues[BlastFields.matrix]);
     setFilter(defaultFormValues[BlastFields.filter]);
@@ -282,6 +286,7 @@ const BlastForm = () => {
       sequence: sequence.selected as Sequence,
       database: database.selected as Database,
       taxIDs: taxIDs.selected as SelectedTaxon[],
+      negativeTaxIDs: negativeTaxIDs.selected as SelectedTaxon[],
       threshold: threshold.selected as Exp,
       // remove "auto", and transform into corresponding matrix
       matrix:
@@ -452,10 +457,10 @@ const BlastForm = () => {
             <FormSelect formValue={database} updateFormValue={setDatabase} />
             <section className="tools-form-section__item tools-form-section__item--taxon-select">
               <AutocompleteWrapper
-                placeholder="Enter organism names or tax IDs"
-                url={uniProtKBApiUrls.organismSuggester}
+                placeholder="Enter taxon names or IDs to include"
+                url={uniProtKBApiUrls.taxonomySuggester}
                 onSelect={updateTaxonFormValue}
-                title="Restrict by organism"
+                title="Include these taxons"
                 clearOnSelect
               />
             </section>
@@ -486,7 +491,7 @@ const BlastForm = () => {
                   style={{
                     width: `${(jobName.selected as string).length + 2}ch`,
                   }}
-                  placeholder="my job title"
+                  placeholder={'"my job title"'}
                   value={jobName.selected as string}
                   onChange={(event) => {
                     setJobNameEdited(Boolean(event.target.value));

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -460,7 +460,7 @@ const BlastForm = () => {
                 placeholder="Enter taxon names or IDs to include"
                 url={uniProtKBApiUrls.taxonomySuggester}
                 onSelect={updateTaxonFormValue}
-                title="Include these taxons"
+                title="Restrict by taxonomy"
                 clearOnSelect
               />
             </section>

--- a/src/tools/blast/components/__tests__/BlastForm.spec.tsx
+++ b/src/tools/blast/components/__tests__/BlastForm.spec.tsx
@@ -1,10 +1,14 @@
 import { createMemoryHistory } from 'history';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+
 import renderWithRedux from '../../../../shared/__test-helpers__/RenderWithRedux';
+
 import BlastForm from '../BlastForm';
+
 import initialState from '../../../../app/state/rootInitialState';
+
 import { mockSuggesterApi } from '../../../../query-builder/components/__tests__/__mocks__/autocompleteWrapperData';
 
 const mock = new MockAdapter(axios);
@@ -32,13 +36,14 @@ describe('BlastForm test', () => {
   });
 
   it('Sets sequence type based on the sequence', () => {
-    const { getByTestId } = component;
-    const textArea = getByTestId('sequence-submission-input');
+    const textArea = screen.getByTestId('sequence-submission-input');
     fireEvent.change(textArea, { target: { value: aaSequence } });
-    const stype1 = getByTestId('Sequence type-protein');
+    const stype1 = screen.getByTestId(
+      'Sequence type-protein'
+    ) as HTMLOptionElement;
     expect(stype1.selected).toBeTruthy();
     fireEvent.change(textArea, { target: { value: ntSequence } });
-    const stype2 = getByTestId('Sequence type-dna');
+    const stype2 = screen.getByTestId('Sequence type-dna') as HTMLOptionElement;
     expect(stype2.selected).toBeTruthy();
   });
 
@@ -47,10 +52,9 @@ describe('BlastForm test', () => {
   it.skip('Sets a name automatically', () => {});
 
   it('Sets the automatic matrix based on the sequence', () => {
-    const { getByTestId } = component;
-    const textArea = getByTestId('sequence-submission-input');
+    const textArea = screen.getByTestId('sequence-submission-input');
     fireEvent.change(textArea, { target: { value: aaSequence } });
-    const matrix = getByTestId('Matrix-auto');
+    const matrix = screen.getByTestId('Matrix-auto') as HTMLOptionElement;
     expect(matrix.text).toEqual('Auto - PAM30');
     fireEvent.change(textArea, {
       target: { value: `${aaSequence}${aaSequence}` },
@@ -69,25 +73,19 @@ describe('BlastForm test', () => {
   });
 
   it('Adds and removes a taxon', async () => {
-    const {
-      getByPlaceholderText,
-      findByText,
-      queryByText,
-      getByTestId,
-    } = component;
-    const autocompleteInput = getByPlaceholderText(
-      'Enter organism names or tax IDs'
+    const autocompleteInput = screen.getByPlaceholderText(
+      'Enter taxon names or IDs to include'
     );
     fireEvent.change(autocompleteInput, {
       target: { value: mockSuggesterApi.query },
     });
-    const autocompleteItem = await findByText('rotavirus [1906931]');
+    const autocompleteItem = await screen.findByText('rotavirus [1906931]');
     fireEvent.click(autocompleteItem);
-    const chip = await findByText('Human rotavirus [1906931]');
+    const chip = await screen.findByText('Human rotavirus [1906931]');
     expect(chip).toBeTruthy();
-    fireEvent.click(getByTestId('remove-icon'));
-    await waitFor(() =>
-      expect(queryByText('Human rotavirus [1906931]')).toBeFalsy()
-    );
+    fireEvent.click(screen.getByTestId('remove-icon'));
+    expect(
+      screen.queryByText('Human rotavirus [1906931]')
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -192,7 +192,7 @@ exports[`BlastForm test Renders the form 1`] = `
           class="tools-form-section__item tools-form-section__item--taxon-select"
         >
           <label>
-            Restrict by organism
+            Include these taxons
             <div
               class="autocomplete-container"
             >
@@ -201,7 +201,7 @@ exports[`BlastForm test Renders the form 1`] = `
               >
                 <input
                   data-testid="search-input"
-                  placeholder="Enter organism names or tax IDs"
+                  placeholder="Enter taxon names or IDs to include"
                   type="text"
                   value=""
                 />
@@ -242,7 +242,7 @@ exports[`BlastForm test Renders the form 1`] = `
               autocomplete="off"
               maxlength="100"
               name="title"
-              placeholder="my job title"
+              placeholder="\\"my job title\\""
               style="width: 2ch;"
               type="text"
               value=""

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -192,7 +192,7 @@ exports[`BlastForm test Renders the form 1`] = `
           class="tools-form-section__item tools-form-section__item--taxon-select"
         >
           <label>
-            Include these taxons
+            Restrict by taxonomy
             <div
               class="autocomplete-container"
             >

--- a/src/tools/blast/config/BlastFormData.ts
+++ b/src/tools/blast/config/BlastFormData.ts
@@ -13,7 +13,9 @@ export type BlastFormValue = {
   fieldName: string;
   selected?: string | SelectedTaxon[] | boolean | number;
   type?: BlastFieldTypes;
-  values?: { label?: string; value?: string | boolean | number }[];
+  values?: Readonly<
+    Array<{ label?: string; value?: string | boolean | number }>
+  >;
 };
 
 export enum BlastFields {
@@ -21,6 +23,7 @@ export enum BlastFields {
   stype = 'Sequence type',
   sequence = 'Sequence',
   taxons = 'Taxons',
+  excludedtaxons = 'Excluded taxons',
   database = 'Target database',
   threshold = 'E-Threshold',
   matrix = 'Matrix',
@@ -30,9 +33,9 @@ export enum BlastFields {
   name = 'Name',
 }
 
-export type BlastFormValues = { [x in BlastFields]: BlastFormValue };
+export type BlastFormValues = Record<BlastFields, Readonly<BlastFormValue>>;
 
-export default Object.freeze({
+const formData: Readonly<BlastFormValues> = Object.freeze({
   [BlastFields.program]: Object.freeze({
     fieldName: 'program',
     values: Object.freeze([{ value: 'blastp' }, { value: 'blastx' }] as Array<{
@@ -77,6 +80,10 @@ export default Object.freeze({
   }),
   [BlastFields.taxons]: Object.freeze({
     fieldName: 'taxIDs',
+    type: BlastFieldTypes.autocomplete,
+  }),
+  [BlastFields.excludedtaxons]: Object.freeze({
+    fieldName: 'negativeTaxIDs',
     type: BlastFieldTypes.autocomplete,
   }),
   // 'exp' parameter
@@ -149,4 +156,6 @@ export default Object.freeze({
     type: BlastFieldTypes.textarea,
     selected: '',
   }),
-}) as Readonly<BlastFormValues>;
+});
+
+export default formData;

--- a/src/tools/blast/types/blastFormParameters.ts
+++ b/src/tools/blast/types/blastFormParameters.ts
@@ -18,6 +18,7 @@ export type FormParameters = {
   sequence: Sequence;
   database: Database;
   taxIDs: SelectedTaxon[];
+  negativeTaxIDs: SelectedTaxon[];
   threshold: Exp;
   matrix: Matrix;
   filter: Filter;

--- a/src/tools/blast/types/blastServerParameters.ts
+++ b/src/tools/blast/types/blastServerParameters.ts
@@ -187,17 +187,9 @@ export type WordSize =
 // Specify one or more TaxIDs so that the BLAST search becomes taxonomically aware.
 export type TaxIDs = string;
 
-// https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/parameterdetails/taxidsfile
-// Specify one or more TaxIDs so that the BLAST search becomes taxonomically aware.
-export type TaxIDsFile = string; // path to a file
-
-// https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/parameterdetails/excludedtaxids
+// https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/parameterdetails/negative_taxids
 // TaxIDs excluded from the BLAST search.
-export type ExcludedTaxIDs = string;
-
-// https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/parameterdetails/excludedtaxidsfile
-// TaxIDs excluded from the BLAST search.
-export type ExcludedTaxIDsFile = string; // path to a file
+export type NegativeTaxIDs = string;
 
 // https://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/parameterdetails/compstats
 // Use composition-based statistics.
@@ -264,9 +256,7 @@ export type ServerParameters = {
   gapalign?: GapAlign; // gapped
   wordsize?: WordSize;
   taxids?: TaxIDs; // taxons included
-  taxidsfile?: TaxIDsFile; // taxons file included
-  excludedtaxids?: ExcludedTaxIDs; // taxons excluded
-  excludedtaxidsfile?: ExcludedTaxIDsFile; // taxons file excluded
+  negative_taxids?: NegativeTaxIDs; // taxons excluded
   compstats?: CompStats;
   align?: Align;
   transltable?: TranslTable;

--- a/src/tools/components/InputParameters.tsx
+++ b/src/tools/components/InputParameters.tsx
@@ -15,11 +15,6 @@ type InputParametersProps = {
   jobType: JobTypes;
 };
 
-const hideParameters = new Set<
-  | keyof PublicServerParameters[JobTypes.ALIGN]
-  | keyof PublicServerParameters[JobTypes.BLAST]
->(['taxidsfile', 'excludedtaxidsfile']);
-
 const InputParameters: FC<InputParametersProps> = ({
   id,
   inputParamsData,
@@ -46,19 +41,10 @@ const InputParameters: FC<InputParametersProps> = ({
           <Loader />
         ) : (
           <InfoList
-            infoData={Object.entries(data)
-              .filter(
-                ([key]) =>
-                  !hideParameters.has(
-                    key as
-                      | keyof PublicServerParameters[JobTypes.ALIGN]
-                      | keyof PublicServerParameters[JobTypes.BLAST]
-                  )
-              )
-              .map(([key, value]) => ({
-                title: key,
-                content: <CodeBlock lightMode>{`${value}`}</CodeBlock>,
-              }))}
+            infoData={Object.entries(data).map(([key, value]) => ({
+              title: key,
+              content: <CodeBlock lightMode>{`${value}`}</CodeBlock>,
+            }))}
           />
         )}
       </section>

--- a/src/uniprotkb/components/entry/__tests__/Entry.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/Entry.spec.tsx
@@ -2,13 +2,17 @@ import { Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import { fireEvent, waitFor } from '@testing-library/dom';
-import Entry from '../Entry';
+import { fireEvent, waitFor, screen } from '@testing-library/dom';
+import joinUrl from 'url-join';
+
 import renderWithRedux from '../../../../shared/__test-helpers__/RenderWithRedux';
+
+import Entry from '../Entry';
+
 import apiUrls, {
   getUniProtPublicationsQueryUrl,
 } from '../../../../shared/config/apiUrls';
-import joinUrl from 'url-join';
+
 import entryData from '../../../__mocks__/entryModelData.json';
 import nonHumanEntryData from '../../../__mocks__/nonHumanEntryModelData.json';
 import deletedEntryData from '../../../../shared/__mocks__/deletedEntryModelData.json';
@@ -63,7 +67,7 @@ mock.onGet(joinUrl(apiUrls.variation, primaryAccession)).reply(200, {});
 
 let component;
 
-describe.skip('Entry', () => {
+describe('Entry', () => {
   beforeEach(async () => {
     await act(async () => {
       component = renderWithRedux(
@@ -85,7 +89,7 @@ describe.skip('Entry', () => {
     });
   });
 
-  it('should switch to publications and apply a filter', async () => {
+  it.skip('should switch to publications and apply a filter', async () => {
     await act(async () => {
       const { getByText } = component;
       const button = getByText('Publications', { selector: 'a' });
@@ -108,11 +112,9 @@ describe.skip('Entry', () => {
       }
     );
 
-    await act(async () => {
-      const { findByTestId } = component;
-      const message = await findByTestId('deleted-entry-message');
-      expect(message).toBeTruthy();
-    });
+    expect(
+      await screen.findByTestId('deleted-entry-message')
+    ).toBeInTheDocument();
   });
 
   it('should render obsolete page for demerged entries', async () => {
@@ -126,10 +128,8 @@ describe.skip('Entry', () => {
       }
     );
 
-    await act(async () => {
-      const { findByTestId } = component;
-      const message = await findByTestId('demerged-entry-message');
-      expect(message).toBeTruthy();
-    });
+    expect(
+      await screen.findByTestId('demerged-entry-message')
+    ).toBeInTheDocument();
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -1,0 +1,2506 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Entry should render main 1`] = `
+<DocumentFragment>
+  <div
+    class="sidebar-layout entry-page sticky-tabs-container"
+  >
+    <section
+      class="sidebar-layout__sidebar"
+    >
+      <ul
+        class="in-page-nav"
+      >
+        <div
+          class="marker"
+        />
+        <li
+          class=""
+        >
+          <a
+            class="active"
+            href="/uniprotkb/P21802/entry#function"
+          >
+            Function
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#names-and-taxonomy"
+          >
+            Names & Taxonomy
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#subcellular-location"
+          >
+            Subcellular Location
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#disease-and-drugs"
+          >
+            Disease & Drugs
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#ptm-processing"
+          >
+            PTM/Processing
+          </a>
+        </li>
+        <li
+          class="disabled"
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#expression"
+          >
+            Expression
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#interaction"
+          >
+            Interaction
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#structure"
+          >
+            Structure
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#family-and-domains"
+          >
+            Family & Domains
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#sequence"
+          >
+            Sequence
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class=""
+            href="/uniprotkb/P21802/entry#similar-proteins"
+          >
+            Similar Proteins
+          </a>
+        </li>
+      </ul>
+    </section>
+    <section
+      class="sidebar-layout__content"
+    >
+      <section
+        class="sidebar-layout__title"
+      >
+        <h2>
+          <span
+            class="entry-title"
+          >
+            <span
+              class="entry-title__status icon--reviewed"
+              title="This marks a reviewed UniProtKB entry"
+            >
+              <test-file-stub />
+            </span>
+            P21802 · uniprot_id
+          </span>
+        </h2>
+        <section>
+          rec full Name · 
+          <a
+            href="/taxonomy/9606"
+          >
+            scientific name
+          </a>
+           · 
+          <strong>
+            EC number:
+          </strong>
+           1.2.3.4 · 
+          <strong>
+            Gene:
+          </strong>
+           some Gene (some Syn) · 10 amino-acids · 1: Evidence at protein level · 
+          <span
+            title="Annotation Score"
+          >
+            <span
+              class="doughnut-chart--small colour-platinum"
+            >
+              <span
+                class="doughnut-chart--small__left-wrap"
+              >
+                <span
+                  class="doughnut-chart--small__left-wrap__loader colour-sea-blue"
+                  style="transform: rotate(0deg);"
+                />
+              </span>
+              <span
+                class="doughnut-chart--small__right-wrap"
+              >
+                <span
+                  class="doughnut-chart--small__right-wrap__loader colour-sea-blue"
+                  style="transform: rotate(72deg);"
+                />
+              </span>
+              <span
+                class="doughnut-chart--small__inner-circle"
+              >
+                1/5
+              </span>
+            </span>
+          </span>
+        </section>
+      </section>
+      <div
+        class="tabs"
+      >
+        <div
+          class="tabs__header"
+          role="tablist"
+        >
+          <div
+            aria-controls="0"
+            class="tabs__header__item tabs__header__item--active"
+            data-target="entry"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/uniprotkb/P21802/entry"
+            >
+              Entry
+            </a>
+          </div>
+          <div
+            aria-controls="0"
+            class="tabs__header__item"
+            data-target="feature-viewer"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/uniprotkb/P21802/feature-viewer"
+            >
+              Feature viewer
+            </a>
+          </div>
+          <div
+            aria-controls="0"
+            class="tabs__header__item"
+            data-target="publications"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/uniprotkb/P21802/publications"
+            >
+              Publications
+            </a>
+          </div>
+          <div
+            aria-controls="0"
+            class="tabs__header__item"
+            data-target="external-links"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/uniprotkb/P21802/external-links"
+            >
+              External links
+            </a>
+          </div>
+        </div>
+        <div
+          data-testid="tab-content"
+          id="0"
+          role="tabpanel"
+        >
+          <div
+            class="button-group"
+          >
+            <button
+              class="button tertiary"
+              title="Run a BLAST job against P21802"
+              type="button"
+            >
+              BLAST
+            </button>
+            <button
+              class="button tertiary"
+              title="Run an Align job against 2 entries"
+              type="button"
+            >
+              Align
+            </button>
+            <div
+              class="dropdown-container"
+            >
+              <button
+                class="button tertiary dropdown"
+                type="button"
+              >
+                <test-file-stub />
+                Download
+              </button>
+              <div
+                class="dropdown-menu"
+              />
+            </div>
+            <button
+              class="button tertiary"
+              title="Add 1 entry to the basket"
+              type="button"
+            >
+              <test-file-stub />
+              Add
+            </button>
+          </div>
+          <div
+            data-entry-section="true"
+            id="function"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Function
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    catalytic activity
+                  </h3>
+                  <span
+                    class="text-block"
+                  >
+                    <strong>
+                      1.2.4.5
+                    </strong>
+                     some reaction
+                    <button
+                      aria-controls="1"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="1"
+                    />
+                    This reaction proceeds in the 
+                    <span
+                      data-testid="direction-text"
+                    >
+                      backward
+                    </span>
+                     direction 
+                    <button
+                      aria-controls="2"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        Imported
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="2"
+                    />
+                  </span>
+                  <h3>
+                    cofactor
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    <span>
+                      Cofactor Name 
+                      <button
+                        aria-controls="3"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-unreviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="3"
+                      />
+                    </span>
+                    <section
+                      class="text-block"
+                    >
+                      value2
+                      <button
+                        aria-controls="4"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-unreviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="4"
+                      />
+                    </section>
+                  </section>
+                  <h3>
+                    Absorption
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    Abs(max) = ~10nm
+                  </section>
+                  <section
+                    class="text-block"
+                  >
+                    <section
+                      class="text-block"
+                    >
+                      value1
+                      <button
+                        aria-controls="5"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-reviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="5"
+                      />
+                    </section>
+                    <button
+                      aria-controls="6"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-reviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="6"
+                    />
+                  </section>
+                  <h3>
+                    Kinetics
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    <ul
+                      class="no-bullet"
+                    >
+                      <li>
+                        K
+                        <sub>
+                          M
+                        </sub>
+                        =2.0999999046325684uM for sub1 
+                        <button
+                          aria-controls="7"
+                          aria-expanded="false"
+                          class="evidence-tag svg-colour-reviewed"
+                          data-testid="evidence-tag-trigger"
+                          type="button"
+                        >
+                          <test-file-stub
+                            height="12"
+                            width="12"
+                          />
+                          <span
+                            class="evidence-tag__label"
+                            title=""
+                          >
+                            1 automatic annotation
+                          </span>
+                        </button>
+                        <div
+                          class="evidence-tag-content "
+                          data-testid="evidence-tag-content"
+                          id="7"
+                        />
+                      </li>
+                    </ul>
+                  </section>
+                  <section
+                    class="text-block"
+                  >
+                    <section
+                      class="text-block"
+                    >
+                      value1
+                      <button
+                        aria-controls="8"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-reviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="8"
+                      />
+                    </section>
+                  </section>
+                  <h3>
+                    pH Dependence
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    value1
+                    <button
+                      aria-controls="9"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-reviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="9"
+                    />
+                  </section>
+                  <h3>
+                    Redox Potential
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    value1
+                    <button
+                      aria-controls="10"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-reviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="10"
+                    />
+                  </section>
+                  <h3>
+                    Temperature Dependence
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    value1
+                    <button
+                      aria-controls="11"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-reviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="11"
+                    />
+                  </section>
+                  <div
+                    class="GoRibbon"
+                  >
+                    <h3>
+                      GO Annotations
+                    </h3>
+                  </div>
+                  <h3>
+                    Enzyme and pathway databases
+                  </h3>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            ENZYME
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="https://enzyme.expasy.org/EC/1.2.3.4"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                Search...
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                                
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="names-and-taxonomy"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Names & Taxonomy
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    Protein names
+                  </h3>
+                  <ul
+                    class="info-list"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Recommended name
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          rec full Name 
+                          <button
+                            aria-controls="12"
+                            aria-expanded="false"
+                            class="evidence-tag svg-colour-reviewed"
+                            data-testid="evidence-tag-trigger"
+                            type="button"
+                          >
+                            <test-file-stub
+                              height="12"
+                              width="12"
+                            />
+                            <span
+                              class="evidence-tag__label"
+                              title=""
+                            >
+                              1 automatic annotation
+                            </span>
+                          </button>
+                          <div
+                            class="evidence-tag-content "
+                            data-testid="evidence-tag-content"
+                            id="12"
+                          />
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            EC number
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          1.2.3.4 
+                          <button
+                            aria-controls="13"
+                            aria-expanded="false"
+                            class="evidence-tag svg-colour-reviewed"
+                            data-testid="evidence-tag-trigger"
+                            type="button"
+                          >
+                            <test-file-stub
+                              height="12"
+                              width="12"
+                            />
+                            <span
+                              class="evidence-tag__label"
+                              title=""
+                            >
+                              1 automatic annotation
+                            </span>
+                          </button>
+                          <div
+                            class="evidence-tag-content "
+                            data-testid="evidence-tag-content"
+                            id="13"
+                          />
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Short names
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          recommended short name 
+                          <button
+                            aria-controls="14"
+                            aria-expanded="false"
+                            class="evidence-tag svg-colour-reviewed"
+                            data-testid="evidence-tag-trigger"
+                            type="button"
+                          >
+                            <test-file-stub
+                              height="12"
+                              width="12"
+                            />
+                            <span
+                              class="evidence-tag__label"
+                              title=""
+                            >
+                              1 automatic annotation
+                            </span>
+                          </button>
+                          <div
+                            class="evidence-tag-content "
+                            data-testid="evidence-tag-content"
+                            id="14"
+                          />
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Alternative names
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              a full alt Name 
+                              <button
+                                aria-controls="15"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-reviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="15"
+                              />
+                               (short alt name1 
+                              <button
+                                aria-controls="16"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-reviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="16"
+                              />
+                              ) 
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Cleaved into 1 chains
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              containsrec full Name (containsrecommended short name)  
+                              <strong>
+                                Alternative names: 
+                              </strong>
+                              containsa full alt Name (containsshort alt name1) 
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Submission names
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              sub full Name 
+                              <button
+                                aria-controls="17"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-reviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="17"
+                              />
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Biotech name
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          biotech 
+                          <button
+                            aria-controls="18"
+                            aria-expanded="false"
+                            class="evidence-tag svg-colour-reviewed"
+                            data-testid="evidence-tag-trigger"
+                            type="button"
+                          >
+                            <test-file-stub
+                              height="12"
+                              width="12"
+                            />
+                            <span
+                              class="evidence-tag__label"
+                              title=""
+                            >
+                              1 automatic annotation
+                            </span>
+                          </button>
+                          <div
+                            class="evidence-tag-content "
+                            data-testid="evidence-tag-content"
+                            id="18"
+                          />
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            CD Antigen Name
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        />
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            INN Name
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        />
+                      </div>
+                    </li>
+                  </ul>
+                  <h3>
+                    Gene names
+                  </h3>
+                  <ul
+                    class="expandable-list no-bullet"
+                  >
+                    <li>
+                      <ul
+                        class="info-list"
+                      >
+                        <li>
+                          <div
+                            class="decorated-list-item"
+                          >
+                            <div
+                              class="decorated-list-item__title"
+                            >
+                              <h5
+                                class="bold"
+                              >
+                                Name
+                              </h5>
+                            </div>
+                            <div
+                              class="decorated-list-item__content"
+                            >
+                              some Gene 
+                              <button
+                                aria-controls="19"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-unreviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="19"
+                              />
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="decorated-list-item"
+                          >
+                            <div
+                              class="decorated-list-item__title"
+                            >
+                              <h5
+                                class="bold"
+                              >
+                                Synonyms
+                              </h5>
+                            </div>
+                            <div
+                              class="decorated-list-item__content"
+                            >
+                              some Syn 
+                              <button
+                                aria-controls="20"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-unreviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="20"
+                              />
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="decorated-list-item"
+                          >
+                            <div
+                              class="decorated-list-item__title"
+                            >
+                              <h5
+                                class="bold"
+                              >
+                                ORF names
+                              </h5>
+                            </div>
+                            <div
+                              class="decorated-list-item__content"
+                            >
+                              some orf 
+                              <button
+                                aria-controls="21"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-reviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 publication
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="21"
+                              />
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="decorated-list-item"
+                          >
+                            <div
+                              class="decorated-list-item__title"
+                            >
+                              <h5
+                                class="bold"
+                              >
+                                Ordered locus names
+                              </h5>
+                            </div>
+                            <div
+                              class="decorated-list-item__content"
+                            >
+                              some locus 
+                              <button
+                                aria-controls="22"
+                                aria-expanded="false"
+                                class="evidence-tag svg-colour-unreviewed"
+                                data-testid="evidence-tag-trigger"
+                                type="button"
+                              >
+                                <test-file-stub
+                                  height="12"
+                                  width="12"
+                                />
+                                <span
+                                  class="evidence-tag__label"
+                                  title=""
+                                >
+                                  1 automatic annotation
+                                </span>
+                              </button>
+                              <div
+                                class="evidence-tag-content "
+                                data-testid="evidence-tag-content"
+                                id="22"
+                              />
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                  <h3>
+                    Organism names
+                  </h3>
+                  <ul
+                    class="info-list"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Organism
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <a
+                            href="/taxonomy/9606"
+                          >
+                            scientific name (common name)
+                          </a>
+                          <button
+                            aria-controls="23"
+                            aria-expanded="false"
+                            class="evidence-tag svg-colour-unreviewed"
+                            data-testid="evidence-tag-trigger"
+                            type="button"
+                          >
+                            <test-file-stub
+                              height="12"
+                              width="12"
+                            />
+                            <span
+                              class="evidence-tag__label"
+                              title=""
+                            >
+                              1 automatic annotation
+                            </span>
+                          </button>
+                          <div
+                            class="evidence-tag-content "
+                            data-testid="evidence-tag-content"
+                            id="23"
+                          />
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Taxonomic identifier
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <a
+                            href="/taxonomy/9606"
+                          >
+                            9606 
+                          </a>
+                          <a
+                            class="external-link"
+                            href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?lvl=0&id=9606"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            NCBI
+                            <test-file-stub
+                              width="12.5"
+                            />
+                          </a>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Taxonomic lineage
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          lineage 1
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Virus hosts
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <p>
+                            <a
+                              href="/taxonomy/9606"
+                            >
+                              scientific name (common name)  (synonyms 1)
+                            </a>
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <h3>
+                    Accessions
+                  </h3>
+                  <ul
+                    class="info-list"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Primary accession
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          P21802
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Secondary accessions
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              P21802
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <h3>
+                    Proteome
+                  </h3>
+                  <ul
+                    class="expandable-list no-bullet"
+                  />
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="subcellular-location"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Subcellular Location
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <section
+                    class="text-block"
+                  >
+                    <h3>
+                      molecule value
+                    </h3>
+                    <div>
+                      <strong>
+                        location value
+                      </strong>
+                       
+                      <button
+                        aria-controls="24"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-unreviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="24"
+                      />
+                      : topology value 
+                      <button
+                        aria-controls="25"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-unreviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="25"
+                      />
+                    </div>
+                    <section
+                      class="text-block"
+                    >
+                      value
+                      <button
+                        aria-controls="26"
+                        aria-expanded="false"
+                        class="evidence-tag svg-colour-unreviewed"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                          title=""
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="26"
+                      />
+                    </section>
+                  </section>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="disease-and-drugs"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Disease & Drugs
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    Involvement in disease
+                  </h3>
+                  <h3>
+                    DiseaseEntry Id (someAcron)
+                  </h3>
+                  <span
+                    class="text-block"
+                  >
+                    <button
+                      aria-controls="27"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="27"
+                    />
+                  </span>
+                  <ul
+                    class="info-list"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Note
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              value2
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Description
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          some description
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            See also
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <a
+                            class="external-link"
+                            href="https://www.omim.org/entry/3124"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            3124
+                            <test-file-stub
+                              width="12.5"
+                            />
+                          </a>
+                            
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <h3
+                    style="text-transform: capitalize;"
+                  >
+                    disruption phenotype
+                  </h3>
+                  <h5>
+                    Isoform 4
+                  </h5>
+                  <section
+                    class="text-block"
+                  >
+                    value
+                    <button
+                      aria-controls="28"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="28"
+                    />
+                  </section>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="ptm-processing"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    PTM/Processing
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    Features
+                  </h3>
+                  <p>
+                    Showing features for chain.
+                  </p>
+                  <protvista-manager
+                    attributes="highlight displaystart displayend selectedid"
+                  >
+                    <protvista-navigation
+                      length="10"
+                    />
+                    <protvista-track
+                      layout="non-overlapping"
+                      length="10"
+                    />
+                    <protvista-sequence
+                      height="20"
+                      length="10"
+                      sequence="SAPSQDFMRF"
+                    />
+                    <protvista-datatable
+                      filter-scroll="true"
+                    />
+                    <div
+                      class="evidence-tag-content false"
+                    />
+                  </protvista-manager>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="interaction"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Interaction
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <interaction-viewer
+                    accession="P21802"
+                  />
+                  <protvista-datatable
+                    filter-scroll="true"
+                  />
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="structure"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Structure
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    3D structure databases
+                  </h3>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            ModBase
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="http://salilab.org/modbase-cgi/model_search.cgi?searchkw=name&kword=P21802"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                Search...
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                                
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            SWISS-MODEL-Workspace
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="https://swissmodel.expasy.org/interactive/?ac=P21802"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                Submit a new modelling project...
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                                
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="family-and-domains"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Family & Domains
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <h3>
+                    Keywords
+                  </h3>
+                  <ul
+                    class="info-list"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Domain
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                href="/keywords/KW-11111"
+                              >
+                                 #keyword value
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <h3>
+                    Family and domain databases
+                  </h3>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            MobiDB
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="http://mobidb.bio.unipd.it/entries/P21802"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                Search...
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                                
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            ProtoNet
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="http://www.protonet.cs.huji.ac.il/sp.php?prot=P21802"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                Search...
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                                
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            data-entry-section="true"
+            id="sequence"
+          >
+            <div
+              class="card"
+            >
+              <section>
+                <div
+                  class="card__header"
+                >
+                  <h2
+                    class="card__title"
+                  >
+                    Sequence
+                  </h2>
+                </div>
+                <div
+                  class="card__content"
+                >
+                  <div
+                    class="button-group"
+                  >
+                    <button
+                      class="button tertiary"
+                      title="Run a BLAST job against isoID1"
+                      type="button"
+                    >
+                      BLAST 1 isoform
+                    </button>
+                    <button
+                      class="button tertiary disabled"
+                      disabled=""
+                      title="Select at least 2 entries to run an Align job"
+                      type="button"
+                    >
+                      Align
+                    </button>
+                  </div>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Sequence status
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          Fragment
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <p>
+                    This entry describes 
+                    <strong>
+                      1
+                    </strong>
+                     isoforms produced by 
+                    <strong>
+                      Alternative initiation
+                    </strong>
+                    .
+                  </p>
+                  <p>
+                    value1
+                  </p>
+                  <hr />
+                  <h3
+                    id="isoID1"
+                  >
+                    isoID1
+                  </h3>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item decorated-list-item--compact"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Name
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          name
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item decorated-list-item--compact"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Synonyms
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          syn value
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item decorated-list-item--compact"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Note
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          value1
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                  <button
+                    class="button secondary"
+                    type="button"
+                  >
+                    Show sequence 
+                  </button>
+                  <h3>
+                    Sequence caution
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    The sequence 
+                    <a
+                      class="external-link"
+                      href="//www.ebi.ac.uk/ena/data/view/sequence"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      sequence
+                      <test-file-stub
+                        width="12.5"
+                      />
+                    </a>
+                     differs from that shown. Reason: Erroneous initiation Text note
+                    <button
+                      aria-controls="29"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="29"
+                    />
+                  </section>
+                  <h3>
+                    Mass Spectrometry
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    <h3>
+                      isoform 1
+                    </h3>
+                    Molecular mass is 2.1 Da. Determined by LSI. note value
+                    <button
+                      aria-controls="30"
+                      aria-expanded="false"
+                      class="evidence-tag svg-colour-unreviewed"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                        title=""
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="30"
+                    />
+                  </section>
+                  <h3>
+                    RNA Editing
+                  </h3>
+                  <section
+                    class="text-block"
+                  >
+                    <div>
+                      Edited at positions 
+                      <span>
+                        rna position 
+                        <button
+                          aria-controls="31"
+                          aria-expanded="false"
+                          class="evidence-tag svg-colour-unreviewed"
+                          data-testid="evidence-tag-trigger"
+                          type="button"
+                        >
+                          <test-file-stub
+                            height="12"
+                            width="12"
+                          />
+                          <span
+                            class="evidence-tag__label"
+                            title=""
+                          >
+                            1 automatic annotation
+                          </span>
+                        </button>
+                        <div
+                          class="evidence-tag-content "
+                          data-testid="evidence-tag-content"
+                          id="31"
+                        />
+                      </span>
+                    </div>
+                    <div>
+                      <span>
+                        value 
+                        <button
+                          aria-controls="32"
+                          aria-expanded="false"
+                          class="evidence-tag svg-colour-unreviewed"
+                          data-testid="evidence-tag-trigger"
+                          type="button"
+                        >
+                          <test-file-stub
+                            height="12"
+                            width="12"
+                          />
+                          <span
+                            class="evidence-tag__label"
+                            title=""
+                          >
+                            1 automatic annotation
+                          </span>
+                        </button>
+                        <div
+                          class="evidence-tag-content "
+                          data-testid="evidence-tag-content"
+                          id="32"
+                        />
+                      </span>
+                    </div>
+                  </section>
+                  <h3>
+                    Genome annotation databases
+                  </h3>
+                  <ul
+                    class="info-list info-list--columns"
+                  >
+                    <li>
+                      <div
+                        class="decorated-list-item"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
+                            Ensembl
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          <ul
+                            class="expandable-list no-bullet"
+                          >
+                            <li>
+                              <a
+                                class="external-link"
+                                href="https://www.ensembl.org/id/id value"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                id value
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                               
+                              <a
+                                class="external-link"
+                                href="https://www.ensembl.org/id/description value"
+                                rel="noopener"
+                                target="_blank"
+                              >
+                                description value
+                                <test-file-stub
+                                  width="12.5"
+                                />
+                              </a>
+                               [
+                              <a
+                                href="#Q9NXB0-1"
+                              >
+                                Q9NXB0-1
+                              </a>
+                              ]
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div
+            class="message message--failure"
+            role="status"
+          >
+            <div
+              class="message__side-border"
+            />
+            <test-file-stub
+              height="1.125em"
+              width="1.125em"
+            />
+            <section
+              class="message__content"
+            >
+              <small>
+                Request failed with status code 404
+              </small>
+            </section>
+          </div>
+          <div
+            class="hero-container hero-container--side-padding"
+          >
+            <em>
+              Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care.
+            </em>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Purpose
Have taxonomy filtering working in BLAST search

## Approach
Now that the backend has been optimised, make available to the user filtering by any level of taxonomy (not just the subset of "organism" as until now).
Also, changed model and code to be able to tackle the newly available excluding taxonomy feature available in the backend (not visible in the frontend yet)

## Testing
Updated tests and snapshots.
Changed wording to reflect the complete availability of the whole taxonomy tree.
Try running BLAST searches with some higher level taxonomy nodes

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Also, reactivated some tests in UniProtKB entry in order to improve test coverage.