### PR TITLE
2021 08 query builder db bug

### DIFF
--- a/src/query-builder/components/Field.tsx
+++ b/src/query-builder/components/Field.tsx
@@ -15,7 +15,7 @@ import {
 
 type FieldProps = {
   field: SearchTermType;
-  handleChange: (updatedQueryBit: QueryBit) => void;
+  handleChange: (updatedQueryBit: QueryBit, reset?: boolean) => void;
   initialValue?: QueryBit;
 };
 

--- a/src/query-builder/components/TextField.tsx
+++ b/src/query-builder/components/TextField.tsx
@@ -6,7 +6,7 @@ import { DataType, QueryBit, SearchTermType } from '../types/searchTypes';
 
 const TextField: FC<{
   field: SearchTermType;
-  handleChange: (queryBit: QueryBit) => void;
+  handleChange: (queryBit: QueryBit, reset?: boolean) => void;
   initialValue?: QueryBit;
 }> = ({ field, handleChange, initialValue }) => {
   const [value, setValue] = useState(
@@ -16,15 +16,15 @@ const TextField: FC<{
   useEffect(() => {
     const trimmed = value.trim();
     if (trimmed.length) {
-      if (field.valuePrefix && field.term === 'xref' && trimmed === '*') {
-        // Query is faster with this hack: using 'database' instead
-        // Remove last '-' from the the prefix, and don't include '*'
-        handleChange({ database: `${field.valuePrefix.replace(/-$/, '')}` });
-      } else {
-        handleChange({
-          [field.term]: `${field.valuePrefix || ''}${trimmed}`,
-        });
-      }
+      // Query is faster with this hack: using 'database' instead
+      // Remove last '-' from the the prefix, and don't include '*'
+      const queryBit =
+        field.valuePrefix && field.term === 'xref' && trimmed === '*'
+          ? { database: `${field.valuePrefix.replace(/-$/, '')}` }
+          : {
+              [field.term]: `${field.valuePrefix || ''}${trimmed}`,
+            };
+      handleChange(queryBit, field.term === 'xref');
     }
   }, [field, value, handleChange]);
 

--- a/src/query-builder/components/__tests__/TextField.spec.tsx
+++ b/src/query-builder/components/__tests__/TextField.spec.tsx
@@ -33,9 +33,12 @@ describe('TextField', () => {
     const inputElt = screen.getByRole('textbox') as HTMLInputElement;
     expect(inputElt.value).toBe('');
     fireEvent.change(inputElt, { target: { value: updatedValue } });
-    expect(props.handleChange).toBeCalledWith({
-      [props.field.term]: updatedValue.trim(),
-    });
+    expect(props.handleChange).toBeCalledWith(
+      {
+        [props.field.term]: updatedValue.trim(),
+      },
+      false
+    );
   });
 
   test("should generate correct query for 'All'", () => {
@@ -58,9 +61,12 @@ describe('TextField', () => {
       name: propsAll.field.label,
     });
     fireEvent.change(inputElt, { target: { value: updatedValue } });
-    expect(propsAll.handleChange).toBeCalledWith({
-      [propsAll.field.term]: `${updatedValue}`,
-    });
+    expect(propsAll.handleChange).toBeCalledWith(
+      {
+        [propsAll.field.term]: `${updatedValue}`,
+      },
+      false
+    );
   });
 
   test('should generate correct query with prefix', () => {
@@ -84,10 +90,13 @@ describe('TextField', () => {
       name: propsPrefix.field.label,
     });
     fireEvent.change(inputElt, { target: { value: updatedValue } });
-    expect(propsPrefix.handleChange).toBeCalledWith({
-      [propsPrefix.field
-        .term]: `${propsPrefix.field.valuePrefix}${updatedValue}`,
-    });
+    expect(propsPrefix.handleChange).toBeCalledWith(
+      {
+        [propsPrefix.field
+          .term]: `${propsPrefix.field.valuePrefix}${updatedValue}`,
+      },
+      false
+    );
   });
 
   test('should generate correct query for database *', () => {
@@ -110,9 +119,12 @@ describe('TextField', () => {
       name: propsPrefix.field.label,
     });
     fireEvent.change(inputElt, { target: { value: '*' } });
-    expect(propsPrefix.handleChange).toBeCalledWith({
-      database: 'embl',
-    });
+    expect(propsPrefix.handleChange).toBeCalledWith(
+      {
+        database: 'embl',
+      },
+      true
+    );
   });
 
   test('should validate initial query with regex', () => {

--- a/src/query-builder/utils/fieldInitializer.ts
+++ b/src/query-builder/utils/fieldInitializer.ts
@@ -21,6 +21,10 @@ const initializer = (
     return initialValue.go_evidence;
   }
 
+  if (field.term === 'xref' && initialValue?.database) {
+    return '*';
+  }
+
   // Deal with autocomplete fields (they use 'autoCompleteQueryTerm')
   // instead of 'term'
   if (

--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -53,7 +53,19 @@ const parseAndMatchQuery = (
     );
     // if it exists, assign it 'searchTerm'
     if (matching.length) {
-      if (matching.length === 1 || clause.searchTerm.term === 'go') {
+      if (clause.queryBits.database) {
+        const matchingXref = matching.find(
+          ({ valuePrefix }) => valuePrefix === `${clause.queryBits.database}-`
+        );
+        if (matchingXref) {
+          validatedQuery.push({
+            ...clause,
+            searchTerm: matchingXref,
+          });
+        } else {
+          invalid.push(clause);
+        }
+      } else if (matching.length === 1 || clause.searchTerm.term === 'go') {
         // only one search term matching or this is GO in which case only add the parent SearchTerm
         validatedQuery.push({
           ...clause,

--- a/src/query-builder/utils/queryStringProcessor.ts
+++ b/src/query-builder/utils/queryStringProcessor.ts
@@ -146,7 +146,11 @@ export const parse = (queryString = '', startId = 0): Clause[] => {
         };
       } else {
         // term
-        currentClause.searchTerm.term = key || 'All';
+        if (key === 'database') {
+          currentClause.searchTerm.term = 'xref';
+        } else {
+          currentClause.searchTerm.term = key || 'All';
+        }
         // "default"
         if (key) {
           currentClause.queryBits[key] = value;


### PR DESCRIPTION
## Purpose
Jira: [query builder with database term bug](https://www.ebi.ac.uk/panda/jira/browse/TRM-25580)
There are two ways of generating a query to find entries which are associated with a specific cross-reference (call it `DB`):

1. `xref:DB-*`
2. `database:DB`

The latter is preferred as this results in a quicker SOLR query. However, the front end needs to still parse both of these query strings to populate the query builder form which is the purpose of this PR

## Approach

1. In `fieldInitializer` detect when term is `'xref'` and `database` is a `queryBit` key to return `*` to correctly populate the form.
2. Handle `clause.queryBits.database` special case in `parseAndMatchQuery`,
3. Reset the `queryBit` when a cross-reference text form input is changed to prevent both `database` and `xref` coexisting as `queryBit` keys.


## Testing
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
