### PR TITLE
fix useLocalStorage

### DIFF
--- a/src/shared/hooks/__tests__/useDataApi.spec.ts
+++ b/src/shared/hooks/__tests__/useDataApi.spec.ts
@@ -10,7 +10,7 @@ import useDataApiWithStale from '../useDataApiWithStale';
 
 const url = '/some/path';
 const url2 = '/some/other/path';
-let mock = new MockAdapter(axios);
+const mock = new MockAdapter(axios);
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({ useDispatch: () => mockDispatch }));

--- a/src/shared/hooks/__tests__/useLocalStorage.spec.ts
+++ b/src/shared/hooks/__tests__/useLocalStorage.spec.ts
@@ -1,7 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { JsonValue } from 'type-fest';
 
-import useLocalStorage, { localStorageCache } from '../useLocalStorage';
+import useLocalStorage, {
+  localStorageCache,
+  UserPreferenceKey,
+} from '../useLocalStorage';
 
 describe('useLocalStorage hook', () => {
   afterEach(() => {
@@ -28,6 +31,26 @@ describe('useLocalStorage hook', () => {
     );
 
     expect(result.current[0]).toEqual('previous value');
+  });
+
+  test('get 2 values with same hook, basic, first time, already saved', async () => {
+    window.localStorage.setItem('gdpr', JSON.stringify('previous value'));
+    window.localStorage.setItem('view-mode', JSON.stringify('previous view'));
+    const { result, rerender } = renderHook<
+      { key: UserPreferenceKey },
+      [
+        state: JsonValue,
+        setState: React.Dispatch<React.SetStateAction<JsonValue>>
+      ]
+    >((props) => useLocalStorage<JsonValue>(props.key, 'default value'), {
+      initialProps: { key: 'gdpr' as const },
+    });
+
+    expect(result.current[0]).toEqual('previous value');
+
+    rerender({ key: 'view-mode' as const });
+
+    expect(result.current[0]).toEqual('previous view');
   });
 
   test('set value, basic, already saved', async () => {


### PR DESCRIPTION
## Purpose
Fix an issue when using the same useLocalStorage hook but changing its key.

## Approach
It was still using the value for the previous key, so added a useEffect changing the state of the hook when the key changes.
Use stringified versions of the defaultValue in order to not enter in infinite loops when the useEffects depended on it and using complex values.

## Testing
Added a specific test for when the key used in the hook changes

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
