### PR TITLE
Increase jest test timeout.

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,7 +6,7 @@ const nodeCrypto = require('crypto');
 
 global.crypto = {
   ...global.crypto,
-  getRandomValues: function (buffer) {
+  getRandomValues(buffer) {
     return nodeCrypto.randomFillSync(buffer);
   },
 };
@@ -20,3 +20,5 @@ jest.mock('/shared/hooks/useCustomElement', () => ({
 global.beforeEach(() => {
   resetUuidV1();
 });
+
+jest.setTimeout(30000);


### PR DESCRIPTION
Seeing an issue where our [tests are timing out](https://gitlab.ebi.ac.uk/uniprot/uniprot-website/uniprot-website/-/jobs/495940) on the gitlab CI runners I’m guessing because:

- not all runners have the specs
- the machines are shared and maybe another process is stealing resources

This PR just pushes the timeout to 30s.