### PR TITLE
add hook to scroll to top on pathname change

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -9,6 +9,8 @@ import GDPR from '../../shared/components/gdpr/GDPR';
 
 import history from '../../shared/utils/browserHistory';
 
+import useScrollToTop from '../../shared/hooks/useScrollToTop';
+
 import {
   allSearchResultLocations,
   Location,
@@ -179,147 +181,151 @@ const reportBugLinkStyles: CSSProperties = {
   zIndex: 99,
 };
 
-const App = () => (
-  <FranklinSite>
-    <Router history={history}>
-      <BaseLayout>
-        <Suspense fallback={<Loader />}>
-          <Switch>
-            {/* Home */}
-            <Route
-              path={LocationToPath[Location.Home]}
-              exact
-              component={HomePage}
-            />
-            {/* Entry pages */}
-            {/* Main namespaces */}
-            <Route
-              path={LocationToPath[Location.UniProtKBEntry]}
-              component={UniProtKBEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.UniRefEntry]}
-              component={UniRefEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.UniParcEntry]}
-              component={UniParcEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.ProteomesEntry]}
-              component={ProteomesEntryPage}
-            />
-            {/* Supporting data */}
-            <Route
-              path={LocationToPath[Location.TaxonomyEntry]}
-              component={TaxonomyEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.KeywordsEntry]}
-              component={KeywordsEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.CitationsEntry]}
-              component={CitationsEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.DiseasesEntry]}
-              component={DiseasesEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.DatabaseEntry]}
-              component={DatabaseEntryPage}
-            />
-            <Route
-              path={LocationToPath[Location.LocationsEntry]}
-              component={LocationsEntryPage}
-            />
-            {/* Result pages */}
-            <Route
-              path={allSearchResultLocations}
-              component={GenericResultsPage}
-            />
-            {/* Tools */}
-            <Route
-              path={LocationToPath[Location.BlastResult]}
-              component={BlastResult}
-            />
-            <Route
-              path={LocationToPath[Location.Blast]}
-              render={() => (
-                <SingleColumnLayout>
-                  <BlastForm />
-                </SingleColumnLayout>
-              )}
-            />
-            <Route
-              path={LocationToPath[Location.AlignResult]}
-              component={AlignResult}
-            />
-            <Route
-              path={LocationToPath[Location.Align]}
-              render={() => (
-                <SingleColumnLayout>
-                  <AlignForm />
-                </SingleColumnLayout>
-              )}
-            />
-            {/* <Route
+const App = () => {
+  useScrollToTop(history);
+
+  return (
+    <FranklinSite>
+      <Router history={history}>
+        <BaseLayout>
+          <Suspense fallback={<Loader />}>
+            <Switch>
+              {/* Home */}
+              <Route
+                path={LocationToPath[Location.Home]}
+                exact
+                component={HomePage}
+              />
+              {/* Entry pages */}
+              {/* Main namespaces */}
+              <Route
+                path={LocationToPath[Location.UniProtKBEntry]}
+                component={UniProtKBEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.UniRefEntry]}
+                component={UniRefEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.UniParcEntry]}
+                component={UniParcEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.ProteomesEntry]}
+                component={ProteomesEntryPage}
+              />
+              {/* Supporting data */}
+              <Route
+                path={LocationToPath[Location.TaxonomyEntry]}
+                component={TaxonomyEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.KeywordsEntry]}
+                component={KeywordsEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.CitationsEntry]}
+                component={CitationsEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.DiseasesEntry]}
+                component={DiseasesEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.DatabaseEntry]}
+                component={DatabaseEntryPage}
+              />
+              <Route
+                path={LocationToPath[Location.LocationsEntry]}
+                component={LocationsEntryPage}
+              />
+              {/* Result pages */}
+              <Route
+                path={allSearchResultLocations}
+                component={GenericResultsPage}
+              />
+              {/* Tools */}
+              <Route
+                path={LocationToPath[Location.BlastResult]}
+                component={BlastResult}
+              />
+              <Route
+                path={LocationToPath[Location.Blast]}
+                render={() => (
+                  <SingleColumnLayout>
+                    <BlastForm />
+                  </SingleColumnLayout>
+                )}
+              />
+              <Route
+                path={LocationToPath[Location.AlignResult]}
+                component={AlignResult}
+              />
+              <Route
+                path={LocationToPath[Location.Align]}
+                render={() => (
+                  <SingleColumnLayout>
+                    <AlignForm />
+                  </SingleColumnLayout>
+                )}
+              />
+              {/* <Route
               path={LocationToPath[Location.PeptideSearchResult]}
               component={PeptideSearchResult}
             /> */}
