### PR TITLE
A8 bq10 no subcell viz

### DIFF
--- a/src/uniprotkb/adapters/subcellularLocationConverter.ts
+++ b/src/uniprotkb/adapters/subcellularLocationConverter.ts
@@ -1,10 +1,12 @@
-import KeywordCategory from '../types/keywordCategory';
-import FeatureType from '../types/featureType';
 import { convertSection, UIModel } from './sectionConverter';
+import { hasContent } from '../../shared/utils/utils';
+
 import { UniProtkbAPIModel } from './uniProtkbConverter';
-import { CommentType } from '../types/commentTypes';
 import { TaxonomyDatum } from '../../supporting-data/taxonomy/adapters/taxonomyConverter';
 import { Xref } from '../../shared/types/apiModel';
+import KeywordCategory from '../types/keywordCategory';
+import FeatureType from '../types/featureType';
+import { CommentType } from '../types/commentTypes';
 
 const commentCategories: CommentType[] = ['SUBCELLULAR LOCATION'];
 
@@ -31,7 +33,10 @@ const convertSubcellularLocation = (
     undefined,
     uniProtKBCrossReferences
   );
-  if (data.organism) {
+
+  // If there is no subcellular data, don't add organism data which will cause
+  // the section render to falsely believe the section should be rendered
+  if (hasContent(subcellularLocationData) && data.organism) {
     subcellularLocationData.organismData = data.organism;
   }
   return subcellularLocationData;

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -23,7 +23,7 @@ enum COLOR_BY {
 }
 
 type RibbonData = {
-  entities: unknown;
+  entities: unknown[];
   config: unknown;
   dataError: unknown;
   dataReceived: unknown;
@@ -60,9 +60,15 @@ const RibbonContainer: FC<RibbonData> = ({
 
 const GoRibbon: FC<{ primaryAccession: string }> = ({ primaryAccession }) => (
   <div className="GoRibbon">
-    <h3>GO Annotations</h3>
     <RibbonDataProvider subject={`UniProtKB:${primaryAccession}`}>
-      {(data: RibbonData) => <RibbonContainer {...data} />}
+      {(data: RibbonData) => (
+        <>
+          {(!!data.entities?.length || !data.dataReceived) && (
+            <h3>GO Annotations</h3>
+          )}
+          <RibbonContainer {...data} />
+        </>
+      )}
     </RibbonDataProvider>
   </div>
 );

--- a/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
+++ b/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
@@ -44,8 +44,12 @@ const NamesAndTaxonomySection = ({ data, primaryAccession }: Props) => {
       <TaxonomyListView data={data.organismData} hosts={data.organismHosts} />
       <h3>Accessions</h3>
       <AccessionsView data={data} />
-      <h3>Proteome</h3>
-      <ProteomesListView data={data.proteomesData} />
+      {!!data.proteomesData?.length && (
+        <>
+          <h3>Proteome</h3>
+          <ProteomesListView data={data.proteomesData} />
+        </>
+      )}
       <XRefView xrefs={data.xrefData} primaryAccession={primaryAccession} />
     </Card>
   );

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -661,11 +661,7 @@ exports[`Entry basic should render main 1`] = `
                 </section>
                 <div
                   class="GoRibbon"
-                >
-                  <h3>
-                    GO Annotations
-                  </h3>
-                </div>
+                />
                 <h3>
                   Enzyme and pathway databases
                 </h3>
@@ -1616,9 +1612,6 @@ exports[`Entry basic should render main 1`] = `
                     </div>
                   </li>
                 </ul>
-                <h3>
-                  Proteome
-                </h3>
               </div>
             </div>
           </section>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -1322,9 +1322,6 @@ exports[`Entry view should render 1`] = `
             </div>
           </li>
         </ul>
-        <h3>
-          Proteome
-        </h3>
       </div>
     </div>
   </section>
@@ -2725,11 +2722,7 @@ exports[`Entry view should render for non-human entry 1`] = `
         </protvista-manager>
         <div
           class="GoRibbon"
-        >
-          <h3>
-            GO Annotations
-          </h3>
-        </div>
+        />
         <h3>
           Keywords
         </h3>
@@ -3168,9 +3161,6 @@ exports[`Entry view should render for non-human entry 1`] = `
             </div>
           </li>
         </ul>
-        <h3>
-          Proteome
-        </h3>
       </div>
     </div>
   </section>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3177,26 +3177,6 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="subcellular-location"
-  >
-    <div
-      class="card__container"
-    >
-      <div
-        class="card__header card__header--with-separator"
-      >
-        <h2>
-          Subcellular Location
-        </h2>
-      </div>
-      <div
-        class="card__content"
-      />
-    </div>
-  </section>
-  <section
-    class="card"
-    data-entry-section="true"
     id="phenotypes"
   >
     <div


### PR DESCRIPTION
## Purpose
1. Subcell viz section rendering without any subcell data.
2. GO annotations header rendered when GO ribbon has no slim entities
3. Proteomes header rendered without proteomes data

## Approach
1. Within subcellularLocationConverter.ts check if there is no subcellular data and if not don't add organism data which will cause the section render to falsely believe the section should be rendered.
2. Check if GO data exists. **Note** that the header and loading message appears until data has loaded and if empty these disappear - this is the approach I took but happy if there are nicer suggestions.
3. Check if proteomes data exists

## Testing
All snapshot updated (the sections are removed)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
