### PR TITLE
update the proteomes column renderer for UniParc

### DIFF
--- a/src/uniparc/config/UniParcColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcColumnConfiguration.tsx
@@ -170,7 +170,7 @@ UniParcColumnConfiguration.set(UniParcColumn.proteome, {
           <Link to={getEntryPath(Namespace.proteomes, xref.proteomeId)}>
             {xref.proteomeId}
           </Link>
-          {xref.component ? `:${xref.component}` : undefined}
+          {xref.component ? ` (${xref.component})` : undefined}
         </Fragment>
       ))}
     </ExpandableList>

--- a/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
+++ b/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
@@ -435,7 +435,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000000344
       </a>
-      :Genome
+       (Genome)
     </li>
     <li>
       <a
@@ -443,7 +443,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000166173
       </a>
-      :Genome
+       (Genome)
     </li>
     <li>
       <a
@@ -451,7 +451,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000111173
       </a>
-      :Genome
+       (Genome)
     </li>
     <li>
       <a
@@ -459,7 +459,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000113999
       </a>
-      :Genome
+       (Genome)
     </li>
     <li>
       <a
@@ -467,7 +467,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000181229
       </a>
-      :Genome
+       (Genome)
     </li>
     <li>
       <button

--- a/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
+++ b/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
@@ -435,6 +435,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000000344
       </a>
+      :Genome
     </li>
     <li>
       <a
@@ -442,6 +443,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000166173
       </a>
+      :Genome
     </li>
     <li>
       <a
@@ -449,6 +451,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000111173
       </a>
+      :Genome
     </li>
     <li>
       <a
@@ -456,6 +459,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000113999
       </a>
+      :Genome
     </li>
     <li>
       <a
@@ -463,6 +467,7 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
       >
         UP000181229
       </a>
+      :Genome
     </li>
     <li>
       <button


### PR DESCRIPTION
## Purpose
Add missing component in the proteomes renderer of the UniParc results page (table view). Matches behaviour of the current website.

## Approach


## Testing
Updated snapshot

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