-            <Route
-              path={LocationToPath[Location.PeptideSearch]}
-              render={() => (
-                <SingleColumnLayout>
-                  <PeptideSearchForm />
-                </SingleColumnLayout>
-              )}
-            />
-            {/* <Route
+              <Route
+                path={LocationToPath[Location.PeptideSearch]}
+                render={() => (
+                  <SingleColumnLayout>
+                    <PeptideSearchForm />
+                  </SingleColumnLayout>
+                )}
+              />
+              {/* <Route
               path={LocationToPath[Location.IDMappingResult]}
               component={IDMappingResult}
             /> */}
-            <Route
-              path={LocationToPath[Location.IDMapping]}
-              render={() => (
-                <SingleColumnLayout>
-                  <IDMappingForm />
-                </SingleColumnLayout>
-              )}
-            />
-            <Route
-              path={LocationToPath[Location.Dashboard]}
-              render={() => (
-                <SingleColumnLayout>
-                  <Dashboard />
-                </SingleColumnLayout>
-              )}
-            />
-            {/* Catch-all handler -> Redirect or not found */}
-            <Route
-              component={() => (
-                <SingleColumnLayout>
-                  <ResourceNotFoundPage />
-                </SingleColumnLayout>
-              )}
-            />
-          </Switch>
-        </Suspense>
-      </BaseLayout>
-      <ErrorBoundary fallback={null}>
-        <GDPR />
-      </ErrorBoundary>
-    </Router>
-    <a
-      style={reportBugLinkStyles}
-      target="_blank"
-      href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
-      rel="noopener noreferrer"
-    >
-      Report bug
-    </a>
-  </FranklinSite>
-);
+              <Route
+                path={LocationToPath[Location.IDMapping]}
+                render={() => (
+                  <SingleColumnLayout>
+                    <IDMappingForm />
+                  </SingleColumnLayout>
+                )}
+              />
+              <Route
+                path={LocationToPath[Location.Dashboard]}
+                render={() => (
+                  <SingleColumnLayout>
+                    <Dashboard />
+                  </SingleColumnLayout>
+                )}
+              />
+              {/* Catch-all handler -> Redirect or not found */}
+              <Route
+                component={() => (
+                  <SingleColumnLayout>
+                    <ResourceNotFoundPage />
+                  </SingleColumnLayout>
+                )}
+              />
+            </Switch>
+          </Suspense>
+        </BaseLayout>
+        <ErrorBoundary fallback={null}>
+          <GDPR />
+        </ErrorBoundary>
+      </Router>
+      <a
+        style={reportBugLinkStyles}
+        target="_blank"
+        href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
+        rel="noopener noreferrer"
+      >
+        Report bug
+      </a>
+    </FranklinSite>
+  );
+};
 
 export default App;

--- a/src/shared/hooks/useScrollToTop.ts
+++ b/src/shared/hooks/useScrollToTop.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { History } from 'history';
+
+const useScrollToTop = (history: History) => {
+  useEffect(() => {
+    let previousPathname = history.location.pathname;
+    const unlisten = history.listen((location) => {
+      if (previousPathname !== location.pathname) {
+        window.scrollTo(0, 0);
+      }
+      previousPathname = location.pathname;
+    });
+
+    return () => {
+      unlisten();
+    };
+  }, [history]);
+};
+
+export default useScrollToTop;


### PR DESCRIPTION
## Purpose
Scroll to top of the page when changing pathname. [TRM-25715](https://www.ebi.ac.uk/panda/jira/browse/TRM-25715)

## Approach
Add hook to listen to history changes, when the pathname changes, scroll to the top of the page

## Testing
No unit test possible (as far as I could think of)
To try, for example, scroll down on the home page, then click on the tile to go to the BLAST form, the top of the form should be visible.
Also, doesn't break the default scroll restauration when clicking the back button (you should go back at the same level on the home page)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
