### PR TITLE
Use ResultsFacets in BLAST results

### DIFF
--- a/src/tools/blast/components/results/BlastResultSidebar.tsx
+++ b/src/tools/blast/components/results/BlastResultSidebar.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { Loader, Facets, Facet } from 'franklin-sites';
+import { Loader, Facets } from 'franklin-sites';
 
 import BlastResultLocalFacets from './BlastResultLocalFacets';
 
@@ -10,11 +10,9 @@ import { getAccessionsURL } from '../../../../shared/config/apiUrls';
 import { getParamsFromURL } from '../../../../uniprotkb/utils/resultsUtils';
 
 import { BlastHit } from '../../types/blastResults';
-import Response, {
-  FacetObject,
-} from '../../../../uniprotkb/types/responseTypes';
+import Response from '../../../../uniprotkb/types/responseTypes';
 
-import helper from '../../../../shared/styles/helper.module.scss';
+import ResultsFacets from '../../../../shared/components/results/ResultsFacets';
 
 const facets = [
   'reviewed',
@@ -35,10 +33,11 @@ const BlastResultSidebar = memo<BlastResultSidebarProps>(
   ({ accessions, allHits }) => {
     const { search } = useLocation();
     const { selectedFacets } = getParamsFromURL(search);
-    const { data, loading, isStale } = useDataApiWithStale<Response['data']>(
+    const dataApiObject = useDataApiWithStale<Response['data']>(
       getAccessionsURL(accessions, { size: 0, facets, selectedFacets })
     );
 
+    const { loading, isStale } = dataApiObject;
     if (loading && !isStale) {
       return <Loader />;
     }
@@ -46,13 +45,7 @@ const BlastResultSidebar = memo<BlastResultSidebarProps>(
     return (
       <Facets>
         <BlastResultLocalFacets allHits={allHits} />
-        {data?.facets?.map((facet: FacetObject) => (
-          <Facet
-            key={facet.name}
-            data={facet}
-            className={isStale ? helper.stale : undefined}
-          />
-        ))}
+        <ResultsFacets dataApiObject={dataApiObject} />
       </Facets>
     );
   }


### PR DESCRIPTION
## Purpose
@aurel-l noticed that BLAST facets were missing icons

## Approach
Reuse the same component to display facets

## Testing
N/A

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
