### PR TITLE
display less evidences in uniprotkb results

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "classnames": "2.3.1",
     "core-js": "3.11.2",
     "d3": "5.16.0",
-    "franklin-sites": "0.0.133",
+    "franklin-sites": "0.0.134",
     "history": "4.10.1",
     "idb": "6.0.0",
     "interaction-viewer": "3.1.2",

--- a/src/proteomes/config/ProteomesColumnConfiguration.tsx
+++ b/src/proteomes/config/ProteomesColumnConfiguration.tsx
@@ -73,12 +73,11 @@ ProteomesColumnConfiguration.set(ProteomesColumn.organism, {
 
 ProteomesColumnConfiguration.set(ProteomesColumn.components, {
   label: 'Components',
-  render: ({ components }) =>
-    components && (
-      <ExpandableList descriptionString="components" displayNumberOfHiddenItems>
-        {components?.map(({ name }) => name)}
-      </ExpandableList>
-    ),
+  render: ({ components }) => (
+    <ExpandableList descriptionString="components" displayNumberOfHiddenItems>
+      {components?.map(({ name }) => name)}
+    </ExpandableList>
+  ),
 });
 
 ProteomesColumnConfiguration.set(ProteomesColumn.mnemonic, {

--- a/src/supporting-data/citations/config/CitationsColumnConfiguration.tsx
+++ b/src/supporting-data/citations/config/CitationsColumnConfiguration.tsx
@@ -55,22 +55,20 @@ export const CitationsColumnConfiguration: ColumnConfiguration<
 // COLUMN RENDERERS BELOW
 CitationsColumnConfiguration.set(CitationsColumn.authoringGroup, {
   label: 'Authoring group',
-  render: ({ citation }) =>
-    citation?.authoringGroup && (
-      <ExpandableList descriptionString="groups" displayNumberOfHiddenItems>
-        {citation.authoringGroup}
-      </ExpandableList>
-    ),
+  render: ({ citation }) => (
+    <ExpandableList descriptionString="groups" displayNumberOfHiddenItems>
+      {citation?.authoringGroup}
+    </ExpandableList>
+  ),
 });
 
 CitationsColumnConfiguration.set(CitationsColumn.authors, {
   label: 'Authors',
-  render: ({ citation }) =>
-    citation?.authors && (
-      <ExpandableList descriptionString="authors" displayNumberOfHiddenItems>
-        {citation.authors}
-      </ExpandableList>
-    ),
+  render: ({ citation }) => (
+    <ExpandableList descriptionString="authors" displayNumberOfHiddenItems>
+      {citation?.authors}
+    </ExpandableList>
+  ),
 });
 
 CitationsColumnConfiguration.set(CitationsColumn.doi, {

--- a/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
+++ b/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
@@ -45,35 +45,33 @@ DiseasesColumnConfiguration.set(DiseasesColumn.acronym, {
 
 DiseasesColumnConfiguration.set(DiseasesColumn.alternativeNames, {
   label: 'Alternative names',
-  render: ({ alternativeNames }) =>
-    alternativeNames?.length && (
-      <ExpandableList
-        descriptionString="alternative names"
-        displayNumberOfHiddenItems
-      >
-        {alternativeNames}
-      </ExpandableList>
-    ),
+  render: ({ alternativeNames }) => (
+    <ExpandableList
+      descriptionString="alternative names"
+      displayNumberOfHiddenItems
+    >
+      {alternativeNames}
+    </ExpandableList>
+  ),
 });
 
 // NOTE: should probably be links
 DiseasesColumnConfiguration.set(DiseasesColumn.crossReferences, {
   label: 'Cross references',
   // TODO: https://www.ebi.ac.uk/panda/jira/browse/TRM-25838
-  render: ({ crossReferences }) =>
-    crossReferences?.length && (
-      <ExpandableList
-        descriptionString="cross references"
-        displayNumberOfHiddenItems
-      >
-        {crossReferences.map(
-          ({ databaseType, id, properties }) =>
-            `${databaseType}: ${id}${
-              properties?.length ? ` (${properties.join(', ')})` : ''
-            }`
-        )}
-      </ExpandableList>
-    ),
+  render: ({ crossReferences }) => (
+    <ExpandableList
+      descriptionString="cross references"
+      displayNumberOfHiddenItems
+    >
+      {crossReferences?.map(
+        ({ databaseType, id, properties }) =>
+          `${databaseType}: ${id}${
+            properties?.length ? ` (${properties.join(', ')})` : ''
+          }`
+      )}
+    </ExpandableList>
+  ),
 });
 
 DiseasesColumnConfiguration.set(DiseasesColumn.definition, {
@@ -93,16 +91,15 @@ DiseasesColumnConfiguration.set(DiseasesColumn.id, {
 
 DiseasesColumnConfiguration.set(DiseasesColumn.keywords, {
   label: 'Keywords',
-  render: ({ keywords }) =>
-    keywords?.length && (
-      <ExpandableList descriptionString="keywords" displayNumberOfHiddenItems>
-        {keywords.map(({ name, id }) => (
-          <Link key={id} to={getEntryPathForKeyword(id)}>
-            {name}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ keywords }) => (
+    <ExpandableList descriptionString="keywords" displayNumberOfHiddenItems>
+      {keywords?.map(({ name, id }) => (
+        <Link key={id} to={getEntryPathForKeyword(id)}>
+          {name}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 DiseasesColumnConfiguration.set(DiseasesColumn.name, {

--- a/src/supporting-data/keywords/config/KeywordsColumnConfiguration.tsx
+++ b/src/supporting-data/keywords/config/KeywordsColumnConfiguration.tsx
@@ -49,16 +49,15 @@ KeywordsColumnConfiguration.set(KeywordsColumn.category, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.children, {
   label: 'Children',
-  render: ({ children }) =>
-    children?.length && (
-      <ExpandableList descriptionString="children" displayNumberOfHiddenItems>
-        {children.map((child) => (
-          <Link key={child.keyword.id} to={getEntryPath(child.keyword.id)}>
-            {child.keyword.name}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ children }) => (
+    <ExpandableList descriptionString="children" displayNumberOfHiddenItems>
+      {children?.map((child) => (
+        <Link key={child.keyword.id} to={getEntryPath(child.keyword.id)}>
+          {child.keyword.name}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.definition, {
@@ -68,16 +67,15 @@ KeywordsColumnConfiguration.set(KeywordsColumn.definition, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.geneOntologies, {
   label: 'Gene Ontologies',
-  render: ({ geneOntologies }) =>
-    geneOntologies?.length && (
-      <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
-        {geneOntologies.map(({ name, goId }) => (
-          <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
-            {name} ({goId})
-          </ExternalLink>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ geneOntologies }) => (
+    <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
+      {geneOntologies?.map(({ name, goId }) => (
+        <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
+          {name} ({goId})
+        </ExternalLink>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.id, {
@@ -93,38 +91,35 @@ KeywordsColumnConfiguration.set(KeywordsColumn.name, {
 
 KeywordsColumnConfiguration.set(KeywordsColumn.parents, {
   label: 'Parents',
-  render: ({ parents }) =>
-    parents?.length && (
-      <ExpandableList descriptionString="parents" displayNumberOfHiddenItems>
-        {parents.map((parent) => (
-          <Link key={parent.keyword.id} to={getEntryPath(parent.keyword.id)}>
-            {parent.keyword.name}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ parents }) => (
+    <ExpandableList descriptionString="parents" displayNumberOfHiddenItems>
+      {parents?.map((parent) => (
+        <Link key={parent.keyword.id} to={getEntryPath(parent.keyword.id)}>
+          {parent.keyword.name}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.links, {
   label: 'Links',
-  render: ({ links }) =>
-    links?.length && (
-      <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
-        {links.map((link) => (
-          <ExternalLink key={link} url={link} tidyUrl />
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ links }) => (
+    <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
+      {links?.map((link) => (
+        <ExternalLink key={link} url={link} tidyUrl />
+      ))}
+    </ExpandableList>
+  ),
 });
 
 KeywordsColumnConfiguration.set(KeywordsColumn.synonym, {
   label: 'Synonyms',
-  render: ({ synonyms }) =>
-    synonyms?.length && (
-      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-        {synonyms}
-      </ExpandableList>
-    ),
+  render: ({ synonyms }) => (
+    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+      {synonyms}
+    </ExpandableList>
+  ),
 });
 
 export default KeywordsColumnConfiguration;

--- a/src/supporting-data/locations/config/LocationsColumnConfiguration.tsx
+++ b/src/supporting-data/locations/config/LocationsColumnConfiguration.tsx
@@ -64,16 +64,15 @@ LocationsColumnConfiguration.set(LocationsColumn.definition, {
 
 LocationsColumnConfiguration.set(LocationsColumn.geneOntologies, {
   label: 'Gene Ontologies',
-  render: ({ geneOntologies }) =>
-    geneOntologies?.length && (
-      <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
-        {geneOntologies.map(({ name, goId }) => (
-          <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
-            {name} ({goId})
-          </ExternalLink>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ geneOntologies }) => (
+    <ExpandableList descriptionString="GO terms" displayNumberOfHiddenItems>
+      {geneOntologies?.map(({ name, goId }) => (
+        <ExternalLink key={goId} url={externalUrls.QuickGO(goId)}>
+          {name} ({goId})
+        </ExternalLink>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.id, {
@@ -84,16 +83,15 @@ LocationsColumnConfiguration.set(LocationsColumn.id, {
 
 LocationsColumnConfiguration.set(LocationsColumn.isA, {
   label: 'Is a',
-  render: ({ isA }) =>
-    isA?.length && (
-      <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
-        {isA.map((location) => (
-          <Link key={location.id} to={getEntryPath(location.id)}>
-            {location.name}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ isA }) => (
+    <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
+      {isA?.map((location) => (
+        <Link key={location.id} to={getEntryPath(location.id)}>
+          {location.name}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.keyword, {
@@ -106,14 +104,13 @@ LocationsColumnConfiguration.set(LocationsColumn.keyword, {
 
 LocationsColumnConfiguration.set(LocationsColumn.links, {
   label: 'Links',
-  render: ({ links }) =>
-    links?.length && (
-      <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
-        {links.map((link) => (
-          <ExternalLink key={link} url={link} tidyUrl />
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ links }) => (
+    <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
+      {links?.map((link) => (
+        <ExternalLink key={link} url={link} tidyUrl />
+      ))}
+    </ExpandableList>
+  ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.name, {
@@ -128,37 +125,34 @@ LocationsColumnConfiguration.set(LocationsColumn.note, {
 
 LocationsColumnConfiguration.set(LocationsColumn.partOf, {
   label: 'Part of',
-  render: ({ partOf }) =>
-    partOf?.length && (
-      <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
-        {partOf.map((location) => (
-          <Link key={location.id} to={getEntryPath(location.id)}>
-            {location.name}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ partOf }) => (
+    <ExpandableList descriptionString="locations" displayNumberOfHiddenItems>
+      {partOf?.map((location) => (
+        <Link key={location.id} to={getEntryPath(location.id)}>
+          {location.name}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.references, {
   label: 'References',
   // TODO: review and feedback to backend which format we want (needs to be consistent)
-  render: ({ references }) =>
-    references?.length && (
-      <ExpandableList descriptionString="references" displayNumberOfHiddenItems>
-        {references}
-      </ExpandableList>
-    ),
+  render: ({ references }) => (
+    <ExpandableList descriptionString="references" displayNumberOfHiddenItems>
+      {references}
+    </ExpandableList>
+  ),
 });
 
 LocationsColumnConfiguration.set(LocationsColumn.synonyms, {
   label: 'Synonyms',
-  render: ({ synonyms }) =>
-    synonyms?.length && (
-      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-        {synonyms}
-      </ExpandableList>
-    ),
+  render: ({ synonyms }) => (
+    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+      {synonyms}
+    </ExpandableList>
+  ),
 });
 
 export default LocationsColumnConfiguration;

--- a/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
+++ b/src/supporting-data/taxonomy/config/TaxonomyColumnConfiguration.tsx
@@ -51,16 +51,15 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.commonName, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.hosts, {
   label: 'Hosts',
-  render: ({ hosts }) =>
-    hosts?.length && (
-      <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
-        {hosts.map(({ taxonId, scientificName, commonName }) => (
-          <Link key={taxonId} to={getEntryPath(taxonId)}>
-            {commonName || scientificName || taxonId}
-          </Link>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ hosts }) => (
+    <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
+      {hosts?.map(({ taxonId, scientificName, commonName }) => (
+        <Link key={taxonId} to={getEntryPath(taxonId)}>
+          {commonName || scientificName || taxonId}
+        </Link>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.id, {
@@ -88,14 +87,13 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.lineage, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.links, {
   label: 'Links',
-  render: ({ links }) =>
-    links?.length && (
-      <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
-        {links.map((link) => (
-          <ExternalLink key={link} url={link} tidyUrl />
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ links }) => (
+    <ExpandableList descriptionString="links" displayNumberOfHiddenItems>
+      {links?.map((link) => (
+        <ExternalLink key={link} url={link} tidyUrl />
+      ))}
+    </ExpandableList>
+  ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.mnemonic, {
@@ -105,12 +103,11 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.mnemonic, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.otherNames, {
   label: 'Other names',
-  render: ({ otherNames }) =>
-    otherNames?.length && (
-      <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
-        {otherNames}
-      </ExpandableList>
-    ),
+  render: ({ otherNames }) => (
+    <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
+      {otherNames}
+    </ExpandableList>
+  ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.parent, {
@@ -135,27 +132,25 @@ TaxonomyColumnConfiguration.set(TaxonomyColumn.scientificName, {
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.strains, {
   label: 'Strains',
-  render: ({ strains }) =>
-    strains?.length && (
-      <ExpandableList descriptionString="strains" displayNumberOfHiddenItems>
-        {strains.map((strain) => (
-          <>
-            {strain.name}
-            {strain.synonyms?.length && ` (${strain.synonyms.join(', ')})`}
-          </>
-        ))}
-      </ExpandableList>
-    ),
+  render: ({ strains }) => (
+    <ExpandableList descriptionString="strains" displayNumberOfHiddenItems>
+      {strains?.map((strain) => (
+        <>
+          {strain.name}
+          {strain.synonyms?.length && ` (${strain.synonyms.join(', ')})`}
+        </>
+      ))}
+    </ExpandableList>
+  ),
 });
 
 TaxonomyColumnConfiguration.set(TaxonomyColumn.synonyms, {
   label: 'Synonyms',
-  render: ({ synonyms }) =>
-    synonyms?.length && (
-      <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
-        {synonyms}
-      </ExpandableList>
-    ),
+  render: ({ synonyms }) => (
+    <ExpandableList descriptionString="synonyms" displayNumberOfHiddenItems>
+      {synonyms}
+    </ExpandableList>
+  ),
 });
 
 export default TaxonomyColumnConfiguration;

--- a/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
+++ b/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
@@ -1,60 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniParcColumnConfiguration component should render column "CDD": CDD 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "CDD": CDD 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "Gene3D": Gene3D 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "Gene3D": Gene3D 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "HAMAP": HAMAP 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "HAMAP": HAMAP 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "PANTHER": PANTHER 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "PANTHER": PANTHER 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "PIRSF": PIRSF 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "PIRSF": PIRSF 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "PRINTS": PRINTS 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "PRINTS": PRINTS 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "PROSITE": PROSITE 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "PROSITE": PROSITE 1`] = `<DocumentFragment />`;
 
 exports[`UniParcColumnConfiguration component should render column "Pfam": Pfam 1`] = `
 <DocumentFragment>
@@ -97,37 +55,13 @@ exports[`UniParcColumnConfiguration component should render column "Pfam": Pfam 
 </DocumentFragment>
 `;
 
-exports[`UniParcColumnConfiguration component should render column "SFLD": SFLD 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "SFLD": SFLD 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "SMART": SMART 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "SMART": SMART 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "SUPFAM": SUPFAM 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "SUPFAM": SUPFAM 1`] = `<DocumentFragment />`;
 
-exports[`UniParcColumnConfiguration component should render column "TIGRFAMs": TIGRFAMs 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniParcColumnConfiguration component should render column "TIGRFAMs": TIGRFAMs 1`] = `<DocumentFragment />`;
 
 exports[`UniParcColumnConfiguration component should render column "accession": accession 1`] = `
 <DocumentFragment>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -1467,9 +1467,6 @@ exports[`Entry should render main 1`] = `
                 <h3>
                   Proteome
                 </h3>
-                <ul
-                  class="expandable-list no-bullet"
-                />
               </div>
             </div>
           </section>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -1173,9 +1173,6 @@ exports[`Entry view should render 1`] = `
         <h3>
           Proteome
         </h3>
-        <ul
-          class="expandable-list no-bullet"
-        />
       </div>
     </div>
   </section>
@@ -2954,13 +2951,28 @@ exports[`Entry view should render for non-human entry 1`] = `
               </div>
             </div>
           </li>
+          <li>
+            <div
+              class="decorated-list-item"
+            >
+              <div
+                class="decorated-list-item__title"
+              >
+                <h5
+                  class="bold"
+                >
+                  Secondary accessions
+                </h5>
+              </div>
+              <div
+                class="decorated-list-item__content"
+              />
+            </div>
+          </li>
         </ul>
         <h3>
           Proteome
         </h3>
-        <ul
-          class="expandable-list no-bullet"
-        />
       </div>
     </div>
   </section>

--- a/src/uniprotkb/components/protein-data-views/AccessionsView.tsx
+++ b/src/uniprotkb/components/protein-data-views/AccessionsView.tsx
@@ -12,9 +12,9 @@ const AccessionsView: FC<{ data: NamesAndTaxonomyUIModel }> = ({ data }) => (
       },
       {
         title: `Secondary accessions`,
-        content: data.secondaryAccessions && (
+        content: (
           <ExpandableList descriptionString="accessions">
-            {data.secondaryAccessions.map((accession) => (
+            {data.secondaryAccessions?.map((accession) => (
               <Fragment key={accession}>{accession}</Fragment>
             ))}
           </ExpandableList>

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -3,21 +3,15 @@ import { Fragment, FC } from 'react';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 import { FreeTextComment, TextWithEvidence } from '../../types/commentTypes';
 
-type FreeTextProps = {
-  comments?: FreeTextComment[];
-  title?: string;
-  showMolecule?: boolean;
-};
+type TextViewProps = { comments: TextWithEvidence[]; noEvidence?: boolean };
 
-export const TextView: FC<{ comments: TextWithEvidence[] }> = ({
-  comments,
-}) => (
+export const TextView = ({ comments, noEvidence }: TextViewProps) => (
   <section className="text-block">
     {comments.map((comment, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <Fragment key={index}>
         {comment.value}
-        {comment.evidences && (
+        {!noEvidence && comment.evidences && (
           <UniProtKBEvidenceTag evidences={comment.evidences} />
         )}
       </Fragment>
@@ -25,12 +19,20 @@ export const TextView: FC<{ comments: TextWithEvidence[] }> = ({
   </section>
 );
 
+type FreeTextProps = {
+  comments?: FreeTextComment[];
+  title?: string;
+  showMolecule?: boolean;
+  noEvidence?: boolean;
+};
+
 const FreeTextView: FC<FreeTextProps> = ({
   comments,
   title,
   showMolecule = true,
+  noEvidence,
 }) => {
-  if (!comments || comments.length <= 0) {
+  if (!comments?.length) {
     return null;
   }
   const freeTextData = comments.map(
@@ -39,7 +41,7 @@ const FreeTextView: FC<FreeTextProps> = ({
         // eslint-disable-next-line react/no-array-index-key
         <Fragment key={index}>
           {showMolecule && item.molecule && <h5>{item.molecule}</h5>}
-          <TextView comments={item.texts} />
+          <TextView comments={item.texts} noEvidence={noEvidence} />
         </Fragment>
       )
   );

--- a/src/uniprotkb/components/protein-data-views/KeywordView.tsx
+++ b/src/uniprotkb/components/protein-data-views/KeywordView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, FC } from 'react';
+import { FC } from 'react';
 import { InfoList, ExpandableList } from 'franklin-sites';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
@@ -33,31 +33,21 @@ export const KeywordList: FC<KeywordListProps> = ({
   keywords,
   idOnly,
   inline,
-}) => {
-  if (!keywords) {
-    return null;
-  }
-
-  return (
-    <ExpandableList
-      descriptionString={idOnly ? 'keyword IDs' : 'keywords'}
-      className={cn({ 'keyword-view--inline': inline })}
-    >
-      {keywords.map((keyword, index) => {
-        const { id, name } = keyword;
-        if (!id || !name) {
-          return null;
-        }
-        return (
-          // eslint-disable-next-line react/no-array-index-key
-          <Fragment key={index}>
-            <KeywordItem id={id} value={idOnly ? id : name} />
-          </Fragment>
-        );
-      })}
-    </ExpandableList>
-  );
-};
+}) => (
+  <ExpandableList
+    descriptionString={idOnly ? 'keyword IDs' : 'keywords'}
+    className={cn({ 'keyword-view--inline': inline })}
+  >
+    {keywords.map((keyword, index) => {
+      const { id, name } = keyword;
+      if (!id || !name) {
+        return null;
+      }
+      // eslint-disable-next-line react/no-array-index-key
+      return <KeywordItem key={index} id={id} value={idOnly ? id : name} />;
+    })}
+  </ExpandableList>
+);
 
 const KeywordView: FC<{ keywords: KeywordUIModel[] }> = ({ keywords }) => {
   if (!keywords?.length) {

--- a/src/uniprotkb/components/protein-data-views/ProteinNamesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteinNamesView.tsx
@@ -87,20 +87,16 @@ const ProteinDescriptionView: FC<{
 };
 
 export const ECNumbersView: FC<{
-  ecNumbers: ValueWithEvidence[];
+  ecNumbers?: ValueWithEvidence[];
   isCompact?: boolean;
 }> = ({ ecNumbers, isCompact = false }) => (
   <>
-    {ecNumbers.map(
-      (ecNumber, index): JSX.Element =>
-        isCompact ? (
-          // eslint-disable-next-line react/no-array-index-key
-          <Fragment key={index}>{ecNumber.value}</Fragment>
-        ) : (
-          // eslint-disable-next-line react/no-array-index-key
-          <NameWithEvidence data={ecNumber} key={index} />
-        )
-    )}
+    {ecNumbers?.map((ecNumber, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Fragment key={index}>
+        {isCompact ? ecNumber.value : <NameWithEvidence data={ecNumber} />}
+      </Fragment>
+    ))}
   </>
 );
 

--- a/src/uniprotkb/components/protein-data-views/ProteomesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteomesView.tsx
@@ -20,30 +20,25 @@ const ProteomesComponents: FC<{
 const ProteomesView: FC<{ data?: Xref[]; isCompact?: boolean }> = ({
   data,
   isCompact = false,
-}) => {
-  if (!data) {
-    return null;
-  }
-  return (
-    <ExpandableList descriptionString="proteomes" displayNumberOfHiddenItems>
-      {data.map((proteome) => (
-        <InfoList
-          key={`${proteome.id}-${proteome.properties?.Component}`}
-          isCompact={isCompact}
-          infoData={[
-            {
-              title: 'Identifier',
-              content: <ProteomesId id={proteome.id} />,
-            },
-            {
-              title: 'Component',
-              content: <ProteomesComponents components={proteome.properties} />,
-            },
-          ]}
-        />
-      ))}
-    </ExpandableList>
-  );
-};
+}) => (
+  <ExpandableList descriptionString="proteomes" displayNumberOfHiddenItems>
+    {data?.map((proteome) => (
+      <InfoList
+        key={`${proteome.id}-${proteome.properties?.Component}`}
+        isCompact={isCompact}
+        infoData={[
+          {
+            title: 'Identifier',
+            content: <ProteomesId id={proteome.id} />,
+          },
+          {
+            title: 'Component',
+            content: <ProteomesComponents components={proteome.properties} />,
+          },
+        ]}
+      />
+    ))}
+  </ExpandableList>
+);
 
 export default ProteomesView;

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/KeywordView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/KeywordView.spec.tsx.snap
@@ -23,11 +23,7 @@ exports[`Keyword should render Keywords for section 1`] = `
         </div>
         <div
           class="decorated-list-item__content"
-        >
-          <ul
-            class="expandable-list no-bullet"
-          />
-        </div>
+        />
       </div>
     </li>
   </ul>

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -3,6 +3,7 @@ import { ExpandableList, LongNumber, Sequence } from 'franklin-sites';
 import { Link } from 'react-router-dom';
 
 import SimpleView from '../../shared/components/views/SimpleView';
+import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
 import TaxonomyView, {
   TaxonomyLineage,
 } from '../../shared/components/entry/TaxonomyView';
@@ -412,7 +413,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccPolymorphism, {
   label: 'Polymorphysm',
   render: (data) => {
     const { polymorphysm } = data[EntrySection.Sequence];
-    return polymorphysm && <FreeTextView comments={polymorphysm} />;
+    return <FreeTextView comments={polymorphysm} noEvidence />;
   },
 });
 
@@ -511,13 +512,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ec, {
   label: 'EC Number',
   render: (data) => {
     const { proteinNamesData } = data[EntrySection.NamesAndTaxonomy];
-    const ecNumbers = proteinNamesData?.recommendedName?.ecNumbers?.map(
-      (ecNumber) => ecNumber.value
-    );
     return (
-      <ExpandableList descriptionString="EC numbers" numberCollapsedItems={1}>
-        {ecNumbers}
-      </ExpandableList>
+      <ECNumbersView
+        ecNumbers={proteinNamesData?.recommendedName?.ecNumbers}
+        isCompact
+      />
     );
   },
 });
@@ -542,16 +541,10 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccActivityRegulation, {
 UniProtKBColumnConfiguration.set(UniProtKBColumn.ccFunction, {
   label: 'Function',
   render: (data) => {
-    const functionComments = ((data[EntrySection.Function].commentsData.get(
+    const functionComments = (data[EntrySection.Function].commentsData.get(
       CommentType.FUNCTION
-    ) || []) as FreeTextComment[]).flatMap(
-      (comment) => comment.texts?.map((text) => text.value) || []
-    );
-    return (
-      <ExpandableList descriptionString="functions" numberCollapsedItems={1}>
-        {functionComments}
-      </ExpandableList>
-    );
+    ) || []) as FreeTextComment[];
+    return <FreeTextView comments={functionComments} noEvidence />;
   },
 });
 
@@ -677,9 +670,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccMiscellaneous, {
     const miscellaneousComments = data[EntrySection.Function].commentsData.get(
       CommentType.MISCELLANEOUS
     ) as FreeTextComment[];
-    return (
-      miscellaneousComments && <FreeTextView comments={miscellaneousComments} />
-    );
+    return <FreeTextView comments={miscellaneousComments} noEvidence />;
   },
 });
 
@@ -753,7 +744,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccSubunit, {
     const subunitComments = data[EntrySection.Interaction].commentsData.get(
       CommentType.SUBUNIT
     ) as FreeTextComment[];
-    return subunitComments && <FreeTextView comments={subunitComments} />;
+    return <FreeTextView comments={subunitComments} noEvidence />;
   },
 });
 
@@ -763,9 +754,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccDevelopmentalStage, {
     const developmentComments = data[EntrySection.Expression].commentsData.get(
       CommentType.DEVELOPMENTAL_STAGE
     ) as FreeTextComment[];
-    return (
-      developmentComments && <FreeTextView comments={developmentComments} />
-    );
+    return <FreeTextView comments={developmentComments} noEvidence />;
   },
 });
 
@@ -775,7 +764,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInduction, {
     const inductionComments = data[EntrySection.Expression].commentsData.get(
       CommentType.INDUCTION
     ) as FreeTextComment[];
-    return inductionComments && <FreeTextView comments={inductionComments} />;
+    return <FreeTextView comments={inductionComments} noEvidence />;
   },
 });
 
@@ -785,7 +774,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccTissueSpecificity, {
     const tissueComment = data[EntrySection.Expression].commentsData.get(
       CommentType.TISSUE_SPECIFICITY
     ) as FreeTextComment[];
-    return tissueComment && <FreeTextView comments={tissueComment} />;
+    return <FreeTextView comments={tissueComment} noEvidence />;
   },
 });
 
@@ -876,7 +865,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccDomain, {
     const domainData = data[EntrySection.FamilyAndDomains].commentsData.get(
       CommentType.DOMAIN
     ) as FreeTextComment[];
-    return domainData && <FreeTextView comments={domainData} />;
+    return <FreeTextView comments={domainData} noEvidence />;
   },
 });
 
@@ -886,7 +875,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccPtm, {
     const ptmData = data[EntrySection.ProteinProcessing].commentsData.get(
       CommentType.PTM
     ) as FreeTextComment[];
-    return ptmData && <FreeTextView comments={ptmData} />;
+    return <FreeTextView comments={ptmData} noEvidence />;
   },
 });
 
@@ -896,7 +885,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccAllergen, {
     const allergenData = data[EntrySection.DiseaseAndDrugs].commentsData.get(
       CommentType.ALLERGEN
     ) as FreeTextComment[];
-    return allergenData && <FreeTextView comments={allergenData} />;
+    return <FreeTextView comments={allergenData} noEvidence />;
   },
 });
 
@@ -906,7 +895,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccBiotechnology, {
     const biotechData = data[EntrySection.DiseaseAndDrugs].commentsData.get(
       CommentType.BIOTECHNOLOGY
     ) as FreeTextComment[];
-    return biotechData && <FreeTextView comments={biotechData} />;
+    return <FreeTextView comments={biotechData} noEvidence />;
   },
 });
 
@@ -916,7 +905,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccDisruptionPhenotype, {
     const disruptionData = data[EntrySection.DiseaseAndDrugs].commentsData.get(
       CommentType.DISRUPTION_PHENOTYPE
     ) as FreeTextComment[];
-    return disruptionData && <FreeTextView comments={disruptionData} />;
+    return <FreeTextView comments={disruptionData} noEvidence />;
   },
 });
 
@@ -948,7 +937,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccPharmaceutical, {
     const pharmaData = data[EntrySection.DiseaseAndDrugs].commentsData.get(
       CommentType.PHARMACEUTICAL
     ) as FreeTextComment[];
-    return pharmaData && <FreeTextView comments={pharmaData} />;
+    return <FreeTextView comments={pharmaData} noEvidence />;
   },
 });
 
@@ -958,7 +947,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccToxicDose, {
     const toxicData = data[EntrySection.DiseaseAndDrugs].commentsData.get(
       CommentType.TOXIC_DOSE
     ) as FreeTextComment[];
-    return toxicData && <FreeTextView comments={toxicData} />;
+    return <FreeTextView comments={toxicData} noEvidence />;
   },
 });
 
@@ -1101,7 +1090,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinFamilies, {
     const familiesData = data[EntrySection.FamilyAndDomains].commentsData.get(
       CommentType.SIMILARITY
     ) as FreeTextComment[];
-    return familiesData && <FreeTextView comments={familiesData} />;
+    return <FreeTextView comments={familiesData} noEvidence />;
   },
 });
 
@@ -1120,7 +1109,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccSimilarity, {
     const familiesData = data[EntrySection.FamilyAndDomains].commentsData.get(
       CommentType.SIMILARITY
     ) as FreeTextComment[];
-    return familiesData && <FreeTextView comments={familiesData} />;
+    return <FreeTextView comments={familiesData} noEvidence />;
   },
 });
 

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -1,14 +1,11 @@
 /* eslint-disable camelcase */
-import { Fragment } from 'react';
 import { ExpandableList, LongNumber, Sequence } from 'franklin-sites';
 import { Link } from 'react-router-dom';
 
 import SimpleView from '../../shared/components/views/SimpleView';
-import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
 import TaxonomyView, {
   TaxonomyLineage,
 } from '../../shared/components/entry/TaxonomyView';
-import { geneAlternativeNamesView } from '../components/protein-data-views/GeneNamesView';
 import { UniProtkbUIModel } from '../adapters/uniProtkbConverter';
 import ProteomesView from '../components/protein-data-views/ProteomesView';
 import FeaturesView from '../components/protein-data-views/UniProtKBFeaturesView';
@@ -126,7 +123,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.id, {
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
-  label: 'Protein names',
+  label: 'Protein Names',
   render: (data) => {
     const { proteinNamesData } = data[EntrySection.NamesAndTaxonomy];
 
@@ -204,82 +201,68 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.length, {
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.genePrimary, {
-  label: 'Gene names (Primary)',
+  label: 'Gene Names (Primary)',
   render(data) {
     const { geneNamesData } = data[EntrySection.NamesAndTaxonomy];
-    return (
-      <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
-        {geneNamesData &&
-          geneNamesData.map(
-            (geneData) =>
-              geneData.geneName && (
-                <div key={geneData.geneName.value}>
-                  {geneData.geneName.value}
-                </div>
-              )
-          )}
+
+    const names = geneNamesData?.map((geneNames) => geneNames.geneName?.value);
+
+    return names?.length ? (
+      <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
+        {names}
       </ExpandableList>
-    );
+    ) : null;
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.geneOln, {
-  label: 'Gene names (Ordered locus)',
+  label: 'Gene Names (Ordered locus)',
   render(data) {
     const { geneNamesData } = data[EntrySection.NamesAndTaxonomy];
-    return (
-      <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
-        {geneNamesData &&
-          geneNamesData.map(
-            (geneData) =>
-              geneData.orderedLocusNames && (
-                <Fragment key={geneData.orderedLocusNames.join('')}>
-                  {geneAlternativeNamesView(geneData.orderedLocusNames)}
-                </Fragment>
-              )
-          )}
-      </ExpandableList>
+
+    const names = geneNamesData?.flatMap((geneNames) =>
+      geneNames.orderedLocusNames?.map((synonym) => synonym.value)
     );
+
+    return names?.length ? (
+      <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
+        {names}
+      </ExpandableList>
+    ) : null;
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.geneOrf, {
-  label: 'Gene names (ORF)',
+  label: 'Gene Names (ORF)',
   render(data) {
     const { geneNamesData } = data[EntrySection.NamesAndTaxonomy];
-    return (
-      <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
-        {geneNamesData &&
-          geneNamesData.map(
-            (geneData) =>
-              geneData.orfNames && (
-                <Fragment key={geneData.orfNames.join('')}>
-                  {geneAlternativeNamesView(geneData.orfNames)}
-                </Fragment>
-              )
-          )}
-      </ExpandableList>
+
+    const names = geneNamesData?.flatMap((geneNames) =>
+      geneNames.orfNames?.map((synonym) => synonym.value)
     );
+
+    return names?.length ? (
+      <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
+        {names}
+      </ExpandableList>
+    ) : null;
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.geneSynonym, {
-  label: 'Gene names (Synonyms)',
+  label: 'Gene Names (Synonyms)',
   render(data) {
     const { geneNamesData } = data[EntrySection.NamesAndTaxonomy];
-    return (
-      <ExpandableList descriptionString="names" displayNumberOfHiddenItems>
-        {geneNamesData &&
-          geneNamesData.map(
-            (geneData) =>
-              geneData.synonyms && (
-                <Fragment key={geneData.synonyms.join('')}>
-                  {geneAlternativeNamesView(geneData.synonyms)}
-                </Fragment>
-              )
-          )}
+
+    const names = geneNamesData?.flatMap((geneNames) => [
+      geneNames.synonyms?.map((synonym) => synonym.value),
+    ]);
+
+    return names?.length ? (
+      <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
+        {names}
       </ExpandableList>
-    );
+    ) : null;
   },
 });
 
@@ -530,32 +513,47 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ec, {
   label: 'EC Number',
   render: (data) => {
     const { proteinNamesData } = data[EntrySection.NamesAndTaxonomy];
-    const ecNumbers = proteinNamesData?.recommendedName?.ecNumbers;
-    return ecNumbers && <ECNumbersView ecNumbers={ecNumbers} />;
+    const ecNumbers = proteinNamesData?.recommendedName?.ecNumbers?.map(
+      (ecNumber) => ecNumber.value
+    );
+    return ecNumbers?.length ? (
+      <ExpandableList descriptionString="EC numbers" numberCollapsedItems={1}>
+        {ecNumbers}
+      </ExpandableList>
+    ) : null;
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.ccActivityRegulation, {
   label: 'Activity Regulation',
   render: (data) => {
-    const activityRegulationComments = data[
+    const activityRegulationComments = ((data[
       EntrySection.Function
-    ].commentsData.get(CommentType.ACTIVITY_REGULATION) as FreeTextComment[];
-    return (
-      activityRegulationComments && (
-        <FreeTextView comments={activityRegulationComments} />
-      )
+    ].commentsData.get(CommentType.ACTIVITY_REGULATION) ||
+      []) as FreeTextComment[]).flatMap(
+      (comment) => comment.texts?.map((text) => text.value) || []
     );
+    return activityRegulationComments?.length ? (
+      <ExpandableList numberCollapsedItems={1}>
+        {activityRegulationComments}
+      </ExpandableList>
+    ) : null;
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.ccFunction, {
   label: 'Function',
   render: (data) => {
-    const functionComments = data[EntrySection.Function].commentsData.get(
+    const functionComments = ((data[EntrySection.Function].commentsData.get(
       CommentType.FUNCTION
-    ) as FreeTextComment[];
-    return functionComments && <FreeTextView comments={functionComments} />;
+    ) || []) as FreeTextComment[]).flatMap(
+      (comment) => comment.texts?.map((text) => text.value) || []
+    );
+    return functionComments?.length ? (
+      <ExpandableList descriptionString="functions" numberCollapsedItems={1}>
+        {functionComments}
+      </ExpandableList>
+    ) : null;
   },
 });
 
@@ -585,10 +583,16 @@ UniProtKBColumnConfiguration.set(
 UniProtKBColumnConfiguration.set(UniProtKBColumn.ccPathway, {
   label: 'Pathway',
   render: (data) => {
-    const pathwayComments = data[EntrySection.Function].commentsData.get(
+    const pathwayComments = ((data[EntrySection.Function].commentsData.get(
       CommentType.PATHWAY
-    ) as FreeTextComment[];
-    return pathwayComments && <FreeTextView comments={pathwayComments} />;
+    ) || []) as FreeTextComment[]).flatMap(
+      (pathwayComment) => pathwayComment.texts?.map((text) => text.value) || []
+    );
+    return pathwayComments?.length ? (
+      <ExpandableList descriptionString="pathways" numberCollapsedItems={1}>
+        {pathwayComments}
+      </ExpandableList>
+    ) : null;
   },
 });
 
@@ -1168,6 +1172,7 @@ const getXrefColumn = (databaseName: string) => ({
 // cc_caution
 // feature: do we need? UX
 // similarity: this field is wrongly named in the API json (should be cc_similarity). Jira.
+// ft_non_cons
 
 // Add all database cross-reference columns
 Object.values(UniProtKBColumn)

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -141,14 +141,14 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
       )
     );
 
-    return uniqueNames.length ? (
+    return (
       <ExpandableList
         descriptionString="protein names"
         numberCollapsedItems={1}
       >
         {uniqueNames}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -169,11 +169,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.geneNames, {
       )
     );
 
-    return uniqueNames.length ? (
+    return (
       <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
         {uniqueNames}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -207,11 +207,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.genePrimary, {
 
     const names = geneNamesData?.map((geneNames) => geneNames.geneName?.value);
 
-    return names?.length ? (
+    return (
       <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
         {names}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -224,11 +224,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.geneOln, {
       geneNames.orderedLocusNames?.map((synonym) => synonym.value)
     );
 
-    return names?.length ? (
+    return (
       <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
         {names}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -241,11 +241,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.geneOrf, {
       geneNames.orfNames?.map((synonym) => synonym.value)
     );
 
-    return names?.length ? (
+    return (
       <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
         {names}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -258,11 +258,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.geneSynonym, {
       geneNames.synonyms?.map((synonym) => synonym.value),
     ]);
 
-    return names?.length ? (
+    return (
       <ExpandableList descriptionString="gene names" numberCollapsedItems={1}>
         {names}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -299,15 +299,13 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.virusHosts, {
   render: (data) => {
     const { virusHosts } = data[EntrySection.NamesAndTaxonomy];
     return (
-      virusHosts && (
-        <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
-          {virusHosts.map((host) => (
-            <p key={host.taxonId}>
-              <TaxonomyView key={host.taxonId} data={host} />
-            </p>
-          ))}
-        </ExpandableList>
-      )
+      <ExpandableList descriptionString="hosts" displayNumberOfHiddenItems>
+        {virusHosts?.map((host) => (
+          <p key={host.taxonId}>
+            <TaxonomyView key={host.taxonId} data={host} />
+          </p>
+        ))}
+      </ExpandableList>
     );
   },
 });
@@ -516,11 +514,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ec, {
     const ecNumbers = proteinNamesData?.recommendedName?.ecNumbers?.map(
       (ecNumber) => ecNumber.value
     );
-    return ecNumbers?.length ? (
+    return (
       <ExpandableList descriptionString="EC numbers" numberCollapsedItems={1}>
         {ecNumbers}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -533,11 +531,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccActivityRegulation, {
       []) as FreeTextComment[]).flatMap(
       (comment) => comment.texts?.map((text) => text.value) || []
     );
-    return activityRegulationComments?.length ? (
+    return (
       <ExpandableList numberCollapsedItems={1}>
         {activityRegulationComments}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -549,11 +547,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccFunction, {
     ) || []) as FreeTextComment[]).flatMap(
       (comment) => comment.texts?.map((text) => text.value) || []
     );
-    return functionComments?.length ? (
+    return (
       <ExpandableList descriptionString="functions" numberCollapsedItems={1}>
         {functionComments}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -588,11 +586,11 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccPathway, {
     ) || []) as FreeTextComment[]).flatMap(
       (pathwayComment) => pathwayComment.texts?.map((text) => text.value) || []
     );
-    return pathwayComments?.length ? (
+    return (
       <ExpandableList descriptionString="pathways" numberCollapsedItems={1}>
         {pathwayComments}
       </ExpandableList>
-    ) : null;
+    );
   },
 });
 
@@ -719,34 +717,32 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
       CommentType.INTERACTION
     ) as InteractionComment[];
     return (
-      interactionComments && (
-        <ExpandableList displayNumberOfHiddenItems>
-          {interactionComments.map((interactionCC) =>
-            interactionCC.interactions.map((interaction) => (
-              <div
-                key={
-                  interaction.type === InteractionType.SELF
-                    ? 'self'
-                    : `${interaction.interactantOne.uniProtkbAccession}-${interaction.interactantTwo.uniProtkbAccession}`
-                }
-              >
-                {interaction.type === InteractionType.SELF ? (
-                  'Itself'
-                ) : (
-                  <Link
-                    to={getEntryPath(
-                      Namespace.uniprotkb,
-                      interaction.interactantOne.uniProtkbAccession
-                    )}
-                  >
-                    {interaction.interactantOne.uniProtkbAccession}
-                  </Link>
-                )}
-              </div>
-            ))
-          )}
-        </ExpandableList>
-      )
+      <ExpandableList displayNumberOfHiddenItems>
+        {interactionComments?.map((interactionCC) =>
+          interactionCC.interactions.map((interaction) => (
+            <div
+              key={
+                interaction.type === InteractionType.SELF
+                  ? 'self'
+                  : `${interaction.interactantOne.uniProtkbAccession}-${interaction.interactantTwo.uniProtkbAccession}`
+              }
+            >
+              {interaction.type === InteractionType.SELF ? (
+                'Itself'
+              ) : (
+                <Link
+                  to={getEntryPath(
+                    Namespace.uniprotkb,
+                    interaction.interactantOne.uniProtkbAccession
+                  )}
+                >
+                  {interaction.interactantOne.uniProtkbAccession}
+                </Link>
+              )}
+            </div>
+          ))
+        )}
+      </ExpandableList>
     );
   },
 });
@@ -1037,22 +1033,21 @@ UniProtKBColumnConfiguration.set(
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.litPubmedId, {
   label: 'Citation ID',
-  render: (data) =>
-    data.references && (
-      <ExpandableList descriptionString="IDs" displayNumberOfHiddenItems>
-        {data.references.map(
-          (reference) =>
-            reference.citation && (
-              <Link
-                key={reference.citation.id}
-                to={getEntryPath(Namespace.citations, reference.citation.id)}
-              >
-                {reference.citation.id}
-              </Link>
-            )
-        )}
-      </ExpandableList>
-    ),
+  render: (data) => (
+    <ExpandableList descriptionString="IDs" displayNumberOfHiddenItems>
+      {data.references?.map(
+        (reference) =>
+          reference.citation && (
+            <Link
+              key={reference.citation.id}
+              to={getEntryPath(Namespace.citations, reference.citation.id)}
+            >
+              {reference.citation.id}
+            </Link>
+          )
+      )}
+    </ExpandableList>
+  ),
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.mappedPubmedId, {

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1019,11 +1019,7 @@ exports[`UniProtKBColumnConfiguration component should render column "go": go 1`
 <DocumentFragment>
   <section
     class="text-block"
-  >
-    <ul
-      class="expandable-list no-bullet"
-    />
-  </section>
+  />
 </DocumentFragment>
 `;
 
@@ -1035,11 +1031,7 @@ exports[`UniProtKBColumnConfiguration component should render column "go_id": go
 <DocumentFragment>
   <section
     class="text-block"
-  >
-    <ul
-      class="expandable-list no-bullet"
-    />
-  </section>
+  />
 </DocumentFragment>
 `;
 
@@ -1462,10 +1454,4 @@ exports[`UniProtKBColumnConfiguration component should render column "virus_host
 </DocumentFragment>
 `;
 
-exports[`UniProtKBColumnConfiguration component should render column "xref_proteomes": xref_proteomes 1`] = `
-<DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  />
-</DocumentFragment>
-`;
+exports[`UniProtKBColumnConfiguration component should render column "xref_proteomes": xref_proteomes 1`] = `<DocumentFragment />`;

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -791,29 +791,13 @@ exports[`UniProtKBColumnConfiguration component should render column "date_seque
 
 exports[`UniProtKBColumnConfiguration component should render column "ec": ec 1`] = `
 <DocumentFragment>
-  1.2.3.4 
-  <button
-    aria-controls="0"
-    aria-expanded="false"
-    class="svg-colour-reviewed evidence-tag"
-    data-testid="evidence-tag-trigger"
-    type="button"
+  <ul
+    class="expandable-list no-bullet"
   >
-    <test-file-stub
-      height="12"
-      width="12"
-    />
-    <span
-      class="evidence-tag__label"
-    >
-      1 automatic annotation
-    </span>
-  </button>
-  <div
-    class="evidence-tag-content "
-    data-testid="evidence-tag-content"
-    id="0"
-  />
+    <li>
+      1.2.3.4
+    </li>
+  </ul>
 </DocumentFragment>
 `;
 
@@ -989,29 +973,7 @@ exports[`UniProtKBColumnConfiguration component should render column "gene_oln":
     class="expandable-list no-bullet"
   >
     <li>
-      some locus 
-      <button
-        aria-controls="0"
-        aria-expanded="false"
-        class="svg-colour-unreviewed evidence-tag"
-        data-testid="evidence-tag-trigger"
-        type="button"
-      >
-        <test-file-stub
-          height="12"
-          width="12"
-        />
-        <span
-          class="evidence-tag__label"
-        >
-          1 automatic annotation
-        </span>
-      </button>
-      <div
-        class="evidence-tag-content "
-        data-testid="evidence-tag-content"
-        id="0"
-      />
+      some locus
     </li>
   </ul>
 </DocumentFragment>
@@ -1023,29 +985,7 @@ exports[`UniProtKBColumnConfiguration component should render column "gene_orf":
     class="expandable-list no-bullet"
   >
     <li>
-      some orf 
-      <button
-        aria-controls="0"
-        aria-expanded="false"
-        class="svg-colour-reviewed evidence-tag"
-        data-testid="evidence-tag-trigger"
-        type="button"
-      >
-        <test-file-stub
-          height="12"
-          width="12"
-        />
-        <span
-          class="evidence-tag__label"
-        >
-          1 publication
-        </span>
-      </button>
-      <div
-        class="evidence-tag-content "
-        data-testid="evidence-tag-content"
-        id="0"
-      />
+      some orf
     </li>
   </ul>
 </DocumentFragment>
@@ -1057,9 +997,7 @@ exports[`UniProtKBColumnConfiguration component should render column "gene_prima
     class="expandable-list no-bullet"
   >
     <li>
-      <div>
-        some Gene
-      </div>
+      some Gene
     </li>
   </ul>
 </DocumentFragment>
@@ -1071,29 +1009,7 @@ exports[`UniProtKBColumnConfiguration component should render column "gene_synon
     class="expandable-list no-bullet"
   >
     <li>
-      some Syn 
-      <button
-        aria-controls="0"
-        aria-expanded="false"
-        class="svg-colour-unreviewed evidence-tag"
-        data-testid="evidence-tag-trigger"
-        type="button"
-      >
-        <test-file-stub
-          height="12"
-          width="12"
-        />
-        <span
-          class="evidence-tag__label"
-        >
-          1 automatic annotation
-        </span>
-      </button>
-      <div
-        class="evidence-tag-content "
-        data-testid="evidence-tag-content"
-        id="0"
-      />
+      some Syn
     </li>
   </ul>
 </DocumentFragment>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -458,28 +458,6 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_disrupt
     class="text-block"
   >
     value
-    <button
-      aria-controls="0"
-      aria-expanded="false"
-      class="svg-colour-unreviewed evidence-tag"
-      data-testid="evidence-tag-trigger"
-      type="button"
-    >
-      <test-file-stub
-        height="12"
-        width="12"
-      />
-      <span
-        class="evidence-tag__label"
-      >
-        1 automatic annotation
-      </span>
-    </button>
-    <div
-      class="evidence-tag-content "
-      data-testid="evidence-tag-content"
-      id="0"
-    />
   </section>
 </DocumentFragment>
 `;
@@ -791,13 +769,7 @@ exports[`UniProtKBColumnConfiguration component should render column "date_seque
 
 exports[`UniProtKBColumnConfiguration component should render column "ec": ec 1`] = `
 <DocumentFragment>
-  <ul
-    class="expandable-list no-bullet"
-  >
-    <li>
-      1.2.3.4
-    </li>
-  </ul>
+  1.2.3.4
 </DocumentFragment>
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5913,10 +5913,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-franklin-sites@0.0.133:
-  version "0.0.133"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.133.tgz#fe2538faeeee64086df700e4b061535b860bfdc5"
-  integrity sha512-LLKYyN1GAPVoPhzy8nbweRY+Z3VsVTxBIGGnnsh8G7XB60/yL9C43D/qscHaeLE/0mRoxAUUnfvQJbvm3pvrpA==
+franklin-sites@0.0.134:
+  version "0.0.134"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.134.tgz#4a24950833074c3a47731a5cfd647321a32e2925"
+  integrity sha512-T/NPyeuOQwfNI0bahxu8lnhHxJ+CEs2G9CoDEUrNZP/9cVYcWlu9AIq2/6BuVS/jQO7ACVlreuHHifDH+eseGg==
   dependencies:
     classnames "2.3.1"
     d3 "5.16.0"


### PR DESCRIPTION
## Purpose
Remove the evidence tags on the UniProtKB results columns [TRM-25949](https://www.ebi.ac.uk/panda/jira/browse/TRM-25949)

## Approach
Remove the evidence tags on *some* of the UniProtKB results columns, use plain text expandable lists instead.
Will need a complete review of all the columns anyway because a lot are using the same components as on the Entry page when it doesn't really make sense within a table cell. And some columns just don't have an implementation yet.

## Testing
Updated snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Check the columns that have been modified (see diff view of the column config file)
