### PR TITLE
2021 08 use useBasket

### DIFF
--- a/src/proteomes/config/__tests__/__snapshots__/ProteomesColumnConfiguration.spec.tsx.snap
+++ b/src/proteomes/config/__tests__/__snapshots__/ProteomesColumnConfiguration.spec.tsx.snap
@@ -302,7 +302,7 @@ exports[`ProteomesColumnConfiguration component should render column "protein_co
 exports[`ProteomesColumnConfiguration component should render column "upid": upid 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <span
       class="entry-title__status icon--reference-proteome"

--- a/src/shared/components/BasketStatus.tsx
+++ b/src/shared/components/BasketStatus.tsx
@@ -1,0 +1,44 @@
+import { Button, BasketIcon } from 'franklin-sites';
+
+import useBasket from '../hooks/useBasket';
+
+import accessionToNamespace from '../utils/accessionToNamespace';
+
+import styles from './styles/basket-status.module.scss';
+
+type Props = { id?: string };
+
+const BasketStatus = ({ id }: Props) => {
+  const [basket, setBasket] = useBasket();
+
+  if (!id) {
+    return null;
+  }
+
+  const namespace = accessionToNamespace(id);
+
+  const inBasket = Boolean(basket.get(namespace)?.has(id));
+
+  if (!inBasket) {
+    return null;
+  }
+
+  return (
+    <Button
+      className={styles['basket-status']}
+      onClick={() => {
+        setBasket((currentBasket) => {
+          const newSet = new Set(currentBasket.get(namespace));
+          newSet.delete(id);
+          return new Map([...currentBasket, [namespace, newSet]]);
+        });
+      }}
+      variant="tertiary"
+      title={`Remove ${id} from basket`}
+    >
+      <BasketIcon width="1ch" height="1ch" />
+    </Button>
+  );
+};
+
+export default BasketStatus;

--- a/src/shared/components/BasketStatus.tsx
+++ b/src/shared/components/BasketStatus.tsx
@@ -9,7 +9,7 @@ import styles from './styles/basket-status.module.scss';
 type Props = { id?: string };
 
 const BasketStatus = ({ id }: Props) => {
-  const [basket, setBasket] = useBasket();
+  const [basket /* , setBasket */] = useBasket();
 
   if (!id) {
     return null;
@@ -23,16 +23,19 @@ const BasketStatus = ({ id }: Props) => {
     return null;
   }
 
+  // TODO: for Xavier to replace with "open basket" logic
+  // const removeEntry = () => {
+  //   setBasket((currentBasket) => {
+  //     const newSet = new Set(currentBasket.get(namespace));
+  //     newSet.delete(id);
+  //     return new Map([...currentBasket, [namespace, newSet]]);
+  //   });
+  // }
+
   return (
     <Button
       className={styles['basket-status']}
-      onClick={() => {
-        setBasket((currentBasket) => {
-          const newSet = new Set(currentBasket.get(namespace));
-          newSet.delete(id);
-          return new Map([...currentBasket, [namespace, newSet]]);
-        });
-      }}
+      // onClick={removeEntry}
       variant="tertiary"
       title={`Remove ${id} from basket`}
     >

--- a/src/shared/components/action-buttons/AddToBasket.tsx
+++ b/src/shared/components/action-buttons/AddToBasket.tsx
@@ -1,6 +1,9 @@
 import { FC } from 'react';
-// import { useDispatch } from 'react-redux';
 import { BasketIcon, Button } from 'franklin-sites';
+import { ValueOf } from 'type-fest';
+
+import useNS from '../../hooks/useNS';
+import useBasket, { Basket, basketableNS } from '../../hooks/useBasket';
 
 import { pluralise } from '../../utils/utils';
 
@@ -9,7 +12,8 @@ type AddToBasketButtonProps = {
 };
 
 const AddToBasketButton: FC<AddToBasketButtonProps> = ({ selectedEntries }) => {
-  // const dispatch = useDispatch();
+  const ns = useNS();
+  const [, setBasket] = useBasket();
 
   const n = selectedEntries.length;
 
@@ -20,8 +24,21 @@ const AddToBasketButton: FC<AddToBasketButtonProps> = ({ selectedEntries }) => {
     : 'Select at least one entry to add to the basket';
 
   const handleClick = () => {
-    console.log('handle add to basket');
-    // dispatch(/* action to add entries to basket */);
+    if (!(ns && basketableNS.has(ns))) {
+      return;
+    }
+    setBasket((currentBasket) => {
+      const key = ns as keyof Basket;
+      const newSubBasket: ValueOf<Basket> = new Set([
+        ...currentBasket[key],
+        ...selectedEntries,
+      ]);
+      const newBasket = {
+        ...currentBasket,
+        [key]: newSubBasket,
+      };
+      return newBasket;
+    });
   };
 
   return (

--- a/src/shared/components/entry/styles/entry-title.scss
+++ b/src/shared/components/entry/styles/entry-title.scss
@@ -1,5 +1,6 @@
 .entry-title {
   position: relative;
+  margin-right: 1ch;
 
   &__status {
     display: inline-flex;

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import {
   Header,
@@ -11,6 +11,7 @@ import {
 import SearchContainer from '../search/SearchContainer';
 
 import useNS from '../../hooks/useNS';
+import useBasket from '../../hooks/useBasket';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
@@ -46,6 +47,27 @@ const headerItems = [
   },
 ];
 
+// Move in the codebase wherever needed
+const Basket = () => {
+  const [basket] = useBasket();
+
+  const count = useMemo(
+    () =>
+      Object.values(basket)
+        .map((ns) => ns.size)
+        .reduce((total, current) => total + current, 0),
+    [basket]
+  );
+
+  console.log('basket count:', count);
+
+  return (
+    <span title="Basket">
+      <BasketIcon width={secondaryItemIconSize} />
+    </span>
+  );
+};
+
 const secondaryItems = [
   // TODO: update link
   {
@@ -73,11 +95,7 @@ const secondaryItems = [
     path: LocationToPath[Location.Dashboard],
   },
   {
-    label: (
-      <span title="Basket">
-        <BasketIcon width={secondaryItemIconSize} />
-      </span>
-    ),
+    label: <Basket />,
     path: '/',
   },
 ];

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -6,6 +6,7 @@ import {
   EnvelopeIcon,
   BasketIcon,
   ToolboxIcon,
+  Bubble,
 } from 'franklin-sites';
 
 import SearchContainer from '../search/SearchContainer';
@@ -53,17 +54,18 @@ const Basket = () => {
 
   const count = useMemo(
     () =>
-      Object.values(basket)
+      Array.from(basket.values())
         .map((ns) => ns.size)
         .reduce((total, current) => total + current, 0),
     [basket]
   );
 
-  console.log('basket count:', count);
-
   return (
     <span title="Basket">
       <BasketIcon width={secondaryItemIconSize} />
+      {count ? (
+        <Bubble colourClass="colour-yankees-blue" size="small" value={count} />
+      ) : null}
     </span>
   );
 };

--- a/src/shared/components/results/AccessionView.tsx
+++ b/src/shared/components/results/AccessionView.tsx
@@ -1,27 +1,26 @@
-import { FC } from 'react';
 import { Link } from 'react-router-dom';
 
+import BasketStatus from '../BasketStatus';
 import EntryTypeIcon, { EntryType } from '../entry/EntryTypeIcon';
 
 import { getEntryPath } from '../../../app/config/urls';
 
 import { SearchableNamespace } from '../../types/namespaces';
 
-import './styles/accession-view.scss';
+import helper from '../../styles/helper.module.scss';
 
-const AccessionView: FC<{
-  id: string | number;
+type Props = {
+  id: string;
   namespace: SearchableNamespace;
   entryType?: string | EntryType;
-}> = ({ id, namespace, entryType }) => {
-  const link = <Link to={getEntryPath(namespace, id)}>{id}</Link>;
-
-  return (
-    <div className="accession-view">
-      <EntryTypeIcon entryType={entryType} />
-      {link}
-    </div>
-  );
 };
+
+const AccessionView = ({ id, namespace, entryType }: Props) => (
+  <div className={helper['no-wrap']}>
+    <BasketStatus id={id} />
+    {entryType && <EntryTypeIcon entryType={entryType} />}
+    <Link to={getEntryPath(namespace, id)}>{id}</Link>
+  </div>
+);
 
 export default AccessionView;

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react';
 import { Loader } from 'franklin-sites';
 
 import useDataApiWithStale from '../../hooks/useDataApiWithStale';
@@ -14,7 +13,7 @@ import ResultsDataHeader from './ResultsDataHeader';
 
 import Response from '../../../uniprotkb/types/responseTypes';
 
-const Results: FC = () => {
+const Results = () => {
   const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   // Query for facets

--- a/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
@@ -3951,7 +3951,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P35575"
@@ -3971,7 +3971,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/O43826"
@@ -3991,7 +3991,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P11166"
@@ -4011,7 +4011,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P11169"
@@ -4031,7 +4031,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P13866"
@@ -4051,7 +4051,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9BUM1"
@@ -4071,7 +4071,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P14672"
@@ -4091,7 +4091,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9NY64"
@@ -4111,7 +4111,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9NRM0"
@@ -4131,7 +4131,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9NQR9"
@@ -4151,7 +4151,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P11168"
@@ -4171,7 +4171,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9NYU1"
@@ -4191,7 +4191,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/O95528"
@@ -4211,7 +4211,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P22732"
@@ -4231,7 +4231,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q16851"
@@ -4251,7 +4251,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q8WWX8"
@@ -4271,7 +4271,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9BYW1"
@@ -4291,7 +4291,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q9NYU2"
@@ -4311,7 +4311,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P31639"
@@ -4331,7 +4331,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P11413"
@@ -4351,7 +4351,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P69786"
@@ -4371,7 +4371,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/P15280"
@@ -4391,7 +4391,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/Q6PXP3"
@@ -4411,7 +4411,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/O94964"
@@ -4431,7 +4431,7 @@ exports[`ResultsData component should render the table view 1`] = `
           </td>
           <td>
             <div
-              class="accession-view"
+              class="no-wrap"
             >
               <a
                 href="/uniprotkb/O95479"

--- a/src/shared/components/results/styles/accession-view.scss
+++ b/src/shared/components/results/styles/accession-view.scss
@@ -1,3 +1,0 @@
-.accession-view {
-  white-space: nowrap;
-}

--- a/src/shared/components/styles/basket-status.module.scss
+++ b/src/shared/components/styles/basket-status.module.scss
@@ -1,0 +1,17 @@
+.basket-status {
+  margin: 0 0 0 auto;
+  animation: appear 1 0.5s both ease-out;
+}
+
+:global(.data-table) .basket-status {
+  margin-bottom: 0.25em;
+}
+
+@keyframes appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/shared/hooks/__tests__/useBasket.spec.ts
+++ b/src/shared/hooks/__tests__/useBasket.spec.ts
@@ -4,19 +4,24 @@ import { Namespace } from '../../types/namespaces';
 
 import useBasket from '../useBasket';
 
+import { localStorageCache } from '../useLocalStorage';
+
 describe('useBasket hook', () => {
   afterEach(() => {
     window.localStorage.clear();
+    localStorageCache.clear();
   });
 
   test('get value, basic, first time', async () => {
     const { result } = renderHook(() => useBasket());
 
-    expect(result.current[0]).toEqual({
-      [Namespace.uniprotkb]: new Set(),
-      [Namespace.uniref]: new Set(),
-      [Namespace.uniparc]: new Set(),
-    });
+    expect(result.current[0]).toEqual(
+      new Map([
+        [Namespace.uniprotkb, new Set()],
+        [Namespace.uniref, new Set()],
+        [Namespace.uniparc, new Set()],
+      ])
+    );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(JSON.parse(window.localStorage.getItem('basket')!)).toEqual({
       [Namespace.uniprotkb]: [],
@@ -36,11 +41,13 @@ describe('useBasket hook', () => {
     );
     const { result } = renderHook(() => useBasket());
 
-    expect(result.current[0]).toEqual({
-      [Namespace.uniprotkb]: new Set(['P05067']),
-      [Namespace.uniref]: new Set(),
-      [Namespace.uniparc]: new Set(['UPI0000000001', 'UPI0000000002']),
-    });
+    expect(result.current[0]).toEqual(
+      new Map([
+        [Namespace.uniprotkb, new Set(['P05067'])],
+        [Namespace.uniref, new Set()],
+        [Namespace.uniparc, new Set(['UPI0000000001', 'UPI0000000002'])],
+      ])
+    );
   });
 
   test('set value, basic, already saved', async () => {
@@ -55,18 +62,22 @@ describe('useBasket hook', () => {
     const { result } = renderHook(() => useBasket());
 
     act(() =>
-      result.current[1]({
-        [Namespace.uniprotkb]: new Set(),
-        [Namespace.uniref]: new Set(),
-        [Namespace.uniparc]: new Set(['UPI0000000001', 'UPI0000000002']),
-      })
+      result.current[1](
+        new Map([
+          [Namespace.uniprotkb, new Set()],
+          [Namespace.uniref, new Set()],
+          [Namespace.uniparc, new Set(['UPI0000000001', 'UPI0000000002'])],
+        ])
+      )
     );
 
-    expect(result.current[0]).toEqual({
-      [Namespace.uniprotkb]: new Set(),
-      [Namespace.uniref]: new Set(),
-      [Namespace.uniparc]: new Set(['UPI0000000001', 'UPI0000000002']),
-    });
+    expect(result.current[0]).toEqual(
+      new Map([
+        [Namespace.uniprotkb, new Set()],
+        [Namespace.uniref, new Set()],
+        [Namespace.uniparc, new Set(['UPI0000000001', 'UPI0000000002'])],
+      ])
+    );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(JSON.parse(window.localStorage.getItem('basket')!)).toEqual({
       [Namespace.uniprotkb]: [],
@@ -87,17 +98,19 @@ describe('useBasket hook', () => {
     const { result } = renderHook(() => useBasket());
 
     act(() =>
-      result.current[1]((currentValue) => ({
-        ...currentValue,
-        [Namespace.uniprotkb]: new Set(),
-      }))
+      result.current[1](
+        (currentValue) =>
+          new Map([...currentValue, [Namespace.uniprotkb, new Set()]])
+      )
     );
 
-    expect(result.current[0]).toEqual({
-      [Namespace.uniprotkb]: new Set([]),
-      [Namespace.uniref]: new Set([]),
-      [Namespace.uniparc]: new Set(['UPI0000000001', 'UPI0000000002']),
-    });
+    expect(result.current[0]).toEqual(
+      new Map([
+        [Namespace.uniprotkb, new Set([])],
+        [Namespace.uniref, new Set([])],
+        [Namespace.uniparc, new Set(['UPI0000000001', 'UPI0000000002'])],
+      ])
+    );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(JSON.parse(window.localStorage.getItem('basket')!)).toEqual({
       [Namespace.uniprotkb]: [],

--- a/src/shared/hooks/__tests__/useLocalStorage.spec.ts
+++ b/src/shared/hooks/__tests__/useLocalStorage.spec.ts
@@ -1,11 +1,12 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { JsonValue } from 'type-fest';
 
-import useLocalStorage from '../useLocalStorage';
+import useLocalStorage, { localStorageCache } from '../useLocalStorage';
 
 describe('useLocalStorage hook', () => {
   afterEach(() => {
     window.localStorage.clear();
+    localStorageCache.clear();
   });
 
   test('get value, basic, first time', async () => {

--- a/src/shared/hooks/useBasket.ts
+++ b/src/shared/hooks/useBasket.ts
@@ -32,6 +32,12 @@ const serialise = (basket: Basket): StringifiableBasket => {
   return object;
 };
 
+export const basketableNS = new Set([
+  Namespace.uniprotkb,
+  Namespace.uniref,
+  Namespace.uniparc,
+]);
+
 const useBasket = (): [
   state: Basket,
   setState: Dispatch<SetStateAction<Basket>>

--- a/src/shared/hooks/useBasket.ts
+++ b/src/shared/hooks/useBasket.ts
@@ -4,49 +4,47 @@ import useLocalStorage from './useLocalStorage';
 
 import { Namespace } from '../types/namespaces';
 
-export type Basket = {
-  [Namespace.uniprotkb]: Set<string>;
-  [Namespace.uniref]: Set<`UniRef${50 | 90 | 100}_${string}`>;
-  [Namespace.uniparc]: Set<`UPI${string}`>;
-};
+export type Basket = Map<Namespace, Set<string>>;
 
-type StringifiableBasket = {
-  [Namespace.uniprotkb]: Array<string>;
-  [Namespace.uniref]: Array<`UniRef${50 | 90 | 100}_${string}`>;
-  [Namespace.uniparc]: Array<`UPI${string}`>;
-};
+type StringifiableBasket = { [key in Namespace]?: Array<string> };
 
 const deserialise = (stringifiableBasket: StringifiableBasket): Basket => {
   const entries = Object.entries(stringifiableBasket);
-  const object = Object.fromEntries(
-    entries.map(([key, value]) => [key, new Set(value.filter(Boolean))])
-  ) as Basket;
+  const object: Basket = new Map(
+    entries.map(([key, value]) => [
+      key as Namespace,
+      new Set(value?.filter(Boolean)),
+    ])
+  );
   return object;
 };
 
-const serialise = (basket: Basket): StringifiableBasket => {
-  const entries = Object.entries(basket);
-  const object = Object.fromEntries(
-    entries.map(([key, value]) => [key, Array.from(value).filter(Boolean)])
-  ) as StringifiableBasket;
-  return object;
-};
-
-export const basketableNS = new Set([
+const basketableNS = new Set([
   Namespace.uniprotkb,
   Namespace.uniref,
   Namespace.uniparc,
 ]);
 
+const serialise = (basket: Basket): StringifiableBasket => {
+  const entries = Array.from(basket.entries());
+  const object: StringifiableBasket = Object.fromEntries(
+    entries
+      // Safeguard, make sure to only store namespaces that belong in the basket
+      .filter(([key]) => basketableNS.has(key))
+      // Transform Array into Set, removes possibly empty values (safeguard)
+      .map(([key, value]) => [key, Array.from(value).filter(Boolean)])
+  );
+  return object;
+};
+
 const useBasket = (): [
   state: Basket,
   setState: Dispatch<SetStateAction<Basket>>
 ] => {
-  const [state, setState] = useLocalStorage<StringifiableBasket>('basket', {
-    [Namespace.uniprotkb]: [],
-    [Namespace.uniref]: [],
-    [Namespace.uniparc]: [],
-  });
+  const [state, setState] = useLocalStorage<StringifiableBasket>(
+    'basket',
+    Object.fromEntries(Array.from(basketableNS).map((key) => [key, []]))
+  );
 
   const basket = useMemo(() => deserialise(state), [state]);
 

--- a/src/shared/utils/accessionToNamespace.ts
+++ b/src/shared/utils/accessionToNamespace.ts
@@ -1,0 +1,13 @@
+import { Namespace } from '../types/namespaces';
+
+const accessionToNamespace = (accession: string): Namespace => {
+  if (accession.startsWith('UniRef')) {
+    return Namespace.uniref;
+  }
+  if (accession.startsWith('UPI')) {
+    return Namespace.uniparc;
+  }
+  return Namespace.uniprotkb;
+};
+
+export default accessionToNamespace;

--- a/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`DatabaseColumnConfiguration component should render column "doi_id": do
 exports[`DatabaseColumnConfiguration component should render column "id": id 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <a
       href="/database/DB-0022"

--- a/src/supporting-data/locations/config/__tests__/__snapshots__/LocationsColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/locations/config/__tests__/__snapshots__/LocationsColumnConfiguration.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`LocationsColumnConfiguration component should render column "gene_ontol
 exports[`LocationsColumnConfiguration component should render column "id": id 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <a
       href="/locations/SL-0099"

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -13,6 +13,9 @@ import EntryTitle from '../../../shared/components/entry/EntryTitle';
 import EntryMain from './EntryMain';
 import UniParcFeaturesView from './UniParcFeaturesView';
 import XRefsFacets from './XRefsFacets';
+import BasketStatus from '../../../shared/components/BasketStatus';
+import BlastButton from '../../../shared/components/action-buttons/Blast';
+import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
 
 import SideBarLayout from '../../../shared/components/layouts/SideBarLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
@@ -135,6 +138,7 @@ const Entry: FC = () => {
               mainTitle="UniParc"
               optionalTitle={transformedData.uniParcId}
             />
+            <BasketStatus id={transformedData.uniParcId} />
           </h1>
         </ErrorBoundary>
       }
@@ -154,6 +158,10 @@ const Entry: FC = () => {
           }
           id={TabLocation.Entry}
         >
+          <div className="button-group">
+            <BlastButton selectedEntries={[match.params.accession]} />
+            <AddToBasketButton selectedEntries={[match.params.accession]} />
+          </div>
           <EntryMain
             transformedData={transformedData}
             xrefs={xrefsDataObject}

--- a/src/uniparc/components/results/UniParcCard.tsx
+++ b/src/uniparc/components/results/UniParcCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Card, LongNumber } from 'franklin-sites';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
+import BasketStatus from '../../../shared/components/BasketStatus';
 
 import {
   UniParcAPIModel,
@@ -69,6 +70,7 @@ const UniParcCard = ({ data, selected, handleEntrySelection }: Props) => {
           <h2 className="tiny">
             <EntryTitle mainTitle={id} entryType={EntryType.UNIPARC} />
           </h2>
+          <BasketStatus id={id} />
         </>
       }
       headerSeparator={false}

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -8,6 +8,7 @@ import {
   EntryTypeIcon,
 } from '../../shared/components/entry/EntryTypeIcon';
 import TaxonomyView from '../../shared/components/entry/TaxonomyView';
+import BasketStatus from '../../shared/components/BasketStatus';
 
 import { getEntryPath } from '../../app/config/urls';
 
@@ -107,15 +108,18 @@ const getAccessionColumn =
     ) {
       // internal link
       cell = (
-        <Link
-          /**
-           * TODO: when we have entry history pages, we need to handle it
-           * differently (current website points to `/<accession>?version=*`)
-           */
-          to={getEntryPath(Namespace.uniprotkb, xref.id)}
-        >
-          {xref.id}
-        </Link>
+        <>
+          {xref.active && <BasketStatus id={xref.id} />}
+          <Link
+            /**
+             * TODO: when we have entry history pages, we need to handle it
+             * differently (current website points to `/<accession>?version=*`)
+             */
+            to={getEntryPath(Namespace.uniprotkb, xref.id)}
+          >
+            {xref.id}
+          </Link>
+        </>
       );
     } else {
       const template = xref.database && templateMap.get(xref.database);

--- a/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
+++ b/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
@@ -445,7 +445,7 @@ exports[`UniParcColumnConfiguration component should render column "sequence": s
 exports[`UniParcColumnConfiguration component should render column "upi": upi 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <a
       href="/uniparc/UPI0000000001"

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -40,6 +40,7 @@ import SideBarLayout from '../../../shared/components/layouts/SideBarLayout';
 import ObsoleteEntryPage from '../../../shared/components/error-pages/ObsoleteEntryPage';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
 import ErrorBoundary from '../../../shared/components/error-component/ErrorBoundary';
+import BasketStatus from '../../../shared/components/BasketStatus';
 
 import UniProtKBEntryConfig from '../../config/UniProtEntryConfig';
 
@@ -219,6 +220,7 @@ const Entry: FC = () => {
               optionalTitle={data.uniProtkbId}
               entryType={data.entryType}
             />
+            <BasketStatus id={data.primaryAccession} />
           </h1>
           <ProteinOverview data={data} />
         </ErrorBoundary>

--- a/src/uniprotkb/components/entry/__tests__/ComputationallyMappedSequences.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/ComputationallyMappedSequences.spec.tsx
@@ -1,5 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { screen } from '@testing-library/react';
 
 import ComputationalyMappedSequences from '../ComputationallyMappedSequences';
 
@@ -57,15 +56,13 @@ describe('Computationally mapped isoforms', () => {
 
   test('Should go to results with all accessions', async () => {
     (useDataApi as jest.Mock).mockReturnValue({ loading: false, data });
-    const history = createMemoryHistory();
 
-    customRender(<ComputationalyMappedSequences primaryAccession="P05067" />, {
-      history,
-    });
-    const button = await screen.findByRole('button', { name: /View all/i });
-    fireEvent.click(button);
-    expect(history.location.search).toEqual(
-      '?query=(accession:A0A0A0MRG2 OR accession:E9PG40 OR accession:H7C0V9 OR accession:H7C2L2)'
+    customRender(<ComputationalyMappedSequences primaryAccession="P05067" />);
+    const link = (await screen.findByRole('link', {
+      name: /View all/i,
+    })) as HTMLAnchorElement;
+    expect(link.href).toContain(
+      '?query=(accession:A0A0A0MRG2%20OR%20accession:E9PG40%20OR%20accession:H7C0V9%20OR%20accession:H7C2L2)'
     );
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/ComputationallyMappedSequences.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/ComputationallyMappedSequences.spec.tsx.snap
@@ -39,12 +39,11 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
         <test-file-stub />
         Add
       </button>
-      <button
-        class="button tertiary"
-        type="button"
+      <a
+        href="/uniprotkb?query=(accession:A0A0A0MRG2 OR accession:E9PG40 OR accession:H7C0V9 OR accession:H7C2L2)"
       >
         View all
-      </button>
+      </a>
     </div>
     <table
       class="data-table data-table--compact"
@@ -61,6 +60,9 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
           >
             Entry
           </th>
+          <th
+            class=""
+          />
           <th
             class=""
           >
@@ -88,17 +90,23 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
             />
           </td>
           <td>
-            <a
-              href="/uniprotkb/A0A0A0MRG2"
+            <div
+              class="no-wrap"
             >
-              <span
-                class="entry-title__status icon--unreviewed"
-                title="This marks an unreviewed UniProtKB entry"
+              <a
+                href="/uniprotkb/A0A0A0MRG2"
               >
-                <test-file-stub />
-              </span>
-              A0A0A0MRG2
-            </a>
+                A0A0A0MRG2
+              </a>
+            </div>
+          </td>
+          <td>
+            <span
+              class="entry-title__status icon--unreviewed"
+              title="This marks an unreviewed UniProtKB entry"
+            >
+              <test-file-stub />
+            </span>
           </td>
           <td>
             A0A0A0MRG2_HUMAN
@@ -119,17 +127,23 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
             />
           </td>
           <td>
-            <a
-              href="/uniprotkb/E9PG40"
+            <div
+              class="no-wrap"
             >
-              <span
-                class="entry-title__status icon--unreviewed"
-                title="This marks an unreviewed UniProtKB entry"
+              <a
+                href="/uniprotkb/E9PG40"
               >
-                <test-file-stub />
-              </span>
-              E9PG40
-            </a>
+                E9PG40
+              </a>
+            </div>
+          </td>
+          <td>
+            <span
+              class="entry-title__status icon--unreviewed"
+              title="This marks an unreviewed UniProtKB entry"
+            >
+              <test-file-stub />
+            </span>
           </td>
           <td>
             E9PG40_HUMAN
@@ -150,17 +164,23 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
             />
           </td>
           <td>
-            <a
-              href="/uniprotkb/H7C0V9"
+            <div
+              class="no-wrap"
             >
-              <span
-                class="entry-title__status icon--unreviewed"
-                title="This marks an unreviewed UniProtKB entry"
+              <a
+                href="/uniprotkb/H7C0V9"
               >
-                <test-file-stub />
-              </span>
-              H7C0V9
-            </a>
+                H7C0V9
+              </a>
+            </div>
+          </td>
+          <td>
+            <span
+              class="entry-title__status icon--unreviewed"
+              title="This marks an unreviewed UniProtKB entry"
+            >
+              <test-file-stub />
+            </span>
           </td>
           <td>
             H7C0V9_HUMAN
@@ -181,17 +201,23 @@ exports[`Computationally mapped isoforms Should render correctly 1`] = `
             />
           </td>
           <td>
-            <a
-              href="/uniprotkb/H7C2L2"
+            <div
+              class="no-wrap"
             >
-              <span
-                class="entry-title__status icon--unreviewed"
-                title="This marks an unreviewed UniProtKB entry"
+              <a
+                href="/uniprotkb/H7C2L2"
               >
-                <test-file-stub />
-              </span>
-              H7C2L2
-            </a>
+                H7C2L2
+              </a>
+            </div>
+          </td>
+          <td>
+            <span
+              class="entry-title__status icon--unreviewed"
+              title="This marks an unreviewed UniProtKB entry"
+            >
+              <test-file-stub />
+            </span>
           </td>
           <td>
             H7C2L2_HUMAN

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
@@ -1,14 +1,13 @@
 import { FC } from 'react';
 import { DataTable, Loader, Message } from 'franklin-sites';
-import { Link } from 'react-router-dom';
 
 import EntryTypeIcon from '../../../../shared/components/entry/EntryTypeIcon';
 import TaxonomyView from '../../../../shared/components/entry/TaxonomyView';
+import AccessionView from '../../../../shared/components/results/AccessionView';
 
 import useDataApi from '../../../../shared/hooks/useDataApi';
 
 import { getAccessionsURL } from '../../../../shared/config/apiUrls';
-import { getEntryPath } from '../../../../app/config/urls';
 
 import { Namespace } from '../../../../shared/types/namespaces';
 
@@ -29,12 +28,17 @@ const columnConfig = [
     label: 'Accession',
     name: 'accession',
     render: (row: UniProtkbAPIModel) => (
-      <>
-        <EntryTypeIcon entryType={row.entryType} />
-        <Link to={getEntryPath(Namespace.uniprotkb, row.primaryAccession)}>
-          {row.primaryAccession}
-        </Link>
-      </>
+      <AccessionView
+        id={row.primaryAccession}
+        namespace={Namespace.uniprotkb}
+      />
+    ),
+  },
+  {
+    label: '',
+    name: 'reviewed',
+    render: (row: UniProtkbAPIModel) => (
+      <EntryTypeIcon entryType={row.entryType} />
     ),
   },
   {

--- a/src/uniprotkb/components/results/UniProtKBCard.tsx
+++ b/src/uniprotkb/components/results/UniProtKBCard.tsx
@@ -4,6 +4,7 @@ import { Card } from 'franklin-sites';
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
 import { KeywordList } from '../protein-data-views/KeywordView';
 import ProteinOverview from '../protein-data-views/ProteinOverviewView';
+import BasketStatus from '../../../shared/components/BasketStatus';
 
 import getProteinHighlights from '../../adapters/proteinHighlights';
 import { getKeywordsForCategories } from '../../utils/KeywordsUtil';
@@ -65,6 +66,7 @@ const UniProtKBCard = ({ data, selected, handleEntrySelection }: Props) => {
               entryType={data.entryType}
             />
           </h2>
+          <BasketStatus id={id} />
         </>
       }
       headerSeparator={false}

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -66,7 +66,7 @@ exports[`UniProtKBColumnConfiguration component should render column "absorption
 exports[`UniProtKBColumnConfiguration component should render column "accession": accession 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <a
       href="/uniprotkb/P21802"

--- a/src/uniref/components/entry/Entry.tsx
+++ b/src/uniref/components/entry/Entry.tsx
@@ -3,18 +3,13 @@ import { useDispatch } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { Loader } from 'franklin-sites';
 
-import {
-  MessageLevel,
-  MessageFormat,
-  MessageType,
-  MessageTag,
-} from '../../../messages/types/messagesTypes';
-import { Namespace } from '../../../shared/types/namespaces';
-
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
 import Overview from '../data-views/Overview';
 import EntryMain from './EntryMain';
 import MembersFacets from './MembersFacets';
+import BasketStatus from '../../../shared/components/BasketStatus';
+import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
+import BlastButton from '../../../shared/components/action-buttons/Blast';
 
 import SideBarLayout from '../../../shared/components/layouts/SideBarLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
@@ -30,6 +25,13 @@ import useDataApi from '../../../shared/hooks/useDataApi';
 import uniRefConverter, {
   UniRefAPIModel,
 } from '../../adapters/uniRefConverter';
+import {
+  MessageLevel,
+  MessageFormat,
+  MessageType,
+  MessageTag,
+} from '../../../messages/types/messagesTypes';
+import { Namespace } from '../../../shared/types/namespaces';
 
 import '../../../shared/components/entry/styles/entry-page.scss';
 
@@ -80,8 +82,13 @@ const Entry: FC = () => {
               mainTitle="UniRef"
               optionalTitle={`${transformedData.id} (${transformedData.identity}%)`}
             />
+            <BasketStatus id={accession} />
           </h1>
           <Overview transformedData={transformedData} />
+          <div className="button-group">
+            <BlastButton selectedEntries={[accession]} />
+            <AddToBasketButton selectedEntries={[accession]} />
+          </div>
         </ErrorBoundary>
       }
     >

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -6,6 +6,7 @@ import AddToBasket from '../../../shared/components/action-buttons/AddToBasket';
 import AlignButton from '../../../shared/components/action-buttons/Align';
 import BlastButton from '../../../shared/components/action-buttons/Blast';
 import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
+import BasketStatus from '../../../shared/components/BasketStatus';
 import MemberLink from './MemberLink';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
@@ -33,6 +34,8 @@ import {
 } from '../../adapters/uniRefConverter';
 import { UniRefMembersResults } from '../../types/membersEndpoint';
 
+import helper from '../../../shared/styles/helper.module.scss';
+
 // OK so, if it's UniProt KB, use first accession as unique key and as first
 // column, if it's UniParc use ID (see entryname renderer lower for counterpart)
 const getKey = (member: UniRefMember) =>
@@ -55,7 +58,15 @@ const columns: ColumDescriptor[] = [
   {
     name: 'members',
     label: 'Cluster Members',
-    render: (member) => <MemberLink accession={getKey(member)} />,
+    render: (member) => {
+      const id = getKey(member);
+      return (
+        <div className={helper['no-wrap']}>
+          <BasketStatus id={id} />
+          <MemberLink accession={id} />
+        </div>
+      );
+    },
   },
   {
     name: 'entryNames',

--- a/src/uniref/components/results/UniRefCard.tsx
+++ b/src/uniref/components/results/UniRefCard.tsx
@@ -2,6 +2,7 @@ import { Card } from 'franklin-sites';
 
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
 import RenderColumnsInCard from '../../../shared/components/results/RenderColumnsInCard';
+import BasketStatus from '../../../shared/components/BasketStatus';
 
 import { getEntryPath } from '../../../app/config/urls';
 import { getIdKeyFor } from '../../../shared/utils/getIdKeyForNamespace';
@@ -46,6 +47,7 @@ const UniRefCard = ({ data, selected, handleEntrySelection }: Props) => {
           <h2 className="tiny">
             <EntryTitle mainTitle={id} entryType={data.memberIdTypes} />
           </h2>
+          <BasketStatus id={id} />
         </>
       }
       headerSeparator={false}

--- a/src/uniref/config/__tests__/__snapshots__/UniRefColumnConfiguration.spec.tsx.snap
+++ b/src/uniref/config/__tests__/__snapshots__/UniRefColumnConfiguration.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`UniRefColumnConfiguration component should render column "from": from 1
 exports[`UniRefColumnConfiguration component should render column "id": id 1`] = `
 <DocumentFragment>
   <div
-    class="accession-view"
+    class="no-wrap"
   >
     <a
       href="/uniref/UniRef100_A0A0B7GQ86"


### PR DESCRIPTION
## Purpose
use useBasket around the website [TRM-26120](https://www.ebi.ac.uk/panda/jira/browse/TRM-26120) excluding the subtask about using the bubble component (need franklin changes).

## Approach
 - Change basket from object of Sets, to Map of Sets (was helping with types and simplifying the code)
 - Add a Map as a caching layer on top of localStorage to avoid reading from it too much (especially in result pages where each accession cell uses a useBasket hook)
 - Add a basket icon next to most of the accessions around the website
   - In entry pages, on the right of the title
   - In result page, on the left of the accession in the table view
   - In result page, on the top right of the card in the card view 
 - Clicking on the basket icon marking the presence of the accession removes it from the basket
 - Use more `AccessionView` around the website
 - Other fixes here and there

## Testing
 - Update snapshots

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
