### PR TITLE
Fix interaction column renderer

### DIFF
--- a/src/tools/adapters/parameters.ts
+++ b/src/tools/adapters/parameters.ts
@@ -93,6 +93,7 @@ export function formParametersToServerParameters<T extends JobTypes>(
           program,
           matrix,
           alignments: hits,
+          scores: hits,
           exp: threshold,
           filter,
           gapalign: gapped,

--- a/src/uniprotkb/__mocks__/uniProtKBEntryModelData.ts
+++ b/src/uniprotkb/__mocks__/uniProtKBEntryModelData.ts
@@ -800,7 +800,7 @@ const mock: UniProtkbAPIModel = {
       interactions: [
         {
           interactantOne: {
-            uniProtKBAccession: 'P12345',
+            uniProtKBAccession: 'P21802',
             geneName: 'gen',
             chainId: 'PROC_12344',
             intActId: 'EBI-0001',
@@ -822,7 +822,7 @@ const mock: UniProtkbAPIModel = {
             intActId: 'EBI-00011',
           },
           interactantTwo: {
-            uniProtKBAccession: 'P12346',
+            uniProtKBAccession: 'P21802',
             geneName: 'gene1',
             chainId: 'PROC_123454',
             intActId: 'EBI-00012',

--- a/src/uniprotkb/adapters/__tests__/interactionConverter.spec.ts
+++ b/src/uniprotkb/adapters/__tests__/interactionConverter.spec.ts
@@ -22,7 +22,7 @@ describe('Interaction data converter', () => {
                     chainId: 'PROC_12344',
                     geneName: 'gen',
                     intActId: 'EBI-0001',
-                    uniProtKBAccession: 'P12345',
+                    uniProtKBAccession: 'P21802',
                   },
                   interactantTwo: {
                     chainId: 'PROC_12347',
@@ -44,7 +44,7 @@ describe('Interaction data converter', () => {
                     chainId: 'PROC_123454',
                     geneName: 'gene1',
                     intActId: 'EBI-00012',
-                    uniProtKBAccession: 'P12346',
+                    uniProtKBAccession: 'P21802',
                   },
                   numberOfExperiments: 6,
                   organismDiffer: true,

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -671,6 +671,8 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
 
     interactionComments?.forEach((interactionCC) =>
       interactionCC.interactions.forEach((interaction) => {
+        // Note: currently the interaction type is missing from the request.
+        // Check again when it has been added.
         if (
           interaction.type === InteractionType.SELF ||
           (interaction.interactantOne.uniProtKBAccession === primaryAccession &&

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -71,12 +71,11 @@ import EntryTypeIcon, {
 
 import { getEntryPath } from '../../app/config/urls';
 import { fromColumnConfig } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
+import { sortInteractionData } from '../utils/resultsUtils';
 
 import { Namespace } from '../../shared/types/namespaces';
 import { ColumnConfiguration } from '../../shared/types/columnConfiguration';
 import AccessionView from '../../shared/components/results/AccessionView';
-
-import { Interactant } from '../adapters/interactionConverter';
 
 import helper from '../../shared/styles/helper.module.scss';
 
@@ -741,18 +740,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
       })
     );
 
-    const sortedInteractions = Array.from(interactionDataMap.values()).sort(
-      (a, b) => {
-        if (typeof a !== 'string' && typeof b !== 'string') {
-          return (
-            (a as Interactant).geneName?.localeCompare(
-              (b as Interactant).geneName || ''
-            ) || -1
-          );
-        }
-        return -2;
-      }
-    );
+    const sortedInteractions = sortInteractionData(interactionDataMap);
 
     return (
       <ExpandableList displayNumberOfHiddenItems>

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -703,33 +703,67 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
     const interactionComments = data[EntrySection.Interaction].commentsData.get(
       'INTERACTION'
     ) as InteractionComment[];
-    return (
-      <ExpandableList displayNumberOfHiddenItems>
-        {interactionComments?.map((interactionCC) =>
-          interactionCC.interactions.map((interaction) => (
-            <div
-              key={
-                interaction.type === InteractionType.SELF
-                  ? 'self'
-                  : `${interaction.interactantOne.uniProtKBAccession}-${interaction.interactantTwo.uniProtKBAccession}`
-              }
-            >
-              {interaction.type === InteractionType.SELF
-                ? 'Itself'
-                : interaction.interactantOne.uniProtKBAccession && (
-                    <Link
-                      to={getEntryPath(
-                        Namespace.uniprotkb,
-                        interaction.interactantOne.uniProtKBAccession
-                      )}
-                    >
-                      {interaction.interactantOne.uniProtKBAccession}
-                    </Link>
+    const { primaryAccession } = data;
+
+    const interactionElements = interactionComments
+      ?.map((interactionCC) =>
+        interactionCC.interactions.map((interaction) => {
+          if (interaction.type === InteractionType.SELF) {
+            return 'self';
+          }
+          if (
+            interaction.interactantOne.uniProtKBAccession ===
+              primaryAccession &&
+            interaction.interactantTwo.uniProtKBAccession
+          ) {
+            return (
+              <div
+                key={`${interaction.interactantOne.uniProtKBAccession}-${interaction.interactantTwo.uniProtKBAccession}`}
+              >
+                <Link
+                  to={getEntryPath(
+                    Namespace.uniprotkb,
+                    interaction.interactantTwo.uniProtKBAccession
                   )}
-            </div>
-          ))
-        )}
-      </ExpandableList>
+                >
+                  {interaction.interactantTwo.uniProtKBAccession}
+                </Link>
+              </div>
+            );
+          }
+          if (
+            interaction.interactantTwo.uniProtKBAccession ===
+              primaryAccession &&
+            interaction.interactantOne.uniProtKBAccession
+          ) {
+            return (
+              <div
+                key={`${interaction.interactantOne.uniProtKBAccession}-${interaction.interactantTwo.uniProtKBAccession}`}
+              >
+                <Link
+                  to={getEntryPath(
+                    Namespace.uniprotkb,
+                    interaction.interactantOne.uniProtKBAccession
+                  )}
+                >
+                  {interaction.interactantOne.uniProtKBAccession}
+                </Link>
+              </div>
+            );
+          }
+          // Some of the interactions are second level so don't feature the primaryAccession
+          // just ignore them.
+          return null;
+        })
+      )
+      .flat();
+
+    return (
+      interactionElements && (
+        <ExpandableList displayNumberOfHiddenItems>
+          {interactionElements.map((element) => element)}
+        </ExpandableList>
+      )
     );
   },
 });

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -6,7 +6,6 @@ import {
   Sequence,
 } from 'franklin-sites';
 import { Link } from 'react-router-dom';
-import { Fragment } from 'react';
 
 import SimpleView from '../../shared/components/views/SimpleView';
 import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
@@ -78,6 +77,8 @@ import { ColumnConfiguration } from '../../shared/types/columnConfiguration';
 import AccessionView from '../../shared/components/results/AccessionView';
 
 import { Interactant } from '../adapters/interactionConverter';
+
+import helper from '../../shared/styles/helper.module.scss';
 
 export const defaultColumns = [
   UniProtKBColumn.accession,
@@ -712,10 +713,13 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
 
     interactionComments?.forEach((interactionCC) =>
       interactionCC.interactions.forEach((interaction) => {
-        if (interaction.type === InteractionType.SELF) {
-          interactionDataMap.set('self', 'self');
-        }
         if (
+          interaction.type === InteractionType.SELF ||
+          (interaction.interactantOne.uniProtKBAccession === primaryAccession &&
+            interaction.interactantTwo.uniProtKBAccession === primaryAccession)
+        ) {
+          interactionDataMap.set('self', 'self');
+        } else if (
           interaction.interactantOne.uniProtKBAccession === primaryAccession &&
           interaction.interactantTwo.uniProtKBAccession
         ) {
@@ -723,8 +727,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
             interaction.interactantTwo.uniProtKBAccession,
             interaction.interactantTwo
           );
-        }
-        if (
+        } else if (
           interaction.interactantTwo.uniProtKBAccession === primaryAccession &&
           interaction.interactantOne.uniProtKBAccession
         ) {
@@ -747,7 +750,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
             ) || -1
           );
         }
-        return -1;
+        return -2;
       }
     );
 
@@ -756,9 +759,12 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
         {sortedInteractions.map((interactant) =>
           typeof interactant === 'string' ? (
             // SELF
-            interactant
+            'Itself'
           ) : (
-            <Fragment key={interactant.uniProtKBAccession}>
+            <div
+              key={interactant.uniProtKBAccession}
+              className={helper['no-wrap']}
+            >
               {interactant.uniProtKBAccession && (
                 <Link
                   to={getEntryPath(
@@ -769,8 +775,8 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccInteraction, {
                   {interactant.uniProtKBAccession}
                 </Link>
               )}{' '}
-              {interactant?.geneName}
-            </Fragment>
+              {interactant.geneName && `(${interactant.geneName})`}
+            </div>
           )
         )}
       </ExpandableList>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -527,45 +527,19 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_interac
   >
     <li>
       <a
-        href="/uniprotkb/P12345-1"
-      >
-        P12345-1
-      </a>
-       gene1 (
-      <a
-        class="external-link"
-        href="https://www.ebi.ac.uk/intact/query/id:EBI-0002"
-        rel="noopener"
-        target="_blank"
-      >
-        EBI-0002
-        <test-file-stub
-          data-testid="external-link-icon"
-          width="12.5"
-        />
-      </a>
-      )
-    </li>
-    <li>
-      <a
         href="/uniprotkb/P12345"
       >
         P12345
       </a>
-       gen (
+       gen
+    </li>
+    <li>
       <a
-        class="external-link"
-        href="https://www.ebi.ac.uk/intact/query/id:EBI-00011"
-        rel="noopener"
-        target="_blank"
+        href="/uniprotkb/P12345-1"
       >
-        EBI-00011
-        <test-file-stub
-          data-testid="external-link-icon"
-          width="12.5"
-        />
+        P12345-1
       </a>
-      )
+       gene1
     </li>
   </ul>
 </DocumentFragment>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -526,22 +526,46 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_interac
     class="expandable-list no-bullet"
   >
     <li>
-      <div>
-        <a
-          href="/uniprotkb/P12345-1"
-        >
-          P12345-1
-        </a>
-      </div>
+      <a
+        href="/uniprotkb/P12345-1"
+      >
+        P12345-1
+      </a>
+       gene1 (
+      <a
+        class="external-link"
+        href="https://www.ebi.ac.uk/intact/query/id:EBI-0002"
+        rel="noopener"
+        target="_blank"
+      >
+        EBI-0002
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      )
     </li>
     <li>
-      <div>
-        <a
-          href="/uniprotkb/P12345"
-        >
-          P12345
-        </a>
-      </div>
+      <a
+        href="/uniprotkb/P12345"
+      >
+        P12345
+      </a>
+       gen (
+      <a
+        class="external-link"
+        href="https://www.ebi.ac.uk/intact/query/id:EBI-00011"
+        rel="noopener"
+        target="_blank"
+      >
+        EBI-00011
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+      )
     </li>
   </ul>
 </DocumentFragment>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -528,9 +528,9 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_interac
     <li>
       <div>
         <a
-          href="/uniprotkb/P12345"
+          href="/uniprotkb/P12345-1"
         >
-          P12345
+          P12345-1
         </a>
       </div>
     </li>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -526,20 +526,28 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_interac
     class="expandable-list no-bullet"
   >
     <li>
-      <a
-        href="/uniprotkb/P12345"
+      <div
+        class="no-wrap"
       >
-        P12345
-      </a>
-       gen
+        <a
+          href="/uniprotkb/P12345"
+        >
+          P12345
+        </a>
+         (gen)
+      </div>
     </li>
     <li>
-      <a
-        href="/uniprotkb/P12345-1"
+      <div
+        class="no-wrap"
       >
-        P12345-1
-      </a>
-       gene1
+        <a
+          href="/uniprotkb/P12345-1"
+        >
+          P12345-1
+        </a>
+         (gene1)
+      </div>
     </li>
   </ul>
 </DocumentFragment>

--- a/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
+++ b/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
@@ -1,8 +1,12 @@
-import { getSortableColumnToSortColumn } from '../resultsUtils';
+import {
+  getSortableColumnToSortColumn,
+  sortInteractionData,
+} from '../resultsUtils';
 
 import { ReceivedFieldData } from '../../types/resultsTypes';
 
 import resultFields from '../../__mocks__/resultFields';
+import { Interactant } from '../../adapters/interactionConverter';
 
 describe('getSortableColumnToSortColumn', () => {
   it('should return columns with the sortField property', () => {
@@ -18,6 +22,23 @@ describe('getSortableColumnToSortColumn', () => {
       ['length', 'length'],
       ['mass', 'mass'],
       ['annotation_score', 'annotation_score'],
+    ]);
+  });
+
+  it('should sort interaction data properly', () => {
+    const orderedData = sortInteractionData(
+      new Map<string, Interactant | string>([
+        ['AB', { intActId: 'A', geneName: 'AB' }],
+        ['C', { intActId: 'C' }],
+        ['AA', { intActId: 'A', geneName: 'AA' }],
+        ['A', 'self'],
+      ])
+    );
+    expect(orderedData).toEqual([
+      'self',
+      { intActId: 'C' },
+      { intActId: 'A', geneName: 'AA' },
+      { intActId: 'A', geneName: 'AB' },
     ]);
   });
 });

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -7,6 +7,7 @@ import {
   SortDirection,
   ReceivedFieldData,
 } from '../types/resultsTypes';
+import { Interactant } from '../adapters/interactionConverter';
 
 const facetsAsArray = (facetString: string): SelectedFacet[] =>
   facetString.split(',').map((stringItem) => {
@@ -99,3 +100,17 @@ export const getSortableColumnToSortColumn = (
   });
   return sortableColumnToSortColumn;
 };
+
+export const sortInteractionData = (
+  interactionDataMap: Map<string, Interactant | string>
+) =>
+  Array.from(interactionDataMap.values()).sort((a, b) => {
+    if (typeof a !== 'string' && typeof b !== 'string') {
+      return (
+        (a as Interactant).geneName?.localeCompare(
+          (b as Interactant).geneName || ''
+        ) || -1
+      );
+    }
+    return -2;
+  });


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-24893
In the UniProtkb results table, the "interacts with" columns always displayed the "current" accession instead of the interactor.

## Approach
Add logic to pick either interactantOne or interactantTwo as the interactant to display.

## Testing
Updated the example data to reflect reality, as well as corresponding snapshots.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
