### PR TITLE
Hot fix for rendering GO ids and terms.

### DIFF
--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -778,7 +778,9 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.go, {
   label: 'Gene Ontology',
   render(data) {
     const { goTerms } = data[EntrySection.Function] as FunctionUIModel;
-    return goTerms && <GOTermsView data={Object.values(goTerms).flat()} />;
+    return (
+      goTerms && <GOTermsView data={Array.from(goTerms.values()).flat()} />
+    );
   },
 });
 
@@ -790,7 +792,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.goId, {
       goTerms && (
         <section className="text-block">
           <ExpandableList descriptionString="IDs" displayNumberOfHiddenItems>
-            {Object.values(goTerms)
+            {Array.from(goTerms.values())
               .flat()
               .map(
                 ({ id }: GoTerm) =>

--- a/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
+++ b/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
@@ -20,6 +20,8 @@ describe('UniProtKBColumnConfiguration component', () => {
     });
   });
 
+  // TODO: find mock data to generate non-null snapshot for:
+  // go_id, go, and many others
   for (const [key, column] of UniProtKBColumnConfiguration) {
     test(`should render column "${key}"`, () => {
       const { asFragment } = renderWithRedux(


### PR DESCRIPTION
## Purpose
Saw that some GO columns weren't rendering.

## Approach
Converted Map to an Array

## Testing
Add TODOs

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

**To view search in uniprotkb for (go:0002381)**