### PR TITLE
supporting data starting point

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -60,42 +60,42 @@ const ProteomesEntryPage = lazy(
       /* webpackChunkName: "proteomes-entry" */ '../../proteomes/components/entry/Entry'
     )
 );
-// const TaxonomyEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "taxonomy-entry" */ '../../supporting-data/taxonomy/components/entry/Entry'
-//     )
-// );
-// const KeywordsEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "keywords-entry" */ '../../supporting-data/keywords/components/entry/Entry'
-//     )
-// );
-// const CitationsEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "citations-entry" */ '../../supporting-data/citations/components/entry/Entry'
-//     )
-// );
-// const DiseasesEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "diseases-entry" */ '../../supporting-data/diseases/components/entry/Entry'
-//     )
-// );
-// const DatabaseEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "database-entry" */ '../../supporting-data/database/components/entry/Entry'
-//     )
-// );
-// const LocationsEntryPage = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "locations-entry" */ '../../supporting-data/locations/components/entry/Entry'
-//     )
-// );
+const TaxonomyEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "taxonomy-entry" */ '../../supporting-data/taxonomy/components/entry/Entry'
+    )
+);
+const KeywordsEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "keywords-entry" */ '../../supporting-data/keywords/components/entry/Entry'
+    )
+);
+const CitationsEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "citations-entry" */ '../../supporting-data/citations/components/entry/Entry'
+    )
+);
+const DiseasesEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "diseases-entry" */ '../../supporting-data/diseases/components/entry/Entry'
+    )
+);
+const DatabaseEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "database-entry" */ '../../supporting-data/database/components/entry/Entry'
+    )
+);
+const LocationsEntryPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "locations-entry" */ '../../supporting-data/locations/components/entry/Entry'
+    )
+);
 // Tools
 const BlastResult = lazy(
   () =>
@@ -210,30 +210,30 @@ const App = () => (
               component={ProteomesEntryPage}
             />
             {/* Supporting data */}
-            {/* <Route
+            <Route
               path={LocationToPath[Location.TaxonomyEntry]}
               component={TaxonomyEntryPage}
-            /> */}
-            {/* <Route
+            />
+            <Route
               path={LocationToPath[Location.KeywordsEntry]}
               component={KeywordsEntryPage}
-            /> */}
-            {/* <Route
+            />
+            <Route
               path={LocationToPath[Location.CitationsEntry]}
               component={CitationsEntryPage}
-            /> */}
-            {/* <Route
+            />
+            <Route
               path={LocationToPath[Location.DiseasesEntry]}
               component={DiseasesEntryPage}
-            /> */}
-            {/* <Route
+            />
+            <Route
               path={LocationToPath[Location.DatabaseEntry]}
               component={DatabaseEntryPage}
-            /> */}
-            {/* <Route
+            />
+            <Route
               path={LocationToPath[Location.LocationsEntry]}
               component={LocationsEntryPage}
-            /> */}
+            />
             {/* Result pages */}
             <Route
               path={allSearchResultLocations}

--- a/src/supporting-data/citations/components/entry/Entry.tsx
+++ b/src/supporting-data/citations/components/entry/Entry.tsx
@@ -1,0 +1,40 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+import { SetOptional } from 'type-fest';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import LiteratureCitation from '../LiteratureCitation';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { CitationsAPIModel } from '../../adapters/citationsConverter';
+
+const CitationsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const { data, loading, error, status, progress } = useDataApi<
+    SetOptional<CitationsAPIModel, 'statistics'>
+  >(apiUrls.entry(accession, Namespace.citations));
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <Card>
+        <LiteratureCitation data={data} displayAll />
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default CitationsEntry;

--- a/src/supporting-data/citations/components/results/CitationsCard.tsx
+++ b/src/supporting-data/citations/components/results/CitationsCard.tsx
@@ -19,7 +19,7 @@ const CitationCard: FC<{
   data: SetOptional<CitationsAPIModel, 'statistics'>;
   selected?: boolean;
   handleEntrySelection?: (rowId: string) => void;
-}> = ({ data, selected, handleEntrySelection, children }) => {
+}> = ({ data, selected, handleEntrySelection }) => {
   const history = useHistory();
 
   const id = getIdKey(data as CitationsAPIModel);
@@ -48,7 +48,7 @@ const CitationCard: FC<{
           </div>
         )}
         <div className="result-card__right">
-          <LiteratureCitation data={data}>{children}</LiteratureCitation>
+          <LiteratureCitation data={data} />
         </div>
       </div>
     </Card>

--- a/src/supporting-data/database/components/entry/Entry.tsx
+++ b/src/supporting-data/database/components/entry/Entry.tsx
@@ -1,0 +1,68 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { DatabaseAPIModel } from '../../adapters/databaseConverter';
+import DatabaseColumnConfiguration, {
+  DatabaseColumn,
+} from '../../config/DatabaseColumnConfiguration';
+
+const DatabaseEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const {
+    data,
+    loading,
+    error,
+    status,
+    progress,
+  } = useDataApi<DatabaseAPIModel>(
+    apiUrls.entry(accession, Namespace.database)
+  );
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <h2>Database - {data.abbrev}</h2>
+      <Card>
+        <RenderColumnsInCard
+          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.name)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.server)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.dbUrl)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.linkType)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.category)}
+          data={data}
+        />
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default DatabaseEntry;

