### PR TITLE
fix default namespace after searching from home page

### DIFF
--- a/src/app/components/HomePage.tsx
+++ b/src/app/components/HomePage.tsx
@@ -52,7 +52,7 @@ const HomePage = () => {
             title={`Find your ${namespaceFindYour[selectedNamespace]}`}
             footer={mission}
           >
-            <section className="uniprot-grid uniprot-grid--centered">
+            <div className="uniprot-grid uniprot-grid--centered">
               <SearchContainer
                 namespace={selectedNamespace}
                 onNamespaceChange={(namespace) =>
@@ -61,7 +61,7 @@ const HomePage = () => {
                 className="uniprot-grid-cell--span-12"
                 includeFooter
               />
-            </section>
+            </div>
           </HeroHeader>
         </ErrorBoundary>
 

--- a/src/app/components/__tests__/__snapshots__/HomePage.spec.tsx.snap
+++ b/src/app/components/__tests__/__snapshots__/HomePage.spec.tsx.snap
@@ -12,11 +12,12 @@ exports[`HomePage component should render 1`] = `
         <h1>
           Find your protein
         </h1>
-        <section
+        <div
           class="uniprot-grid uniprot-grid--centered"
         >
           <section
             class="uniprot-grid-cell--span-12"
+            role="search"
           >
             <form
               class="main-search"
@@ -49,10 +50,10 @@ exports[`HomePage component should render 1`] = `
                 Search
               </button>
             </form>
-            <section
+            <div
               class="search-container-footer"
             >
-              <section>
+              <div>
                 Examples: 
                 <button
                   class="button tertiary"
@@ -74,18 +75,18 @@ exports[`HomePage component should render 1`] = `
                 >
                   Albumin
                 </button>
-              </section>
-              <section>
+              </div>
+              <div>
                 <a
                   class="button tertiary"
                   href="/uploadlists"
                 >
                   Search with a list of IDs
                 </a>
-              </section>
-            </section>
+              </div>
+            </div>
           </section>
-        </section>
+        </div>
       </div>
       <div
         class="hero-header__footer"

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -6,6 +6,7 @@ import SlidingPanel, { Position } from './SlidingPanel';
 import SearchContainer from '../../../uniprotkb/components/search/SearchContainer';
 
 import lazy from '../../utils/lazy';
+
 import useNS from '../../hooks/useNS';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
@@ -78,14 +79,25 @@ const QueryBuilder = lazy(
     )
 );
 
-const UniProtHeader = () => {
-  const homeMatch = useRouteMatch(LocationToPath[Location.Home]);
-
+const SearchContainerWithNamespace = () => {
   const namespace = useNS();
 
   const [selectedNamespace, setSelectedNamespace] = useState(
     namespace || Namespace.uniprotkb
   );
+
+  return (
+    <SearchContainer
+      namespace={selectedNamespace}
+      onNamespaceChange={(namespace: Namespace) =>
+        setSelectedNamespace(namespace)
+      }
+    />
+  );
+};
+
+const UniProtHeader = () => {
+  const homeMatch = useRouteMatch(LocationToPath[Location.Home]);
   const [displayQueryBuilder, setDisplayQueryBuilder] = useState(false);
 
   const isHomePage = Boolean(homeMatch?.isExact);
@@ -114,16 +126,7 @@ const UniProtHeader = () => {
       <Header
         items={displayedLinks}
         isNegative={isHomePage}
-        search={
-          isHomePage ? undefined : (
-            <SearchContainer
-              namespace={selectedNamespace}
-              onNamespaceChange={(namespace: Namespace) =>
-                setSelectedNamespace(namespace)
-              }
-            />
-          )
-        }
+        search={!isHomePage && <SearchContainerWithNamespace />}
         logo={<Logo width={120} height={50} />}
       />
       {displayQueryBuilder && (

--- a/src/uniprotkb/components/search/SearchContainer.tsx
+++ b/src/uniprotkb/components/search/SearchContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, FC, Fragment } from 'react';
+import { useState, useEffect, FC, Fragment, HTMLAttributes } from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import queryString from 'query-string';
 import { MainSearch, Button } from 'franklin-sites';
@@ -17,12 +17,15 @@ const examples: Partial<Record<Namespace, string[]>> = {
   [Namespace.uniprotkb]: ['p53', 'Human EGFR', 'Albumin'],
 };
 
-const Search: FC<{
-  className?: string;
+type Props = {
   includeFooter?: boolean;
   namespace: Namespace;
   onNamespaceChange: (namespace: Namespace) => void;
-}> = ({ className, includeFooter = false, namespace, onNamespaceChange }) => {
+};
+
+const SearchContainer: FC<
+  Props & Exclude<HTMLAttributes<HTMLDivElement>, 'role'>
+> = ({ includeFooter, namespace, onNamespaceChange, ...props }) => {
   const history = useHistory();
   const location = useLocation();
 
@@ -64,7 +67,7 @@ const Search: FC<{
   }, [location]);
 
   return (
-    <section className={className}>
+    <section role="search" {...props}>
       <MainSearch
         namespaces={NamespaceLabels}
         searchTerm={searchTerm}
@@ -74,8 +77,8 @@ const Search: FC<{
         selectedNamespace={namespace}
       />
       {includeFooter && (
-        <section className="search-container-footer">
-          <section>
+        <div className="search-container-footer">
+          <div>
             {examples[namespace] && (
               <>
                 Examples:{' '}
@@ -92,8 +95,8 @@ const Search: FC<{
                 ))}
               </>
             )}
-          </section>
-          <section>
+          </div>
+          <div>
             <Button
               variant="tertiary"
               element={Link}
@@ -101,11 +104,11 @@ const Search: FC<{
             >
               Search with a list of IDs
             </Button>
-          </section>
-        </section>
+          </div>
+        </div>
       )}
     </section>
   );
 };
 
-export default Search;
+export default SearchContainer;

--- a/src/uniprotkb/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/uniprotkb/components/search/__tests__/SearchContainer.spec.tsx
@@ -1,39 +1,32 @@
-import { cleanup, fireEvent } from '@testing-library/react';
-import { Namespace } from '../../../../shared/types/namespaces';
-import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
-import Search from '../SearchContainer';
+import { screen, fireEvent } from '@testing-library/react';
 
-const props = {
-  dispatchCopyQueryClausesToSearch: jest.fn(),
-  location: {
-    search: '',
-  },
-  history: {
-    push: jest.fn(),
-    replace: jest.fn(),
-  },
-};
+import renderWithRouter from '../../../../shared/__test-helpers__/RenderWithRouter';
+
+import SearchContainer from '../SearchContainer';
+
+import { Namespace } from '../../../../shared/types/namespaces';
 
 let component;
 
 describe('Search shallow components', () => {
   beforeEach(() => {
     component = renderWithRouter(
-      <Search {...props} includeFooter namespace={Namespace.uniprotkb} />
+      <SearchContainer
+        includeFooter
+        namespace={Namespace.uniprotkb}
+        onNamespaceChange={() => {}}
+      />
     );
   });
 
-  test('should render', () => {
+  it('should render', () => {
     const { asFragment } = component;
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('it should ', () => {
-    const { getByText, getByDisplayValue, queryByDisplayValue } = component;
-    expect(queryByDisplayValue('Albumin')).toBeNull();
-    fireEvent.click(getByText('Albumin'));
-    expect(getByDisplayValue('Albumin')).toBeTruthy();
+  it('should change the search text when clicking on a suggestion', () => {
+    expect(screen.queryByDisplayValue('Albumin')).not.toBeInTheDocument();
+    fireEvent.click(screen.queryByRole('button', { name: 'Albumin' }));
+    expect(screen.getByDisplayValue('Albumin')).toBeInTheDocument();
   });
-
-  afterAll(cleanup);
 });

--- a/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
+++ b/src/uniprotkb/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Search shallow components should render 1`] = `
 <DocumentFragment>
-  <section>
+  <section
+    role="search"
+  >
     <form
       class="main-search"
       data-testid="main-search-form"
@@ -34,10 +36,10 @@ exports[`Search shallow components should render 1`] = `
         Search
       </button>
     </form>
-    <section
+    <div
       class="search-container-footer"
     >
-      <section>
+      <div>
         Examples: 
         <button
           class="button tertiary"
@@ -59,16 +61,16 @@ exports[`Search shallow components should render 1`] = `
         >
           Albumin
         </button>
-      </section>
-      <section>
+      </div>
+      <div>
         <a
           class="button tertiary"
           href="/uploadlists"
         >
           Search with a list of IDs
         </a>
-      </section>
-    </section>
+      </div>
+    </div>
   </section>
 </DocumentFragment>
 `;


### PR DESCRIPTION
## Purpose
Fix issue where the namespace wouldn't be initialised correctly on the search box in the header after submitting a search from the home page on another namespace than UniProtKB.

## Approach
Move state around in order to initialise it correctly when the search box is actually rendered in the header and not before

## Testing
Updated tests and snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
