### PR TITLE
2021 09 direct results

### DIFF
--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -17,7 +17,7 @@ const Results = () => {
   const [selectedEntries, handleEntrySelection] = useItemSelect();
 
   // Query for facets
-  const { url: initialApiFacetUrl } = useNSQuery({
+  const initialApiFacetUrl = useNSQuery({
     size: 0,
     withFacets: true,
     withColumns: false,
@@ -33,7 +33,7 @@ const Results = () => {
   const facetTotal = facetHeaders?.['x-total-records'];
 
   // Query for results data
-  const { url: initialApiUrl, direct } = useNSQuery({ withFacets: false });
+  const initialApiUrl = useNSQuery({ withFacets: false });
   const resultsDataObject = usePagination(initialApiUrl);
   const {
     initialLoading: resultsDataInitialLoading,
@@ -69,7 +69,6 @@ const Results = () => {
       <ResultsDataHeader total={total} selectedEntries={selectedEntries} />
       <ResultsData
         resultsDataObject={resultsDataObject}
-        direct={direct}
         selectedEntries={selectedEntries}
         handleEntrySelection={handleEntrySelection}
       />

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -30,14 +30,12 @@ export enum ViewMode {
 
 const ResultsData: FC<{
   resultsDataObject: PaginatedResults;
-  direct?: boolean;
   selectedEntries: string[];
   handleEntrySelection: (id: string) => void;
   namespaceFallback?: Namespace;
   displayIdMappingColumns?: boolean;
 }> = ({
   resultsDataObject,
-  direct,
   selectedEntries,
   handleEntrySelection,
   namespaceFallback,
@@ -46,7 +44,7 @@ const ResultsData: FC<{
   const namespace = useNS() || namespaceFallback || Namespace.uniprotkb;
   const [viewMode] = useLocalStorage<ViewMode>('view-mode', ViewMode.CARD);
   const history = useHistory();
-  const { query } = getParamsFromURL(useLocation().search);
+  const { query, direct } = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(
     namespaceFallback,
     displayIdMappingColumns

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -40,7 +40,7 @@ const useNSQuery = ({
   }
 
   const { search: queryParamFromUrl } = location;
-  const { query, selectedFacets, sortColumn, sortDirection, direct } =
+  const { query, selectedFacets, sortColumn, sortDirection } =
     getParamsFromURL(queryParamFromUrl);
 
   const url = useMemo(() => {
@@ -73,7 +73,7 @@ const useNSQuery = ({
     accessions,
   ]);
 
-  return { url, direct };
+  return url;
 };
 
 export default useNSQuery;

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -54,7 +54,7 @@ const PeptideSearchResult: FC = () => {
   const accessions = jobData?.split(',').filter(Boolean);
 
   // Query for facets
-  const { url: initialApiFacetUrl } = useNSQuery({
+  const initialApiFacetUrl = useNSQuery({
     size: 0,
     withFacets: true,
     withColumns: false,
@@ -70,7 +70,7 @@ const PeptideSearchResult: FC = () => {
   const facetTotal = facetHeaders?.['x-total-records'];
 
   // Query for results data
-  const { url: initialApiUrl, direct } = useNSQuery({ accessions });
+  const initialApiUrl = useNSQuery({ accessions });
   const resultsDataObject = usePagination(initialApiUrl);
   const {
     initialLoading: resultsDataInitialLoading,
@@ -128,7 +128,6 @@ const PeptideSearchResult: FC = () => {
       />
       <ResultsData
         resultsDataObject={resultsDataObject}
-        direct={direct}
         selectedEntries={selectedEntries}
         handleEntrySelection={handleEntrySelection}
       />

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -1,4 +1,5 @@
-import queryStringModule from 'query-string';
+import qs from 'query-string';
+
 import { Column } from '../../shared/config/columns';
 import { SortableColumn } from '../types/columnTypes';
 import {
@@ -26,8 +27,7 @@ export type URLResultParams = {
 };
 
 export const getParamsFromURL = (url: string): URLResultParams => {
-  const urlParams = queryStringModule.parse(url, { parseBooleans: true });
-  const { query, facets, sort, dir, activeFacet, direct } = urlParams;
+  const { query, facets, sort, dir, activeFacet, direct } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {
@@ -42,7 +42,8 @@ export const getParamsFromURL = (url: string): URLResultParams => {
     selectedFacets,
     sortColumn: sort as SortableColumn,
     sortDirection: sortDirection && SortDirection[sortDirection],
-    direct: Boolean(direct),
+    // flag, so if '?direct' we get null, if not in querystring we get undefined
+    direct: direct !== undefined,
   };
 };
 


### PR DESCRIPTION
## Purpose
Redirect to entry page https://www.ebi.ac.uk/panda/jira/browse/TRM-26172

## Approach
Different behaviour to the one in the Jira as difficult to define what is a "subsequent query".
Redirect to the entry page if only one result and if the search matches the accession or the ID of that result.

Also, fixed `?direct` approach that wasn't passed down the components as needed. Done by removing prop drilling and getting the value of that flag only where needed.

## Testing
Added tests for all 3 cases of redirecting to entry page. Testing redirect (through `history.location.pathname`)

Can check behaviour by searching for an accession ("P05067"), an ID ("KVD30_HUMAN", some ID searches like "A4_HUMAN" return multiple results so won't work for all IDs), or an ID of any namespace ("9606" in taxonomy).

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
