### PR TITLE
Change endpoint to get release info

### DIFF
--- a/src/shared/components/layouts/ReleaseInfo.tsx
+++ b/src/shared/components/layouts/ReleaseInfo.tsx
@@ -16,7 +16,7 @@ const today = new Date();
 const ReleaseInfo = () => {
   // TODO: replace with statistics endpoint
   const { headers } = useDataApi(
-    `${apiUrls.search(Namespace.uniprotkb)}?query=*&size=0`,
+    `${apiUrls.queryBuilderTerms(Namespace.uniprotkb)}`,
     fetchOptions
   );
   // NOTE: don't use release number as date, might be different


### PR DESCRIPTION
## Purpose
Use a less expensive endpoint to get that information from.  Also allows us to pre-cache the search fields. This is still temporary until a dedicated endpoint exists.

## Approach
Updated url

## Testing
N/A

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
