### PR TITLE
create dateParse helper function in order to avoid invalid dates

### DIFF
--- a/jest.global.setup.ts
+++ b/jest.global.setup.ts
@@ -1,0 +1,4 @@
+module.exports = async () => {
+  // Force time zone to be UTC during tests
+  process.env.TZ = 'UTC';
+};

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/jest.setup.ts"
-    ]
+    ],
+    "globalSetup": "<rootDir>/jest.global.setup.ts"
   },
   "lint-staged": {
     "*.+(ts|tsx|js|jsx|css|scss)": [

--- a/src/shared/components/layouts/ReleaseInfo.tsx
+++ b/src/shared/components/layouts/ReleaseInfo.tsx
@@ -1,7 +1,12 @@
 import { Method } from 'axios';
 import cn from 'classnames';
-import apiUrls from '../../config/apiUrls';
+
 import useDataApi from '../../hooks/useDataApi';
+
+import apiUrls from '../../config/apiUrls';
+
+import parseDate from '../../utils/parseDate';
+
 import { Namespace } from '../../types/namespaces';
 
 import './styles/release-info.scss';
@@ -16,9 +21,7 @@ const ReleaseInfo = () => {
     `${apiUrls.search(Namespace.uniprotkb)}?query=*&size=0`,
     fetchOptions
   );
-  const releaseDate = headers?.['x-release']
-    ? new Date(headers['x-release'])
-    : undefined;
+  const releaseDate = parseDate(headers?.['x-release']);
 
   return (
     <>

--- a/src/shared/utils/__tests__/parseDate.spec.ts
+++ b/src/shared/utils/__tests__/parseDate.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import parseDate from '../parseDate';
+
+const testCases: [
+  input?: string | number | Date,
+  year?: number,
+  month?: number, // starts at 0
+  day?: number // starts at 1
+][] = [
+  ['2021', 2021, undefined, undefined],
+  ['2021-12', 2021, 11, undefined],
+  ['2021-12-10', 2021, 11, 10],
+  ['2021-12-10 12:00:11', 2021, 11, 10],
+  ['DEC-2021', 2021, 11, undefined],
+  ['December 10, 21 00:20:18', 2021, 11, 10],
+  ['2021-12-10T14:48:00.000Z', 2021, 11, 10],
+  ['abc', undefined, undefined, undefined],
+  [new Date(2021, 11, 10), 2021, 11, 10],
+  [1639094400000, 2021, 11, 10],
+  [undefined, undefined, undefined, undefined],
+];
+
+describe('timezone sanity check', () => {
+  it('should always be UTC, as per global jest config', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0);
+  });
+});
+
+describe('parseDate', () => {
+  it.each(testCases)('should parse date "%s"', (input, year, month, day) => {
+    const parsed = parseDate(input);
+    expect(Number.isNaN(parsed?.getTime())).toBe(false);
+    if (year === undefined) {
+      expect(parsed).toBeUndefined();
+    } else {
+      expect(parsed.getFullYear()).toBe(year);
+      if (month !== undefined) {
+        expect(parsed.getMonth()).toBe(month);
+        if (day !== undefined) {
+          expect(parsed.getDate()).toBe(day);
+        }
+      }
+    }
+  });
+});

--- a/src/shared/utils/__tests__/parseDate.spec.ts
+++ b/src/shared/utils/__tests__/parseDate.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import parseDate from '../parseDate';
+import parseDate, { parseEdgeCases } from '../parseDate';
 
 const testCases: [
   input?: string | number | Date,
@@ -43,5 +43,15 @@ describe('parseDate', () => {
         }
       }
     }
+  });
+});
+
+// Some edge cases might be triggered only from specific browsers (non-V8), test
+// the logic independently to make sure it works
+describe('parseEdgeCases', () => {
+  it('should parse date "DEC-2021"', () => {
+    const parsed = parseEdgeCases('DEC-2021');
+    expect(parsed.getFullYear()).toBe(2021);
+    expect(parsed.getMonth()).toBe(11);
   });
 });