--- a/src/supporting-data/diseases/components/entry/Entry.tsx
+++ b/src/supporting-data/diseases/components/entry/Entry.tsx
@@ -1,0 +1,71 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { DiseasesAPIModel } from '../../adapters/diseasesConverter';
+import DiseasesColumnConfiguration, {
+  DiseasesColumn,
+} from '../../config/DiseasesColumnConfiguration';
+
+const DiseasesEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const {
+    data,
+    loading,
+    error,
+    status,
+    progress,
+  } = useDataApi<DiseasesAPIModel>(
+    apiUrls.entry(accession, Namespace.diseases)
+  );
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <h2>Disease - {data.name}</h2>
+      <Card>
+        <RenderColumnsInCard
+          renderers={DiseasesColumnConfiguration.get(DiseasesColumn.definition)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DiseasesColumnConfiguration.get(DiseasesColumn.acronym)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={DiseasesColumnConfiguration.get(
+            DiseasesColumn.crossReferences
+          )}
+          data={data}
+        />
+        <p>
+          <h3>Disclaimer</h3>
+          Any medical or genetic information present in this entry is provided
+          for research, educational and informational purposes only. It is not
+          in any way intended to be used as a substitute for professional
+          medical advice, diagnosis, treatment or care. Our staff consists of
+          biologists and biochemists that are not trained to give medical
+          advice.
+        </p>
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default DiseasesEntry;

--- a/src/supporting-data/keywords/components/entry/Entry.tsx
+++ b/src/supporting-data/keywords/components/entry/Entry.tsx
@@ -1,0 +1,68 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { KeywordsAPIModel } from '../../adapters/keywordsConverter';
+import KeywordsColumnConfiguration, {
+  KeywordsColumn,
+} from '../../config/KeywordsColumnConfiguration';
+
+const KeywordsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const {
+    data,
+    loading,
+    error,
+    status,
+    progress,
+  } = useDataApi<KeywordsAPIModel>(
+    apiUrls.entry(accession, Namespace.keywords)
+  );
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <h2>Keyword - {data.keyword.name}</h2>
+      <Card>
+        <RenderColumnsInCard
+          renderers={KeywordsColumnConfiguration.get(
+            KeywordsColumn.description
+          )}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={KeywordsColumnConfiguration.get(KeywordsColumn.synonym)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={KeywordsColumnConfiguration.get(KeywordsColumn.category)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={KeywordsColumnConfiguration.get(
+            KeywordsColumn.geneOntology
+          )}
+          data={data}
+        />
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default KeywordsEntry;

--- a/src/supporting-data/locations/components/entry/Entry.tsx
+++ b/src/supporting-data/locations/components/entry/Entry.tsx
@@ -1,0 +1,68 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { LocationsAPIModel } from '../../adapters/locationsConverter';
+import LocationsColumnConfiguration, {
+  LocationsColumn,
+} from '../../config/LocationsColumnConfiguration';
+
+const LocationsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const {
+    data,
+    loading,
+    error,
+    status,
+    progress,
+  } = useDataApi<LocationsAPIModel>(
+    apiUrls.entry(accession, Namespace.locations)
+  );
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <h2>Cellular component - {data.name}</h2>
+      <Card>
+        <RenderColumnsInCard
+          renderers={LocationsColumnConfiguration.get(
+            LocationsColumn.definition
+          )}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={LocationsColumnConfiguration.get(LocationsColumn.synonyms)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={LocationsColumnConfiguration.get(LocationsColumn.category)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={LocationsColumnConfiguration.get(
+            LocationsColumn.geneOntologies
+          )}
+          data={data}
+        />
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default LocationsEntry;

--- a/src/supporting-data/taxonomy/components/entry/Entry.tsx
+++ b/src/supporting-data/taxonomy/components/entry/Entry.tsx
@@ -1,0 +1,85 @@
+import { RouteChildrenProps } from 'react-router-dom';
+import { Loader, Card } from 'franklin-sites';
+
+import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
+import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../../shared/config/apiUrls';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { TaxonomyAPIModel } from '../../adapters/taxonomyConverter';
+import TaxonomyColumnConfiguration, {
+  TaxonomyColumn,
+} from '../../config/TaxonomyColumnConfiguration';
+
+const TaxonomyEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const accession = props.match?.params.accession;
+
+  const {
+    data,
+    loading,
+    error,
+    status,
+    progress,
+  } = useDataApi<TaxonomyAPIModel>(
+    apiUrls.entry(accession, Namespace.taxonomy)
+  );
+
+  if (error || !accession) {
+    return <ErrorHandler status={status} />;
+  }
+
+  if (loading || !data) {
+    return <Loader progress={progress} />;
+  }
+
+  return (
+    <SingleColumnLayout>
+      <h2>
+        Taxonomy - {data.scientificName || data.taxonId}{' '}
+        <small>({data.rank})</small>
+      </h2>
+      <Card>
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.mnemonic)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.id)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(
+            TaxonomyColumn.scientificName
+          )}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.commonName)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.synonym)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.rank)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.lineage)}
+          data={data}
+        />
+        <RenderColumnsInCard
+          renderers={TaxonomyColumnConfiguration.get(TaxonomyColumn.parent)}
+          data={data}
+        />
+      </Card>
+    </SingleColumnLayout>
+  );
+};
+
+export default TaxonomyEntry;


### PR DESCRIPTION
## Purpose
Starting point for supporting data entry pages. Doesn't aim to close any specific jira as none of them fit exactly with the mockups.
This is to build upon!

## Approach
Connect routes for supporting data URLs to components, load data, copy approach for supporting data result page cards, but with more columns rendered.
A lot of copy pasted code, but didn't want to generalise something now when specs are still moving but we need this to be ready yesterday!

## Testing
No specific unit-test for now.
Checked that the pages where rendering

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
