### PR TITLE
2021 03 use item select

### DIFF
--- a/src/shared/components/results/ResultsContainer.tsx
+++ b/src/shared/components/results/ResultsContainer.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from 'react';
+import { FC, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { PageIntro, Loader } from 'franklin-sites';
 
@@ -8,6 +8,8 @@ import ResultsFacets from './ResultsFacets';
 import NoResultsPage from '../error-pages/NoResultsPage';
 import ErrorHandler from '../error-pages/ErrorHandler';
 import SideBarLayout from '../layouts/SideBarLayout';
+
+import useItemSelect from '../../hooks/useItemSelect';
 
 import {
   getLocationObjForParams,
@@ -43,8 +45,7 @@ const Results: FC = () => {
   const { query, selectedFacets, sortColumn, sortDirection } = getParamsFromURL(
     queryParamFromUrl
   );
-  const [selectedEntries, setSelectedEntries] = useState<string[]>([]);
-
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
   const [viewMode, setViewMode] = useLocalStorage<ViewMode>(
     'view-mode',
     ViewMode.CARD
@@ -101,15 +102,6 @@ const Results: FC = () => {
   if (total === 0 || !(total || loading)) {
     return <NoResultsPage />;
   }
-
-  const handleEntrySelection = (rowId: string): void => {
-    const filtered = selectedEntries.filter((id) => id !== rowId);
-    setSelectedEntries(
-      filtered.length === selectedEntries.length
-        ? [...selectedEntries, rowId]
-        : filtered
-    );
-  };
 
   const handleTableColumnsChange = (columns: Column[]) => {
     if (

--- a/src/shared/hooks/__tests__/useItemSelect.spec.ts
+++ b/src/shared/hooks/__tests__/useItemSelect.spec.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useItemSelect from '../useItemSelect';
+
+describe('useItemSelect', () => {
+  it('should return correct default selectedItems, handleItemSelection', () => {
+    const { result } = renderHook(() => useItemSelect());
+    expect(result.current[0]).toEqual([]);
+    expect(typeof result.current[1]).toBe('function');
+  });
+
+  it('should return passed selectedItems', () => {
+    const { result } = renderHook(() => useItemSelect(['id1']));
+    expect(result.current[0]).toEqual(['id1']);
+    expect(typeof result.current[1]).toBe('function');
+  });
+
+  it('should add and remove item', () => {
+    const { result } = renderHook(() => useItemSelect());
+    act(() => {
+      result.current[1]('id1');
+    });
+    expect(result.current[0]).toEqual(['id1']);
+    act(() => {
+      result.current[1]('id1');
+    });
+    expect(result.current[0]).toEqual([]);
+  });
+});

--- a/src/shared/hooks/useItemSelect.ts
+++ b/src/shared/hooks/useItemSelect.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+
+const useItemSelect = (
+  items: string[] = []
+): [selectedItems: string[], handleSelectedItem: (id: string) => void] => {
+  const [selectedItems, setSelectedItems] = useState(items);
+
+  const handleEntrySelection = useCallback((rowId: string) => {
+    setSelectedItems((selectedEntries) => {
+      const filtered = selectedEntries.filter((id) => id !== rowId);
+      return filtered.length === selectedEntries.length
+        ? [...selectedEntries, rowId]
+        : filtered;
+    });
+  }, []);
+
+  return [selectedItems, handleEntrySelection];
+};
+
+export default useItemSelect;

--- a/src/shared/hooks/useItemSelect.ts
+++ b/src/shared/hooks/useItemSelect.ts
@@ -5,6 +5,7 @@ const useItemSelect = (
 ): [selectedItems: string[], handleSelectedItem: (id: string) => void] => {
   const [selectedItems, setSelectedItems] = useState(items);
 
+  // TODO: handle multiple simultaneous item selections rather just than a single item.
   const handleEntrySelection = useCallback((rowId: string) => {
     setSelectedItems((selectedEntries) => {
       const filtered = selectedEntries.filter((id) => id !== rowId);

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, lazy, Suspense } from 'react';
+import { useEffect, useState, lazy, Suspense } from 'react';
 import {
   Link,
   useRouteMatch,
@@ -16,6 +16,7 @@ import useDataApi, {
   UseDataAPIState,
 } from '../../../../shared/hooks/useDataApi';
 import useSequenceInfo from '../../utils/useSequenceInfo';
+import useItemSelect from '../../../../shared/hooks/useItemSelect';
 
 import inputParamsXMLToObject from '../../adapters/inputParamsXMLToObject';
 
@@ -117,7 +118,7 @@ const AlignResult = () => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const match = useRouteMatch<Params>(LocationToPath[Location.AlignResult])!;
 
-  const [selectedEntries, setSelectedEntries] = useState<string[]>([]);
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   // if URL doesn't finish with "overview" redirect to /overview by default
   useEffect(() => {
@@ -140,16 +141,6 @@ const AlignResult = () => {
   const inputParamsData = useParamsData(match?.params.id || '');
 
   const sequenceInfo = useSequenceInfo(inputParamsData.data?.sequence);
-
-  // Note: this function is duplicated in ResultsContainer.tsx
-  const handleSelectedEntries = useCallback((rowId: string) => {
-    setSelectedEntries((selectedEntries) => {
-      const filtered = selectedEntries.filter((id) => id !== rowId);
-      return filtered.length === selectedEntries.length
-        ? [...selectedEntries, rowId]
-        : filtered;
-    });
-  }, []);
 
   if (loading) {
     return <Loader />;
@@ -192,7 +183,7 @@ const AlignResult = () => {
                 data={data}
                 sequenceInfo={sequenceInfo}
                 selectedEntries={selectedEntries}
-                handleSelectedEntries={handleSelectedEntries}
+                handleEntrySelection={handleEntrySelection}
               />
             </ErrorBoundary>
           </Suspense>
@@ -217,7 +208,7 @@ const AlignResult = () => {
                 id={match.params.id}
                 sequenceInfo={sequenceInfo}
                 selectedEntries={selectedEntries}
-                handleSelectedEntries={handleSelectedEntries}
+                handleEntrySelection={handleEntrySelection}
               />
             </Suspense>
           </ErrorBoundary>
@@ -242,7 +233,7 @@ const AlignResult = () => {
                 id={match.params.id}
                 sequenceInfo={sequenceInfo}
                 selectedEntries={selectedEntries}
-                handleSelectedEntries={handleSelectedEntries}
+                handleEntrySelection={handleEntrySelection}
               />
             </Suspense>
           </ErrorBoundary>

--- a/src/tools/align/components/results/AlignResultOverview.tsx
+++ b/src/tools/align/components/results/AlignResultOverview.tsx
@@ -18,7 +18,7 @@ type AlignResultOverviewProps = {
   data: string;
   sequenceInfo: SequenceInfo;
   selectedEntries: string[];
-  handleSelectedEntries: (rowId: string) => void;
+  handleEntrySelection: (rowId: string) => void;
 };
 
 type EnrichedSequence = AlnClustalSequence & {
@@ -82,7 +82,7 @@ const AlignResultOverview: FC<AlignResultOverviewProps> = ({
   data,
   sequenceInfo,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
 }) => {
   const clustalParsed = useMemo(() => alnClustalNum(data), [data]);
 
@@ -106,7 +106,7 @@ const AlignResultOverview: FC<AlignResultOverviewProps> = ({
       defaultView={View.wrapped}
       tool={Tool.align}
       selectedEntries={selectedEntries}
-      handleSelectedEntries={handleSelectedEntries}
+      handleEntrySelection={handleEntrySelection}
     />
   );
 };

--- a/src/tools/align/components/results/AlignResultPIM.tsx
+++ b/src/tools/align/components/results/AlignResultPIM.tsx
@@ -26,14 +26,14 @@ type AlignResultPIMProps = {
   id: string;
   sequenceInfo: SequenceInfo;
   selectedEntries: string[];
-  handleSelectedEntries: (rowId: string) => void;
+  handleEntrySelection: (rowId: string) => void;
 };
 
 const AlignResultPIM: FC<AlignResultPIMProps> = ({
   id,
   sequenceInfo,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
 }) => {
   const [hovered, setHovered] = useState<number[]>([]);
   const [contrast, setContrast] = useState(DEFAULT_CONTRAST);
@@ -83,7 +83,7 @@ const AlignResultPIM: FC<AlignResultPIMProps> = ({
                 checked={Boolean(
                   accession && selectedEntries?.includes(accession)
                 )}
-                onSequenceChecked={handleSelectedEntries}
+                onSequenceChecked={handleEntrySelection}
               >
                 {name}
               </AlignLabel>

--- a/src/tools/align/components/results/AlignResultPhyloTree.tsx
+++ b/src/tools/align/components/results/AlignResultPhyloTree.tsx
@@ -19,14 +19,14 @@ type AlignResultPhyloTreeProps = {
   id: string;
   sequenceInfo: SequenceInfo;
   selectedEntries: string[];
-  handleSelectedEntries: (rowId: string) => void;
+  handleEntrySelection: (rowId: string) => void;
 };
 
 const AlignResultPhyloTree: FC<AlignResultPhyloTreeProps> = ({
   id,
   sequenceInfo,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
 }) => {
   const [showDistance, setShowDistance] = useState(true);
   const [alignLabels, setAlignLabels] = useState(true);
@@ -117,7 +117,7 @@ const AlignResultPhyloTree: FC<AlignResultPhyloTreeProps> = ({
           circularLayout={circularLayout}
           sequenceInfo={sequenceInfo}
           selectedEntries={selectedEntries}
-          handleSelectedEntries={handleSelectedEntries}
+          handleEntrySelection={handleEntrySelection}
         />
       )}
     </section>

--- a/src/tools/align/components/results/PhyloTree.tsx
+++ b/src/tools/align/components/results/PhyloTree.tsx
@@ -53,7 +53,7 @@ type PhyloTreeProps = {
   circularLayout: boolean;
   sequenceInfo: SequenceInfo;
   selectedEntries: string[];
-  handleSelectedEntries: (rowId: string) => void;
+  handleEntrySelection: (rowId: string) => void;
 };
 
 const PhyloTree: FC<PhyloTreeProps> = ({
@@ -63,7 +63,7 @@ const PhyloTree: FC<PhyloTreeProps> = ({
   circularLayout,
   sequenceInfo,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const redrawRef = useRef<Redraw & Cancelable>();
@@ -359,7 +359,7 @@ const PhyloTree: FC<PhyloTreeProps> = ({
                     checked={Boolean(
                       accession && selectedEntries?.includes(accession)
                     )}
-                    onSequenceChecked={handleSelectedEntries}
+                    onSequenceChecked={handleEntrySelection}
                   >
                     {name || ''}
                   </AlignLabel>

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -167,6 +167,7 @@ const BlastResult = () => {
   const match = useRouteMatch<Params>(LocationToPath[Location.BlastResult])!;
   const location = useLocation();
 
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
   const [
     hspDetailPanel,
     setHspDetailPanel,
@@ -262,8 +263,6 @@ const BlastResult = () => {
     () => (data?.hits ? data.hits.filter((hit) => hit.extra) : []),
     [data]
   );
-
-  const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   const inputParamsData = useParamsData(match?.params.id || '');
 

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -1,11 +1,4 @@
-import {
-  useMemo,
-  useEffect,
-  useCallback,
-  useState,
-  lazy,
-  Suspense,
-} from 'react';
+import { useMemo, useEffect, useState, lazy, Suspense } from 'react';
 import {
   Link,
   useRouteMatch,
@@ -25,6 +18,8 @@ import ResultButtons from '../../../components/ResultButtons';
 import useDataApi, {
   UseDataAPIState,
 } from '../../../../shared/hooks/useDataApi';
+import useItemSelect from '../../../../shared/hooks/useItemSelect';
+
 import {
   getParamsFromURL,
   URLResultParams,
@@ -172,7 +167,6 @@ const BlastResult = () => {
   const match = useRouteMatch<Params>(LocationToPath[Location.BlastResult])!;
   const location = useLocation();
 
-  const [selectedEntries, setSelectedEntries] = useState<string[]>([]);
   const [
     hspDetailPanel,
     setHspDetailPanel,
@@ -269,17 +263,9 @@ const BlastResult = () => {
     [data]
   );
 
-  const inputParamsData = useParamsData(match?.params.id || '');
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
 
-  // Note: this function is duplicated in ResultsContainer.tsx
-  const handleSelectedEntries = useCallback((rowId: string) => {
-    setSelectedEntries((selectedEntries) => {
-      const filtered = selectedEntries.filter((id) => id !== rowId);
-      return filtered.length === selectedEntries.length
-        ? [...selectedEntries, rowId]
-        : filtered;
-    });
-  }, []);
+  const inputParamsData = useParamsData(match?.params.id || '');
 
   if (blastLoading) {
     return <Loader progress={blastProgress} />;
@@ -364,7 +350,7 @@ const BlastResult = () => {
                     : { ...blastData, hits: hitsFiltered }
                 }
                 selectedEntries={selectedEntries}
-                handleSelectedEntries={handleSelectedEntries}
+                handleEntrySelection={handleEntrySelection}
                 setHspDetailPanel={setHspDetailPanel}
               />
             </ErrorBoundary>

--- a/src/tools/blast/components/results/BlastResultTable.tsx
+++ b/src/tools/blast/components/results/BlastResultTable.tsx
@@ -242,13 +242,13 @@ const BlastSummaryHsps: FC<{
 const BlastResultTable: FC<{
   data: BlastResults | null;
   selectedEntries: string[];
-  handleSelectedEntries: (rowId: string) => void;
+  handleEntrySelection: (rowId: string) => void;
   setHspDetailPanel: (props: HSPDetailPanelProps) => void;
   loading: boolean;
 }> = ({
   data,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
   setHspDetailPanel,
   loading,
 }) => {
@@ -418,7 +418,7 @@ const BlastResultTable: FC<{
       columns={columns}
       data={hitsRef.current.slice(0, nItemsToRender)}
       selected={selectedEntries}
-      onSelectRow={handleSelectedEntries}
+      onSelectRow={handleEntrySelection}
       fixedLayout
     />
   );

--- a/src/tools/blast/components/results/__tests__/BlastResultTable.spec.tsx
+++ b/src/tools/blast/components/results/__tests__/BlastResultTable.spec.tsx
@@ -20,7 +20,7 @@ describe('BlastResultTable tests', () => {
       <BlastResultTable
         data={blastResultsMockData as BlastResults}
         selectedEntries={[]}
-        handleSelectedEntries={() => {}}
+        handleEntrySelection={() => {}}
         setHspDetailPanel={() => {}}
         loading={false}
       />

--- a/src/tools/components/AlignmentView.tsx
+++ b/src/tools/components/AlignmentView.tsx
@@ -94,7 +94,7 @@ export type AlignmentComponentProps = {
   setActiveId?: Dispatch<SetStateAction<string | undefined>>;
   omitInsertionsInCoords?: boolean;
   selectedEntries?: string[];
-  handleSelectedEntries?: (rowId: string) => void;
+  handleEntrySelection?: (rowId: string) => void;
   selectedMSAFeatures?: MSAFeature[];
   activeAnnotation: ProcessedFeature[];
   activeAlignment?: MSAInput;
@@ -131,7 +131,7 @@ const AlignmentView: FC<{
   defaultView?: View;
   tool: Tool;
   selectedEntries?: string[];
-  handleSelectedEntries?: (rowId: string) => void;
+  handleEntrySelection?: (rowId: string) => void;
   containerSelector?: string;
 }> = ({
   alignment,
@@ -139,7 +139,7 @@ const AlignmentView: FC<{
   defaultView,
   tool,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
   containerSelector,
 }) => {
   const [tooltipContent, setTooltipContent] = useState<{
@@ -263,7 +263,7 @@ const AlignmentView: FC<{
           setActiveId,
           omitInsertionsInCoords: true,
           selectedEntries,
-          handleSelectedEntries,
+          handleEntrySelection,
         }
       : {};
 

--- a/src/tools/components/Overview.tsx
+++ b/src/tools/components/Overview.tsx
@@ -39,7 +39,7 @@ const AlignOverview: FC<AlignmentComponentProps> = ({
   setActiveId,
   omitInsertionsInCoords,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
   onMSAFeatureClick,
   selectedMSAFeatures,
   activeAnnotation,
@@ -223,7 +223,7 @@ const AlignOverview: FC<AlignmentComponentProps> = ({
             checked={Boolean(
               s.accession && selectedEntries?.includes(s.accession)
             )}
-            onSequenceChecked={handleSelectedEntries}
+            onSequenceChecked={handleEntrySelection}
             onIdClick={setActiveId ? () => setActiveId(s.accession) : undefined}
             active={!!activeId && setActiveId && activeId === s.accession}
           >

--- a/src/tools/components/Wrapped.tsx
+++ b/src/tools/components/Wrapped.tsx
@@ -63,7 +63,7 @@ export type WrappedRowProps = {
   activeId?: string;
   setActiveId?: Dispatch<SetStateAction<string | undefined>>;
   selectedEntries?: string[];
-  handleSelectedEntries?: (rowId: string) => void;
+  handleEntrySelection?: (rowId: string) => void;
   trackStart: number;
   trackEnd: number;
   delayRender: boolean;
@@ -86,7 +86,7 @@ export const WrappedRow: FC<WrappedRowProps> = ({
   activeId,
   setActiveId,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
   trackStart,
   trackEnd,
   delayRender,
@@ -159,7 +159,7 @@ export const WrappedRow: FC<WrappedRowProps> = ({
             checked={Boolean(
               s.accession && selectedEntries?.includes(s.accession)
             )}
-            onSequenceChecked={handleSelectedEntries}
+            onSequenceChecked={handleEntrySelection}
             onIdClick={setActiveId ? () => setActiveId(s.accession) : undefined}
             active={!!activeId && setActiveId && activeId === s.accession}
           >
@@ -217,7 +217,7 @@ const Wrapped: FC<AlignmentComponentProps> = ({
   setActiveId,
   omitInsertionsInCoords = false,
   selectedEntries,
-  handleSelectedEntries,
+  handleEntrySelection,
   selectedMSAFeatures,
   activeAnnotation,
   activeAlignment,
@@ -315,7 +315,7 @@ const Wrapped: FC<AlignmentComponentProps> = ({
           activeId={activeId}
           setActiveId={setActiveId}
           selectedEntries={selectedEntries}
-          handleSelectedEntries={handleSelectedEntries}
+          handleEntrySelection={handleEntrySelection}
           delayRender={index >= nItemsToRender}
           trackStart={trackStart}
           trackEnd={trackEnd}

--- a/src/tools/components/__tests__/AlignmentView.spec.tsx
+++ b/src/tools/components/__tests__/AlignmentView.spec.tsx
@@ -46,7 +46,7 @@ describe('AlignmentView', () => {
 
   describe('Align', () => {
     let rendered, alignment;
-    let handleSelectedEntries = jest.fn();
+    let handleEntrySelection = jest.fn();
     beforeEach(() => {
       resetUuidV1();
       alignment = mockData.Align;
@@ -58,7 +58,7 @@ describe('AlignmentView', () => {
             defaultView={View.overview}
             tool={Tool.align}
             selectedEntries={[]}
-            handleSelectedEntries={handleSelectedEntries}
+            handleEntrySelection={handleEntrySelection}
           />
         </div>
       );

--- a/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
+++ b/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unused-prop-types */
-import { useCallback, useMemo, useState, FC, ReactNode } from 'react';
+import { useCallback, useMemo, FC, ReactNode } from 'react';
 import { DataTable, Message, Button } from 'franklin-sites';
 import { Link, useHistory } from 'react-router-dom';
 
@@ -11,6 +11,7 @@ import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 import apiUrls from '../../../shared/config/apiUrls';
+import useItemSelect from '../../../shared/hooks/useItemSelect';
 
 import {
   getEntryPath,
@@ -45,7 +46,7 @@ type GeneCentricData = {
 const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
   primaryAccession,
 }) => {
-  const [selectedEntries, setSelectedEntries] = useState<string[]>([]);
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   const columns = useMemo<
     Array<{
@@ -89,16 +90,6 @@ const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
   const { data, loading, error, status } = useDataApi<GeneCentricData>(
     apiUrls.genecentric(primaryAccession)
   );
-
-  // Note: this function is duplicated in ResultsContainer.tsx
-  const handleSelectedEntries = useCallback((rowId: string) => {
-    setSelectedEntries((selectedEntries) => {
-      const filtered = selectedEntries.filter((id) => id !== rowId);
-      return filtered.length === selectedEntries.length
-        ? [...selectedEntries, rowId]
-        : filtered;
-    });
-  }, []);
 
   const filteredData = useMemo(
     () =>
@@ -162,7 +153,7 @@ const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
                 columns={columns}
                 data={filteredData}
                 selected={selectedEntries}
-                onSelectRow={handleSelectedEntries}
+                onSelectRow={handleEntrySelection}
               />
             </>
           ) : null}

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState, useEffect, FC } from 'react';
+import { memo, useState, useEffect, FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Card, DataTableWithLoader, Loader } from 'franklin-sites';
 
@@ -10,6 +10,7 @@ import MemberLink from './MemberLink';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 import usePrefetch from '../../../shared/hooks/usePrefetch';
+import useItemSelect from '../../../shared/hooks/useItemSelect';
 
 import getNextURLFromHeaders from '../../../shared/utils/getNextURLFromHeaders';
 import { getParamsFromURL } from '../../../uniprotkb/utils/resultsUtils';
@@ -256,8 +257,6 @@ export const MembersSection: FC<Props> = ({
     ),
   });
 
-  const [selectedEntries, setSelectedEntries] = useState<string[]>([]);
-
   const [url, setUrl] = useState<string | undefined>(initialUrl);
   const [metadata, setMetadata] = useState<{
     total: number;
@@ -292,15 +291,7 @@ export const MembersSection: FC<Props> = ({
     }));
   }, [data, headers]);
 
-  // Note: this function is duplicated in ResultsContainer.tsx
-  const handleSelectedEntries = useCallback((rowId: string) => {
-    setSelectedEntries((selectedEntries) => {
-      const filtered = selectedEntries.filter((id) => id !== rowId);
-      return filtered.length === selectedEntries.length
-        ? [...selectedEntries, rowId]
-        : filtered;
-    });
-  }, []);
+  const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   const { total, nextUrl } = metadata;
 
@@ -331,7 +322,7 @@ export const MembersSection: FC<Props> = ({
           getIdKey={getKey}
           density="compact"
           selected={selectedEntries}
-          onSelectRow={handleSelectedEntries}
+          onSelectRow={handleEntrySelection}
         />
       </Card>
     </div>


### PR DESCRIPTION
## Purpose
The same item selection logic being used in several places.

## Approach
* Created a `useItemSelect` hook.
* Replaced `handleSelectedEntries` --> `handleItemSelection` as we are only really handling one item at a time.

## Testing
Wrote useItemSelect tests.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