--- a/src/shared/utils/parseDate.ts
+++ b/src/shared/utils/parseDate.ts
@@ -1,0 +1,50 @@
+const edgeCase1 = /'\w{3}-\d{4}'/;
+
+const months = [
+  'jan',
+  'feb',
+  'mar',
+  'apr',
+  'may',
+  'jun',
+  'jul',
+  'aug',
+  'sep',
+  'oct',
+  'nov',
+  'dec',
+];
+
+/**
+ * Either returns a valid date, or undefined, but no invalid date
+ * @param input date to parse
+ * @returns {Date | undefined} valid date if possible, otherwise undefined
+ */
+const parseDate = (input?: string | number | Date | null): Date | undefined => {
+  if (!input) {
+    return undefined;
+  }
+  if (input instanceof Date) {
+    return input;
+  }
+  // easy case
+  let output = new Date(input);
+  if (!Number.isNaN(output.getTime())) {
+    return output;
+  }
+  /* edge cases */
+  // This one is specific to Firefox and Safari, as of April 2021.
+  // This will not be able to be covered by tests as node is using the V8 engine
+  if (typeof input === 'string' && edgeCase1.test(input)) {
+    const [month, year] = input.split('-');
+    const monthIndex = months.indexOf(month.toLowerCase());
+    output = new Date(+year, monthIndex);
+    if (monthIndex >= 0 && !Number.isNaN(output.getTime())) {
+      return output;
+    }
+  }
+  // otherwise just return undefined
+  return undefined;
+};
+
+export default parseDate;

