### PR TITLE
more supporting data entry pages content using infolist

### DIFF
--- a/src/shared/components/MedicalDisclaimer.tsx
+++ b/src/shared/components/MedicalDisclaimer.tsx
@@ -1,0 +1,16 @@
+import { HeroContainer } from 'franklin-sites';
+
+const MedicalDisclaimer = ({ title = <h3>Disclaimer</h3> }) => (
+  <HeroContainer>
+    {title}
+    <em>
+      Any medical or genetic information present in this entry is provided for
+      research, educational and informational purposes only. It is not in any
+      way intended to be used as a substitute for professional medical advice,
+      diagnosis, treatment or care. Our staff consists of biologists and
+      biochemists that are not trained to give medical advice.
+    </em>
+  </HeroContainer>
+);
+
+export default MedicalDisclaimer;

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -8,6 +8,7 @@ import { mainNamespaces } from '../../types/namespaces';
 
 import { FacetObject } from '../../../uniprotkb/types/responseTypes';
 
+import helper from '../../styles/helper.module.scss';
 import './styles/results-view.scss';
 
 const ResultsFacets: FC<{ facets: FacetObject[]; isStale?: boolean }> = ({
@@ -23,7 +24,7 @@ const ResultsFacets: FC<{ facets: FacetObject[]; isStale?: boolean }> = ({
   const after = splitIndex === -1 ? facets : facets.slice(splitIndex + 1);
 
   return (
-    <Facets className={isStale ? 'is-stale' : undefined}>
+    <Facets className={isStale ? helper.stale : undefined}>
       {before.map((facet) => (
         <Facet key={facet.name} data={facet} />
       ))}

--- a/src/shared/components/results/styles/results-view.scss
+++ b/src/shared/components/results/styles/results-view.scss
@@ -1,11 +1,5 @@
 @import '../../../styles/settings';
 
-.is-stale {
-  opacity: 0.5;
-  pointer-events: none;
-  user-select: none;
-}
-
 .results-view {
   width: 100%;
 

--- a/src/shared/styles/helper.module.scss
+++ b/src/shared/styles/helper.module.scss
@@ -1,4 +1,4 @@
-.is-stale {
+.stale {
   opacity: 0.5;
   pointer-events: none;
   user-select: none;

--- a/src/supporting-data/database/components/entry/Entry.tsx
+++ b/src/supporting-data/database/components/entry/Entry.tsx
@@ -1,11 +1,10 @@
 import { RouteChildrenProps } from 'react-router-dom';
-import { Loader, Card } from 'franklin-sites';
+import { Loader, Card, InfoList } from 'franklin-sites';
 
 import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
-import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
 
-import useDataApi from '../../../../shared/hooks/useDataApi';
+import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 
 import apiUrls from '../../../../shared/config/apiUrls';
 
@@ -14,6 +13,18 @@ import { DatabaseAPIModel } from '../../adapters/databaseConverter';
 import DatabaseColumnConfiguration, {
   DatabaseColumn,
 } from '../../config/DatabaseColumnConfiguration';
+
+import helper from '../../../../shared/styles/helper.module.scss';
+
+const columns = [
+  DatabaseColumn.name,
+  DatabaseColumn.server,
+  DatabaseColumn.dbUrl,
+  DatabaseColumn.linkType,
+  DatabaseColumn.category,
+  DatabaseColumn.doiId,
+  DatabaseColumn.pubmedId,
+];
 
 const DatabaseEntry = (props: RouteChildrenProps<{ accession: string }>) => {
   const accession = props.match?.params.accession;
@@ -24,42 +35,34 @@ const DatabaseEntry = (props: RouteChildrenProps<{ accession: string }>) => {
     error,
     status,
     progress,
-  } = useDataApi<DatabaseAPIModel>(
+    isStale,
+  } = useDataApiWithStale<DatabaseAPIModel>(
     apiUrls.entry(accession, Namespace.database)
   );
 
-  if (error || !accession) {
+  if (error || !accession || (!loading && !data)) {
     return <ErrorHandler status={status} />;
   }
 
-  if (loading || !data) {
+  if (!data) {
     return <Loader progress={progress} />;
   }
+
+  const infoData =
+    data &&
+    columns.map((column) => {
+      const renderer = DatabaseColumnConfiguration.get(column);
+      return {
+        title: renderer?.label,
+        content: renderer?.render(data),
+      };
+    });
 
   return (
     <SingleColumnLayout>
       <h2>Database - {data.abbrev}</h2>
-      <Card>
-        <RenderColumnsInCard
-          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.name)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.server)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.dbUrl)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.linkType)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={DatabaseColumnConfiguration.get(DatabaseColumn.category)}
-          data={data}
-        />
+      <Card className={isStale ? helper.stale : undefined}>
+        {infoData && <InfoList infoData={infoData} isCompact />}
       </Card>
     </SingleColumnLayout>
   );

--- a/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
+++ b/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
@@ -36,7 +36,11 @@ exports[`DatabaseCard tests should render the card component 1`] = `
                 <strong>
                   Category: 
                 </strong>
-                Sequence databases
+                <a
+                  href="/database?facets=category_facet:Sequence databases"
+                >
+                  Sequence databases
+                </a>
               </span>
             </div>
           </div>

--- a/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
+++ b/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
@@ -1,12 +1,9 @@
-import { ExternalLink, CodeBlock /* , LongNumber */ } from 'franklin-sites';
-
-// import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import { ExternalLink, CodeBlock } from 'franklin-sites';
 
 import externalUrls from '../../../shared/config/externalUrls';
 
 import { DatabaseAPIModel } from '../adapters/databaseConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-// import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../../shared/types/namespaces';
 import AccessionView from '../../../shared/components/results/AccessionView';
 
@@ -26,13 +23,10 @@ export enum DatabaseColumn {
   unreviewedProteinCount = 'unreviewed_protein_count',
 }
 
-// TODO: decide which ones should be default
 export const defaultColumns = [
   DatabaseColumn.id,
   DatabaseColumn.name,
   DatabaseColumn.abbrev,
-  // DatabaseColumn.reviewedProteinCount,
-  // DatabaseColumn.unreviewedProteinCount,
   DatabaseColumn.category,
 ];
 
@@ -95,33 +89,5 @@ DatabaseColumnConfiguration.set(DatabaseColumn.server, {
   label: 'Server',
   render: ({ server }) => server && <ExternalLink url={server} tidyUrl />,
 });
-
-// TODO: might not be needed as a column
-// DatabaseColumnConfiguration.set(DatabaseColumn.reviewedProteinCount, {
-//   label: (
-//     <>
-//       <EntryTypeIcon entryType={EntryType.REVIEWED} />
-//       Mapped reviewed entries
-//     </>
-//   ),
-//   render: ({ reviewedProteinCount }) =>
-//     reviewedProteinCount !== undefined && (
-//       <LongNumber>{reviewedProteinCount}</LongNumber>
-//     ),
-// });
-
-// TODO: might not be needed as a column
-// DatabaseColumnConfiguration.set(DatabaseColumn.unreviewedProteinCount, {
-//   label: (
-//     <>
-//       <EntryTypeIcon entryType={EntryType.UNREVIEWED} />
-//       Mapped unreviewed entries
-//     </>
-//   ),
-//   render: ({ unreviewedProteinCount }) =>
-//     unreviewedProteinCount !== undefined && (
-//       <LongNumber>{unreviewedProteinCount}</LongNumber>
-//     ),
-// });
 
 export default DatabaseColumnConfiguration;

--- a/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
+++ b/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
@@ -1,11 +1,18 @@
+import { Link } from 'react-router-dom';
 import { ExternalLink, CodeBlock } from 'franklin-sites';
 
+import AccessionView from '../../../shared/components/results/AccessionView';
+
 import externalUrls from '../../../shared/config/externalUrls';
+import { LocationToPath, Location } from '../../../app/config/urls';
+import {
+  getLocationObjForParams,
+  getParamsFromURL,
+} from '../../../uniprotkb/utils/resultsUtils';
 
 import { DatabaseAPIModel } from '../adapters/databaseConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
 import { Namespace } from '../../../shared/types/namespaces';
-import AccessionView from '../../../shared/components/results/AccessionView';
 
 export enum DatabaseColumn {
   abbrev = 'abbrev',
@@ -45,7 +52,26 @@ DatabaseColumnConfiguration.set(DatabaseColumn.abbrev, {
 
 DatabaseColumnConfiguration.set(DatabaseColumn.category, {
   label: 'Category',
-  render: ({ category }) => category,
+  render: ({ category }) =>
+    category && (
+      <Link
+        to={({ search }) => {
+          const parsed = getParamsFromURL(search);
+          return getLocationObjForParams({
+            pathname: LocationToPath[Location.DatabaseResults],
+            ...parsed,
+            selectedFacets: [
+              ...parsed.selectedFacets.filter(
+                ({ name }) => name !== 'category_facet'
+              ),
+              { name: 'category_facet', value: category },
+            ],
+          });
+        }}
+      >
+        {category}
+      </Link>
+    ),
 });
 
 DatabaseColumnConfiguration.set(DatabaseColumn.dbUrl, {

--- a/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
@@ -8,7 +8,11 @@ exports[`DatabaseColumnConfiguration component should render column "abbrev": ab
 
 exports[`DatabaseColumnConfiguration component should render column "category": category 1`] = `
 <DocumentFragment>
-  Sequence databases
+  <a
+    href="/database?facets=category_facet:Sequence databases"
+  >
+    Sequence databases
+  </a>
 </DocumentFragment>
 `;
 

--- a/src/supporting-data/diseases/components/entry/Entry.tsx
+++ b/src/supporting-data/diseases/components/entry/Entry.tsx
@@ -3,6 +3,7 @@ import { Loader, Card, InfoList } from 'franklin-sites';
 
 import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
+import MedicalDisclaimer from '../../../../shared/components/MedicalDisclaimer';
 
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 
@@ -60,15 +61,8 @@ const DiseasesEntry = (props: RouteChildrenProps<{ accession: string }>) => {
       <h2>Disease - {data.name}</h2>
       <Card className={isStale ? helper.stale : undefined}>
         {infoData && <InfoList infoData={infoData} isCompact />}
-        <p>
-          <h3>Disclaimer</h3>
-          Any medical or genetic information present in this entry is provided
-          for research, educational and informational purposes only. It is not
-          in any way intended to be used as a substitute for professional
-          medical advice, diagnosis, treatment or care. Our staff consists of
-          biologists and biochemists that are not trained to give medical
-          advice.
-        </p>
+
+        <MedicalDisclaimer />
       </Card>
     </SingleColumnLayout>
   );

--- a/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
+++ b/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
@@ -1,13 +1,10 @@
 import { Link } from 'react-router-dom';
-import { ExpandableList /* , LongNumber */ } from 'franklin-sites';
-
-// import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import { ExpandableList } from 'franklin-sites';
 
 import { getEntryPathFor } from '../../../app/config/urls';
 
 import { DiseasesAPIModel } from '../adapters/diseasesConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-// import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../../shared/types/namespaces';
 import AccessionView from '../../../shared/components/results/AccessionView';
 
@@ -23,7 +20,6 @@ export enum DiseasesColumn {
   unreviewedProteinCount = 'unreviewed_protein_count',
 }
 
-// TODO: decide which ones should be default
 export const defaultColumns = [
   DiseasesColumn.id,
   DiseasesColumn.name,
@@ -47,32 +43,35 @@ DiseasesColumnConfiguration.set(DiseasesColumn.acronym, {
 
 DiseasesColumnConfiguration.set(DiseasesColumn.alternativeNames, {
   label: 'Alternative names',
-  render: ({ alternativeNames }) => (
-    <ExpandableList
-      descriptionString="alternative names"
-      displayNumberOfHiddenItems
-    >
-      {alternativeNames}
-    </ExpandableList>
-  ),
+  render: ({ alternativeNames }) =>
+    alternativeNames?.length && (
+      <ExpandableList
+        descriptionString="alternative names"
+        displayNumberOfHiddenItems
+      >
+        {alternativeNames}
+      </ExpandableList>
+    ),
 });
 
 // NOTE: should probably be links
 DiseasesColumnConfiguration.set(DiseasesColumn.crossReferences, {
   label: 'Cross references',
-  render: ({ crossReferences }) => (
-    <ExpandableList
-      descriptionString="cross references"
-      displayNumberOfHiddenItems
-    >
-      {crossReferences?.map(
-        ({ databaseType, id, properties }) =>
-          `${databaseType}: ${id}${
-            properties?.length ? ` (${properties.join(', ')})` : ''
-          }`
-      )}
-    </ExpandableList>
-  ),
+  // TODO: https://www.ebi.ac.uk/panda/jira/browse/TRM-25838
+  render: ({ crossReferences }) =>
+    crossReferences?.length && (
+      <ExpandableList
+        descriptionString="cross references"
+        displayNumberOfHiddenItems
+      >
+        {crossReferences.map(
+          ({ databaseType, id, properties }) =>
+            `${databaseType}: ${id}${
+              properties?.length ? ` (${properties.join(', ')})` : ''
+            }`
+        )}
+      </ExpandableList>
+    ),
 });
 
 DiseasesColumnConfiguration.set(DiseasesColumn.definition, {
@@ -88,48 +87,21 @@ DiseasesColumnConfiguration.set(DiseasesColumn.id, {
 
 DiseasesColumnConfiguration.set(DiseasesColumn.keywords, {
   label: 'Keywords',
-  render: ({ keywords }) => (
-    <ExpandableList descriptionString="keywords" displayNumberOfHiddenItems>
-      {keywords?.map(({ name, id }) => (
-        <Link key={id} to={getEntryPathForKeyword(id)}>
-          {name}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ keywords }) =>
+    keywords?.length && (
+      <ExpandableList descriptionString="keywords" displayNumberOfHiddenItems>
+        {keywords.map(({ name, id }) => (
+          <Link key={id} to={getEntryPathForKeyword(id)}>
+            {name}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 DiseasesColumnConfiguration.set(DiseasesColumn.name, {
   label: 'Name',
   render: ({ name }) => name,
 });
-
-// TODO: might not be needed as a column
-// DiseasesColumnConfiguration.set(DiseasesColumn.reviewedProteinCount, {
-//   label: (
-//     <>
-//       <EntryTypeIcon entryType={EntryType.REVIEWED} />
-//       Mapped reviewed entries
-//     </>
-//   ),
-//   render: ({ reviewedProteinCount }) =>
-//     reviewedProteinCount !== undefined && (
-//       <LongNumber>{reviewedProteinCount}</LongNumber>
-//     ),
-// });
-
-// TODO: might not be needed as a column
-// DiseasesColumnConfiguration.set(DiseasesColumn.unreviewedProteinCount, {
-//   label: (
-//     <>
-//       <EntryTypeIcon entryType={EntryType.UNREVIEWED} />
-//       Mapped unreviewed entries
-//     </>
-//   ),
-//   render: ({ unreviewedProteinCount }) =>
-//     unreviewedProteinCount !== undefined && (
-//       <LongNumber>{unreviewedProteinCount}</LongNumber>
-//     ),
-// });
 
 export default DiseasesColumnConfiguration;

--- a/src/supporting-data/keywords/components/entry/Entry.tsx
+++ b/src/supporting-data/keywords/components/entry/Entry.tsx
@@ -1,11 +1,10 @@
 import { RouteChildrenProps } from 'react-router-dom';
-import { Loader, Card } from 'franklin-sites';
+import { Loader, Card, InfoList } from 'franklin-sites';
 
 import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
-import RenderColumnsInCard from '../../../../shared/components/results/RenderColumnsInCard';
 
-import useDataApi from '../../../../shared/hooks/useDataApi';
+import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 
 import apiUrls from '../../../../shared/config/apiUrls';
 
@@ -14,6 +13,18 @@ import { KeywordsAPIModel } from '../../adapters/keywordsConverter';
 import KeywordsColumnConfiguration, {
   KeywordsColumn,
 } from '../../config/KeywordsColumnConfiguration';
+
+import helper from '../../../../shared/styles/helper.module.scss';
+
+const columns = [
+  KeywordsColumn.description,
+  KeywordsColumn.synonym,
+  KeywordsColumn.category,
+  KeywordsColumn.geneOntology,
+  KeywordsColumn.parent,
+  KeywordsColumn.children,
+  KeywordsColumn.sites,
+];
 
 const KeywordsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
   const accession = props.match?.params.accession;
@@ -24,42 +35,34 @@ const KeywordsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
     error,
     status,
     progress,
-  } = useDataApi<KeywordsAPIModel>(
+    isStale,
+  } = useDataApiWithStale<KeywordsAPIModel>(
     apiUrls.entry(accession, Namespace.keywords)
   );
 
-  if (error || !accession) {
+  if (error || !accession || (!loading && !data)) {
     return <ErrorHandler status={status} />;
   }
 
-  if (loading || !data) {
+  if (!data) {
     return <Loader progress={progress} />;
   }
+
+  const infoData =
+    data &&
+    columns.map((column) => {
+      const renderer = KeywordsColumnConfiguration.get(column);
+      return {
+        title: renderer?.label,
+        content: renderer?.render(data),
+      };
+    });
 
   return (
     <SingleColumnLayout>
       <h2>Keyword - {data.keyword.name}</h2>
-      <Card>
-        <RenderColumnsInCard
-          renderers={KeywordsColumnConfiguration.get(
-            KeywordsColumn.description
-          )}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={KeywordsColumnConfiguration.get(KeywordsColumn.synonym)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={KeywordsColumnConfiguration.get(KeywordsColumn.category)}
-          data={data}
-        />
-        <RenderColumnsInCard
-          renderers={KeywordsColumnConfiguration.get(
-            KeywordsColumn.geneOntology
-          )}
-          data={data}
-        />
+      <Card className={isStale ? helper.stale : undefined}>
+        {infoData && <InfoList infoData={infoData} isCompact />}
       </Card>
     </SingleColumnLayout>
   );

--- a/src/supporting-data/keywords/config/KeywordsColumnConfiguration.tsx
+++ b/src/supporting-data/keywords/config/KeywordsColumnConfiguration.tsx
@@ -1,18 +1,14 @@
 import { Link } from 'react-router-dom';
-import {
-  ExpandableList,
-  ExternalLink /* , LongNumber */,
-} from 'franklin-sites';
+import { ExpandableList, ExternalLink } from 'franklin-sites';
 
-// import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import AccessionView from '../../../shared/components/results/AccessionView';
 
 import { getEntryPathFor } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
 
 import { KeywordsAPIModel } from '../adapters/keywordsConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-// import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../../shared/types/namespaces';
-import AccessionView from '../../../shared/components/results/AccessionView';
 
 export enum KeywordsColumn {
   category = 'category',
@@ -31,7 +27,6 @@ export enum KeywordsColumn {
   synonym = 'synonym',
 }
 
-// TODO: decide which ones should be default
 export const defaultColumns = [
   KeywordsColumn.id,
   KeywordsColumn.name,
@@ -41,7 +36,7 @@ export const defaultColumns = [
 
 export const primaryKeyColumn = KeywordsColumn.id;
 
-const getEntryPath = getEntryPathFor(Namespace.diseases);
+const getEntryPath = getEntryPathFor(Namespace.keywords);
 
 export const KeywordsColumnConfiguration: ColumnConfiguration<
   KeywordsColumn,
@@ -56,15 +51,16 @@ KeywordsColumnConfiguration.set(KeywordsColumn.category, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.children, {
   label: 'Children',
-  render: ({ children }) => (
-    <ExpandableList descriptionString="children" displayNumberOfHiddenItems>
-      {children?.map((child) => (
-        <Link key={child.keyword.id} to={getEntryPath(child.keyword.id)}>
-          {child.keyword.name}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ children }) =>
+    children?.length && (
+      <ExpandableList descriptionString="children" displayNumberOfHiddenItems>
+        {children.map((child) => (
+          <Link key={child.keyword.id} to={getEntryPath(child.keyword.id)}>
+            {child.keyword.name}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.description, {
@@ -74,11 +70,16 @@ KeywordsColumnConfiguration.set(KeywordsColumn.description, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.geneOntology, {
   label: 'Gene Ontologies',
-  render: ({ geneOntologies }) => (
-    <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
-      {geneOntologies?.map(({ name, goId }) => `${name} (${goId})`)}
-    </ExpandableList>
-  ),
+  render: ({ geneOntologies }) =>
+    geneOntologies?.length && (
+      <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
+        {geneOntologies.map(({ name, goId }) => (
+          <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
+            {name} ({goId})
+          </ExternalLink>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.id, {
@@ -94,58 +95,38 @@ KeywordsColumnConfiguration.set(KeywordsColumn.name, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.parent, {
   label: 'Parent',
-  render: ({ parents }) => (
-    <ExpandableList descriptionString="parents" displayNumberOfHiddenItems>
-      {parents?.map((parent) => (
-        <Link key={parent.keyword.id} to={getEntryPath(parent.keyword.id)}>
-          {parent.keyword.name}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ parents }) =>
+    parents?.length && (
+      <ExpandableList descriptionString="parents" displayNumberOfHiddenItems>
+        {parents.map((parent) => (
+          <Link key={parent.keyword.id} to={getEntryPath(parent.keyword.id)}>
+            {parent.keyword.name}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.sites, {
   label: 'Sites',
-  render: ({ sites }) => (
-    <ExpandableList descriptionString="sites" displayNumberOfHiddenItems>
-      {sites?.map((site) => (
-        <ExternalLink key={site} url={site} tidyUrl />
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ sites }) =>
+    sites?.length && (
+      <ExpandableList descriptionString="sites" displayNumberOfHiddenItems>
+        {sites.map((site) => (
+          <ExternalLink key={site} url={site} tidyUrl />
+        ))}
+      </ExpandableList>
+    ),
 });
 
-// TODO: might not be needed as a column
-// KeywordsColumnConfiguration.set(KeywordsColumn.statistics, {
-//   label: 'Mapping to',
-//   render: ({ statistics }) => (
-//     <>
-//       {statistics?.reviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.REVIEWED} />
-//           <LongNumber>{statistics.reviewedProteinCount}</LongNumber> reviewed
-//           entr{statistics.reviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//       {statistics?.unreviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.UNREVIEWED} />
-//           <LongNumber>{statistics.unreviewedProteinCount}</LongNumber>{' '}
-//           unreviewed entr{statistics.unreviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//     </>
-//   ),
-// });
-
 KeywordsColumnConfiguration.set(KeywordsColumn.synonym, {
-  label: 'Synonym',
-  render: ({ synonyms }) => (
-    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-      {synonyms}
-    </ExpandableList>
-  ),
+  label: 'Synonyms',
+  render: ({ synonyms }) =>
+    synonyms?.length && (
+      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+        {synonyms}
+      </ExpandableList>
+    ),
 });
 
 export default KeywordsColumnConfiguration;

--- a/src/supporting-data/keywords/config/__tests__/__snapshots__/KeywordsColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/keywords/config/__tests__/__snapshots__/KeywordsColumnConfiguration.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`KeywordsColumnConfiguration component should render column "children": 
   >
     <li>
       <a
-        href="/diseases/KW-9992"
+        href="/keywords/KW-9992"
       >
         Molecular function
       </a>
@@ -34,10 +34,32 @@ exports[`KeywordsColumnConfiguration component should render column "gene_ontolo
     class="expandable-list no-bullet"
   >
     <li>
-      catalytic activity (GO:0003824)
+      <a
+        class="external-link"
+        href="//www.ebi.ac.uk/QuickGO/term/GO:0003824"
+        rel="noopener"
+        target="_blank"
+      >
+        catalytic activity (GO:0003824)
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
     </li>
     <li>
-      metabolic process (GO:0008152)
+      <a
+        class="external-link"
+        href="//www.ebi.ac.uk/QuickGO/term/GO:0008152"
+        rel="noopener"
+        target="_blank"
+      >
+        metabolic process (GO:0008152)
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
     </li>
   </ul>
 </DocumentFragment>
@@ -63,26 +85,8 @@ exports[`KeywordsColumnConfiguration component should render column "name": name
 </DocumentFragment>
 `;
 
-exports[`KeywordsColumnConfiguration component should render column "parent": parent 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`KeywordsColumnConfiguration component should render column "parent": parent 1`] = `<DocumentFragment />`;
 
-exports[`KeywordsColumnConfiguration component should render column "sites": sites 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`KeywordsColumnConfiguration component should render column "sites": sites 1`] = `<DocumentFragment />`;
 
-exports[`KeywordsColumnConfiguration component should render column "synonym": synonym 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`KeywordsColumnConfiguration component should render column "synonym": synonym 1`] = `<DocumentFragment />`;

--- a/src/supporting-data/locations/config/LocationsColumnConfiguration.tsx
+++ b/src/supporting-data/locations/config/LocationsColumnConfiguration.tsx
@@ -1,18 +1,14 @@
 import { Link } from 'react-router-dom';
-import {
-  ExpandableList,
-  ExternalLink /* , LongNumber */,
-} from 'franklin-sites';
+import { ExpandableList, ExternalLink } from 'franklin-sites';
 
-// import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import AccessionView from '../../../shared/components/results/AccessionView';
 
 import { getEntryPathFor } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
 
 import { LocationsAPIModel } from '../adapters/locationsConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-// import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../../shared/types/namespaces';
-import AccessionView from '../../../shared/components/results/AccessionView';
 
 export enum LocationsColumn {
   category = 'category',
@@ -32,7 +28,6 @@ export enum LocationsColumn {
   synonyms = 'synonyms',
 }
 
-// TODO: decide which ones should be default
 export const defaultColumns = [
   LocationsColumn.id,
   LocationsColumn.name,
@@ -69,11 +64,16 @@ LocationsColumnConfiguration.set(LocationsColumn.definition, {
 
 LocationsColumnConfiguration.set(LocationsColumn.geneOntologies, {
   label: 'Gene Ontologies',
-  render: ({ geneOntologies }) => (
-    <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
-      {geneOntologies?.map(({ name, goId }) => `${name} (${goId})`)}
-    </ExpandableList>
-  ),
+  render: ({ geneOntologies }) =>
+    geneOntologies?.length && (
+      <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
+        {geneOntologies.map(({ name, goId }) => (
+          <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
+            {name} ({goId})
+          </ExternalLink>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.id, {
@@ -84,15 +84,16 @@ LocationsColumnConfiguration.set(LocationsColumn.id, {
 
 LocationsColumnConfiguration.set(LocationsColumn.isA, {
   label: 'Is a',
-  render: ({ isA }) => (
-    <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
-      {isA?.map((location) => (
-        <Link key={location.id} to={getEntryPath(location.id)}>
-          {location.name}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ isA }) =>
+    isA?.length && (
+      <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
+        {isA.map((location) => (
+          <Link key={location.id} to={getEntryPath(location.id)}>
+            {location.name}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.keyword, {
@@ -105,13 +106,14 @@ LocationsColumnConfiguration.set(LocationsColumn.keyword, {
 
 LocationsColumnConfiguration.set(LocationsColumn.links, {
   label: 'Links',
-  render: ({ links }) => (
-    <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
-      {links?.map((link) => (
-        <ExternalLink key={link} url={link} tidyUrl />
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ links }) =>
+    links?.length && (
+      <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
+        {links.map((link) => (
+          <ExternalLink key={link} url={link} tidyUrl />
+        ))}
+      </ExpandableList>
+    ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.name, {
@@ -126,56 +128,37 @@ LocationsColumnConfiguration.set(LocationsColumn.note, {
 
 LocationsColumnConfiguration.set(LocationsColumn.partOf, {
   label: 'Part of',
-  render: ({ partOf }) => (
-    <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
-      {partOf?.map((location) => (
-        <Link key={location.id} to={getEntryPath(location.id)}>
-          {location.name}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ partOf }) =>
+    partOf?.length && (
+      <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
+        {partOf.map((location) => (
+          <Link key={location.id} to={getEntryPath(location.id)}>
+            {location.name}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.references, {
   label: 'References',
-  render: ({ references }) => (
-    <ExpandableList descriptionString="references" displayNumberOfHiddenItems>
-      {references}
-    </ExpandableList>
-  ),
+  // TODO: review and feedback to backend which format we want (needs to be consistent)
+  render: ({ references }) =>
+    references?.length && (
+      <ExpandableList descriptionString="references" displayNumberOfHiddenItems>
+        {references}
+      </ExpandableList>
+    ),
 });
-
-// TODO: might not be needed as a column
-// LocationsColumnConfiguration.set(LocationsColumn.statistics, {
-//   label: 'Mapping to',
-//   render: ({ statistics }) => (
-//     <>
-//       {statistics?.reviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.REVIEWED} />
-//           <LongNumber>{statistics.reviewedProteinCount}</LongNumber> reviewed
-//           entr{statistics.reviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//       {statistics?.unreviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.UNREVIEWED} />
-//           <LongNumber>{statistics.unreviewedProteinCount}</LongNumber>{' '}
-//           unreviewed entr{statistics.unreviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//     </>
-//   ),
-// });
 
 LocationsColumnConfiguration.set(LocationsColumn.synonyms, {
   label: 'Synonyms',
-  render: ({ synonyms }) => (
-    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-      {synonyms}
-    </ExpandableList>
-  ),
+  render: ({ synonyms }) =>
+    synonyms?.length && (
+      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+        {synonyms}
+      </ExpandableList>
+    ),
 });
 
 export default LocationsColumnConfiguration;

--- a/src/supporting-data/locations/config/__tests__/__snapshots__/LocationsColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/locations/config/__tests__/__snapshots__/LocationsColumnConfiguration.spec.tsx.snap
@@ -24,7 +24,18 @@ exports[`LocationsColumnConfiguration component should render column "gene_ontol
     class="expandable-list no-bullet"
   >
     <li>
-      endoplasmic reticulum-Golgi intermediate compartment membrane (GO:0033116)
+      <a
+        class="external-link"
+        href="//www.ebi.ac.uk/QuickGO/term/GO:0033116"
+        rel="noopener"
+        target="_blank"
+      >
+        endoplasmic reticulum-Golgi intermediate compartment membrane (GO:0033116)
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
     </li>
   </ul>
 </DocumentFragment>
@@ -62,13 +73,7 @@ exports[`LocationsColumnConfiguration component should render column "is_a": is_
 
 exports[`LocationsColumnConfiguration component should render column "keyword": keyword 1`] = `<DocumentFragment />`;
 
-exports[`LocationsColumnConfiguration component should render column "links": links 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`LocationsColumnConfiguration component should render column "links": links 1`] = `<DocumentFragment />`;
 
 exports[`LocationsColumnConfiguration component should render column "name": name 1`] = `
 <DocumentFragment>
@@ -101,13 +106,7 @@ exports[`LocationsColumnConfiguration component should render column "part_of": 
 </DocumentFragment>
 `;
 
-exports[`LocationsColumnConfiguration component should render column "references": references 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`LocationsColumnConfiguration component should render column "references": references 1`] = `<DocumentFragment />`;
 
 exports[`LocationsColumnConfiguration component should render column "synonyms": synonyms 1`] = `
 <DocumentFragment>

--- a/src/supporting-data/taxonomy/adapters/taxonomyConverter.ts
+++ b/src/supporting-data/taxonomy/adapters/taxonomyConverter.ts
@@ -15,7 +15,7 @@ type InactiveReason = {
 };
 
 type Strain = {
-  synonyms: string[];
+  synonyms?: string[];
   name: string;
 };
 

--- a/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
+++ b/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
@@ -143,7 +143,12 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.strain, {
   render: ({ strains }) =>
     strains?.length && (
       <ExpandableList descriptionString="strains" displayNumberOfHiddenItems>
-        {strains.map((strain) => strain.name)}
+        {strains.map((strain) => (
+          <>
+            {strain.name}
+            {strain.synonyms?.length && ` (${strain.synonyms.join(', ')})`}
+          </>
+        ))}
       </ExpandableList>
     ),
 });

--- a/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
+++ b/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
@@ -125,7 +125,7 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.otherNames, {
 TaxonomyColumnConfiguration.set(TaxonomyColumn.parent, {
   label: 'Parent',
   render: ({ parentId }) =>
-    parentId && <Link to={getEntryPath(parentId)}>{parentId}</Link>,
+    parentId ? <Link to={getEntryPath(parentId)}>{parentId}</Link> : undefined,
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.rank, {

--- a/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
+++ b/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
@@ -114,7 +114,7 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.otherNames, {
   render: ({ otherNames }) =>
     otherNames?.length && (
       <ExpandableList
-        descriptionString="other names"
+        descriptionString="names"
         displayNumberOfHiddenItems
       >
         {otherNames}

--- a/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
+++ b/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
@@ -1,17 +1,11 @@
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  ExpandableList,
-  ExternalLink /* , LongNumber */,
-} from 'franklin-sites';
-
-// import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import { ExpandableList, ExternalLink } from 'franklin-sites';
 
 import { getEntryPathFor } from '../../../app/config/urls';
 
 import { Lineage, TaxonomyAPIModel } from '../adapters/taxonomyConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
-// import { EntryType } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../../shared/types/namespaces';
 import AccessionView from '../../../shared/components/results/AccessionView';
 
@@ -63,15 +57,16 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.commonName, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.host, {
   label: 'Hosts',
-  render: ({ hosts }) => (
-    <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
-      {hosts?.map(({ taxonId, scientificName, commonName }) => (
-        <Link key={taxonId} to={getEntryPath(taxonId)}>
-          {commonName || scientificName || taxonId}
-        </Link>
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ hosts }) =>
+    hosts?.length && (
+      <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
+        {hosts.map(({ taxonId, scientificName, commonName }) => (
+          <Link key={taxonId} to={getEntryPath(taxonId)}>
+            {commonName || scientificName || taxonId}
+          </Link>
+        ))}
+      </ExpandableList>
+    ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.id, {
@@ -99,13 +94,14 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.lineage, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.links, {
   label: 'Links',
-  render: ({ links }) => (
-    <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
-      {links?.map((link) => (
-        <ExternalLink key={link} url={link} tidyUrl />
-      ))}
-    </ExpandableList>
-  ),
+  render: ({ links }) =>
+    links?.length && (
+      <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
+        {links.map((link) => (
+          <ExternalLink key={link} url={link} tidyUrl />
+        ))}
+      </ExpandableList>
+    ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.mnemonic, {
@@ -115,11 +111,15 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.mnemonic, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.otherNames, {
   label: 'Other names',
-  render: ({ otherNames }) => (
-    <ExpandableList descriptionString="other names" displayNumberOfHiddenItems>
-      {otherNames}
-    </ExpandableList>
-  ),
+  render: ({ otherNames }) =>
+    otherNames?.length && (
+      <ExpandableList
+        descriptionString="other names"
+        displayNumberOfHiddenItems
+      >
+        {otherNames}
+      </ExpandableList>
+    ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.parent, {
@@ -138,59 +138,24 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.scientificName, {
   render: ({ scientificName }) => scientificName,
 });
 
-// TODO: might not be needed as a column
-// TaxonomyColumnConfiguration.set(TaxonomyColumn.statistics, {
-//   label: 'Mapping to',
-//   render: ({ statistics }) => (
-//     <>
-//       {statistics?.reviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.REVIEWED} />
-//           <LongNumber>{statistics.reviewedProteinCount}</LongNumber> reviewed
-//           entr{statistics.reviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//       {statistics?.unreviewedProteinCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.UNREVIEWED} />
-//           <LongNumber>{statistics.unreviewedProteinCount}</LongNumber>{' '}
-//           unreviewed entr{statistics.unreviewedProteinCount === 1 ? 'y' : 'ies'}
-//         </div>
-//       ) : undefined}
-//       {statistics?.proteomeCount ? (
-//         <div>
-//           <LongNumber>{statistics.proteomeCount}</LongNumber> proteome
-//           {statistics.proteomeCount === 1 ? '' : 's'}
-//         </div>
-//       ) : undefined}
-//       {statistics?.referenceProteomeCount ? (
-//         <div>
-//           <EntryTypeIcon entryType={EntryType.REFERENCE_PROTEOME} />
-//           <LongNumber>{statistics.referenceProteomeCount}</LongNumber>{' '}
-//           references proteome
-//           {statistics.unreviewedProteinCount === 1 ? '' : 's'}
-//         </div>
-//       ) : undefined}
-//     </>
-//   ),
-// });
-
 TaxonomyColumnConfiguration.set(TaxonomyColumn.strain, {
   label: 'Strains',
-  render: ({ strains }) => (
-    <ExpandableList descriptionString="strains" displayNumberOfHiddenItems>
-      {strains?.map((strain) => strain.name)}
-    </ExpandableList>
-  ),
+  render: ({ strains }) =>
+    strains?.length && (
+      <ExpandableList descriptionString="strains" displayNumberOfHiddenItems>
+        {strains.map((strain) => strain.name)}
+      </ExpandableList>
+    ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.synonym, {
   label: 'Synonym',
-  render: ({ synonyms }) => (
-    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-      {synonyms}
-    </ExpandableList>
-  ),
+  render: ({ synonyms }) =>
+    synonyms?.length && (
+      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+        {synonyms}
+      </ExpandableList>
+    ),
 });
 
 export default TaxonomyColumnConfiguration;

--- a/src/supporting-data/taxonomy/config/__tests__/__snapshots__/TaxonomyColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/taxonomy/config/__tests__/__snapshots__/TaxonomyColumnConfiguration.spec.tsx.snap
@@ -2,13 +2,7 @@
 
 exports[`TaxonomyColumnConfiguration component should render column "common_name": common_name 1`] = `<DocumentFragment />`;
 
-exports[`TaxonomyColumnConfiguration component should render column "host": host 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`TaxonomyColumnConfiguration component should render column "host": host 1`] = `<DocumentFragment />`;
 
 exports[`TaxonomyColumnConfiguration component should render column "id": id 1`] = `
 <DocumentFragment>
@@ -82,13 +76,7 @@ exports[`TaxonomyColumnConfiguration component should render column "lineage": l
 </DocumentFragment>
 `;
 
-exports[`TaxonomyColumnConfiguration component should render column "links": links 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`TaxonomyColumnConfiguration component should render column "links": links 1`] = `<DocumentFragment />`;
 
 exports[`TaxonomyColumnConfiguration component should render column "mnemonic": mnemonic 1`] = `
 <DocumentFragment>
@@ -130,18 +118,6 @@ exports[`TaxonomyColumnConfiguration component should render column "scientific_
 </DocumentFragment>
 `;
 
-exports[`TaxonomyColumnConfiguration component should render column "strain": strain 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`TaxonomyColumnConfiguration component should render column "strain": strain 1`] = `<DocumentFragment />`;
 
-exports[`TaxonomyColumnConfiguration component should render column "synonym": synonym 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`TaxonomyColumnConfiguration component should render column "synonym": synonym 1`] = `<DocumentFragment />`;

--- a/src/tools/blast/components/results/BlastResultLocalFacets.tsx
+++ b/src/tools/blast/components/results/BlastResultLocalFacets.tsx
@@ -23,6 +23,7 @@ import { BlastFacet, BlastHit } from '../../types/blastResults';
 import { SelectedFacet } from '../../../../uniprotkb/types/resultsTypes';
 import Response from '../../../../uniprotkb/types/responseTypes';
 
+import helper from '../../../../shared/styles/helper.module.scss';
 import './styles/results-view.scss';
 
 type LocalFacetProps = {
@@ -162,7 +163,7 @@ const BlastResultLocalFacets: FC<{
   }
 
   return (
-    <div className={isStale ? 'is-stale' : undefined}>
+    <div className={isStale ? helper.stale : undefined}>
       <span className="facet-name">Blast parameters</span>
       <ul className="expandable-list no-bullet blast-parameters-facet">
         {localFacets.map((facet) => (

--- a/src/tools/blast/components/results/BlastResultSidebar.tsx
+++ b/src/tools/blast/components/results/BlastResultSidebar.tsx
@@ -14,7 +14,7 @@ import Response, {
   FacetObject,
 } from '../../../../uniprotkb/types/responseTypes';
 
-import '../../../../shared/components/results/styles/results-view.scss';
+import helper from '../../../../shared/styles/helper.module.scss';
 
 const facets = [
   'reviewed',
@@ -50,7 +50,7 @@ const BlastResultSidebar = memo<BlastResultSidebarProps>(
           <Facet
             key={facet.name}
             data={facet}
-            className={isStale ? 'is-stale' : undefined}
+            className={isStale ? helper.stale : undefined}
           />
         ))}
       </Facets>

--- a/src/tools/blast/components/results/styles/results-view.scss
+++ b/src/tools/blast/components/results/styles/results-view.scss
@@ -1,11 +1,5 @@
 @import 'franklin-sites/src/styles/colours';
 
-.is-stale {
-  opacity: 0.5;
-  pointer-events: none;
-  user-select: none;
-}
-
 .blast-parameters-facet {
   font-weight: bold;
 

--- a/src/uniparc/components/entry/XRefsFacets.tsx
+++ b/src/uniparc/components/entry/XRefsFacets.tsx
@@ -21,7 +21,7 @@ import {
 import { UseDataAPIWithStaleState } from '../../../shared/hooks/useDataApiWithStale';
 import { TaxonomyDatum } from '../../../supporting-data/taxonomy/adapters/taxonomyConverter';
 
-import '../../../shared/components/results/styles/results-view.scss';
+import helper from '../../../shared/styles/helper.module.scss';
 
 const exceptions = new Set<string | XRefsInternalDatabases>([
   XRefsInternalDatabasesEnum.REVIEWED,
@@ -152,7 +152,10 @@ const XRefsFacets: FC<{
   }
 
   return (
-    <Facets data={facets} className={xrefs.isStale ? 'is-stale' : undefined} />
+    <Facets
+      data={facets}
+      className={xrefs.isStale ? helper.stale : undefined}
+    />
   );
 };
 

--- a/src/uniparc/components/entry/XRefsSection.tsx
+++ b/src/uniparc/components/entry/XRefsSection.tsx
@@ -32,8 +32,9 @@ import EntrySection, {
 import { UniParcColumn } from '../../config/UniParcColumnConfiguration';
 import { UseDataAPIWithStaleState } from '../../../shared/hooks/useDataApiWithStale';
 
-import './styles/XRefsSection.scss';
+import helper from '../../../shared/styles/helper.module.scss';
 import '../../../shared/components/results/styles/results-view.scss';
+import './styles/XRefsSection.scss';
 
 const getColumns = (
   templateMap: Map<string, string>
@@ -229,7 +230,7 @@ const XRefsSection: FC<Props> = ({ xrefData }) => {
   return (
     <Card
       title={getEntrySectionNameAndId(EntrySection.XRefs).name}
-      className={xrefData.isStale ? 'is-stale' : undefined}
+      className={xrefData.isStale ? helper.stale : undefined}
     >
       {/* Stalled for now */}
       {/* <div className="button-group">

--- a/src/uniprotkb/components/entry/EntryMain.tsx
+++ b/src/uniprotkb/components/entry/EntryMain.tsx
@@ -1,7 +1,7 @@
 import { FC, memo } from 'react';
-import { HeroContainer } from 'franklin-sites';
 
 import ErrorBoundary from '../../../shared/components/error-component/ErrorBoundary';
+import MedicalDisclaimer from '../../../shared/components/MedicalDisclaimer';
 
 import UniProtKBEntryConfig from '../../config/UniProtEntryConfig';
 
@@ -19,14 +19,7 @@ const EntryMain: FC<EntryMainProps> = ({ transformedData }) => (
       <ErrorBoundary key={id}>{sectionContent(transformedData)}</ErrorBoundary>
     ))}
 
-    <HeroContainer>
-      <em>
-        Any medical or genetic information present in this entry is provided for
-        research, educational and informational purposes only. It is not in any
-        way intended to be used as a substitute for professional medical advice,
-        diagnosis, treatment or care.
-      </em>
-    </HeroContainer>
+    <MedicalDisclaimer />
   </>
 );
 

--- a/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
+++ b/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
@@ -12,7 +12,7 @@ import { getParamsFromURL } from '../../utils/resultsUtils';
 
 import { FacetObject } from '../../types/responseTypes';
 
-import './styles/entry-publications-facets.scss';
+import helper from '../../../shared/styles/helper.module.scss';
 
 const EntryPublicationsFacets: FC<{ accession: string }> = ({ accession }) => {
   const { search } = useLocation();
@@ -41,7 +41,7 @@ const EntryPublicationsFacets: FC<{ accession: string }> = ({ accession }) => {
   }
 
   return (
-    <Facets data={data.facets} className={isStale ? 'is-stale' : undefined} />
+    <Facets data={data.facets} className={isStale ? helper.stale : undefined} />
   );
 };
 

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -2549,8 +2549,11 @@ exports[`Entry should render main 1`] = `
           <section
             class="hero-container hero-container--side-padding"
           >
+            <h3>
+              Disclaimer
+            </h3>
             <em>
-              Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care.
+              Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care. Our staff consists of biologists and biochemists that are not trained to give medical advice.
             </em>
           </section>
         </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2242,8 +2242,11 @@ exports[`Entry view should render 1`] = `
   <section
     class="hero-container hero-container--side-padding"
   >
+    <h3>
+      Disclaimer
+    </h3>
     <em>
-      Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care.
+      Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care. Our staff consists of biologists and biochemists that are not trained to give medical advice.
     </em>
   </section>
 </DocumentFragment>
@@ -4209,8 +4212,11 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="hero-container hero-container--side-padding"
   >
+    <h3>
+      Disclaimer
+    </h3>
     <em>
-      Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care.
+      Any medical or genetic information present in this entry is provided for research, educational and informational purposes only. It is not in any way intended to be used as a substitute for professional medical advice, diagnosis, treatment or care. Our staff consists of biologists and biochemists that are not trained to give medical advice.
     </em>
   </section>
 </DocumentFragment>

--- a/src/uniref/components/entry/MembersFacets.tsx
+++ b/src/uniref/components/entry/MembersFacets.tsx
@@ -12,7 +12,7 @@ import {
   UniRefMembersResults,
 } from '../../types/membersEndpoint';
 
-import '../../../shared/components/results/styles/results-view.scss';
+import helper from '../../../shared/styles/helper.module.scss';
 
 const MembersFacet = memo<{ accession: string }>(({ accession }) => {
   const { search } = useLocation();
@@ -40,7 +40,7 @@ const MembersFacet = memo<{ accession: string }>(({ accession }) => {
   }
 
   return (
-    <Facets data={data.facets} className={isStale ? 'is-stale' : undefined} />
+    <Facets data={data.facets} className={isStale ? helper.stale : undefined} />
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10102,9 +10102,9 @@ react-markdown@5.0.3:
     unist-util-visit "^2.0.0"
     xtend "^4.0.1"
 
-"react-msa-viewer@git+https://github.com/ebi-webcomponents/react-msa-viewer.git#semver:1.6.2":
+"react-msa-viewer@https://github.com/ebi-webcomponents/react-msa-viewer#semver:1.6.2":
   version "1.6.2"
-  resolved "git+https://github.com/ebi-webcomponents/react-msa-viewer.git#9017df6f0d214fbd27cc5180e71bf9c3f8f626aa"
+  resolved "https://github.com/ebi-webcomponents/react-msa-viewer#9017df6f0d214fbd27cc5180e71bf9c3f8f626aa"
   dependencies:
     lodash-es "4.17.15"
     plotly-icons "1.3.14"


### PR DESCRIPTION
## Purpose
Nicer content in supporting data entry pages

## Approach
- Use useDataApiWithStale (in order to avoid flash when jumping across entries of same type)
- Use InfoList
- Modify some column renderers in order to return undefined when no data (so that InfoList doesn't display anything)
- Move is-stale classes to a helper file in CSS module

## Testing
Updated snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Anything not covered by this PR has had a Jira created in https://www.ebi.ac.uk/panda/jira/browse/TRM-25517 (that would be for more complex/visualisation bits)
