### PR TITLE
2021 04 fix download columns

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -84,7 +84,7 @@ const Download: FC<DownloadProps> = ({
 
   const downloadUrl = getDownloadUrl({
     query: urlQuery,
-    columns,
+    columns: selectedColumns,
     selectedFacets,
     sortColumn,
     sortDirection,
@@ -109,7 +109,7 @@ const Download: FC<DownloadProps> = ({
   const previewFileFormat = getPreviewFileFormat(fileFormat);
   const previewUrl = getDownloadUrl({
     query: urlQuery,
-    columns,
+    columns: selectedColumns,
     selectedFacets,
     sortColumn,
     sortDirection,

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import customRender from '../../../__test-helpers__/customRender';
 

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -5,12 +5,24 @@ import customRender from '../../../__test-helpers__/customRender';
 import Download, { getPreviewFileFormat } from '../Download';
 
 import { FileFormat } from '../../../types/resultsDownload';
-import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
 import { Namespace } from '../../../types/namespaces';
+import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
+import useUserPreferences from '../../../hooks/useUserPreferences';
 
 import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
 
 import '../../../../uniprotkb/components/__mocks__/mockApi';
+
+jest.mock('../../../hooks/useUserPreferences');
+
+useUserPreferences.mockImplementation(() => [
+  [
+    UniProtKBColumn.accession,
+    UniProtKBColumn.reviewed,
+    UniProtKBColumn.geneNames,
+  ],
+  jest.fn(),
+]);
 
 describe('getPreviewFileFormat', () => {
   test('should replace excel file format with tsv', () => {
@@ -27,15 +39,11 @@ describe('Download component', () => {
   const query = 'nod2';
   const selectedEntries = ['Q9HC29', 'O43353', 'Q3KP66'];
   const onCloseMock = jest.fn();
+
   beforeEach(() => {
     customRender(
       <Download
         query={query}
-        selectedColumns={[
-          UniProtKBColumn.accession,
-          UniProtKBColumn.reviewed,
-          UniProtKBColumn.id,
-        ]}
         selectedEntries={selectedEntries}
         totalNumberResults={10}
         onClose={onCloseMock}
@@ -101,6 +109,13 @@ describe('Download component', () => {
       }
     }
   );
+
+  test('should change the column selection before preview and download', async () => {
+    const formatSelect = screen.getByTestId('file-format-select');
+    fireEvent.change(formatSelect, { target: FileFormat.tsv });
+    const reviewed = await screen.findByText('Customize datas');
+    expect(reviewed).toBeInTheDocument();
+  });
 
   test('should change Preview button text when Download selected radio is selected', () => {
     fireEvent.click(

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import customRender from '../../../__test-helpers__/customRender';
 
@@ -97,16 +97,14 @@ describe('Download component', () => {
     'should show column selection component when %s file type is selected and otherwise hide it',
     async (value, columnSelect) => {
       const formatSelect = screen.getByTestId('file-format-select');
-      await act(async () => {
-        fireEvent.change(formatSelect, { target: { value } });
-        await waitFor(() => {
-          const customise = screen.queryByText('Customize data');
-          if (columnSelect) {
-            expect(customise).toBeInTheDocument();
-          } else {
-            expect(customise).not.toBeInTheDocument();
-          }
-        });
+      fireEvent.change(formatSelect, { target: { value } });
+      await waitFor(() => {
+        const customise = screen.queryByText('Customize data');
+        if (columnSelect) {
+          expect(customise).toBeInTheDocument();
+        } else {
+          expect(customise).not.toBeInTheDocument();
+        }
       });
     }
   );

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -95,17 +95,15 @@ describe('Download component', () => {
     [FileFormat.tsv, true],
   ])(
     'should show column selection component when %s file type is selected and otherwise hide it',
-    async (value, columnSelect) => {
+    (value, columnSelect) => {
       const formatSelect = screen.getByTestId('file-format-select');
       fireEvent.change(formatSelect, { target: { value } });
-      await waitFor(() => {
-        const customise = screen.queryByText('Customize data');
-        if (columnSelect) {
-          expect(customise).toBeInTheDocument();
-        } else {
-          expect(customise).not.toBeInTheDocument();
-        }
-      });
+      const customise = screen.queryByText('Customize data');
+      if (columnSelect) {
+        expect(customise).toBeInTheDocument();
+      } else {
+        expect(customise).not.toBeInTheDocument();
+      }
     }
   );
 


### PR DESCRIPTION
## Purpose
Column selection in download was not applied.

## Approach
The list of columns in the state was not the list passed to the url generator.

## Testing
What test(s) did you write to validate and verify your changes?
Added a test to check the url is updated correctly when removing a column.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
