### PR TITLE
More missing protein submission names

### DIFF
--- a/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
@@ -13,12 +13,10 @@ const ProteinOverview: FC<{
   // or refactoring UniProtKBColumnConfiguration to use UniProtkbAPIModel.
   data: UniProtkbAPIModel;
 }> = ({ data }) => {
-  let recommendedNameNode;
-  const recommendedName =
-    data.proteinDescription?.recommendedName?.fullName.value;
-  if (recommendedName) {
-    recommendedNameNode = `${recommendedName} · `;
-  }
+  const name =
+    data.proteinDescription?.recommendedName?.fullName.value ||
+    data.proteinDescription?.submissionNames?.[0].fullName.value;
+  const nameNode = name && `${name} · `;
 
   const ecNumberNode = data.proteinDescription?.recommendedName?.ecNumbers && (
     <>
@@ -78,7 +76,7 @@ const ProteinOverview: FC<{
 
   return (
     <section>
-      {recommendedNameNode}
+      {nameNode}
       {organismNameNode}
       {ecNumberNode}
       {geneNameListNode}

--- a/src/uniprotkb/components/protein-data-views/__tests__/ProteinOverview.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/ProteinOverview.spec.tsx
@@ -1,8 +1,10 @@
+import { screen } from '@testing-library/react';
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import ProteinOverview from '../ProteinOverviewView';
 
 import swissprotData from '../../__mocks__/swissprotEntry';
+import { ProteinNames } from '../../../adapters/namesAndTaxonomyConverter';
 
 describe('ProteinOverview component', () => {
   test('should render', () => {
@@ -10,5 +12,22 @@ describe('ProteinOverview component', () => {
       <ProteinOverview data={swissprotData} />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('should render', () => {
+    const submissionData = {
+      ...swissprotData,
+      proteinDescription: {
+        submissionNames: [
+          {
+            fullName: {
+              value: 'Some Submission Name',
+            },
+          } as ProteinNames,
+        ],
+      },
+    };
+    customRender(<ProteinOverview data={submissionData} />);
+    expect(screen.getByText(/Some Submission Name/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Purpose
@xwatkins noticed that the submission name is missing from the protein overview.

## Approach
If recommended name not present, use the first submission name.

## Testing
Unit test created

## View changes

- http://localhost:8080/uniprotkb?query=A0A0M9JJ85%2A
- http://localhost:8080/uniprotkb/A0A0M9JJ85/entry

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
