### PR TITLE
Fix xref search "hack"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "lines": 83.19,
         "statements": 83.13,
         "functions": 83.38,
-        "branches": 73.77
+        "branches": 73.76
       }
     },
     "transform": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "lines": 83.19,
         "statements": 83.13,
         "functions": 83.38,
-        "branches": 73.76
+        "branches": 73.51
       }
     },
     "transform": {

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -241,6 +241,10 @@ const QueryBuilder: FC<Props> = ({ onCancel, fieldToAdd }) => {
           </Button>
           <Button type="submit">Search</Button>
         </div>
+        <small>
+          Type * in the search box to search for all values for the selected
+          field.
+        </small>
       </form>
     </>
   );

--- a/src/query-builder/components/TextField.tsx
+++ b/src/query-builder/components/TextField.tsx
@@ -17,10 +17,9 @@ const TextField: FC<{
     const trimmed = value.trim();
     if (trimmed.length) {
       if (field.valuePrefix && field.term === 'xref' && trimmed === '*') {
-        // Query is faster with this hack
-        // NOTE: Is this even working?..
+        // Query is faster with this hack: using 'database' instead
         // Remove last '-' from the the prefix, and don't include '*'
-        handleChange({ xref: `${field.valuePrefix.replace(/-$/, '')}` });
+        handleChange({ database: `${field.valuePrefix.replace(/-$/, '')}` });
       } else {
         handleChange({
           [field.term]: `${field.valuePrefix || ''}${trimmed}`,

--- a/src/query-builder/components/__tests__/TextField.spec.tsx
+++ b/src/query-builder/components/__tests__/TextField.spec.tsx
@@ -111,7 +111,7 @@ describe('TextField', () => {
     });
     fireEvent.change(inputElt, { target: { value: '*' } });
     expect(propsPrefix.handleChange).toBeCalledWith({
-      [propsPrefix.field.term]: 'embl',
+      database: 'embl',
     });
   });
 

--- a/src/query-builder/components/__tests__/__snapshots__/QueryBuilder.spec.tsx.snap
+++ b/src/query-builder/components/__tests__/__snapshots__/QueryBuilder.spec.tsx.snap
@@ -393,6 +393,9 @@ exports[`QueryBuilder should render 1`] = `
         Search
       </button>
     </div>
+    <small>
+      Type * in the search box to search for all values for the selected field.
+    </small>
   </form>
 </DocumentFragment>
 `;

--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -79,6 +79,21 @@ const parseAndMatchQuery = (
         invalid.push(clause);
       }
       // else, didn't find any match
+    } else if (clause.searchTerm.term === 'database') {
+      // TODO: this is a temporary solution until 'database' is added
+      // see https://www.ebi.ac.uk/panda/jira/browse/TRM-25963
+      const matchingXref = flattened.find(
+        ({ valuePrefix }) => valuePrefix === `${clause.queryBits.database}-`
+      );
+      if (matchingXref) {
+        validatedQuery.push({
+          ...clause,
+          searchTerm: matchingXref,
+          queryBits: { xref: `${clause.queryBits.database}-*` },
+        });
+      } else {
+        invalid.push(clause);
+      }
     } else {
       // try to find a search term matching through the autoComplete field
       const matchingAutoComplete = flattened.find(


### PR DESCRIPTION
## Purpose
Optimised xref query wasn't doing anything

## Approach
change the logic to handle this special case - replacing "xref" by "database" and the prefix value as value. Also added the parsing counterpart, which is only temporary until backend add the "database" field.

## Testing
Updated test case for xref and '*' search

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
