### PR TITLE
2021 02 optimise BLAST HSPs

### DIFF
--- a/src/tools/blast/components/results/BlastResultSidebar.tsx
+++ b/src/tools/blast/components/results/BlastResultSidebar.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { memo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Loader, Facets, Facet } from 'franklin-sites';
 
@@ -31,34 +31,33 @@ type BlastResultSidebarProps = {
   allHits: BlastHit[];
 };
 
-const BlastResultSidebar: FC<BlastResultSidebarProps> = ({
-  accessions,
-  allHits,
-}) => {
-  const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
-  const { data, loading, isStale } = useDataApiWithStale<Response['data']>(
-    // NOTE: set size to 0 when backend supports it
-    // NOTE: this is a regression, using 0 used to work before
-    getAccessionsURL(accessions, { size: 1, facets, selectedFacets })
-  );
+const BlastResultSidebar = memo<BlastResultSidebarProps>(
+  ({ accessions, allHits }) => {
+    const { search } = useLocation();
+    const { selectedFacets } = getParamsFromURL(search);
+    const { data, loading, isStale } = useDataApiWithStale<Response['data']>(
+      // NOTE: set size to 0 when backend supports it
+      // NOTE: this is a regression, using 0 used to work before
+      getAccessionsURL(accessions, { size: 1, facets, selectedFacets })
+    );
 
-  if (loading && !isStale) {
-    return <Loader />;
+    if (loading && !isStale) {
+      return <Loader />;
+    }
+
+    return (
+      <Facets>
+        <BlastResultLocalFacets allHits={allHits} />
+        {data?.facets?.map((facet: FacetObject) => (
+          <Facet
+            key={facet.name}
+            data={facet}
+            className={isStale ? 'is-stale' : undefined}
+          />
+        ))}
+      </Facets>
+    );
   }
-
-  return (
-    <Facets>
-      <BlastResultLocalFacets allHits={allHits} />
-      {data?.facets?.map((facet: FacetObject) => (
-        <Facet
-          key={facet.name}
-          data={facet}
-          className={isStale ? 'is-stale' : undefined}
-        />
-      ))}
-    </Facets>
-  );
-};
+);
 
 export default BlastResultSidebar;

--- a/src/tools/blast/components/results/BlastResultTable.tsx
+++ b/src/tools/blast/components/results/BlastResultTable.tsx
@@ -9,7 +9,7 @@ import {
   SetStateAction,
   ReactNode,
 } from 'react';
-import { DataTable, Chip, Loader } from 'franklin-sites';
+import { DataTable, Chip, Loader, Button } from 'franklin-sites';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
 
@@ -188,17 +188,23 @@ const BlastSummaryHsps: FC<{
   setSelectedScoring,
   maxScorings,
 }) => {
-  const [collapsed, setCollapsed] = useState(true);
+  const [restVisible, setRestVisible] = useState(0);
 
-  const hspsOrderedByScore = hsps.sort(
-    (hspA, hspB) => hspB.hsp_bit_score - hspA.hsp_bit_score
+  // "first", ordered by score
+  const [first, ...rest] = useMemo<BlastHsp[]>(
+    () =>
+      // Operate on a copy to not mutate the original data
+      Array.from(hsps).sort(
+        (hspA, hspB) => hspB.hsp_bit_score - hspA.hsp_bit_score
+      ),
+    [hsps]
   );
 
   return (
     <div className="data-table__blast-hsp">
       <div>
         <BlastSummaryTrack
-          hsp={hspsOrderedByScore[0]}
+          hsp={first}
           queryLength={queryLength}
           hitLength={hitLength}
           hitAccession={hitAccession}
@@ -208,29 +214,26 @@ const BlastSummaryHsps: FC<{
           setSelectedScoring={setSelectedScoring}
           maxScorings={maxScorings}
         />
-        {hspsOrderedByScore.length > 1 &&
-          !collapsed &&
-          hspsOrderedByScore
-            .slice(1)
-            .map((hsp) => (
-              <BlastSummaryTrack
-                hsp={hsp}
-                queryLength={queryLength}
-                hitLength={hitLength}
-                key={`hsp_${hsp.hsp_num}`}
-                hitAccession={hitAccession}
-                extra={extra}
-                setHspDetailPanel={setHspDetailPanel}
-                selectedScoring={selectedScoring}
-                setSelectedScoring={setSelectedScoring}
-                maxScorings={maxScorings}
-              />
-            ))}
+        {rest.slice(0, restVisible).map((hsp) => (
+          <BlastSummaryTrack
+            hsp={hsp}
+            queryLength={queryLength}
+            hitLength={hitLength}
+            key={`hsp_${hsp.hsp_num}`}
+            hitAccession={hitAccession}
+            extra={extra}
+            setHspDetailPanel={setHspDetailPanel}
+            selectedScoring={selectedScoring}
+            setSelectedScoring={setSelectedScoring}
+            maxScorings={maxScorings}
+          />
+        ))}
       </div>
-      {hspsOrderedByScore.length > 1 && collapsed && (
-        <button type="button" onClick={() => setCollapsed(false)}>{`+${
-          hspsOrderedByScore.length - 1
-        } more`}</button>
+      {restVisible < rest.length && (
+        <Button
+          variant="tertiary"
+          onClick={() => setRestVisible((restVisible) => restVisible + 10)}
+        >{`+${rest.length - restVisible} more`}</Button>
       )}
     </div>
   );

--- a/src/tools/blast/components/results/BlastResultTable.tsx
+++ b/src/tools/blast/components/results/BlastResultTable.tsx
@@ -292,26 +292,30 @@ const BlastResultTable: FC<{
     [data, ceDefined]
   );
 
-  const maxScorings: Partial<Record<keyof BlastHsp, number>> = useMemo(
-    () => ({
-      hsp_identity: Math.max(
-        ...(data?.hits.flatMap((hit) =>
-          hit.hit_hsps.map((hsp) => hsp.hsp_identity)
-        ) ?? [100])
-      ),
-      hsp_bit_score: Math.max(
-        ...(data?.hits.flatMap((hit) =>
-          hit.hit_hsps.map((hsp) => hsp.hsp_bit_score)
-        ) ?? [1])
-      ),
-      hsp_expect: Math.max(
-        ...(data?.hits.flatMap((hit) =>
-          hit.hit_hsps.map((hsp) => hsp.hsp_expect)
-        ) ?? [1])
-      ),
-    }),
-    [data]
-  );
+  const maxScorings = useMemo<Partial<Record<keyof BlastHsp, number>>>(() => {
+    if (!data?.hits) {
+      return { hsp_identity: 100, hsp_bit_score: 1, hsp_expect: 1 };
+    }
+    const output = {
+      hsp_identity: -Infinity,
+      hsp_bit_score: -Infinity,
+      hsp_expect: -Infinity,
+    };
+    for (const hit of data.hits) {
+      for (const hsp of hit.hit_hsps) {
+        if (output.hsp_identity < hsp.hsp_identity) {
+          output.hsp_identity = hsp.hsp_identity;
+        }
+        if (output.hsp_bit_score < hsp.hsp_bit_score) {
+          output.hsp_bit_score = hsp.hsp_bit_score;
+        }
+        if (output.hsp_expect < hsp.hsp_expect) {
+          output.hsp_expect = hsp.hsp_expect;
+        }
+      }
+    }
+    return output;
+  }, [data]);
 
   const queryLen = data?.query_len;
   const columns = useMemo<

--- a/src/tools/blast/components/results/__tests__/__snapshots__/BlastResultTable.spec.tsx.snap
+++ b/src/tools/blast/components/results/__tests__/__snapshots__/BlastResultTable.spec.tsx.snap
@@ -142,6 +142,7 @@ Hit length: 486"
               </div>
             </div>
             <button
+              class="button tertiary"
               type="button"
             >
               +1 more

--- a/src/tools/blast/components/results/styles/BlastResultTable.scss
+++ b/src/tools/blast/components/results/styles/BlastResultTable.scss
@@ -25,6 +25,11 @@
   $self: &;
   display: flex;
 
+  & > .button {
+    margin-bottom: 0;
+    align-self: flex-end;
+  }
+
   .chip {
     margin-top: 0;
 


### PR DESCRIPTION
## Purpose
Prevent crashing the browser when calculating and displaying too many HSPs.

## Approach
 - Display them 10 by 10 instead of just all or nothing as before
 - Optimise calculating max scores by simplifying code to use for loops (would cause stack overflow issues otherwise in cases with too manys HSPs)

## Testing
Run BLAST on a Titin sequence (e.g Q9I7U4), max sure to ask for only 50 hits, but it will still take a while to run
Play with the "+n more" button on a BLAST result

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
