### PR TITLE
2021 08 publication and annotation links

### DIFF
--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -44,7 +44,7 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
   EuropePMC: (id) => `//europepmc.org/article/MED/${id}`,
   CommunityCurationGet: (id) =>
-    ` https://community.uniprot.org/bbsub/bbsubinfo.html?accession=${id}`,
+    `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${id}`,
   CommunityCurationAdd: (id) =>
     `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
 };

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -43,6 +43,10 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   DOI: (id) => `https://dx.doi.org/${id}`,
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
   EuropePMC: (id) => `//europepmc.org/article/MED/${id}`,
+  CommunityCurationGet: (id) =>
+    ` https://community.uniprot.org/bbsub/bbsubinfo.html?accession=${id}`,
+  CommunityCurationAdd: (id) =>
+    `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
 };
 
 export const getIntActQueryForAccessionUrl = (accession: string) =>

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import { Method } from 'axios';
 import { CommunityAnnotationIcon } from 'franklin-sites';
 
@@ -9,21 +10,22 @@ const fetchOptions: { method: Method } = {
   method: 'HEAD',
 };
 
-const CommunityAnnotationLink = ({ accession }: { accession: string }) => {
+type CommunityAnnotationLinkProps = {
+  accession: string;
+};
+const CommunityAnnotationLink: FC<CommunityAnnotationLinkProps> = ({
+  accession,
+}) => {
   const url = externalUrls.CommunityCurationGet(accession);
   const { headers } = useDataApi(url, fetchOptions);
   const nSubmissions = +(headers?.['x-total-results'] || 0);
+  if (!nSubmissions) {
+    return null;
+  }
   return (
-    !!nSubmissions && (
-      <a
-        href={url}
-        className="button tertiary"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <CommunityAnnotationIcon /> {`Community curation (${nSubmissions})`}
-      </a>
-    )
+    <a href={url} className="button tertiary" target="_blank" rel="noreferrer">
+      <CommunityAnnotationIcon /> {`Community curation (${nSubmissions})`}
+    </a>
   );
 };
 

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -13,6 +13,7 @@ const fetchOptions: { method: Method } = {
 type CommunityAnnotationLinkProps = {
   accession: string;
 };
+
 const CommunityAnnotationLink: FC<CommunityAnnotationLinkProps> = ({
   accession,
 }) => {

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -12,7 +12,7 @@ const fetchOptions: { method: Method } = {
 const CommunityAnnotationLink = ({ accession }: { accession: string }) => {
   const url = externalUrls.CommunityCurationGet(accession);
   const { headers } = useDataApi(url, fetchOptions);
-  const nSubmissions = +(headers?.['x-total-results'] || NaN);
+  const nSubmissions = +(headers?.['x-total-results'] || 0);
   return (
     !!nSubmissions && (
       <a

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -1,0 +1,30 @@
+import { Method } from 'axios';
+import { CommunityAnnotationIcon } from 'franklin-sites';
+
+import useDataApi from '../../../shared/hooks/useDataApi';
+
+import externalUrls from '../../../shared/config/externalUrls';
+
+const fetchOptions: { method: Method } = {
+  method: 'HEAD',
+};
+
+const CommunityAnnotationLink = ({ accession }: { accession: string }) => {
+  const url = externalUrls.CommunityCurationGet(accession);
+  const { headers } = useDataApi(url, fetchOptions);
+  const nSubmissions = +(headers?.['x-total-results'] || NaN);
+  return (
+    !!nSubmissions && (
+      <a
+        href={url}
+        className="button tertiary"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <CommunityAnnotationIcon /> {`Community curation (${nSubmissions})`}
+      </a>
+    )
+  );
+};
+
+export default CommunityAnnotationLink;

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -13,8 +13,6 @@ import {
   DropdownButton,
   Tabs,
   Tab,
-  Button,
-  CommunityAnnotationIcon,
 } from 'franklin-sites';
 
 import EntrySection, {

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -13,6 +13,8 @@ import {
   DropdownButton,
   Tabs,
   Tab,
+  Button,
+  CommunityAnnotationIcon,
 } from 'franklin-sites';
 
 import EntrySection, {
@@ -63,6 +65,7 @@ import { EntryType } from '../../../shared/components/entry/EntryTypeIcon';
 
 import '../../../shared/styles/sticky.scss';
 import '../../../shared/components/entry/styles/entry-page.scss';
+import externalUrls from '../../../shared/config/externalUrls';
 
 export enum TabLocation {
   Entry = 'entry',
@@ -276,6 +279,23 @@ const Entry: FC = () => {
               </div>
             </DropdownButton>
             <AddToBasketButton selectedEntries={match.params.accession} />
+            <a
+              href={externalUrls.CommunityCurationGet(match.params.accession)}
+              className="button tertiary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <CommunityAnnotationIcon />
+              Community curation (3)
+            </a>
+            <a
+              href={externalUrls.CommunityCurationAdd(match.params.accession)}
+              className="button tertiary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Add a publication
+            </a>
           </div>
           <EntryMain transformedData={transformedData} />
         </Tab>

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -50,6 +50,7 @@ import { addMessage } from '../../../messages/state/messagesActions';
 import { hasExternalLinks, getListOfIsoformAccessions } from '../../utils';
 import { hasContent } from '../../../shared/utils/utils';
 import apiUrls from '../../../shared/config/apiUrls';
+import externalUrls from '../../../shared/config/externalUrls';
 import { fileFormatEntryDownload } from '../../config/download';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
@@ -64,7 +65,6 @@ import { EntryType } from '../../../shared/components/entry/EntryTypeIcon';
 
 import '../../../shared/styles/sticky.scss';
 import '../../../shared/components/entry/styles/entry-page.scss';
-import externalUrls from '../../../shared/config/externalUrls';
 
 export enum TabLocation {
   Entry = 'entry',

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -43,6 +43,7 @@ import ObsoleteEntryPage from '../../../shared/components/error-pages/ObsoleteEn
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
 import ErrorBoundary from '../../../shared/components/error-component/ErrorBoundary';
 import BasketStatus from '../../../shared/components/BasketStatus';
+import CommunityAnnotationLink from './CommunityAnnotationLink';
 
 import UniProtKBEntryConfig from '../../config/UniProtEntryConfig';
 
@@ -279,15 +280,7 @@ const Entry: FC = () => {
               </div>
             </DropdownButton>
             <AddToBasketButton selectedEntries={match.params.accession} />
-            <a
-              href={externalUrls.CommunityCurationGet(match.params.accession)}
-              className="button tertiary"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <CommunityAnnotationIcon />
-              Community curation (3)
-            </a>
+            <CommunityAnnotationLink accession={match.params.accession} />
             <a
               href={externalUrls.CommunityCurationAdd(match.params.accession)}
               className="button tertiary"

--- a/src/uniprotkb/components/entry/__tests__/CommunitAnnotationLink.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/CommunitAnnotationLink.spec.tsx
@@ -1,0 +1,29 @@
+import { screen, render } from '@testing-library/react';
+
+import CommunityAnnotationLink from '../CommunityAnnotationLink';
+
+import useDataApi from '../../../../shared/hooks/useDataApi';
+
+jest.mock('../../../../shared/hooks/useDataApi');
+
+describe('CommunityAnnotationLink', () => {
+  it('should render with >0 number of submissions', () => {
+    (useDataApi as jest.Mock).mockReturnValue({
+      loading: false,
+      headers: { 'x-total-results': 3 },
+    });
+    const { asFragment } = render(
+      <CommunityAnnotationLink accession="P05067" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByText('Community curation (3)')).toBeInTheDocument();
+  });
+  it('should render nothing with no submission', () => {
+    (useDataApi as jest.Mock).mockReturnValue({
+      loading: false,
+      headers: { 'x-total-results': 0 },
+    });
+    render(<CommunityAnnotationLink accession="P05067" />);
+    expect(screen.queryByText('Community curation')).not.toBeInTheDocument();
+  });
+});

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunitAnnotationLink.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunitAnnotationLink.spec.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommunityAnnotationLink should render with >0 number of submissions 1`] = `
+<DocumentFragment>
+  <a
+    class="button tertiary"
+    href="https://community.uniprot.org/cgi-bin/bbsub_query?accession=P05067"
+    rel="noreferrer"
+    target="_blank"
+  >
+    <test-file-stub />
+     Community curation (3)
+  </a>
+</DocumentFragment>
+`;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -299,6 +299,14 @@ exports[`Entry basic should render main 1`] = `
               <test-file-stub />
               Add
             </button>
+            <a
+              class="button tertiary"
+              href="https://community.uniprot.org/bbsub/bbsub.html?accession=P21802"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Add a publication
+            </a>
           </div>
           <section
             class="card"


### PR DESCRIPTION
## Purpose
"Add a publication" and "Community annotation" links ([jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-26094))

## Approach
* All entries now have an `Add a publication` link
* Only those entries that have community curation submissions show a link. The vast majority of entries don't have community annotations (https://beta.uniprot.org/uniprotkb?query=(community_pubmed_id:*) has 1,425 results) so I opted to not display any sort of loading indication when querying for community submission count


## Testing
Unit test and snapshot

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
