### PR TITLE
Submission protein names

### DIFF
--- a/src/proteomes/config/__tests__/ProteomesColumnConfiguration.spec.tsx
+++ b/src/proteomes/config/__tests__/ProteomesColumnConfiguration.spec.tsx
@@ -1,29 +1,22 @@
-import ProteomesColumnConfiguration from '../ProteomesColumnConfiguration';
+import ProteomesColumnConfiguration, {
+  ProteomesColumn,
+} from '../ProteomesColumnConfiguration';
 
 import proteomesConverter, {
   ProteomesAPIModel,
   ProteomesUIModel,
 } from '../../adapters/proteomesConverter';
-import customRender from '../../../shared/__test-helpers__/customRender';
+import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
 
 import data from '../../__mocks__/proteomesEntryModelData';
 
 jest.mock('../../../tools/utils/storage');
 
+const transformedData: ProteomesUIModel = proteomesConverter(data);
+
 describe('ProteomesColumnConfiguration component', () => {
-  let transformedData: ProteomesUIModel;
-
-  beforeAll(() => {
-    transformedData = proteomesConverter(data as ProteomesAPIModel);
-  });
-
-  test.each(Array.from(ProteomesColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<ProteomesColumn, ProteomesAPIModel>(
+    ProteomesColumnConfiguration,
+    transformedData
   );
 });

--- a/src/proteomes/config/__tests__/__snapshots__/ProteomesColumnConfiguration.spec.tsx.snap
+++ b/src/proteomes/config/__tests__/__snapshots__/ProteomesColumnConfiguration.spec.tsx.snap
@@ -54,6 +54,102 @@ exports[`ProteomesColumnConfiguration component should render column "components
 </DocumentFragment>
 `;
 
+exports[`ProteomesColumnConfiguration component should render column "components": components-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      Chromosome 1
+    </li>
+    <li>
+      Chromosome 2
+    </li>
+    <li>
+      Chromosome 3
+    </li>
+    <li>
+      Chromosome 4
+    </li>
+    <li>
+      Chromosome 5
+    </li>
+    <li>
+      Chromosome 6
+    </li>
+    <li>
+      Chromosome 7
+    </li>
+    <li>
+      Chromosome 8
+    </li>
+    <li>
+      Chromosome 9
+    </li>
+    <li>
+      Chromosome 10
+    </li>
+    <li>
+      Chromosome 11
+    </li>
+    <li>
+      Chromosome 12
+    </li>
+    <li>
+      Chromosome 13
+    </li>
+    <li>
+      Chromosome 14
+    </li>
+    <li>
+      Chromosome 15
+    </li>
+    <li>
+      Chromosome 16
+    </li>
+    <li>
+      Chromosome 17
+    </li>
+    <li>
+      Chromosome 18
+    </li>
+    <li>
+      Chromosome 19
+    </li>
+    <li>
+      Chromosome 20
+    </li>
+    <li>
+      Chromosome 21
+    </li>
+    <li>
+      Chromosome 22
+    </li>
+    <li>
+      Chromosome X
+    </li>
+    <li>
+      Chromosome Y
+    </li>
+    <li>
+      Mitochondrion
+    </li>
+    <li>
+      Unplaced
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less components
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`ProteomesColumnConfiguration component should render column "cpd": cpd 1`] = `
 <DocumentFragment>
   Unknown

--- a/src/shared/__test-helpers__/queryMoreButton.ts
+++ b/src/shared/__test-helpers__/queryMoreButton.ts
@@ -1,0 +1,7 @@
+import { screen } from '@testing-library/react';
+
+const queryShowMore = () =>
+  screen.queryByTitle('Show more') ||
+  screen.queryByTestId('expandable-message');
+
+export default queryShowMore;

--- a/src/shared/__test-helpers__/queryMoreButton.ts
+++ b/src/shared/__test-helpers__/queryMoreButton.ts
@@ -1,7 +1,0 @@
-import { screen } from '@testing-library/react';
-
-const queryShowMore = () =>
-  screen.queryByTitle('Show more') ||
-  screen.queryByTestId('expandable-message');
-
-export default queryShowMore;

--- a/src/shared/__test-helpers__/testColumnConfiguration.tsx
+++ b/src/shared/__test-helpers__/testColumnConfiguration.tsx
@@ -1,0 +1,26 @@
+import { screen } from '@testing-library/react';
+import { ColumnConfiguration } from '../types/columnConfiguration';
+import customRender from './customRender';
+
+function testColumnConfiguration<Column, UIModel>(
+  columnConfiguration: ColumnConfiguration<Column, UIModel>,
+  data: UIModel
+) {
+  test.each(Array.from(columnConfiguration.entries()))(
+    `should render column "%s"`,
+    (key, column) => {
+      const { asFragment } = customRender(<>{column.render(data)}</>);
+      expect(asFragment()).toMatchSnapshot(key);
+
+      const hasMoreButton =
+        screen.queryByTitle('Show more') ||
+        screen.queryByTestId('expandable-message');
+      if (hasMoreButton) {
+        hasMoreButton.click();
+        expect(asFragment()).toMatchSnapshot(`${key}-expanded`);
+      }
+    }
+  );
+}
+
+export default testColumnConfiguration;

--- a/src/shared/__test-helpers__/testColumnConfiguration.tsx
+++ b/src/shared/__test-helpers__/testColumnConfiguration.tsx
@@ -2,10 +2,10 @@ import { screen } from '@testing-library/react';
 import { ColumnConfiguration } from '../types/columnConfiguration';
 import customRender from './customRender';
 
-function testColumnConfiguration<Column, UIModel>(
-  columnConfiguration: ColumnConfiguration<Column, UIModel>,
-  data: UIModel
-) {
+function testColumnConfiguration<
+  Column,
+  UIModel extends Record<string, unknown>
+>(columnConfiguration: ColumnConfiguration<Column, UIModel>, data: UIModel) {
   test.each(Array.from(columnConfiguration.entries()))(
     `should render column "%s"`,
     (key, column) => {

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getBEMClassName,
   formatPercentage,
   isSameEntry,
+  deepFindAllByKey,
 } from '../utils';
 
 describe('Model Utils', () => {
@@ -152,5 +153,23 @@ describe('isSameEntry', () => {
         { transformedData: { id: 'P54321' } }
       )
     ).toBeFalsy();
+  });
+});
+
+describe('deepFindAllByKey', () => {
+  it('should find all keys in nested object', () => {
+    expect(deepFindAllByKey({ a: 1, b: { c: { d: { a: 2 } } } }, 'a')).toEqual([
+      1, 2,
+    ]);
+  });
+  it('should find all keys in array of nested objects', () => {
+    expect(
+      deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'a')
+    ).toEqual([1, 2]);
+  });
+  it('should find no keys if not present', () => {
+    expect(
+      deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'z')
+    ).toEqual([]);
   });
 });

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -91,6 +91,7 @@ describe('getBEMClassName', () => {
         m: [
           true && 'modifier_1',
           false && 'modifier_2',
+          // eslint-disable-next-line no-constant-condition
           true ? 'modifier_3a' : 'modifier_3b',
         ],
       })
@@ -158,18 +159,22 @@ describe('isSameEntry', () => {
 
 describe('deepFindAllByKey', () => {
   it('should find all keys in nested object', () => {
-    expect(deepFindAllByKey({ a: 1, b: { c: { d: { a: 2 } } } }, 'a')).toEqual([
-      1, 2,
-    ]);
+    expect(
+      Array.from(deepFindAllByKey({ a: 1, b: { c: { d: { a: 2 } } } }, 'a'))
+    ).toEqual([1, 2]);
   });
   it('should find all keys in array of nested objects', () => {
     expect(
-      deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'a')
+      Array.from(
+        deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'a')
+      )
     ).toEqual([1, 2]);
   });
   it('should find no keys if not present', () => {
     expect(
-      deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'z')
+      Array.from(
+        deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'z')
+      )
     ).toEqual([]);
   });
 });

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -89,3 +89,20 @@ export const isSameEntry = (
   prev?.primaryAccession !== undefined
     ? prev.primaryAccession === next.primaryAccession
     : prev.id === next.id;
+
+export const deepFindAllByKey = (
+  o: Record<string, unknown> | Record<string, unknown>[],
+  predicateKey: string,
+  accum: string[] = []
+) => {
+  if (typeof o === 'object') {
+    Object?.entries(o).forEach(([key, value]) => {
+      if (key === predicateKey) {
+        accum.push(value as string);
+      } else {
+        deepFindAllByKey(value as Record<string, unknown>, predicateKey, accum);
+      }
+    });
+  }
+  return accum;
+};

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -90,19 +90,21 @@ export const isSameEntry = (
     ? prev.primaryAccession === next.primaryAccession
     : prev.id === next.id;
 
-export const deepFindAllByKey = (
-  o: Record<string, unknown> | Record<string, unknown>[],
-  predicateKey: string,
-  accum: string[] = []
-) => {
-  if (typeof o === 'object') {
-    Object?.entries(o).forEach(([key, value]) => {
+export function* deepFindAllByKey<T = string>(
+  input: unknown,
+  predicateKey: string
+): Generator<T, void, never> {
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      yield* deepFindAllByKey<T>(item, predicateKey);
+    }
+  } else if (input && typeof input === 'object') {
+    for (const [key, value] of Object.entries(input)) {
       if (key === predicateKey) {
-        accum.push(value as string);
+        yield value;
       } else {
-        deepFindAllByKey(value as Record<string, unknown>, predicateKey, accum);
+        yield* deepFindAllByKey(value, predicateKey);
       }
-    });
+    }
   }
-  return accum;
-};
+}

--- a/src/supporting-data/citations/config/__tests__/CitationsColumnConfiguration.spec.tsx
+++ b/src/supporting-data/citations/config/__tests__/CitationsColumnConfiguration.spec.tsx
@@ -1,29 +1,22 @@
-import CitationsColumnConfiguration from '../CitationsColumnConfiguration';
+import CitationsColumnConfiguration, {
+  CitationsColumn,
+} from '../CitationsColumnConfiguration';
 
 import citationsConverter, {
   CitationsAPIModel,
   CitationsUIModel,
 } from '../../adapters/citationsConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import data from '../../__mocks__/citationsModelData';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: CitationsUIModel = citationsConverter(data[0]);
+
 describe('CitationsColumnConfiguration component', () => {
-  let transformedData: CitationsUIModel;
-
-  beforeAll(() => {
-    transformedData = citationsConverter(data[0] as CitationsAPIModel);
-  });
-
-  test.each(Array.from(CitationsColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<CitationsColumn, Partial<CitationsAPIModel>>(
+    CitationsColumnConfiguration,
+    transformedData
   );
 });

--- a/src/supporting-data/database/config/__tests__/DatabaseColumnConfiguration.spec.tsx
+++ b/src/supporting-data/database/config/__tests__/DatabaseColumnConfiguration.spec.tsx
@@ -1,29 +1,22 @@
-import DatabaseColumnConfiguration from '../DatabaseColumnConfiguration';
+import DatabaseColumnConfiguration, {
+  DatabaseColumn,
+} from '../DatabaseColumnConfiguration';
 
 import databaseConverter, {
   DatabaseAPIModel,
   DatabaseUIModel,
 } from '../../adapters/databaseConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 import data from '../../__mocks__/databaseModelData';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: DatabaseUIModel = databaseConverter(data[0]);
+
 describe('DatabaseColumnConfiguration component', () => {
-  let transformedData: DatabaseUIModel;
-
-  beforeAll(() => {
-    transformedData = databaseConverter(data[0] as DatabaseAPIModel);
-  });
-
-  test.each(Array.from(DatabaseColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<DatabaseColumn, Partial<DatabaseAPIModel>>(
+    DatabaseColumnConfiguration,
+    transformedData
   );
 });

--- a/src/supporting-data/diseases/config/__tests__/DiseasesColumnConfiguration.spec.tsx
+++ b/src/supporting-data/diseases/config/__tests__/DiseasesColumnConfiguration.spec.tsx
@@ -1,30 +1,23 @@
-import DiseasesColumnConfiguration from '../DiseasesColumnConfiguration';
+import DiseasesColumnConfiguration, {
+  DiseasesColumn,
+} from '../DiseasesColumnConfiguration';
 
 import diseasesConverter, {
   DiseasesAPIModel,
   DiseasesUIModel,
 } from '../../adapters/diseasesConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import data from '../../__mocks__/diseasesModelData';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: DiseasesUIModel = diseasesConverter(data[0]);
+
 describe('DiseasesColumnConfiguration component', () => {
-  let transformedData: DiseasesUIModel;
-
-  beforeAll(() => {
-    transformedData = diseasesConverter(data[0] as DiseasesAPIModel);
-  });
-
   // TODO: find mock data to create non-null unreviewed_protein_count snapshot
-  test.each(Array.from(DiseasesColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<DiseasesColumn, Partial<DiseasesAPIModel>>(
+    DiseasesColumnConfiguration,
+    transformedData
   );
 });

--- a/src/supporting-data/keywords/config/__tests__/KeywordsColumnConfiguration.spec.tsx
+++ b/src/supporting-data/keywords/config/__tests__/KeywordsColumnConfiguration.spec.tsx
@@ -1,30 +1,22 @@
-import KeywordsColumnConfiguration from '../KeywordsColumnConfiguration';
+import KeywordsColumnConfiguration, {
+  KeywordsColumn,
+} from '../KeywordsColumnConfiguration';
 
 import citationsConverter, {
   KeywordsAPIModel,
   KeywordsUIModel,
 } from '../../adapters/keywordsConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import data from '../../__mocks__/keywordsModelData';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: KeywordsUIModel = citationsConverter(data[0]);
 describe('KeywordsColumnConfiguration component', () => {
-  let transformedData: KeywordsUIModel;
-
-  beforeAll(() => {
-    transformedData = citationsConverter(data[0] as KeywordsAPIModel);
-  });
-
   // TODO: find mock data to create non-null parent, sites, synonym snapshots
-  test.each(Array.from(KeywordsColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<KeywordsColumn, Partial<KeywordsAPIModel>>(
+    KeywordsColumnConfiguration,
+    transformedData
   );
 });

--- a/src/supporting-data/locations/config/__tests__/LocationsColumnConfiguration.spec.tsx
+++ b/src/supporting-data/locations/config/__tests__/LocationsColumnConfiguration.spec.tsx
@@ -1,30 +1,22 @@
-import LocationsColumnConfiguration from '../LocationsColumnConfiguration';
+import LocationsColumnConfiguration, {
+  LocationsColumn,
+} from '../LocationsColumnConfiguration';
 
 import locationsConverter, {
   LocationsAPIModel,
   LocationsUIModel,
 } from '../../adapters/locationsConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import data from '../../__mocks__/locationsModelData';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: LocationsUIModel = locationsConverter(data[0]);
 describe('LocationsColumnConfiguration component', () => {
-  let transformedData: LocationsUIModel;
-
-  beforeAll(() => {
-    transformedData = locationsConverter(data[0] as LocationsAPIModel);
-  });
-
   // TODO: find mock data to create non-null links, note, references snapshots
-  test.each(Array.from(LocationsColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<LocationsColumn, Partial<LocationsAPIModel>>(
+    LocationsColumnConfiguration,
+    transformedData
   );
 });

--- a/src/supporting-data/taxonomy/config/__tests__/TaxonomyColumnConfiguration.spec.tsx
+++ b/src/supporting-data/taxonomy/config/__tests__/TaxonomyColumnConfiguration.spec.tsx
@@ -1,30 +1,23 @@
-import TaxonomyColumnConfiguration from '../TaxonomyColumnConfiguration';
+import TaxonomyColumnConfiguration, {
+  TaxonomyColumn,
+} from '../TaxonomyColumnConfiguration';
 
 import taxonomyConverter, {
   TaxonomyAPIModel,
   TaxonomyUIModel,
 } from '../../adapters/taxonomyConverter';
-import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import data from '../../__mocks__/taxonomyModelData';
+import testColumnConfiguration from '../../../../shared/__test-helpers__/testColumnConfiguration';
 
 jest.mock('../../../../tools/utils/storage');
 
+const transformedData: TaxonomyUIModel = taxonomyConverter(data[0]);
+
 describe('TaxonomyColumnConfiguration component', () => {
-  let transformedData: TaxonomyUIModel;
-
-  beforeAll(() => {
-    transformedData = taxonomyConverter(data[0] as TaxonomyAPIModel);
-  });
-
   // TODO: find mock data to create non-null host, links, strain, synonym snapshots
-  test.each(Array.from(TaxonomyColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<TaxonomyColumn, Partial<TaxonomyAPIModel>>(
+    TaxonomyColumnConfiguration,
+    transformedData
   );
 });

--- a/src/uniparc/config/__tests__/UniParcColumnConfiguration.spec.tsx
+++ b/src/uniparc/config/__tests__/UniParcColumnConfiguration.spec.tsx
@@ -3,29 +3,22 @@ import UniParcColumnConfiguration, {
 } from '../UniParcColumnConfiguration';
 
 import uniParcConverter, {
+  UniParcAPIModel,
   UniParcUIModel,
 } from '../../adapters/uniParcConverter';
 import customRender from '../../../shared/__test-helpers__/customRender';
+import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
 
 import data from '../../__mocks__/uniParcEntryModelData';
 
 jest.mock('../../../tools/utils/storage');
 
+const transformedData: UniParcUIModel = uniParcConverter(data);
+
 describe('UniParcColumnConfiguration component', () => {
-  let transformedData: UniParcUIModel;
-
-  beforeAll(() => {
-    transformedData = uniParcConverter(data);
-  });
-
-  test.each(Array.from(UniParcColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(transformedData)}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<UniParcColumn, UniParcAPIModel>(
+    UniParcColumnConfiguration,
+    transformedData
   );
 
   describe('edge cases', () => {

--- a/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
+++ b/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
@@ -1,6 +1,10 @@
-import UniParcXRefsColumnConfiguration from '../UniParcXRefsColumnConfiguration';
+import UniParcXRefsColumnConfiguration, {
+  UniParcXRefsColumn,
+} from '../UniParcXRefsColumnConfiguration';
 
-import customRender from '../../../shared/__test-helpers__/customRender';
+import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
+
+import { UniParcXRef } from '../../adapters/uniParcConverter';
 
 import data from '../../__mocks__/uniParcEntryModelData';
 
@@ -9,11 +13,8 @@ jest.mock('../../../tools/utils/storage');
 describe('UniParcXRefsColumnConfiguration component', () => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
   const xrefData = data.uniParcCrossReferences?.[0]!;
-  test.each(Array.from(UniParcXRefsColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(<>{column.render(xrefData)}</>);
-      expect(asFragment()).toMatchSnapshot(key);
-    }
+  testColumnConfiguration<UniParcXRefsColumn, UniParcXRef>(
+    UniParcXRefsColumnConfiguration,
+    xrefData
   );
 });

--- a/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
+++ b/src/uniparc/config/__tests__/__snapshots__/UniParcColumnConfiguration.spec.tsx.snap
@@ -146,6 +146,141 @@ exports[`UniParcColumnConfiguration component should render column "accession": 
 </DocumentFragment>
 `;
 
+exports[`UniParcColumnConfiguration component should render column "accession": accession-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      <a
+        href="/uniprotkb/P07612"
+      >
+        <span
+          class="entry-title__status icon--reviewed"
+          title="This marks a reviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        P07612
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/P07612"
+      >
+        <span
+          class="entry-title__status icon--reviewed"
+          title="This marks a reviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        P07612.1 (obsolete)
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/A0A2I2MDI1"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        A0A2I2MDI1
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/A0A7I8V511"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        A0A7I8V511
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/Q0GNZ6"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        Q0GNZ6
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/Q6RZL4"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        Q6RZL4
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/Q71TT2"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        Q71TT2
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/Q76QK2"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        Q76QK2
+      </a>
+    </li>
+    <li>
+      <a
+        href="/uniprotkb/Q76ZT7"
+      >
+        <span
+          class="entry-title__status icon--unreviewed"
+          title="This marks an unreviewed UniProtKB entry"
+        >
+          <test-file-stub />
+        </span>
+        Q76ZT7.1 (obsolete)
+      </a>
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less entries
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`UniParcColumnConfiguration component should render column "checksum": checksum 1`] = `
 <DocumentFragment>
   28FE89850863372D
@@ -191,6 +326,63 @@ exports[`UniParcColumnConfiguration component should render column "gene": gene 
         type="button"
       >
         8 more gene names
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`UniParcColumnConfiguration component should render column "gene": gene-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      VACWR088
+    </li>
+    <li>
+      L1R
+    </li>
+    <li>
+      VACV VK01 RKI-115 CDS
+    </li>
+    <li>
+      RPXV077
+    </li>
+    <li>
+      N1R
+    </li>
+    <li>
+      CPXV_FIN2000_MAN_093
+    </li>
+    <li>
+      VACV_TT8_108
+    </li>
+    <li>
+      VACV_TT12_108
+    </li>
+    <li>
+      VAC_TKT3_078
+    </li>
+    <li>
+      VAC_TKT4_078
+    </li>
+    <li>
+      VACV_IOC_B141_114
+    </li>
+    <li>
+      VACV_IOC_B388_114
+    </li>
+    <li>
+      LIVPclone14_096
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less gene names
       </button>
     </li>
   </ul>
@@ -271,6 +463,80 @@ exports[`UniParcColumnConfiguration component should render column "organism": o
 </DocumentFragment>
 `;
 
+exports[`UniParcColumnConfiguration component should render column "organism": organism-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      <a
+        href="/taxonomy/10254"
+        title="Vaccinia virus (strain Western Reserve) (VACV), taxon ID 10254"
+      >
+        Vaccinia virus (strain Western Reserve) (VACV)
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/9606"
+        title="Homo sapiens (Human), taxon ID 9606"
+      >
+        Homo sapiens (Human)
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/397342"
+        title="Horsepox virus (HSPV), taxon ID 397342"
+      >
+        Horsepox virus (HSPV)
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/32606"
+        title="Rabbitpox virus, taxon ID 32606"
+      >
+        Rabbitpox virus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/10245"
+        title="Vaccinia virus, taxon ID 10245"
+      >
+        Vaccinia virus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/10243"
+        title="Cowpox virus (CPV), taxon ID 10243"
+      >
+        Cowpox virus (CPV)
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/32630"
+        title="synthetic construct, taxon ID 32630"
+      >
+        synthetic construct
+      </a>
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less organisms
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`UniParcColumnConfiguration component should render column "organism_id": organism_id 1`] = `
 <DocumentFragment>
   <ul
@@ -329,6 +595,80 @@ exports[`UniParcColumnConfiguration component should render column "organism_id"
 </DocumentFragment>
 `;
 
+exports[`UniParcColumnConfiguration component should render column "organism_id": organism_id-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      <a
+        href="/taxonomy/10254"
+        title="Vaccinia virus (strain Western Reserve) (VACV), taxon ID 10254"
+      >
+        10254
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/9606"
+        title="Homo sapiens (Human), taxon ID 9606"
+      >
+        9606
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/397342"
+        title="Horsepox virus (HSPV), taxon ID 397342"
+      >
+        397342
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/32606"
+        title="Rabbitpox virus, taxon ID 32606"
+      >
+        32606
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/10245"
+        title="Vaccinia virus, taxon ID 10245"
+      >
+        10245
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/10243"
+        title="Cowpox virus (CPV), taxon ID 10243"
+      >
+        10243
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/32630"
+        title="synthetic construct, taxon ID 32630"
+      >
+        32630
+      </a>
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less organisms
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`UniParcColumnConfiguration component should render column "protein": protein 1`] = `
 <DocumentFragment>
   <ul
@@ -356,6 +696,63 @@ exports[`UniParcColumnConfiguration component should render column "protein": pr
         type="button"
       >
         8 more protein names
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`UniParcColumnConfiguration component should render column "protein": protein-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      Protein L1
+    </li>
+    <li>
+      IMV membrane protein
+    </li>
+    <li>
+      Polyprotein
+    </li>
+    <li>
+      HSPV089
+    </li>
+    <li>
+      RPXV077
+    </li>
+    <li>
+      L1R
+    </li>
+    <li>
+      Myristylated MP IMV
+    </li>
+    <li>
+      Neutralizing antibody IMV membrane protein target
+    </li>
+    <li>
+      Neutralizing antibody MV membrane protein
+    </li>
+    <li>
+      F2 polypeptide
+    </li>
+    <li>
+      N1R protein
+    </li>
+    <li>
+      Hypothetical protein
+    </li>
+    <li>
+      Putative L1R
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less protein names
       </button>
     </li>
   </ul>
@@ -414,6 +811,136 @@ exports[`UniParcColumnConfiguration component should render column "proteome": p
         type="button"
       >
         9 more proteomes
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`UniParcColumnConfiguration component should render column "proteome": proteome-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      <a
+        href="/proteomes/UP000000344"
+      >
+        UP000000344
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000166173"
+      >
+        UP000166173
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000111173"
+      >
+        UP000111173
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000113999"
+      >
+        UP000113999
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000181229"
+      >
+        UP000181229
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000181062"
+      >
+        UP000181062
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000181110"
+      >
+        UP000181110
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000153808"
+      >
+        UP000153808
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000097422"
+      >
+        UP000097422
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000181484"
+      >
+        UP000181484
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000315999"
+      >
+        UP000315999
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000137384"
+      >
+        UP000137384
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000501395"
+      >
+        UP000501395
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <a
+        href="/proteomes/UP000274976"
+      >
+        UP000274976
+      </a>
+       (Genome)
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less proteomes
       </button>
     </li>
   </ul>

--- a/src/uniprotkb/components/protein-data-views/CSVView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CSVView.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { uniq } from 'lodash-es';
 import { EllipsisReveal } from 'franklin-sites';
 
 import { deepFindAllByKey } from '../../../shared/utils/utils';
@@ -18,7 +17,9 @@ const CSVView: FC<CSVViewProps> = ({
   if (!data) {
     return null;
   }
-  const uniqueValues = uniq(deepFindAllByKey(data, keyPredicate));
+  const uniqueValues = Array.from(
+    new Set(deepFindAllByKey(data, keyPredicate))
+  );
   return (
     <>
       <span

--- a/src/uniprotkb/components/protein-data-views/CSVView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CSVView.tsx
@@ -6,11 +6,15 @@ import { deepFindAllByKey } from '../../../shared/utils/utils';
 
 type CSVViewProps = {
   data?: Record<string, unknown> | Record<string, unknown>[];
-  bolderFirst: boolean;
-  keyPredicate: string;
+  bolderFirst?: boolean;
+  keyPredicate?: string;
 };
 
-const CSVView: FC<CSVViewProps> = ({ data, bolderFirst, keyPredicate }) => {
+const CSVView: FC<CSVViewProps> = ({
+  data,
+  bolderFirst = false,
+  keyPredicate = 'value',
+}) => {
   if (!data) {
     return null;
   }

--- a/src/uniprotkb/components/protein-data-views/CSVView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CSVView.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react';
+import { uniq } from 'lodash-es';
+import { EllipsisReveal } from 'franklin-sites';
+
+import { deepFindAllByKey } from '../../../shared/utils/utils';
+
+type CSVViewProps = {
+  data?: Record<string, unknown> | Record<string, unknown>[];
+  bolderFirst: boolean;
+  keyPredicate: string;
+};
+
+const CSVView: FC<CSVViewProps> = ({ data, bolderFirst, keyPredicate }) => {
+  if (!data) {
+    return null;
+  }
+  const uniqueValues = uniq(deepFindAllByKey(data, keyPredicate));
+  return (
+    <>
+      <span
+        style={{
+          fontWeight: bolderFirst ? 'bolder' : 'initial',
+        }}
+      >
+        {uniqueValues[0]}
+      </span>
+      {uniqueValues.length > 1 && (
+        <EllipsisReveal>
+          {', '}
+          {uniqueValues.splice(1).join(', ')}
+        </EllipsisReveal>
+      )}
+    </>
+  );
+};
+
+export default CSVView;

--- a/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
@@ -1,0 +1,13 @@
+import { screen, render } from '@testing-library/react';
+import CSVView from '../CSVView';
+
+describe('CSVView', () => {
+  it('should return nothing if no data provided', () => {
+    const { container } = render(<CSVView data={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+  it('should make first element is bolder', () => {
+    render(<CSVView data={[{ value: 'foo' }, { value: 'bar' }]} bolderFirst />);
+    expect(screen.getByText('foo')).toHaveStyle({ 'font-weight': 'bolder' });
+  });
+});

--- a/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
@@ -4,7 +4,7 @@ import CSVView from '../CSVView';
 describe('CSVView', () => {
   it('should return nothing if no data provided', () => {
     const { container } = render(<CSVView data={undefined} />);
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
   it('should make first element is bolder', () => {
     render(<CSVView data={[{ value: 'foo' }, { value: 'bar' }]} bolderFirst />);

--- a/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/CSVView.spec.tsx
@@ -6,7 +6,7 @@ describe('CSVView', () => {
     const { container } = render(<CSVView data={undefined} />);
     expect(container).toBeEmptyDOMElement();
   });
-  it('should make first element is bolder', () => {
+  it('should make first element bolder', () => {
     render(<CSVView data={[{ value: 'foo' }, { value: 'bar' }]} bolderFirst />);
     expect(screen.getByText('foo')).toHaveStyle({ 'font-weight': 'bolder' });
   });

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -138,17 +138,24 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
         [
           proteinNamesData?.recommendedName,
           ...(proteinNamesData?.alternativeNames || []),
-        ].flatMap((name) => [
-          name?.fullName.value,
-          ...(name?.shortNames?.map((name) => name.value) || []),
-          ...(name?.ecNumbers?.map((name) => name.value) || []),
-        ])
+          ...(proteinNamesData?.submissionNames || []),
+        ]
+          .flatMap((name) => [
+            name?.fullName.value,
+            ...(name?.shortNames?.map((name) => name.value) || []),
+            ...(name?.ecNumbers?.map((name) => name.value) || []),
+          ])
+          .filter(Boolean)
       )
     );
 
     return (
       <>
-        <strong>{uniqueNames[0]}</strong>
+        {proteinNamesData?.recommendedName ? (
+          <strong>{uniqueNames[0]}</strong>
+        ) : (
+          uniqueNames[0]
+        )}
         {uniqueNames.length > 1 && (
           <EllipsisReveal>
             {', '}

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -131,7 +131,6 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
     return (
       <CSVView
         data={omit(proteinNamesData, 'contains')}
-        keyPredicate="value"
         bolderFirst={Boolean(proteinNamesData?.recommendedName)}
       />
     );
@@ -143,7 +142,6 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.geneNames, {
   render: (data) => (
     <CSVView
       data={data[EntrySection.NamesAndTaxonomy].geneNamesData}
-      keyPredicate="value"
       bolderFirst
     />
   ),

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -1,12 +1,8 @@
 /* eslint-disable camelcase */
-import {
-  EllipsisReveal,
-  ExpandableList,
-  LongNumber,
-  Sequence,
-} from 'franklin-sites';
+import { ExpandableList, LongNumber, Sequence } from 'franklin-sites';
 import { Link } from 'react-router-dom';
 
+import { omit } from 'lodash-es';
 import SimpleView from '../../shared/components/views/SimpleView';
 import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
 import TaxonomyView, {
@@ -75,6 +71,7 @@ import { fromColumnConfig } from '../../tools/id-mapping/config/IdMappingColumnC
 import { Namespace } from '../../shared/types/namespaces';
 import { ColumnConfiguration } from '../../shared/types/columnConfiguration';
 import AccessionView from '../../shared/components/results/AccessionView';
+import CSVView from '../components/protein-data-views/CSVView';
 
 export const defaultColumns = [
   UniProtKBColumn.accession,
@@ -131,72 +128,25 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
   label: 'Protein Names',
   render: (data) => {
     const { proteinNamesData } = data[EntrySection.NamesAndTaxonomy];
-
-    // Note this should be in ProteinNamesView eventually
-    const uniqueNames = Array.from(
-      new Set(
-        [
-          proteinNamesData?.recommendedName,
-          ...(proteinNamesData?.alternativeNames || []),
-          ...(proteinNamesData?.submissionNames || []),
-        ]
-          .flatMap((name) => [
-            name?.fullName.value,
-            ...(name?.shortNames?.map((name) => name.value) || []),
-            ...(name?.ecNumbers?.map((name) => name.value) || []),
-          ])
-          .filter(Boolean)
-      )
-    );
-
     return (
-      <>
-        {proteinNamesData?.recommendedName ? (
-          <strong>{uniqueNames[0]}</strong>
-        ) : (
-          uniqueNames[0]
-        )}
-        {uniqueNames.length > 1 && (
-          <EllipsisReveal>
-            {', '}
-            {uniqueNames.splice(1).join(', ')}
-          </EllipsisReveal>
-        )}
-      </>
+      <CSVView
+        data={omit(proteinNamesData, 'contains')}
+        keyPredicate="value"
+        bolderFirst={Boolean(proteinNamesData?.recommendedName)}
+      />
     );
   },
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.geneNames, {
   label: 'Gene Names',
-  render: (data) => {
-    const { geneNamesData } = data[EntrySection.NamesAndTaxonomy];
-
-    // Note this should be in GeneNamesView eventually
-    const uniqueNames = Array.from(
-      new Set(
-        geneNamesData?.flatMap((geneNames) => [
-          geneNames.geneName?.value,
-          ...(geneNames.synonyms?.map((synonym) => synonym.value) || []),
-          ...(geneNames.orderedLocusNames?.map((synonym) => synonym.value) ||
-            []),
-          ...(geneNames.orfNames?.map((synonym) => synonym.value) || []),
-        ])
-      )
-    ).filter((name) => name);
-
-    return (
-      <>
-        <strong>{uniqueNames[0]}</strong>
-        {uniqueNames.length > 1 && (
-          <EllipsisReveal>
-            {', '}
-            {uniqueNames.splice(1).join(', ')}
-          </EllipsisReveal>
-        )}
-      </>
-    );
-  },
+  render: (data) => (
+    <CSVView
+      data={data[EntrySection.NamesAndTaxonomy].geneNamesData}
+      keyPredicate="value"
+      bolderFirst
+    />
+  ),
 });
 
 UniProtKBColumnConfiguration.set(UniProtKBColumn.organismName, {

--- a/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
+++ b/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
@@ -1,13 +1,17 @@
-import { screen } from '@testing-library/react';
-
 import UniProtKBColumnConfiguration from '../UniProtKBColumnConfiguration';
 
-import uniProtKbConverter from '../../adapters/uniProtkbConverter';
-import customRender from '../../../shared/__test-helpers__/customRender';
+import uniProtKbConverter, {
+  UniProtkbUIModel,
+} from '../../adapters/uniProtkbConverter';
+import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
+
+import { UniProtKBColumn } from '../../types/columnTypes';
 
 import data from '../../__mocks__/uniProtKBEntryModelData';
 
 jest.mock('../../../tools/utils/storage');
+
+const transformedData: UniProtkbUIModel = uniProtKbConverter(data);
 
 describe('UniProtKBColumnConfiguration component', () => {
   beforeAll(() => {
@@ -27,20 +31,8 @@ describe('UniProtKBColumnConfiguration component', () => {
 
   // TODO: find mock data to generate non-null snapshot for:
   // go_id, go, and many others
-  test.each(Array.from(UniProtKBColumnConfiguration.entries()))(
-    `should render column "%s"`,
-    (key, column) => {
-      const { asFragment } = customRender(
-        <>{column.render(uniProtKbConverter(data))}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-      const showMore =
-        screen.queryByTitle('Show more') ||
-        screen.queryByTestId('expandable-message');
-      if (showMore) {
-        showMore.click();
-        expect(asFragment()).toMatchSnapshot(`${key}-expanded`);
-      }
-    }
+  testColumnConfiguration<UniProtKBColumn, UniProtkbUIModel>(
+    UniProtKBColumnConfiguration,
+    transformedData
   );
 });

--- a/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
+++ b/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
@@ -1,3 +1,5 @@
+import { screen } from '@testing-library/react';
+
 import UniProtKBColumnConfiguration from '../UniProtKBColumnConfiguration';
 
 import uniProtKbConverter from '../../adapters/uniProtkbConverter';
@@ -32,6 +34,13 @@ describe('UniProtKBColumnConfiguration component', () => {
         <>{column.render(uniProtKbConverter(data))}</>
       );
       expect(asFragment()).toMatchSnapshot(key);
+      const showMore =
+        screen.queryByTitle('Show more') ||
+        screen.queryByTestId('expandable-message');
+      if (showMore) {
+        showMore.click();
+        expect(asFragment()).toMatchSnapshot(`${key}-expanded`);
+      }
     }
   );
 });

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -988,6 +988,17 @@ exports[`UniProtKBColumnConfiguration component should render column "gene_names
 </DocumentFragment>
 `;
 
+exports[`UniProtKBColumnConfiguration component should render column "gene_names": gene_names-expanded 1`] = `
+<DocumentFragment>
+  <span
+    style="font-weight: bolder;"
+  >
+    some Gene
+  </span>
+  , some Syn, some locus, some orf
+</DocumentFragment>
+`;
+
 exports[`UniProtKBColumnConfiguration component should render column "gene_oln": gene_oln 1`] = `
 <DocumentFragment>
   <ul
@@ -1236,6 +1247,73 @@ exports[`UniProtKBColumnConfiguration component should render column "lit_pubmed
 </DocumentFragment>
 `;
 
+exports[`UniProtKBColumnConfiguration component should render column "lit_pubmed_id": lit_pubmed_id-expanded 1`] = `
+<DocumentFragment>
+  <ul
+    class="expandable-list no-bullet"
+  >
+    <li>
+      <a
+        href="/citations/12345"
+      >
+        12345
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12346"
+      >
+        12346
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12347"
+      >
+        12347
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12348"
+      >
+        12348
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12349"
+      >
+        12349
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12340"
+      >
+        12340
+      </a>
+    </li>
+    <li>
+      <a
+        href="/citations/12341"
+      >
+        12341
+      </a>
+    </li>
+    <li>
+      <button
+        class="button tertiary expandable-list__action"
+        data-testid="expandable-message"
+        type="button"
+      >
+        Less IDs
+      </button>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
 exports[`UniProtKBColumnConfiguration component should render column "mapped_pubmed_id": mapped_pubmed_id 1`] = `<DocumentFragment />`;
 
 exports[`UniProtKBColumnConfiguration component should render column "mass": mass 1`] = `
@@ -1319,6 +1397,17 @@ exports[`UniProtKBColumnConfiguration component should render column "protein_na
   >
     [...]
   </button>
+</DocumentFragment>
+`;
+
+exports[`UniProtKBColumnConfiguration component should render column "protein_name": protein_name-expanded 1`] = `
+<DocumentFragment>
+  <span
+    style="font-weight: bolder;"
+  >
+    rec full Name
+  </span>
+  , recommended short name, 1.2.3.4, a full alt Name, short alt name1, 1.2.3.3, allergen, biotech, cd antigen, inn antigen, sub full Name, 1.2.3.5, includesrec full Name, includesrecommended short name, includesa full alt Name, includesshort alt name1
 </DocumentFragment>
 `;
 

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -972,9 +972,11 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_zn_fing
 
 exports[`UniProtKBColumnConfiguration component should render column "gene_names": gene_names 1`] = `
 <DocumentFragment>
-  <strong>
+  <span
+    style="font-weight: bolder;"
+  >
     some Gene
-  </strong>
+  </span>
   <button
     aria-expanded="false"
     class="button tertiary ellipsis-reveal"
@@ -1304,9 +1306,11 @@ exports[`UniProtKBColumnConfiguration component should render column "protein_ex
 
 exports[`UniProtKBColumnConfiguration component should render column "protein_name": protein_name 1`] = `
 <DocumentFragment>
-  <strong>
+  <span
+    style="font-weight: bolder;"
+  >
     rec full Name
-  </strong>
+  </span>
   <button
     aria-expanded="false"
     class="button tertiary ellipsis-reveal"

--- a/src/uniref/config/__tests__/UniRefColumnConfiguration.spec.tsx
+++ b/src/uniref/config/__tests__/UniRefColumnConfiguration.spec.tsx
@@ -1,18 +1,18 @@
-import UniRefColumnConfiguration from '../UniRefColumnConfiguration';
+import UniRefColumnConfiguration, {
+  UniRefColumn,
+} from '../UniRefColumnConfiguration';
 
-import customRender from '../../../shared/__test-helpers__/customRender';
+import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
 
 import mock from '../../__mocks__/UniRefResultsData';
+
+import { UniRefLiteAPIModel } from '../../adapters/uniRefConverter';
 
 jest.mock('../../../tools/utils/storage');
 
 describe('UniRefColumnConfiguration component', () => {
-  for (const [key, column] of UniRefColumnConfiguration) {
-    test(`should render column "${key}"`, () => {
-      const { asFragment } = customRender(
-        <>{column.render(mock.results[0])}</>
-      );
-      expect(asFragment()).toMatchSnapshot(key);
-    });
-  }
+  testColumnConfiguration<UniRefColumn, Partial<UniRefLiteAPIModel>>(
+    UniRefColumnConfiguration,
+    mock.results[0]
+  );
 });


### PR DESCRIPTION
## Purpose
Jira: [Protein names missing "subNames"](https://www.ebi.ac.uk/panda/jira/browse/TRM-26211)

## Approach
Gene Names and Protein Names column renderers doing very similar things so:

1. Created `deepFindAllByKey` function to extract all of the `value` names for both genes and proteins
2. Created `CSVView` component to render this (including the missing submission names)

## Testing

- Create unit tests for `CSVView` and `deepFindAllByKey`
- Update `UniProtKBColumnConfiguration` snapshot tests to also check to see if there is a "more" button and if so click this and create a new snapshot from this.

## To view changes
As the jira states visit http://localhost:8080/uniprotkb?query=uncharacterized%20protein%20koala and look at the protein names column

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
