### PR TITLE
2021_03-similar_proteins_nodata

### DIFF
--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
@@ -55,6 +55,10 @@ const SimilarProteins: FC<{
         }))
         .filter((item) => item.members.length > 1);
 
+      if (filtered.length <= 0) {
+        return null;
+      }
+
       const clusterTypeGroups: Partial<
         Record<UniRefEntryType, UniRefLiteAPIModel[]>
       > = groupBy(filtered, (cluster) => cluster.entryType);
@@ -82,73 +86,75 @@ const SimilarProteins: FC<{
   if (error) {
     return <Message level="failure">{error?.message}</Message>;
   }
-  if (!clusterData) {
-    return null;
-  }
 
   return (
     <div id={EntrySection.SimilarProteins}>
       <Card title={nameAndId.name}>
-        <Tabs>
-          {Object.entries(uniRefEntryTypeToPercent).map(
-            ([clusterType, percentValue]) =>
-              clusterType in clusterData &&
-              clusterData[clusterType as UniRefEntryType] && (
-                <Tab
-                  id={clusterType}
-                  title={`${percentValue} identity`}
-                  key={clusterType}
-                >
-                  {Object.entries(
-                    clusterData[clusterType as UniRefEntryType] || {}
-                  ).map(([representativeId, clusters]) => (
-                    <section key={representativeId} className="text-block">
-                      <h4>{representativeId}</h4>
-                      {clusters.map((row) => {
-                        const unirefEntryUrl = getEntryPath(
-                          Namespace.uniref,
-                          row.id
-                        );
-                        return (
-                          <section key={row.id}>
-                            <h5>
-                              <Link to={unirefEntryUrl}>{row.id}</Link>
-                            </h5>
-                            <SimilarProteinsTable members={row.members} />
-                            {row.memberCount - row.members.length - 1 > 0 && (
-                              <Link to={unirefEntryUrl}>
-                                {row.memberCount - row.members.length - 1} more
-                              </Link>
-                            )}
-                          </section>
-                        );
-                      })}
-                      <hr />
-                    </section>
-                  ))}
-                  {/* TODO: This query doesn't seem to work currently */}
-                  <Button
-                    element={Link}
-                    to={{
-                      pathname: LocationToPath[Location.UniProtKBResults],
-                      search: `query=(${data?.results
-                        .filter(({ entryType }) => entryType === clusterType)
-                        .map(
-                          ({ id }) =>
-                            `uniref_cluster_${clusterType.replace(
-                              'UniRef',
-                              ''
-                            )}:${id}`
-                        )
-                        .join(' OR ')})`,
-                    }}
+        {clusterData ? (
+          <Tabs>
+            {Object.entries(uniRefEntryTypeToPercent).map(
+              ([clusterType, percentValue]) =>
+                clusterType in clusterData &&
+                clusterData[clusterType as UniRefEntryType] && (
+                  <Tab
+                    id={clusterType}
+                    title={`${percentValue} identity`}
+                    key={clusterType}
                   >
-                    View all
-                  </Button>
-                </Tab>
-              )
-          )}
-        </Tabs>
+                    {Object.entries(
+                      clusterData[clusterType as UniRefEntryType] || {}
+                    ).map(([representativeId, clusters]) => (
+                      <section key={representativeId} className="text-block">
+                        <h4>{representativeId}</h4>
+                        {clusters.map((row) => {
+                          const unirefEntryUrl = getEntryPath(
+                            Namespace.uniref,
+                            row.id
+                          );
+                          return (
+                            <section key={row.id}>
+                              <h5>
+                                <Link to={unirefEntryUrl}>{row.id}</Link>
+                              </h5>
+                              <SimilarProteinsTable members={row.members} />
+                              {row.memberCount - row.members.length - 1 > 0 && (
+                                <Link to={unirefEntryUrl}>
+                                  {row.memberCount - row.members.length - 1}{' '}
+                                  more
+                                </Link>
+                              )}
+                            </section>
+                          );
+                        })}
+                        <hr />
+                      </section>
+                    ))}
+                    {/* TODO: This query doesn't seem to work currently */}
+                    <Button
+                      element={Link}
+                      to={{
+                        pathname: LocationToPath[Location.UniProtKBResults],
+                        search: `query=(${data?.results
+                          .filter(({ entryType }) => entryType === clusterType)
+                          .map(
+                            ({ id }) =>
+                              `uniref_cluster_${clusterType.replace(
+                                'UniRef',
+                                ''
+                              )}:${id}`
+                          )
+                          .join(' OR ')})`,
+                      }}
+                    >
+                      View all
+                    </Button>
+                  </Tab>
+                )
+            )}
+          </Tabs>
+        ) : (
+          <em>No similar proteins found.</em>
+        )}
       </Card>
     </div>
   );

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
@@ -153,7 +153,7 @@ const SimilarProteins: FC<{
             )}
           </Tabs>
         ) : (
-          <em>No similar proteins found.</em>
+          <em>No similar UniProtKB entry found.</em>
         )}
       </Card>
     </div>


### PR DESCRIPTION
## Purpose
For some UniProtKB entries (e.g. A0A009EBH2) an error appeared in the Similar Proteins section.

## Approach
When displaying similar proteins, we query for UniRef members of clusters the protein belongs to. We filter out UniParc entries and isoforms, and this sometimes results in an empty list. Because of the groupBy, this translated into an empty object, so the check for empty data before rendering the component was always failing. I've added an early return to fix this issue.

As we are not able to know whether data will be available for similar proteins until the component is created, this causes an issue with the in-page nav. As a workaround it will always display and I've added a message in the component when no data is available.

## Testing
N.A

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
