### PR TITLE
Remove sticky

### DIFF
--- a/src/shared/components/layouts/styles/side-bar-layout.scss
+++ b/src/shared/components/layouts/styles/side-bar-layout.scss
@@ -41,9 +41,6 @@
   }
 
   &__content {
-    flex: 1;
-    top: $header-height;
-    right: 0;
     width: calc(100vw - 30ch);
   }
 }

--- a/src/shared/components/layouts/styles/side-bar-layout.scss
+++ b/src/shared/components/layouts/styles/side-bar-layout.scss
@@ -42,7 +42,6 @@
 
   &__content {
     flex: 1;
-    position: sticky;
     top: $header-height;
     right: 0;
     width: calc(100vw - 30ch);


### PR DESCRIPTION
## Purpose
When clicking on a protvista tooltip, it would be displayed offset on the x and y axis.

## Approach
Following a suggestion from @aurel-l , remove the `position: sticky` on the content.

## Testing
- long facet
- infinite scroll still works
- sticky action buttons
- wide tables (already an issue about this)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
