### PR TITLE
create and connect locations card in search results

### DIFF
--- a/src/shared/components/results/ResultsView.tsx
+++ b/src/shared/components/results/ResultsView.tsx
@@ -12,6 +12,7 @@ import UniRefCard from '../../../uniref/components/results/UniRefCard';
 import UniParcCard from '../../../uniparc/components/results/UniParcCard';
 import ProteomesCard from '../../../proteomes/components/results/ProteomesCard';
 import CitationCard from '../../../supporting-data/citations/components/results/CitationCard';
+import LocationsCard from '../../../supporting-data/locations/components/results/LocationsCard';
 
 import uniProtKbConverter, {
   UniProtkbAPIModel,
@@ -212,6 +213,15 @@ const cardRenderer = (
       return (cardData) => (
         <CitationCard
           data={cardData as CitationsAPIModel}
+          selected={selectedEntries.includes(getIdKey(cardData))}
+          handleEntrySelection={handleEntrySelection}
+        />
+      );
+    }
+    case Namespace.locations: {
+      return (cardData) => (
+        <LocationsCard
+          data={cardData as LocationsAPIModel}
           selected={selectedEntries.includes(getIdKey(cardData))}
           handleEntrySelection={handleEntrySelection}
         />

--- a/src/supporting-data/locations/components/results/LocationsCard.tsx
+++ b/src/supporting-data/locations/components/results/LocationsCard.tsx
@@ -1,0 +1,54 @@
+import { Card } from 'franklin-sites';
+import { FC, useCallback, MouseEvent } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { getEntryPath } from '../../../../app/config/urls';
+
+import { LocationsAPIModel } from '../../adapters/locationsConverter';
+import { Namespace } from '../../../../shared/types/namespaces';
+
+const BLOCK_CLICK_ON_CARD = new Set(['A', 'INPUT', 'BUTTON']);
+
+const CitationCard: FC<{
+  data: LocationsAPIModel;
+  selected?: boolean;
+  handleEntrySelection?: (rowId: string) => void;
+}> = ({ data, selected, handleEntrySelection }) => {
+  const history = useHistory();
+
+  const handleCardClick = useCallback(
+    (event: MouseEvent) => {
+      if (BLOCK_CLICK_ON_CARD.has((event.target as HTMLElement).tagName)) {
+        return;
+      }
+      history.push(getEntryPath(Namespace.locations, data.id));
+    },
+    [history, data.id]
+  );
+
+  return (
+    <Card onClick={handleCardClick}>
+      <section className="result-card">
+        {handleEntrySelection && (
+          <div className="result-card__left">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={() => handleEntrySelection(data.id)}
+              data-testid="up-card-checkbox"
+            />
+          </div>
+        )}
+        <div className="result-card__right">
+          <h5>{data.name}</h5>
+          <div className="result-card__info-container">{data.definition}</div>
+          <div className="result-card__info-container">
+            <strong>Category:</strong> {data.category}
+          </div>
+        </div>
+      </section>
+    </Card>
+  );
+};
+
+export default CitationCard;

--- a/src/supporting-data/locations/components/results/__tests__/LocationsCard.spec.tsx
+++ b/src/supporting-data/locations/components/results/__tests__/LocationsCard.spec.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import customRender from '../../../../../shared/__test-helpers__/customRender';
+
+import LocationsCard from '../LocationsCard';
+
+import locationsData from '../../../__mocks__/locationsModelData';
+
+describe('CitationCard tests', () => {
+  it('should render the card component', () => {
+    const { asFragment } = customRender(
+      <LocationsCard data={locationsData[0]} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should allow card selection and navigation', () => {
+    const handleClick = jest.fn();
+    const { history } = customRender(
+      <LocationsCard
+        data={locationsData[0]}
+        handleEntrySelection={handleClick}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(handleClick).toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(history.location.pathname).toMatch('/locations/SL-0099');
+  });
+});

--- a/src/supporting-data/locations/components/results/__tests__/__snapshots__/LocationsCard.spec.tsx.snap
+++ b/src/supporting-data/locations/components/results/__tests__/__snapshots__/LocationsCard.spec.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CitationCard tests should render the card component 1`] = `
+<DocumentFragment>
+  <section
+    class="card"
+  >
+    <div
+      class="card--has-hover"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="card__content"
+      >
+        <section
+          class="result-card"
+        >
+          <div
+            class="result-card__right"
+          >
+            <h5>
+              Endoplasmic reticulum-Golgi intermediate compartment membrane
+            </h5>
+            <div
+              class="result-card__info-container"
+            >
+              The membrane surrounding the ER-Golgi intermediate compartment, which is a collection of tubulovesicular membrane clusters in the vicinity of ER exit sites.
+            </div>
+            <div
+              class="result-card__info-container"
+            >
+              <strong>
+                Category:
+              </strong>
+               Cellular component
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/src/uniparc/components/results/UniParcCard.tsx
+++ b/src/uniparc/components/results/UniParcCard.tsx
@@ -76,13 +76,13 @@ const UniRefCard: FC<{
           </h5>
           <div className="result-card__info-container">
             <span className="result-card__info-bit">
-              <strong>Organism{organismCount === 1 ? '' : 's'}: </strong>
+              <strong>Organism{organismCount === 1 ? '' : 's'}:</strong>{' '}
               <LongNumber>{organismCount}</LongNumber>
             </span>
             <span className="result-card__info-bit">
-              <strong>UniprotKB entries:</strong> {uniProtKBCount.reviewed}{' '}
-              reviewed and <LongNumber>{uniProtKBCount.unreviewed}</LongNumber>{' '}
-              unreviewed
+              <strong>UniprotKB entries:</strong>{' '}
+              <LongNumber>{uniProtKBCount.reviewed}</LongNumber> reviewed and{' '}
+              <LongNumber>{uniProtKBCount.unreviewed}</LongNumber> unreviewed
             </span>
           </div>
           <div className="result-card__info-container">

--- a/src/uniparc/components/results/__tests__/UniParcCard.spec.tsx
+++ b/src/uniparc/components/results/__tests__/UniParcCard.spec.tsx
@@ -1,3 +1,5 @@
+import { fireEvent, screen } from '@testing-library/react';
+
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import UniParcCard from '../UniParcCard';
@@ -15,5 +17,19 @@ describe('UniRefCard tests', () => {
       />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should allow card selection and navigation', () => {
+    const handleClick = jest.fn();
+    const { history } = customRender(
+      <UniParcCard
+        data={data as UniParcAPIModel}
+        handleEntrySelection={handleClick}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(handleClick).toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(history.location.pathname).toMatch('/uniparc/UPI0000000001');
   });
 });

--- a/src/uniparc/components/results/__tests__/__snapshots__/UniParcCard.spec.tsx.snap
+++ b/src/uniparc/components/results/__tests__/__snapshots__/UniParcCard.spec.tsx.snap
@@ -47,9 +47,9 @@ exports[`UniRefCard tests should render and match snapshot 1`] = `
                 class="result-card__info-bit"
               >
                 <strong>
-                  Organisms: 
+                  Organisms:
                 </strong>
-                7
+                 7
               </span>
               <span
                 class="result-card__info-bit"


### PR DESCRIPTION
## Purpose
Create a card renderer for the results of the locations search. Matching figma mockup. [TRM-25595](https://www.ebi.ac.uk/panda/jira/browse/TRM-25595)

## Approach
Create a card renderer, connect it to the results mega-component.

## Testing
Snapshot testing + interaction testing (checkbox selection and card click).
Also added tests on interaction testing on UniParc card renderer in order to improve the coverage

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
