### PR TITLE
2021 9 catalytic activity UI updates

### DIFF
--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -48,7 +48,8 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   CommunityCurationAdd: (id) =>
     `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
   ENZYME: (id) => `https://enzyme.expasy.org/EC/${id}`,
-  Rhea: (id) => `https://www.rhea-db.org/rhea?query=ec:${id}`,
+  RheaSearch: (id) => `https://www.rhea-db.org/rhea?query=ec:${id}`,
+  RheaEntry: (id) => `https://www.rhea-db.org/rhea/${id}`,
 };
 
 export const getIntActQueryForAccessionUrl = (accession: string) =>

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -47,6 +47,8 @@ const externalUrls: Record<string, (id: string | number) => string> = {
     `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${id}`,
   CommunityCurationAdd: (id) =>
     `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
+  ENZYME: (id) => `https://enzyme.expasy.org/EC/${id}`,
+  Rhea: (id) => `https://www.rhea-db.org/rhea?query=ec:${id}`,
 };
 
 export const getIntActQueryForAccessionUrl = (accession: string) =>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -332,9 +332,6 @@ exports[`Entry basic should render main 1`] = `
                 <span
                   class="text-block"
                 >
-                  <strong>
-                    1.2.4.5
-                  </strong>
                    some reaction
                   <button
                     aria-controls="1"
@@ -387,6 +384,49 @@ exports[`Entry basic should render main 1`] = `
                     data-testid="evidence-tag-content"
                     id="2"
                   />
+                  <div>
+                    <span
+                      class="ec-number"
+                    >
+                      EC: 1.2.4.5
+                    </span>
+                     ( 
+                    <a
+                      href="/uniprotkb?query=(ec:1.2.4.5)"
+                    >
+                      UniProtKB 
+                      <test-file-stub
+                        width="1.333ch"
+                      />
+                    </a>
+                     | 
+                    <a
+                      class="external-link"
+                      href="https://enzyme.expasy.org/EC/1.2.4.5"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      ENZYME
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    | 
+                    <a
+                      class="external-link"
+                      href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      Rhea
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    )
+                  </div>
                 </span>
                 <h3>
                   cofactor

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -26,9 +26,6 @@ exports[`Entry view should render 1`] = `
         <span
           class="text-block"
         >
-          <strong>
-            1.2.4.5
-          </strong>
            some reaction
           <button
             aria-controls="0"
@@ -81,6 +78,49 @@ exports[`Entry view should render 1`] = `
             data-testid="evidence-tag-content"
             id="1"
           />
+          <div>
+            <span
+              class="ec-number"
+            >
+              EC: 1.2.4.5
+            </span>
+             ( 
+            <a
+              href="/uniprotkb?query=(ec:1.2.4.5)"
+            >
+              UniProtKB 
+              <test-file-stub
+                width="1.333ch"
+              />
+            </a>
+             | 
+            <a
+              class="external-link"
+              href="https://enzyme.expasy.org/EC/1.2.4.5"
+              rel="noopener"
+              target="_blank"
+            >
+              ENZYME
+              <test-file-stub
+                data-testid="external-link-icon"
+                width="12.5"
+              />
+            </a>
+            | 
+            <a
+              class="external-link"
+              href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
+              rel="noopener"
+              target="_blank"
+            >
+              Rhea
+              <test-file-stub
+                data-testid="external-link-icon"
+                width="12.5"
+              />
+            </a>
+            )
+          </div>
         </span>
         <h3>
           cofactor
@@ -2426,7 +2466,6 @@ exports[`Entry view should render for non-human entry 1`] = `
         <span
           class="text-block"
         >
-          <strong />
            an N-acetyl-alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + H2O = acetate + an alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative
           <button
             aria-controls="1"
@@ -2450,12 +2489,36 @@ exports[`Entry view should render for non-human entry 1`] = `
             data-testid="evidence-tag-content"
             id="1"
           />
