### PR TITLE
2021 06 fix ns selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 83.14,
-        "statements": 83.1,
+        "lines": 83.12,
+        "statements": 83.08,
         "functions": 83.26,
-        "branches": 73.5
+        "branches": 73.46
       }
     },
     "transform": {

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -18,7 +18,6 @@ import colors from '../../../node_modules/franklin-sites/src/styles/colours.json
 import ClauseList from './ClauseList';
 
 import useDataApi from '../../shared/hooks/useDataApi';
-import useNS from '../../shared/hooks/useNS';
 
 import { createEmptyClause, defaultQueryFor, getNextId } from '../utils/clause';
 import { stringify } from '../utils/queryStringProcessor';
@@ -48,6 +47,10 @@ type Props = {
    * Add the wanted field into the form when rendering
    */
   fieldToAdd?: string;
+  /**
+   * The namespace to initialise the dropdown with
+   */
+  initialNamespace: Namespace;
 };
 interface Style extends CSSProperties {
   // TODO: define and extend the supported custom properties in franklin
@@ -55,16 +58,18 @@ interface Style extends CSSProperties {
   '--main-button-color': string;
 }
 
-const QueryBuilder: FC<Props> = ({ onCancel, fieldToAdd }) => {
+const QueryBuilder: FC<Props> = ({
+  onCancel,
+  fieldToAdd,
+  initialNamespace,
+}) => {
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();
 
   const [clauses, setClauses] = useState<Clause[]>([]);
 
-  const urlNamespace = useNS() || Namespace.uniprotkb;
-
-  const [namespace, setNamespace] = useState(urlNamespace);
+  const [namespace, setNamespace] = useState(initialNamespace);
   const style = useMemo<Style>(
     () => ({
       // change color of all buttons within this element to match the namespace

--- a/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
+++ b/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
@@ -41,7 +41,12 @@ describe('QueryBuilder', () => {
   test('should render loading', async () => {
     (useDataApi as jest.Mock).mockReturnValue({ loading: true });
 
-    rendered = customRender(<QueryBuilder onCancel={onCancel} />);
+    rendered = customRender(
+      <QueryBuilder
+        onCancel={onCancel}
+        initialNamespace={Namespace.uniprotkb}
+      />
+    );
 
     expect(rendered.asFragment()).toMatchSnapshot();
   });

--- a/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
+++ b/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
@@ -12,6 +12,7 @@ import customRender from '../../../shared/__test-helpers__/customRender';
 import searchTermData from './__mocks__/configure_search-term';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
+import { Namespace } from '../../../shared/types/namespaces';
 
 jest.mock('../../../shared/hooks/useDataApi');
 
@@ -25,9 +26,15 @@ describe('QueryBuilder', () => {
     onCancel.mockClear();
     (useDataApi as jest.Mock).mockReturnValue({ data: searchTermData });
 
-    rendered = customRender(<QueryBuilder onCancel={onCancel} />, {
-      history,
-    });
+    rendered = customRender(
+      <QueryBuilder
+        onCancel={onCancel}
+        initialNamespace={Namespace.uniprotkb}
+      />,
+      {
+        history,
+      }
+    );
   });
 
   // only exception where we want different payload

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -42,7 +42,9 @@ const ResultsFacets: FC<{
       {before.map(
         (facet) => facet.values && <Facet key={facet.name} data={facet} />
       )}
-      {namespace && mainNamespaces.has(namespace) && <TaxonomyFacet />}
+      {namespace && mainNamespaces.has(namespace) && (
+        <TaxonomyFacet namespace={namespace} />
+      )}
       {after.map(
         (facet) => facet.values && <Facet key={facet.name} data={facet} />
       )}

--- a/src/shared/components/results/TaxonomyFacet.tsx
+++ b/src/shared/components/results/TaxonomyFacet.tsx
@@ -12,6 +12,8 @@ import {
   stringify,
 } from '../../../query-builder/utils/queryStringProcessor';
 
+import { Namespace } from '../../types/namespaces';
+
 const QueryBuilder = lazy(
   () =>
     import(
@@ -21,7 +23,7 @@ const QueryBuilder = lazy(
 
 const interestingTerms = /taxonomy|organism/;
 
-const TaxonomyFacet: FC = () => {
+const TaxonomyFacet: FC<{ namespace: Namespace }> = ({ namespace }) => {
   const { search } = useLocation();
 
   const parsedSearch = qsParse(search);
@@ -81,7 +83,11 @@ const TaxonomyFacet: FC = () => {
             yScrollable
             onClose={handleClose}
           >
-            <QueryBuilder onCancel={handleClose} fieldToAdd="taxonomy_name" />
+            <QueryBuilder
+              onCancel={handleClose}
+              fieldToAdd="taxonomy_name"
+              initialNamespace={namespace}
+            />
           </SlidingPanel>
         </Suspense>
       )}

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -212,7 +212,7 @@ const SearchContainer: FC<
             yScrollable
             onClose={handleClose}
           >
-            <QueryBuilder onCancel={handleClose} />
+            <QueryBuilder onCancel={handleClose} initialNamespace={namespace} />
           </SlidingPanel>
         </Suspense>
       )}


### PR DESCRIPTION
## Purpose
When selecting a namespace in the main search and opening advanced search, it should be the same namespace selected

## Approach
Pass down the namespace as a prop instead of relying on url

## Testing
Update existing tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
