### PR TITLE
2021 06 id mapping buttons

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -40,6 +40,7 @@ type DownloadProps = {
   namespace: Namespace;
   onClose: () => void;
   accessions?: string[];
+  base?: string;
 };
 
 const Download: FC<DownloadProps> = ({
@@ -51,6 +52,7 @@ const Download: FC<DownloadProps> = ({
   onClose,
   namespace,
   accessions,
+  base,
 }) => {
   const [columns] = useUserPreferences(
     `table columns for ${namespace}` as const,
@@ -107,6 +109,7 @@ const Download: FC<DownloadProps> = ({
     selectedIdField,
     namespace,
     accessions,
+    base,
   });
 
   const handleDownloadAllChange = (e: ChangeEvent<HTMLInputElement>) =>
@@ -134,6 +137,7 @@ const Download: FC<DownloadProps> = ({
     selectedIdField,
     namespace,
     accessions,
+    base,
   });
   // TODO: this should useDataApi but this hook requires modification to
   // change the headers so whenever this is done replace fetchData with

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -253,16 +253,17 @@ const Download: FC<DownloadProps> = ({
           No
         </label>
       </fieldset>
-      {fileFormatsWithColumns.includes(fileFormat) && (
-        <>
-          <legend>Customize data</legend>
-          <ColumnSelect
-            onChange={setSelectedColumns}
-            selectedColumns={selectedColumns}
-            namespace={namespace}
-          />
-        </>
-      )}
+      {fileFormatsWithColumns.includes(fileFormat) &&
+        namespace !== Namespace.idmapping && (
+          <>
+            <legend>Customize data</legend>
+            <ColumnSelect
+              onChange={setSelectedColumns}
+              selectedColumns={selectedColumns}
+              namespace={namespace}
+            />
+          </>
+        )}
       <section className="button-group sliding-panel__button-row sticky-bottom-right">
         <Button variant="secondary" onClick={onClose}>
           Cancel

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -34,6 +34,7 @@ type ResultsButtonsProps = {
   total: number;
   accessions?: string[];
   namespaceFallback?: Namespace;
+  base?: string;
   disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
 };
 
@@ -42,6 +43,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   selectedEntries,
   accessions,
   namespaceFallback,
+  base,
   disableCardToggle = false,
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
@@ -72,6 +74,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
               totalNumberResults={total}
               onClose={() => setDisplayDownloadPanel(false)}
               namespace={namespace}
+              base={base}
             />
           </SlidingPanel>
         </Suspense>

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -129,8 +129,9 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             })}
           />
         </Button>
-        {(viewMode === ViewMode.TABLE || disableCardToggle) &&
-          namespace !== Namespace.idmapping && <CustomiseButton />}
+        {viewMode === ViewMode.TABLE && namespace !== Namespace.idmapping && (
+          <CustomiseButton />
+        )}
       </div>
     </>
   );

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -33,15 +33,19 @@ type ResultsButtonsProps = {
   selectedEntries: string[];
   total: number;
   accessions?: string[];
+  namespaceFallback?: Namespace;
+  disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
 };
 
 const ResultsButtons: FC<ResultsButtonsProps> = ({
   total,
   selectedEntries,
   accessions,
+  namespaceFallback,
+  disableCardToggle = false,
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
-  const namespace = useNS() || Namespace.uniprotkb;
+  const namespace = useNS() || namespaceFallback || Namespace.uniprotkb;
   const [viewMode, setViewMode] = useUserPreferences<ViewMode>(
     'view-mode',
     ViewMode.CARD
@@ -109,6 +113,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
           title={`Switch to "${
             viewMode === ViewMode.CARD ? 'table' : 'card'
           }" view`}
+          disabled={namespace === Namespace.idmapping || disableCardToggle}
         >
           <TableIcon
             className={cn('results-buttons__toggle', {
@@ -121,7 +126,9 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             })}
           />
         </Button>
-        {viewMode === ViewMode.TABLE && <CustomiseButton />}
+        {viewMode === ViewMode.TABLE && namespace !== Namespace.idmapping && (
+          <CustomiseButton />
+        )}
       </div>
     </>
   );

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -126,9 +126,8 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             })}
           />
         </Button>
-        {viewMode === ViewMode.TABLE && namespace !== Namespace.idmapping && (
-          <CustomiseButton />
-        )}
+        {(viewMode === ViewMode.TABLE || disableCardToggle) &&
+          namespace !== Namespace.idmapping && <CustomiseButton />}
       </div>
     </>
   );

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -96,6 +96,33 @@ const ResultsData: FC<{
     return <Loader progress={progress} />;
   }
 
