### PR TITLE
2021 06 facet icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coverageThreshold": {
       "global": {
         "lines": 83.14,
-        "statements": 83.1,
+        "statements": 83.09,
         "functions": 83.26,
         "branches": 73.5
       }

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -1,16 +1,10 @@
 import { FC } from 'react';
-import {
-  Facets,
-  Facet,
-  Loader,
-  SwissProtIcon,
-  TremblIcon,
-  ReferenceProteomeIcon,
-} from 'franklin-sites';
+import { Facets, Facet, Loader } from 'franklin-sites';
 
 import useNS from '../../hooks/useNS';
 
 import TaxonomyFacet from './TaxonomyFacet';
+import EntryTypeIcon from '../entry/EntryTypeIcon';
 
 import { mainNamespaces } from '../../types/namespaces';
 
@@ -20,37 +14,19 @@ import Response, { FacetValue } from '../../../uniprotkb/types/responseTypes';
 import helper from '../../styles/helper.module.scss';
 import './styles/results-data.scss';
 
-const ICON_HEIGHT = '1em';
+// const ICON_HEIGHT = '1em';
 
 const getDecoratedFacetLabel = (facetValue: FacetValue) => {
-  switch (facetValue.value) {
-    case 'true':
-      return (
-        <>
-          <SwissProtIcon height={ICON_HEIGHT} className="icon--reviewed" />
-          {facetValue.label}
-        </>
-      );
-    case 'false':
-      return (
-        <>
-          <TremblIcon height={ICON_HEIGHT} className="icon--unreviewed" />
-          {facetValue.label}
-        </>
-      );
-    case '1':
-      return (
-        <>
-          <ReferenceProteomeIcon
-            height={ICON_HEIGHT}
-            className="icon--reference-proteome"
-          />
-          {facetValue.label}
-        </>
-      );
-    default:
-      return facetValue.label;
+  const { label } = facetValue;
+  if (typeof label === 'string') {
+    return (
+      <>
+        <EntryTypeIcon entryType={label} />
+        {facetValue.label}
+      </>
+    );
   }
+  return facetValue.label;
 };
 
 const ResultsFacets: FC<{

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -5,6 +5,7 @@ import {
   Loader,
   SwissProtIcon,
   TremblIcon,
+  ReferenceProteomeIcon,
 } from 'franklin-sites';
 
 import useNS from '../../hooks/useNS';
@@ -21,21 +22,36 @@ import './styles/results-data.scss';
 
 const ICON_HEIGHT = '1em';
 
-const getDecoratedFacetValue = (facetValue: FacetValue) => ({
-  ...facetValue,
-  label:
-    facetValue.value === 'true' ? (
-      <>
-        <SwissProtIcon height={ICON_HEIGHT} className="icon--reviewed" />
-        {facetValue.label}
-      </>
-    ) : (
-      <>
-        <TremblIcon height={ICON_HEIGHT} className="icon--unreviewed" />
-        {facetValue.label}
-      </>
-    ),
-});
+const getDecoratedFacetLabel = (facetValue: FacetValue) => {
+  switch (facetValue.value) {
+    case 'true':
+      return (
+        <>
+          <SwissProtIcon height={ICON_HEIGHT} className="icon--reviewed" />
+          {facetValue.label}
+        </>
+      );
+    case 'false':
+      return (
+        <>
+          <TremblIcon height={ICON_HEIGHT} className="icon--unreviewed" />
+          {facetValue.label}
+        </>
+      );
+    case '1':
+      return (
+        <>
+          <ReferenceProteomeIcon
+            height={ICON_HEIGHT}
+            className="icon--reference-proteome"
+          />
+          {facetValue.label}
+        </>
+      );
+    default:
+      return facetValue.label;
+  }
+};
 
 const ResultsFacets: FC<{
   dataApiObject: UseDataAPIWithStaleState<Response['data']>;
@@ -57,12 +73,13 @@ const ResultsFacets: FC<{
 
   // Add relevant icons
   const facetsWithIcons = facets.map((facet) =>
-    facet.name === 'reviewed'
+    facet.name === 'reviewed' || facet.name === 'proteome_type'
       ? {
           ...facet,
-          values: facet.values?.map((facetValue) =>
-            getDecoratedFacetValue(facetValue)
-          ),
+          values: facet.values?.map((facetValue) => ({
+            ...facetValue,
+            label: getDecoratedFacetLabel(facetValue),
+          })),
         }
       : facet
   );

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -14,8 +14,6 @@ import Response, { FacetValue } from '../../../uniprotkb/types/responseTypes';
 import helper from '../../styles/helper.module.scss';
 import './styles/results-data.scss';
 
-// const ICON_HEIGHT = '1em';
-
 const getDecoratedFacetLabel = (facetValue: FacetValue) => {
   const { label } = facetValue;
   if (typeof label === 'string') {

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -20,11 +20,11 @@ const getDecoratedFacetLabel = (facetValue: FacetValue) => {
     return (
       <>
         <EntryTypeIcon entryType={label} />
-        {facetValue.label}
+        {label}
       </>
     );
   }
-  return facetValue.label;
+  return label;
 };
 
 const ResultsFacets: FC<{

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import {
   Facets,
   Facet,
@@ -56,19 +56,15 @@ const ResultsFacets: FC<{
   const { facets } = data;
 
   // Add relevant icons
-  const facetsWithIcons = useMemo(
-    () =>
-      facets.map((facet) =>
-        facet.name === 'reviewed'
-          ? {
-              ...facet,
-              values: facet.values?.map((facetValue) =>
-                getDecoratedFacetValue(facetValue)
-              ),
-            }
-          : facet
-      ),
-    [facets]
+  const facetsWithIcons = facets.map((facet) =>
+    facet.name === 'reviewed'
+      ? {
+          ...facet,
+          values: facet.values?.map((facetValue) =>
+            getDecoratedFacetValue(facetValue)
+          ),
+        }
+      : facet
   );
 
   const splitIndex = facetsWithIcons.findIndex(

--- a/src/shared/components/results/__tests__/ResultsFacets.spec.tsx
+++ b/src/shared/components/results/__tests__/ResultsFacets.spec.tsx
@@ -6,6 +6,8 @@ import customRender from '../../../__test-helpers__/customRender';
 
 import results from '../../../../uniprotkb/components/__mocks__/results.json';
 
+let rendered;
+
 describe('ResultsFacets', () => {
   const resultsFacets = (route: string) =>
     customRender(
@@ -29,6 +31,11 @@ describe('ResultsFacets', () => {
       }
     );
 
+  test('should render', () => {
+    const { asFragment } = resultsFacets('/uniprotkb?query=blah');
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   const regexUnreviewed = /Unreviewed \(TrEMBL\) \(\d+\)/;
 
   test('should select a facet', async () => {
@@ -43,7 +50,7 @@ describe('ResultsFacets', () => {
     });
   });
 
-  it('should deselect a facet', async () => {
+  test('should deselect a facet', async () => {
     const { history } = resultsFacets(
       '/uniprotkb?query=blah&facets=reviewed:false'
     );

--- a/src/shared/components/results/__tests__/ResultsFacets.spec.tsx
+++ b/src/shared/components/results/__tests__/ResultsFacets.spec.tsx
@@ -6,8 +6,6 @@ import customRender from '../../../__test-helpers__/customRender';
 
 import results from '../../../../uniprotkb/components/__mocks__/results.json';
 
-let rendered;
-
 describe('ResultsFacets', () => {
   const resultsFacets = (route: string) =>
     customRender(

--- a/src/shared/components/results/__tests__/__snapshots__/ResultsFacets.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsFacets.spec.tsx.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsFacets should render 1`] = `
+<DocumentFragment>
+  <div
+    class="facets"
+  >
+    <ul
+      class="no-bullet"
+    >
+      <li>
+        <div>
+          <span
+            class="facet-name"
+          >
+            Taxonomy
+          </span>
+          <ul
+            class="expandable-list no-bullet"
+          >
+            <li>
+              <button
+                class="button tertiary expandable-list__action"
+                type="button"
+              >
+                Filter by taxonomy
+              </button>
+            </li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <div>
+          <div
+            class="facet-name"
+          >
+            Status
+          </div>
+          <ul
+            class="expandable-list no-bullet"
+          >
+            <li>
+              <a
+                href="/uniprotkb?facets=reviewed%3Afalse&query=blah"
+              >
+                <test-file-stub
+                  classname="icon--unreviewed"
+                  height="1em"
+                />
+                Unreviewed (TrEMBL) (455)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=reviewed%3Atrue&query=blah"
+              >
+                <test-file-stub
+                  classname="icon--reviewed"
+                  height="1em"
+                />
+                Reviewed (Swiss-Prot) (52)
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <div>
+          <div
+            class="facet-name"
+          >
+            Popular organisms
+          </div>
+          <ul
+            class="expandable-list no-bullet"
+          >
+            <li>
+              <a
+                href="/uniprotkb?facets=popular_organism%3AHuman&query=blah"
+              >
+                Human (18)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=popular_organism%3AMouse&query=blah"
+              >
+                Mouse (11)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=popular_organism%3AS.%20cerevisiae&query=blah"
+              >
+                S. cerevisiae (6)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=popular_organism%3AZebrafish&query=blah"
+              >
+                Zebrafish (4)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=popular_organism%3ABovine&query=blah"
+              >
+                Bovine (3)
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <div>
+          <div
+            class="facet-name"
+          >
+            Other organisms
+          </div>
+          <ul
+            class="expandable-list no-bullet"
+          >
+            <li>
+              <a
+                href="/uniprotkb?facets=other_organism%3AInfluenza%20A%20virus%20%28A%2FIndonesia%2FCDC7%2F2005%28H5N1%29%29&query=blah"
+              >
+                Influenza A virus (A/Indonesia/CDC7/2005(H5N1)) (11)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=other_organism%3AXENLA&query=blah"
+              >
+                XENLA (9)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=other_organism%3ACHLTH&query=blah"
+              >
+                CHLTH (6)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=other_organism%3ASCHPO&query=blah"
+              >
+                SCHPO (6)
+              </a>
+            </li>
+            <li>
+              <a
+                href="/uniprotkb?facets=other_organism%3AXENTR&query=blah"
+              >
+                XENTR (6)
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;

--- a/src/shared/components/results/__tests__/__snapshots__/ResultsFacets.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsFacets.spec.tsx.snap
@@ -43,10 +43,12 @@ exports[`ResultsFacets should render 1`] = `
               <a
                 href="/uniprotkb?facets=reviewed%3Afalse&query=blah"
               >
-                <test-file-stub
-                  classname="icon--unreviewed"
-                  height="1em"
-                />
+                <span
+                  class="entry-title__status icon--unreviewed"
+                  title="This marks an unreviewed UniProtKB entry"
+                >
+                  <test-file-stub />
+                </span>
                 Unreviewed (TrEMBL) (455)
               </a>
             </li>
@@ -54,10 +56,12 @@ exports[`ResultsFacets should render 1`] = `
               <a
                 href="/uniprotkb?facets=reviewed%3Atrue&query=blah"
               >
-                <test-file-stub
-                  classname="icon--reviewed"
-                  height="1em"
-                />
+                <span
+                  class="entry-title__status icon--reviewed"
+                  title="This marks a reviewed UniProtKB entry"
+                >
+                  <test-file-stub />
+                </span>
                 Reviewed (Swiss-Prot) (52)
               </a>
             </li>


### PR DESCRIPTION
## Purpose
Add icons for reviewed / unreviewed (UniProkb) and reference proteome.

## Approach
Check facet name and values to add the icon to the ReactNode. Currently not very restrictive in checking and assignment, ok for now but might cause issues in the future if values change.

## Testing
Added a render which takes into account the new code

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
