### PR TITLE
add progress info to useDataApi, use in BLAST results (but unsupporte…

### DIFF
--- a/src/shared/hooks/__tests__/useDataApi.spec.ts
+++ b/src/shared/hooks/__tests__/useDataApi.spec.ts
@@ -52,6 +52,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url,
       data: 'some data',
       status: 200,
@@ -68,6 +69,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 0,
       url,
       error: new Error('Network Error'),
     });
@@ -83,6 +85,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 0,
       url,
       error: new Error('timeout of 0ms exceeded'),
     });
@@ -109,11 +112,10 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       error: new Error('Request failed with status code 400'),
-      headers: undefined,
       loading: false,
+      progress: 0,
       url,
       status: 400,
-      statusText: undefined,
     });
   });
 
@@ -127,6 +129,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 0,
       url,
       status: 404,
       error: new Error('Request failed with status code 404'),
@@ -158,6 +161,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url,
       data: 'some data',
       status: 200,
@@ -171,6 +175,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url: url2,
       data: 'some other data',
       status: 200,
@@ -195,6 +200,7 @@ describe('useDataApi hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url: url2,
       data: 'some other data',
       status: 200,
@@ -212,6 +218,7 @@ describe('useDataApi hook', () => {
     await waitForNextUpdate();
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url: url2,
       data: 'some data',
       status: 200,
@@ -235,6 +242,7 @@ describe('useDataApiWithStale hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url,
       data: 'some data',
       status: 200,
@@ -253,6 +261,7 @@ describe('useDataApiWithStale hook', () => {
 
     expect(result.current).toEqual({
       loading: false,
+      progress: 1,
       url: url2,
       data: 'some other data',
       status: 200,

--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -1,10 +1,10 @@
-import axios, { CancelToken } from 'axios';
+import axios, { AxiosRequestConfig, CancelToken } from 'axios';
 
 export default function fetchData<T>(
   url: string,
   headers: Record<string, string> = {},
   cancelToken?: CancelToken,
-  axiosOptions = {}
+  axiosOptions: AxiosRequestConfig = {}
 ) {
   return axios.get<T>(url, {
     headers: {

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -194,6 +194,7 @@ const BlastResult = () => {
   // get data from the blast endpoint
   const {
     loading: blastLoading,
+    progress: blastProgress,
     data: blastData,
     error: blastError,
     status: blastStatus,
@@ -281,7 +282,7 @@ const BlastResult = () => {
   }, []);
 
   if (blastLoading) {
-    return <Loader />;
+    return <Loader progress={blastProgress} />;
   }
 
   if (blastError || !blastData || !match) {


### PR DESCRIPTION
## Purpose
Goal is to display progress in BLAST results page

## Approach
Add progress info to useDataApi (when available), use this info in the Loader component in the BLAST results page

## Testing
Updated tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Note that this is currently not doing anything as none of the endpoints we currently use appear to set the `Content-Length` header. But I've sent an email to www-prod to have them add this information, so we'd get that improvement at some point later.
