### PR TITLE
improve UX when a new version of the app is available

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -10,6 +10,7 @@ import GDPR from '../../shared/components/gdpr/GDPR';
 import history from '../../shared/utils/browserHistory';
 
 import useScrollToTop from '../../shared/hooks/useScrollToTop';
+import useReloadApp from '../../shared/hooks/useReloadApp';
 
 import {
   allSearchResultLocations,
@@ -183,6 +184,7 @@ const reportBugLinkStyles: CSSProperties = {
 
 const App = () => {
   useScrollToTop(history);
+  useReloadApp(history);
 
   return (
     <FranklinSite>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,9 @@
 import ReactDOM from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
-import { Button } from 'franklin-sites';
 
 import App from './app/components/App';
 
 import store from './app/state/store';
-
-import { addMessage } from './messages/state/messagesActions';
-
-import { MessageFormat, MessageLevel } from './messages/types/messagesTypes';
-
-// Import this just for types, conditional import lower
-import { SWConfig } from './service-worker/client';
 
 if (!LIVE_RELOAD) {
   // eslint-disable-next-line no-console
@@ -32,38 +24,10 @@ ReactDOM.render(
 );
 
 if ('serviceWorker' in navigator) {
-  const config: SWConfig = {
-    // UI to handle application update
-    // See here for related documentation
-    // https://developers.google.com/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users
-    onWaiting: (acceptUpdate) => {
-      store.dispatch(
-        addMessage({
-          id: 'new-version-website',
-          content: (
-            <>
-              A newer version of this website is available.
-              <br />
-              <Button
-                variant="secondary"
-                className="tiny"
-                onClick={acceptUpdate}
-              >
-                Use latest version
-              </Button>
-            </>
-          ),
-          format: MessageFormat.POP_UP,
-          level: MessageLevel.INFO,
-        })
-      );
-    },
-  };
-
   import(
     /* webpackChunkName: "service-worker-client" */ './service-worker/client'
   ).then((serviceWorkerModule) => {
-    serviceWorkerModule.register(config);
+    serviceWorkerModule.register();
     // switch commented lines if we want to enable/disable service worker
     // Use in case of emergency! (if something wrong with caching in production)
     // serviceWorkerModule.unregister();

--- a/src/service-worker/client.ts
+++ b/src/service-worker/client.ts
@@ -1,5 +1,7 @@
 import { Workbox } from 'workbox-window';
 
+import { needsReload } from './reload-flag';
+
 // No need to test if serviceWorker is supported, we tested that before loading
 // this chunk so we are sure it exists by now
 
@@ -16,11 +18,7 @@ const dropCache = async (cacheName: string) => {
   await Promise.all(keys.map((key) => cache.delete(key)));
 };
 
-export type SWConfig = {
-  onWaiting?: (acceptCallback: () => void) => void;
-};
-
-export function register(config: SWConfig) {
+export function register() {
   if (LIVE_RELOAD) {
     return;
   }
@@ -47,10 +45,11 @@ export function register(config: SWConfig) {
     dropCache(cacheName);
   });
 
-  // Helper function, ask sw to skip waiting, and reload page when controlling
+  // Helper function, when the new SW is controlling, set a flag saying to the
+  // app that a full reload is needed whenever it sees fit
   const skipWaiting = () => {
     workbox.addEventListener('controlling', () => {
-      window.location.reload();
+      needsReload.current = true;
     });
 
     workbox.messageSkipWaiting();
@@ -59,11 +58,7 @@ export function register(config: SWConfig) {
   // See here for related documentation
   // https://developers.google.com/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users
   workbox.addEventListener('waiting', () => {
-    if (config.onWaiting) {
-      config.onWaiting(skipWaiting);
-    } else {
-      skipWaiting();
-    }
+    skipWaiting();
   });
 
   workbox.register();

--- a/src/service-worker/reload-flag.ts
+++ b/src/service-worker/reload-flag.ts
@@ -1,0 +1,4 @@
+// Global mutable object, in order to have a flag available in different places
+
+// reuse the same idea as React refs for the shape of the object
+export const needsReload = { current: false };

--- a/src/shared/hooks/useReloadApp.ts
+++ b/src/shared/hooks/useReloadApp.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { History } from 'history';
+
+import { needsReload } from '../../service-worker/reload-flag';
+
+const useReloadApp = (history: History) => {
+  useEffect(() => {
+    let previousPathname = history.location.pathname;
+    const unlisten = history.listen((location) => {
+      // if the path changes, and the app needs a reload
+      if (previousPathname !== location.pathname && needsReload.current) {
+        console.log('reloading!!!');
+        window.location.reload();
+      }
+      previousPathname = location.pathname;
+    });
+
+    return () => {
+      unlisten();
+    };
+  }, [history]);
+};
+
+export default useReloadApp;


### PR DESCRIPTION
## Purpose
Improve UX when getting a new version of the website

## Approach
Replace the pop up with a forced refresh whenever the user changes path. The reload will happen on changing the page so it should barely be noticeable by the user as they already expect the page to change.
Using a shared module/flag to mark the application as in need of reloading, and did the similar approach as `useScrollToTop` to detect when is a good time to trigger the forced refresh.

## Testing
Local production deploys and test update flow when forcing a change in the codebase

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