--- a/src/shared/utils/parseDate.ts
+++ b/src/shared/utils/parseDate.ts
@@ -1,4 +1,4 @@
-const edgeCase1 = /'\w{3}-\d{4}'/;
+const edgeCase1 = /\w{3}-\d{4}/;
 
 const months = [
   'jan',
@@ -15,6 +15,25 @@ const months = [
   'dec',
 ];
 
+/** @protected */
+export const parseEdgeCases = (input: string) => {
+  let output: Date;
+  // This one is specific to Firefox and Safari, as of April 2021.
+  // This will not be able to be covered by tests as node is using the V8 engine
+  if (edgeCase1.test(input)) {
+    const [month, year] = input.split('-');
+    const monthIndex = months.indexOf(month.toLowerCase());
+    output = new Date(+year, monthIndex);
+    if (monthIndex >= 0 && !Number.isNaN(output.getTime())) {
+      return output;
+    }
+  }
+  // eslint-disable-next-line no-console
+  console.error(`couldn't parse "${input}" as a date`);
+  // otherwise just return undefined
+  return undefined;
+};
+
 /**
  * Either returns a valid date, or undefined, but no invalid date
  * @param input date to parse
@@ -28,20 +47,13 @@ const parseDate = (input?: string | number | Date | null): Date | undefined => {
     return input;
   }
   // easy case
-  let output = new Date(input);
+  const output = new Date(input);
   if (!Number.isNaN(output.getTime())) {
     return output;
   }
   /* edge cases */
-  // This one is specific to Firefox and Safari, as of April 2021.
-  // This will not be able to be covered by tests as node is using the V8 engine
-  if (typeof input === 'string' && edgeCase1.test(input)) {
-    const [month, year] = input.split('-');
-    const monthIndex = months.indexOf(month.toLowerCase());
-    output = new Date(+year, monthIndex);
-    if (monthIndex >= 0 && !Number.isNaN(output.getTime())) {
-      return output;
-    }
+  if (typeof input === 'string') {
+    return parseEdgeCases(input);
   }
   // otherwise just return undefined
   return undefined;

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -13,11 +13,14 @@ import { SetOptional } from 'type-fest';
 import { Location, LocationToPath } from '../../../app/config/urls';
 import externalUrls from '../../../shared/config/externalUrls';
 
-import '../../../shared/styles/literature-citation.scss';
+import parseDate from '../../../shared/utils/parseDate';
+
 import {
   CitationsAPIModel,
   formatCitationData,
 } from '../adapters/citationsConverter';
+
+import '../../../shared/styles/literature-citation.scss';
 
 type AuthorProps = {
   authors: string[];
@@ -107,7 +110,7 @@ export const JournalInfo: FC<JournalInfoProps> = ({
     date = (
       <>
         (
-        <time dateTime={new Date(publicationDate).toISOString()}>
+        <time dateTime={parseDate(publicationDate)?.toISOString()}>
           {publicationDate}
         </time>
         )

--- a/src/supporting-data/citations/config/CitationsColumnConfiguration.tsx
+++ b/src/supporting-data/citations/config/CitationsColumnConfiguration.tsx
@@ -1,13 +1,16 @@
 import { ExpandableList } from 'franklin-sites';
 
+import { JournalInfo } from '../components/LiteratureCitation';
+import AccessionView from '../../../shared/components/results/AccessionView';
+
+import parseDate from '../../../shared/utils/parseDate';
+
 import {
   CitationsAPIModel,
   CitationXRefDB,
 } from '../adapters/citationsConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-import { JournalInfo } from '../components/LiteratureCitation';
 import { Namespace } from '../../../shared/types/namespaces';
-import AccessionView from '../../../shared/components/results/AccessionView';
 
 export enum CitationsColumn {
   // Authoring group is not the author list
@@ -97,7 +100,7 @@ CitationsColumnConfiguration.set(CitationsColumn.publicationDate, {
   label: 'Publication year',
   render: ({ citation }) =>
     citation?.publicationDate && (
-      <time dateTime={new Date(citation.publicationDate).toISOString()}>
+      <time dateTime={parseDate(citation.publicationDate)?.toISOString()}>
         {citation.publicationDate}
       </time>
     ),

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -25,13 +25,14 @@ import { updateJob, deleteJob } from '../../state/toolsActions';
 import { jobTypeToPath } from '../../../app/config/urls';
 
 import useReducedMotion from '../../../shared/hooks/useReducedMotion';
+
 import { getBEMClassName as bem } from '../../../shared/utils/utils';
+import parseDate from '../../../shared/utils/parseDate';
 
 import { Job } from '../../types/toolsJob';
 import { Status } from '../../types/toolsStatuses';
 
 import './styles/Dashboard.scss';
-import parseDate from '../../../shared/utils/parseDate';
 
 const stopPropagation = (
   event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -31,6 +31,7 @@ import { Job } from '../../types/toolsJob';
 import { Status } from '../../types/toolsStatuses';
 
 import './styles/Dashboard.scss';
+import parseDate from '../../../shared/utils/parseDate';
 
 const stopPropagation = (
   event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>
@@ -76,8 +77,11 @@ interface TimeProps {
   children: number;
 }
 
-const Time: FC<TimeProps> = ({ children }) => {
-  const date = new Date(children);
+const Time = ({ children }: TimeProps) => {
+  const date = parseDate(children);
+  if (!date) {
+    return null;
+  }
   const YYYY = date.getFullYear();
   // date.getMonth() starts at 0 for January
   const MM = `${date.getMonth() + 1}`.padStart(2, '0');

--- a/src/uniparc/components/entry/XRefsSection.tsx
+++ b/src/uniparc/components/entry/XRefsSection.tsx
@@ -13,10 +13,9 @@ import {
 } from '../../../shared/components/entry/EntryTypeIcon';
 import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
 
-import { UseDataAPIWithStaleState } from '../../../shared/hooks/useDataApiWithStale';
-
 import useDataApi from '../../../shared/hooks/useDataApi';
 
+import parseDate from '../../../shared/utils/parseDate';
 import apiUrls from '../../../shared/config/apiUrls';
 import { getEntryPath } from '../../../app/config/urls';
 
@@ -31,6 +30,7 @@ import EntrySection, {
   getEntrySectionNameAndId,
 } from '../../types/entrySection';
 import { UniParcColumn } from '../../config/UniParcColumnConfiguration';
+import { UseDataAPIWithStaleState } from '../../../shared/hooks/useDataApiWithStale';
 
 import './styles/XRefsSection.scss';
 import '../../../shared/components/results/styles/results-view.scss';
@@ -157,7 +157,7 @@ const getColumns = (
       xref.created && (
         <time
           className={xref.active ? undefined : 'xref-inactive'}
-          dateTime={new Date(xref.created).toISOString()}
+          dateTime={parseDate(xref.created)?.toISOString()}
         >
           {xref.created}
         </time>
@@ -170,7 +170,7 @@ const getColumns = (
       xref.lastUpdated && (
         <time
           className={xref.active ? undefined : 'xref-inactive'}
-          dateTime={new Date(xref.lastUpdated).toISOString()}
+          dateTime={parseDate(xref.lastUpdated)?.toISOString()}
         >
           {xref.lastUpdated}
         </time>

--- a/src/uniparc/config/UniParcColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcColumnConfiguration.tsx
@@ -15,6 +15,7 @@ import TaxonomyView from '../../shared/components/entry/TaxonomyView';
 import externalUrls from '../../shared/config/externalUrls';
 import { getEntryPath } from '../../app/config/urls';
 
+import parseDate from '../../shared/utils/parseDate';
 import xrefGetter from '../utils/xrefGetter';
 
 import { Namespace } from '../../shared/types/namespaces';
@@ -230,7 +231,7 @@ UniParcColumnConfiguration.set(UniParcColumn.firstSeen, {
     }
     const firstSeen = created.sort()[0];
     return (
-      <time dateTime={new Date(firstSeen).toISOString()}>{firstSeen}</time>
+      <time dateTime={parseDate(firstSeen)?.toISOString()}>{firstSeen}</time>
     );
   },
 });
@@ -243,7 +244,9 @@ UniParcColumnConfiguration.set(UniParcColumn.lastSeen, {
       return null;
     }
     const lastSeen = lastUpdated.sort()[lastUpdated.length - 1];
-    return <time dateTime={new Date(lastSeen).toISOString()}>{lastSeen}</time>;
+    return (
+      <time dateTime={parseDate(lastSeen)?.toISOString()}>{lastSeen}</time>
+    );
   },
 });
 

--- a/src/uniref/components/data-views/Overview.tsx
+++ b/src/uniref/components/data-views/Overview.tsx
@@ -12,6 +12,7 @@ import MemberLink from '../entry/MemberLink';
 import useDataApi from '../../../shared/hooks/useDataApi';
 
 import { getBEMClassName } from '../../../shared/utils/utils';
+import parseDate from '../../../shared/utils/parseDate';
 import { getEntryPath } from '../../../app/config/urls';
 import apiUrls from '../../config/apiUrls';
 
@@ -127,14 +128,12 @@ export const Seed: FC<{ seedId: string }> = ({ seedId }) => (
   </strong>
 );
 
-export const Updated: FC<{ updated: string }> = ({ updated }) => {
-  const date = new Date(updated);
-  return (
-    <>
-      Updated:&nbsp;<time dateTime={date.toISOString()}>{updated}</time>
-    </>
-  );
-};
+export const Updated: FC<{ updated: string }> = ({ updated }) => (
+  <>
+    Updated:&nbsp;
+    <time dateTime={parseDate(updated)?.toISOString()}>{updated}</time>
+  </>
+);
 
 export const Overview: FC<{
   transformedData: UniRefUIModel;

--- a/src/uniref/config/UniRefColumnConfiguration.tsx
+++ b/src/uniref/config/UniRefColumnConfiguration.tsx
@@ -2,14 +2,15 @@ import { Link } from 'react-router-dom';
 import { Button, LongNumber, Sequence } from 'franklin-sites';
 
 import EntryTypeIcon from '../../shared/components/entry/EntryTypeIcon';
+import AccessionView from '../../shared/components/results/AccessionView';
+import TaxonomyView from '../../shared/components/entry/TaxonomyView';
 
 import { getEntryPath } from '../../app/config/urls';
+import parseDate from '../../shared/utils/parseDate';
 
 import { Namespace } from '../../shared/types/namespaces';
 import { UniRefLiteAPIModel } from '../adapters/uniRefConverter';
 import { ColumnConfiguration } from '../../shared/types/columnConfiguration';
-import AccessionView from '../../shared/components/results/AccessionView';
-import TaxonomyView from '../../shared/components/entry/TaxonomyView';
 
 export enum UniRefColumn {
   id = 'id',
@@ -202,7 +203,7 @@ UniRefColumnConfiguration.set(UniRefColumn.created, {
   label: 'Last updated',
   render: ({ updated }) =>
     updated && (
-      <time dateTime={new Date(updated).toISOString()}>{updated}</time>
+      <time dateTime={parseDate(updated)?.toISOString()}>{updated}</time>
     ),
 });
 


### PR DESCRIPTION
## Purpose
Fix issue with some date not being parsed correctly and throwing error on some pages (/proteomes/UP000149066) in some browsers (Firefox and Safari)

## Approach
Create a wrapper `parseDate` around date parsing and handles some edge cases that we know of.
Makes sure that even if it cannot parse the date, it doesn't return an invalid date that would cause an issue further down the line.
Replace all bare uses of `new Date()` with the new wrapper.

## Testing
Added tests for wrapper (note that it's running on V8, so would have the same behaviour as Firefox or Safari).
Made sure the rest of tests were running, and that the problematic page was not crashing in Firefox

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