-          <button
-            class="button tertiary rhea-reaction-visualizer__button"
-            type="button"
+          <div>
+            <strong>
+              Source: 
+            </strong>
+            <a
+              class="external-link"
+              href="https://www.rhea-db.org/rhea/14869"
+              rel="noopener"
+              target="_blank"
+            >
+              Rhea 14869
+              <test-file-stub
+                data-testid="external-link-icon"
+                width="12.5"
+              />
+            </a>
+          </div>
+          <div
+            class="rhea-reaction-visualizer__toggle"
           >
-            Hide Rhea reaction
-          </button>
+            <test-file-stub
+              width="1ch"
+            />
+            <button
+              class="button tertiary"
+              type="button"
+            >
+              Hide Rhea reaction
+            </button>
+          </div>
           <div
             class="rhea-reaction-visualizer__component"
           >

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -116,7 +116,7 @@ export const RheaReactionVisualizer: FC<RheaReactionVisualizerProps> = ({
           <div className="rhea-reaction-visualizer__component">
             <rhea-reaction
               rheaid={rheaId}
-              // showIds // Shows rhea ID as well as CHEBI IDs in images
+              showIds
               zoom
               ref={callback}
               usehost="https://api.rhea-db.org"
@@ -237,6 +237,7 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
                 physiologicalReactions={physiologicalReactions}
               />
             )}