+  const dataTableWithLoader =
+    namespace !== Namespace.idmapping ? (
+      <DataTableWithLoader
+        getIdKey={getIdKey}
+        columns={columns}
+        data={allResults}
+        loading={loading}
+        selected={selectedEntries}
+        onSelectRow={handleEntrySelection}
+        onHeaderClick={updateColumnSort}
+        onLoadMoreItems={handleLoadMoreRows}
+        hasMoreData={hasMoreData}
+        loaderComponent={loadComponent}
+      />
+    ) : (
+      <DataTableWithLoader
+        getIdKey={getIdKey}
+        columns={columns}
+        data={allResults}
+        loading={loading}
+        onHeaderClick={updateColumnSort}
+        onLoadMoreItems={handleLoadMoreRows}
+        hasMoreData={hasMoreData}
+        loaderComponent={loadComponent}
+      />
+    );
+
   return (
     <div className="results-data">
       {viewMode === ViewMode.CARD && !displayIdMappingColumns ? (
@@ -113,18 +140,7 @@ const ResultsData: FC<{
           loaderComponent={loadComponent}
         />
       ) : (
-        <DataTableWithLoader
-          getIdKey={getIdKey}
-          columns={columns}
-          data={allResults}
-          loading={loading}
-          selected={selectedEntries}
-          onSelectRow={handleEntrySelection}
-          onHeaderClick={updateColumnSort}
-          onLoadMoreItems={handleLoadMoreRows}
-          hasMoreData={hasMoreData}
-          loaderComponent={loadComponent}
-        />
+        dataTableWithLoader
       )}
     </div>
   );

--- a/src/shared/components/results/ResultsDataHeader.tsx
+++ b/src/shared/components/results/ResultsDataHeader.tsx
@@ -14,6 +14,7 @@ const ResultsDataHeader: FC<{
   namespaceFallback?: Namespace;
   titlePostscript?: ReactNode;
   accessions?: string[];
+  base?: string;
   disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
 }> = ({
   total = 0,
@@ -21,6 +22,7 @@ const ResultsDataHeader: FC<{
   namespaceFallback,
   titlePostscript,
   accessions,
+  base,
   disableCardToggle = false,
 }) => {
   const namespace = useNS() || namespaceFallback || Namespace.uniprotkb;
@@ -39,6 +41,7 @@ const ResultsDataHeader: FC<{
         accessions={accessions}
         namespaceFallback={namespace}
         disableCardToggle={disableCardToggle}
+        base={base}
       />
     </>
   );

--- a/src/shared/components/results/ResultsDataHeader.tsx
+++ b/src/shared/components/results/ResultsDataHeader.tsx
@@ -6,19 +6,23 @@ import ResultsButtons from './ResultsButtons';
 import useNS from '../../hooks/useNS';
 
 import namespaceToolTitles from '../../config/namespaceToolTitles';
-import { Namespace, SearchableNamespace } from '../../types/namespaces';
+import { Namespace } from '../../types/namespaces';
 
 const ResultsDataHeader: FC<{
   total?: number;
   selectedEntries: string[];
+  namespaceFallback?: Namespace;
   titlePostscript?: ReactNode;
   accessions?: string[];
-}> = ({ total = 0, selectedEntries, titlePostscript, accessions }) => {
-  const namespace = useNS() || Namespace.uniprotkb;
-  const title = useMemo(
-    () => namespaceToolTitles[namespace as SearchableNamespace],
-    [namespace]
-  );
+}> = ({
+  total = 0,
+  selectedEntries,
+  namespaceFallback,
+  titlePostscript,
+  accessions,
+}) => {
+  const namespace = useNS() || namespaceFallback || Namespace.uniprotkb;
+  const title = useMemo(() => namespaceToolTitles[namespace], [namespace]);
 
   return (
     <>

--- a/src/shared/components/results/ResultsDataHeader.tsx
+++ b/src/shared/components/results/ResultsDataHeader.tsx
@@ -14,12 +14,14 @@ const ResultsDataHeader: FC<{
   namespaceFallback?: Namespace;
   titlePostscript?: ReactNode;
   accessions?: string[];
+  disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
 }> = ({
   total = 0,
   selectedEntries,
   namespaceFallback,
   titlePostscript,
   accessions,
+  disableCardToggle = false,
 }) => {
   const namespace = useNS() || namespaceFallback || Namespace.uniprotkb;
   const title = useMemo(() => namespaceToolTitles[namespace], [namespace]);
@@ -35,6 +37,8 @@ const ResultsDataHeader: FC<{
         total={total}
         selectedEntries={selectedEntries}
         accessions={accessions}
+        namespaceFallback={namespace}
+        disableCardToggle={disableCardToggle}
       />
     </>
   );

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -323,8 +323,23 @@ export const getUniProtPublicationsQueryUrl = ({
     size,
   })}`;
 
+type Parameters = {
+  query?: string;
+  accessions?: string;
+  format: string;
+  // TODO: change to set of possible fields (if possible, depending on namespace)
+  fields?: string;
+  sort?: string;
+  includeIsoform?: boolean;
+  size?: number;
+  compressed?: boolean;
+  download: true;
+  facetFilter?: string;
+};
+
 type GetDownloadUrlProps = {
-  query: string;
+  base?: string;
+  query?: string;
   columns: string[];
   selectedFacets: SelectedFacet[];
   sortColumn?: SortableColumn;
@@ -336,9 +351,11 @@ type GetDownloadUrlProps = {
   selectedIdField: Column;
   namespace: Namespace;
   accessions?: string[];
+  idMappingPrefix?: string;
 };
 
 export const getDownloadUrl = ({
+  base,
   query,
   columns,
   selectedFacets = [],
@@ -357,24 +374,14 @@ export const getDownloadUrl = ({
   let endpoint;
   if (accessions) {
     endpoint = apiUrls.accessions;
+  } else if (base) {
+    endpoint = joinUrl(devPrefix, base);
   } else if (size) {
     endpoint = apiUrls.search(namespace);
   } else {
     endpoint = apiUrls.download(namespace);
   }
-  type Parameters = {
-    query?: string;
-    accessions?: string;
-    format: string;
-    // TODO: change to set of possible fields (if possible, depending on namespace)
-    fields?: string;
-    sort?: string;
-    includeIsoform?: boolean;
-    size?: number;
-    compressed?: boolean;
-    download: true;
-    facetFilter?: string;
-  };
+
   const parameters: Parameters = {
     format: fileFormatToUrlParameter[fileFormat] || FileFormat.json,
     download: true,

--- a/src/shared/config/namespaceToolTitles.ts
+++ b/src/shared/config/namespaceToolTitles.ts
@@ -1,7 +1,7 @@
-import { Namespace, SearchableNamespace } from '../types/namespaces';
+import { Namespace } from '../types/namespaces';
 import { JobTypes } from '../../tools/types/toolsJobTypes';
 
-const titles: Record<SearchableNamespace | JobTypes, string> = {
+const titles: Record<Namespace | JobTypes, string> = {
   // Main data
   [Namespace.uniprotkb]: 'UniProtKB',
   [Namespace.uniref]: 'UniRef',
@@ -14,6 +14,7 @@ const titles: Record<SearchableNamespace | JobTypes, string> = {
   [Namespace.diseases]: 'Human diseases',
   [Namespace.database]: 'Cross-referenced databases',
   [Namespace.locations]: 'Subcellular locations',
+  [Namespace.idmapping]: 'ID mapping',
   // Tools
   [JobTypes.ID_MAPPING]: 'Retrieve/ID mapping',
   [JobTypes.ALIGN]: 'Align',

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -1,6 +1,10 @@
 import queryString from 'query-string';
 
-import { createFacetsQueryString } from '../../shared/config/apiUrls';
+import {
+  createFacetsQueryString,
+  devPrefix,
+} from '../../shared/config/apiUrls';
+import joinUrl from '../../shared/config/testingApiUrls'; // TODO: revert import to: import joinUrl from 'url-join'
 import { SelectedFacet } from '../../uniprotkb/types/resultsTypes';
 import { JobTypes } from '../types/toolsJobTypes';
 
@@ -67,18 +71,21 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
       baseURL = 'https://www.ebi.ac.uk/Tools/services/rest/ncbiblast';
       break;
     case JobTypes.ID_MAPPING:
-      baseURL = 'https://wwwdev.ebi.ac.uk/uniprot/api/idmapping';
+      baseURL = joinUrl(devPrefix, '/uniprot/api/idmapping');
       return Object.freeze({
         runUrl: `${baseURL}/run`,
         statusUrl: (jobId) =>
           // The cachebust extra query is just here to avoid using cached value
           `${baseURL}/status/${jobId}?cachebust=${new Date().getTime()}`,
         resultUrl: (redirectUrl, { facets, size, selectedFacets = [] }) =>
-          `https://wwwdev.ebi.ac.uk${redirectUrl}?${queryString.stringify({
-            size,
-            facets: facets?.join(','),
-            query: createFacetsQueryString(selectedFacets),
-          })}`,
+          joinUrl(
+            devPrefix,
+            `${redirectUrl}?${queryString.stringify({
+              size,
+              facets: facets?.join(','),
+              query: createFacetsQueryString(selectedFacets),
+            })}`
+          ),
         detailsUrl: (jobId) => `${baseURL}/details/${jobId}`,
       });
     case JobTypes.PEPTIDE_SEARCH:

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -114,6 +114,7 @@ const IDMappingResult = () => {
         selectedEntries={selectedEntries}
         total={total}
         namespaceFallback={namespaceFallback}
+        disableCardToggle
         titlePostscript={
           total && (
             <small>

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -1,10 +1,5 @@
 import { useMemo } from 'react';
-import {
-  ExpandableList,
-  HeroContainer,
-  Loader,
-  PageIntro,
-} from 'franklin-sites';
+import { ExpandableList, HeroContainer, Loader } from 'franklin-sites';
 import { useLocation, useRouteMatch } from 'react-router-dom';
 
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
@@ -31,6 +26,7 @@ import { Namespace } from '../../../../shared/types/namespaces';
 import ResultsFacets from '../../../../shared/components/results/ResultsFacets';
 import { defaultFacets } from '../../../../shared/config/apiUrls';
 import Response from '../../../../uniprotkb/types/responseTypes';
+import ResultsDataHeader from '../../../../shared/components/results/ResultsDataHeader';
 
 const jobType = JobTypes.ID_MAPPING;
 const urls = toolsURLs(jobType);
@@ -114,25 +110,27 @@ const IDMappingResult = () => {
 
   return (
     <SideBarLayout sidebar={<ResultsFacets dataApiObject={facetsData} />}>
-      <PageIntro title="ID Mapping Results" />
-      {total && (
+      <ResultsDataHeader
+        selectedEntries={selectedEntries}
+        total={total}
+        namespaceFallback={namespaceFallback}
+        titlePostscript={
+          total && (
+            <small>
+              for {detailsData?.from} → {detailsData?.to}
+            </small>
+          )
+        }
+      />
+      {failedIds && (
         <HeroContainer>
-          <strong>{total}</strong> out of{' '}
-          <strong>{total + (failedIds ? failedIds.length : 0)}</strong>{' '}
-          {detailsData?.from} identifiers were successfully mapped to{' '}
-          {detailsData?.to}.
-          {failedIds && (
-            <div>
-              The following id{failedIds.length === 1 ? '' : 's'}{' '}
-              {failedIds.length === 1 ? 'is' : 'were'} not mapped:
-              <ExpandableList descriptionString="ids" numberCollapsedItems={0}>
-                {failedIds.map((id) => id)}
-              </ExpandableList>
-            </div>
-          )}
+          <strong>{failedIds.length}</strong> id
+          {failedIds.length === 1 ? ' is' : 's were'} not mapped:
+          <ExpandableList descriptionString="ids" numberCollapsedItems={0}>
+            {failedIds.map((id) => id)}
+          </ExpandableList>
         </HeroContainer>
       )}
-      {/* TODO only display buttons when namespace exists, otherwise download only */}
       <ResultsData
         resultsDataObject={resultsDataObject}
         selectedEntries={selectedEntries}

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -122,6 +122,7 @@ const IDMappingResult = () => {
             </small>
           )
         }
+        base={detailsData?.redirectURL}
       />
       {failedIds && (
         <HeroContainer>


### PR DESCRIPTION
## Purpose
Add logic to display relevant buttons when looking at ID mapping results.

## Approach
Pass down props with `namespaceFallback` and a flag to disable the card view switch.

## Testing
Visual testing only.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
