### PR TITLE
refactor entry point routes

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -9,7 +9,11 @@ import GDPR from '../../shared/components/gdpr/GDPR';
 
 import history from '../../shared/utils/browserHistory';
 
-import { Location, LocationToPath } from '../config/urls';
+import {
+  allSearchResultLocations,
+  Location,
+  LocationToPath,
+} from '../config/urls';
 
 import './styles/app.scss';
 
@@ -157,86 +161,52 @@ const App = () => (
               exact
               component={HomePage}
             />
+            {/* Entry pages */}
             {/* Main namespaces */}
             <Route
               path={LocationToPath[Location.UniProtKBEntry]}
               component={UniProtKBEntryPage}
             />
             <Route
-              path={LocationToPath[Location.UniProtKBResults]}
-              component={GenericResultsPage}
-            />
-            <Route
               path={LocationToPath[Location.UniRefEntry]}
               component={UniRefEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.UniRefResults]}
-              component={GenericResultsPage}
             />
             <Route
               path={LocationToPath[Location.UniParcEntry]}
               component={UniParcEntryPage}
             />
             <Route
-              path={LocationToPath[Location.UniParcResults]}
-              component={GenericResultsPage}
-            />
-            <Route
               path={LocationToPath[Location.ProteomesEntry]}
               component={ProteomesEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.ProteomesResults]}
-              component={GenericResultsPage}
             />
             {/* Supporting data */}
             {/* <Route
               path={LocationToPath[Location.TaxonomyEntry]}
               component={TaxonomyEntryPage}
             /> */}
-            <Route
-              path={LocationToPath[Location.TaxonomyResults]}
-              component={GenericResultsPage}
-            />
             {/* <Route
               path={LocationToPath[Location.KeywordsEntry]}
               component={KeywordsEntryPage}
             /> */}
-            <Route
-              path={LocationToPath[Location.KeywordsResults]}
-              component={GenericResultsPage}
-            />
             {/* <Route
               path={LocationToPath[Location.CitationsEntry]}
               component={CitationsEntryPage}
             /> */}
-            <Route
-              path={LocationToPath[Location.CitationsResults]}
-              component={GenericResultsPage}
-            />
             {/* <Route
               path={LocationToPath[Location.DiseasesEntry]}
               component={DiseasesEntryPage}
             /> */}
-            <Route
-              path={LocationToPath[Location.DiseasesResults]}
-              component={GenericResultsPage}
-            />
             {/* <Route
               path={LocationToPath[Location.DatabaseEntry]}
               component={DatabaseEntryPage}
             /> */}
-            <Route
-              path={LocationToPath[Location.DatabaseResults]}
-              component={GenericResultsPage}
-            />
             {/* <Route
               path={LocationToPath[Location.LocationsEntry]}
               component={LocationsEntryPage}
             /> */}
+            {/* Result pages */}
             <Route
-              path={LocationToPath[Location.LocationsResults]}
+              path={allSearchResultLocations}
               component={GenericResultsPage}
             />
             {/* Tools */}

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -53,17 +53,17 @@ export const LocationToPath: Record<Location, string> = {
   [Location.ProteomesResults]: `/${Namespace.proteomes}`,
   // Supporting data
   [Location.TaxonomyEntry]: `/${Namespace.taxonomy}/:accession`,
-  [Location.TaxonomyResults]: `/${Namespace.taxonomy}/`,
+  [Location.TaxonomyResults]: `/${Namespace.taxonomy}`,
   [Location.KeywordsEntry]: `/${Namespace.keywords}/:accession`,
-  [Location.KeywordsResults]: `/${Namespace.keywords}/`,
+  [Location.KeywordsResults]: `/${Namespace.keywords}`,
   [Location.CitationsEntry]: `/${Namespace.citations}/:accession`,
-  [Location.CitationsResults]: `/${Namespace.citations}/`,
+  [Location.CitationsResults]: `/${Namespace.citations}`,
   [Location.DiseasesEntry]: `/${Namespace.diseases}/:accession`,
-  [Location.DiseasesResults]: `/${Namespace.diseases}/`,
+  [Location.DiseasesResults]: `/${Namespace.diseases}`,
   [Location.DatabaseEntry]: `/${Namespace.database}/:accession`,
-  [Location.DatabaseResults]: `/${Namespace.database}/`,
+  [Location.DatabaseResults]: `/${Namespace.database}`,
   [Location.LocationsEntry]: `/${Namespace.locations}/:accession`,
-  [Location.LocationsResults]: `/${Namespace.locations}/`,
+  [Location.LocationsResults]: `/${Namespace.locations}`,
   // Tools
   [Location.Dashboard]: '/tool-dashboard',
   [Location.AlignResult]: '/align/:id/:subPage?',
@@ -91,6 +91,11 @@ export const SearchResultsLocations: Record<Namespace, string> = {
   [Namespace.database]: LocationToPath[Location.DatabaseResults],
   [Namespace.locations]: LocationToPath[Location.LocationsResults],
 };
+
+// "/:namespace(uniprotkb|uniparc|........)/""
+export const allSearchResultLocations = `/:namespace(${Object.values(
+  Namespace
+).join('|')})/`;
 
 // All "entry" locations need to have a "accession" param in the pattern
 export const EntryLocations: Record<Namespace, string> = {

--- a/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
+++ b/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
@@ -147,42 +147,42 @@ exports[`HomePage component should render 1`] = `
           >
             <li>
               <a
-                href="/citations/?query=*"
+                href="/citations?query=*"
               >
                 Literature citations
               </a>
             </li>
             <li>
               <a
-                href="/taxonomy/?query=*"
+                href="/taxonomy?query=*"
               >
                 Taxonomy
               </a>
             </li>
             <li>
               <a
-                href="/keywords/?query=*"
+                href="/keywords?query=*"
               >
                 Keywords
               </a>
             </li>
             <li>
               <a
-                href="/locations/?query=*"
+                href="/locations?query=*"
               >
                 Subcellular locations
               </a>
             </li>
             <li>
               <a
-                href="/database/?query=*"
+                href="/database?query=*"
               >
                 Cross-referenced databases
               </a>
             </li>
             <li>
               <a
-                href="/diseases/?query=*"
+                href="/diseases?query=*"
               >
                 Diseases
               </a>

--- a/src/shared/hooks/useNS.ts
+++ b/src/shared/hooks/useNS.ts
@@ -1,17 +1,18 @@
 import { useRouteMatch } from 'react-router-dom';
+import { allSearchResultLocations } from '../../app/config/urls';
 
 import { Namespace } from '../types/namespaces';
 
 const useNS = (): Namespace | undefined => {
-  const match = useRouteMatch<{ potentialNS: Namespace | string }>(
-    '/:potentialNS/'
+  const match = useRouteMatch<{ namespace: Namespace }>(
+    allSearchResultLocations
   );
 
   if (!match) {
     return undefined;
   }
 
-  const potentialNS = match.params.potentialNS.toLowerCase();
+  const potentialNS = match.params.namespace.toLowerCase();
   // eslint-disable-next-line consistent-return
   return Object.values(Namespace).find((ns) => ns === potentialNS);
 };


### PR DESCRIPTION
## Purpose
Refactor the routing on the main entry point in order to simplify logic

## Approach
Now that we have result page renderer for all namespaces, I've refactored the logic in order to have less routes handlers on the main `App` entry point.

## Testing
Current tests still works, current pages still render

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