+
             {reaction.ecNumber && (
               <div>
                 <span className="ec-number">EC: {reaction.ecNumber}</span>
@@ -254,17 +255,25 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
                   ENZYME
                 </ExternalLink>
                 {'| '}
-                <ExternalLink url={externalUrls.Rhea(reaction.ecNumber)}>
+                <ExternalLink url={externalUrls.RheaSearch(reaction.ecNumber)}>
                   Rhea
                 </ExternalLink>
                 )
               </div>
             )}
             {!!rheaId && (
-              <RheaReactionVisualizer
-                rheaId={rheaId}
-                show={rheaId === firstRheaId}
-              />
+              <>
+                <div>
+                  <strong>Source: </strong>
+                  <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
+                    Rhea {rheaId}
+                  </ExternalLink>
+                </div>
+                <RheaReactionVisualizer
+                  rheaId={rheaId}
+                  show={rheaId === firstRheaId}
+                />
+              </>
             )}
           </span>
         );

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState, useCallback, useRef, FC } from 'react';
+import { Link } from 'react-router-dom';
 import {
   useModal,
   ModalBackdrop,
@@ -6,10 +7,15 @@ import {
   Loader,
   ChevronDownIcon,
   ChevronUpIcon,
+  SearchIcon,
+  ExternalLink,
 } from 'franklin-sites';
 import '@swissprot/rhea-reaction-visualizer';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
+
+import { Location, LocationToPath } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
 
 import {
   CatalyticActivityComment,
@@ -19,7 +25,7 @@ import {
 
 import './styles/catalytic-activity-view.scss';
 
-// example accession to view this component: P31937
+// example accessions to view this component: P31937, P0A879
 
 export const getRheaId = (referenceId: string) => {
   const re = /^RHEA:(\d+)$/i;
@@ -110,8 +116,8 @@ export const RheaReactionVisualizer: FC<RheaReactionVisualizerProps> = ({
           <div className="rhea-reaction-visualizer__component">
             <rhea-reaction
               rheaid={rheaId}
+              // showIds // Shows rhea ID as well as CHEBI IDs in images
               zoom
-              // showids
               ref={callback}
               usehost="https://api.rhea-db.org"
             />
@@ -222,9 +228,6 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
         }
         return (
           <span className="text-block" key={reaction.ecNumber || index}>
-            <strong>{reaction.ecNumber}</strong>
-            {/* Need a link to search for EC in UniProtKB:
-             https://www.ebi.ac.uk/panda/jira/browse/TRM-23597 */}
             {` ${reaction.name}`}
             {reaction.evidences && (
               <UniProtKBEvidenceTag evidences={reaction.evidences} />
@@ -233,6 +236,29 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
               <ReactionDirection
                 physiologicalReactions={physiologicalReactions}
               />
+            )}
+            {reaction.ecNumber && (
+              <div>
+                <span className="ec-number">EC: {reaction.ecNumber}</span>
+                {' ( '}
+                <Link
+                  to={{
+                    pathname: LocationToPath[Location.UniProtKBResults],
+                    search: `query=(ec:${reaction.ecNumber})`,
+                  }}
+                >
+                  UniProtKB <SearchIcon width="1.333ch" />
+                </Link>
+                {' | '}
+                <ExternalLink url={externalUrls.ENZYME(reaction.ecNumber)}>
+                  ENZYME
+                </ExternalLink>
+                {'| '}
+                <ExternalLink url={externalUrls.Rhea(reaction.ecNumber)}>
+                  Rhea
+                </ExternalLink>
+                )
+              </div>
             )}
             {!!rheaId && (
               <RheaReactionVisualizer

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,5 +1,12 @@
 import { Fragment, useState, useCallback, useRef, FC } from 'react';
-import { useModal, ModalBackdrop, Window, Loader } from 'franklin-sites';
+import {
+  useModal,
+  ModalBackdrop,
+  Window,
+  Loader,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from 'franklin-sites';
 import '@swissprot/rhea-reaction-visualizer';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
@@ -88,20 +95,23 @@ export const RheaReactionVisualizer: FC<RheaReactionVisualizerProps> = ({
 
   return (
     <>
-      <button
-        type="button"
-        className="button tertiary rhea-reaction-visualizer__button"
-        onClick={() => setShow(!show)}
-      >
-        {`${show ? 'Hide' : 'View'} Rhea reaction`}
-      </button>
+      <div className="rhea-reaction-visualizer__toggle">
+        {show ? <ChevronUpIcon width="1ch" /> : <ChevronDownIcon width="1ch" />}
+        <button
+          type="button"
+          className="button tertiary"
+          onClick={() => setShow(!show)}
+        >
+          {`${show ? 'Hide' : 'View'} Rhea reaction`}
+        </button>
+      </div>
       {show && (
         <>
           <div className="rhea-reaction-visualizer__component">
             <rhea-reaction
               rheaid={rheaId}
               zoom
-              showids
+              // showids
               ref={callback}
               usehost="https://api.rhea-db.org"
             />

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
@@ -8,9 +8,6 @@ exports[`CatalyticActivityView component should render catalytic activity 1`] = 
   <span
     class="text-block"
   >
-    <strong>
-      EC:12112
-    </strong>
      Reaction nameThis reaction proceeds in the 
     <span
       data-testid="direction-text"
@@ -68,6 +65,49 @@ exports[`CatalyticActivityView component should render catalytic activity 1`] = 
       id="1"
     />
      directions 
+    <div>
+      <span
+        class="ec-number"
+      >
+        EC: EC:12112
+      </span>
+       ( 
+      <a
+        href="/uniprotkb?query=(ec:EC:12112)"
+      >
+        UniProtKB 
+        <test-file-stub
+          width="1.333ch"
+        />
+      </a>
+       | 
+      <a
+        class="external-link"
+        href="https://enzyme.expasy.org/EC/EC:12112"
+        rel="noopener"
+        target="_blank"
+      >
+        ENZYME
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      | 
+      <a
+        class="external-link"
+        href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
+        rel="noopener"
+        target="_blank"
+      >
+        Rhea
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      )
+    </div>
   </span>
 </DocumentFragment>
 `;
@@ -77,9 +117,6 @@ exports[`CatalyticActivityView component should render catalytic activity when c
   <span
     class="text-block"
   >
-    <strong>
-      EC:12112
-    </strong>
      Reaction nameThis reaction proceeds in the 
     <span
       data-testid="direction-text"
@@ -137,6 +174,49 @@ exports[`CatalyticActivityView component should render catalytic activity when c
       id="1"
     />
      directions 
+    <div>
+      <span
+        class="ec-number"
+      >
+        EC: EC:12112
+      </span>
+       ( 
+      <a
+        href="/uniprotkb?query=(ec:EC:12112)"
+      >
+        UniProtKB 
+        <test-file-stub
+          width="1.333ch"
+        />
+      </a>
+       | 
+      <a
+        class="external-link"
+        href="https://enzyme.expasy.org/EC/EC:12112"
+        rel="noopener"
+        target="_blank"
+      >
+        ENZYME
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      | 
+      <a
+        class="external-link"
+        href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
+        rel="noopener"
+        target="_blank"
+      >
+        Rhea
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      )
+    </div>
   </span>
 </DocumentFragment>
 `;
@@ -239,12 +319,19 @@ exports[`ReactionDirection component should render ReactionDirection when two ph
 
 exports[`RheaReactionVisualizer component should render RheaReactionVisualizer 1`] = `
 <DocumentFragment>
-  <button
-    class="button tertiary rhea-reaction-visualizer__button"
-    type="button"
+  <div
+    class="rhea-reaction-visualizer__toggle"
   >
-    View Rhea reaction
-  </button>
+    <test-file-stub
+      width="1ch"
+    />
+    <button
+      class="button tertiary"
+      type="button"
+    >
+      View Rhea reaction
+    </button>
+  </div>
 </DocumentFragment>
 `;
 

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
@@ -1,6 +1,14 @@
 .rhea-reaction-visualizer {
-  &__button {
-    margin: 0.5rem;
+  &__toggle {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+
+    svg {
+      position: relative;
+      top: -0.5rem;
+      margin-right: 0.25rem;
+    }
   }
 
   &__component {

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
@@ -31,3 +31,7 @@
   font-weight: bold;
   padding-right: 0.333rem;
 }
+
+.rhea-reaction-source {
+  display: none;
+}

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.scss
@@ -26,3 +26,8 @@
   justify-content: center;
   align-items: center;
 }
+
+.ec-number {
+  font-weight: bold;
+  padding-right: 0.333rem;
+}

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -212,9 +212,6 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
   <span
     class="text-block"
   >
-    <strong>
-      1.2.4.5
-    </strong>
      some reaction
     <button
       aria-controls="0"
@@ -267,6 +264,49 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
       data-testid="evidence-tag-content"
       id="1"
     />
+    <div>
+      <span
+        class="ec-number"
+      >
+        EC: 1.2.4.5
+      </span>
+       ( 
+      <a
+        href="/uniprotkb?query=(ec:1.2.4.5)"
+      >
+        UniProtKB 
+        <test-file-stub
+          width="1.333ch"
+        />
+      </a>
+       | 
+      <a
+        class="external-link"
+        href="https://enzyme.expasy.org/EC/1.2.4.5"
+        rel="noopener"
+        target="_blank"
+      >
+        ENZYME
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      | 
+      <a
+        class="external-link"
+        href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
+        rel="noopener"
+        target="_blank"
+      >
+        Rhea
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      )
+    </div>
   </span>
 </DocumentFragment>
 `;


### PR DESCRIPTION
## Purpose
Jira: [Catalytic activity - UI updates](https://www.ebi.ac.uk/panda/jira/browse/TRM-26174):

> 1. The Rhea ID should always be visible (not under collapsed)
> 2. The EC number should be after the reaction, not before
> 3. The toggle to show/hide the reaction should be on a new line

This PR also accidentally covers the jira: [create link to search UniProtKB for EC](https://www.ebi.ac.uk/panda/jira/browse/TRM-23597)
## Approach

1. Override CSS to hide Rhea ID in `rhea-reaction` and always display in its parent
2. Move the EC number
3. Created a chevron toggle
4. Added respective external URLs

## Testing
Updated snapshots

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
