### PR TITLE
2021 10 missing disease comment

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -1707,29 +1707,6 @@ exports[`Entry basic should render main 1`] = `
                       </strong>
                        
                       <button
-                        aria-controls="40"
-                        aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
-                        data-testid="evidence-tag-trigger"
-                        type="button"
-                      >
-                        <test-file-stub
-                          height="12"
-                          width="12"
-                        />
-                        <span
-                          class="evidence-tag__label"
-                        >
-                          1 automatic annotation
-                        </span>
-                      </button>
-                      <div
-                        class="evidence-tag-content "
-                        data-testid="evidence-tag-content"
-                        id="40"
-                      />
-                      : topology value 
-                      <button
                         aria-controls="41"
                         aria-expanded="false"
                         class="svg-colour-unreviewed evidence-tag"
@@ -1751,11 +1728,7 @@ exports[`Entry basic should render main 1`] = `
                         data-testid="evidence-tag-content"
                         id="41"
                       />
-                    </div>
-                    <div
-                      class="text-block"
-                    >
-                      value
+                      : topology value 
                       <button
                         aria-controls="42"
                         aria-expanded="false"
@@ -1777,6 +1750,33 @@ exports[`Entry basic should render main 1`] = `
                         class="evidence-tag-content "
                         data-testid="evidence-tag-content"
                         id="42"
+                      />
+                    </div>
+                    <div
+                      class="text-block"
+                    >
+                      value
+                      <button
+                        aria-controls="43"
+                        aria-expanded="false"
+                        class="svg-colour-unreviewed evidence-tag"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="43"
                       />
                     </div>
                   </section>
@@ -1858,6 +1858,28 @@ exports[`Entry basic should render main 1`] = `
                         >
                           <li>
                             value2
+                            <button
+                              aria-controls="34"
+                              aria-expanded="false"
+                              class="svg-colour-unreviewed evidence-tag"
+                              data-testid="evidence-tag-trigger"
+                              type="button"
+                            >
+                              <test-file-stub
+                                height="12"
+                                width="12"
+                              />
+                              <span
+                                class="evidence-tag__label"
+                              >
+                                1 automatic annotation
+                              </span>
+                            </button>
+                            <div
+                              class="evidence-tag-content "
+                              data-testid="evidence-tag-content"
+                              id="34"
+                            />
                           </li>
                         </ul>
                       </div>
@@ -1930,38 +1952,6 @@ exports[`Entry basic should render main 1`] = `
                 >
                   value
                   <button
-                    aria-controls="34"
-                    aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
-                    data-testid="evidence-tag-trigger"
-                    type="button"
-                  >
-                    <test-file-stub
-                      height="12"
-                      width="12"
-                    />
-                    <span
-                      class="evidence-tag__label"
-                    >
-                      1 automatic annotation
-                    </span>
-                  </button>
-                  <div
-                    class="evidence-tag-content "
-                    data-testid="evidence-tag-content"
-                    id="34"
-                  />
-                </div>
-                <h3
-                  class="tiny"
-                >
-                  Isoform 4 dfs
-                </h3>
-                <div
-                  class="text-block"
-                >
-                  value
-                  <button
                     aria-controls="35"
                     aria-expanded="false"
                     class="svg-colour-unreviewed evidence-tag"
@@ -1982,6 +1972,38 @@ exports[`Entry basic should render main 1`] = `
                     class="evidence-tag-content "
                     data-testid="evidence-tag-content"
                     id="35"
+                  />
+                </div>
+                <h3
+                  class="tiny"
+                >
+                  Isoform 4 dfs
+                </h3>
+                <div
+                  class="text-block"
+                >
+                  value
+                  <button
+                    aria-controls="36"
+                    aria-expanded="false"
+                    class="svg-colour-unreviewed evidence-tag"
+                    data-testid="evidence-tag-trigger"
+                    type="button"
+                  >
+                    <test-file-stub
+                      height="12"
+                      width="12"
+                    />
+                    <span
+                      class="evidence-tag__label"
+                    >
+                      1 automatic annotation
+                    </span>
+                  </button>
+                  <div
+                    class="evidence-tag-content "
+                    data-testid="evidence-tag-content"
+                    id="36"
                   />
                 </div>
               </div>
@@ -2504,39 +2526,6 @@ exports[`Entry basic should render main 1`] = `
                   </a>
                    differs from that shown. Reason: Erroneous gene model prediction Text note
                   <button
-                    aria-controls="36"
-                    aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
-                    data-testid="evidence-tag-trigger"
-                    type="button"
-                  >
-                    <test-file-stub
-                      height="12"
-                      width="12"
-                    />
-                    <span
-                      class="evidence-tag__label"
-                    >
-                      1 automatic annotation
-                    </span>
-                  </button>
-                  <div
-                    class="evidence-tag-content "
-                    data-testid="evidence-tag-content"
-                    id="36"
-                  />
-                </section>
-                <h3>
-                  Mass Spectrometry
-                </h3>
-                <section
-                  class="text-block"
-                >
-                  <h3>
-                    isoform 1
-                  </h3>
-                  Molecular mass is 2.1 Da. Determined by LSI. note value
-                  <button
                     aria-controls="37"
                     aria-expanded="false"
                     class="svg-colour-unreviewed evidence-tag"
@@ -2560,6 +2549,39 @@ exports[`Entry basic should render main 1`] = `
                   />
                 </section>
                 <h3>
+                  Mass Spectrometry
+                </h3>
+                <section
+                  class="text-block"
+                >
+                  <h3>
+                    isoform 1
+                  </h3>
+                  Molecular mass is 2.1 Da. Determined by LSI. note value
+                  <button
+                    aria-controls="38"
+                    aria-expanded="false"
+                    class="svg-colour-unreviewed evidence-tag"
+                    data-testid="evidence-tag-trigger"
+                    type="button"
+                  >
+                    <test-file-stub
+                      height="12"
+                      width="12"
+                    />
+                    <span
+                      class="evidence-tag__label"
+                    >
+                      1 automatic annotation
+                    </span>
+                  </button>
+                  <div
+                    class="evidence-tag-content "
+                    data-testid="evidence-tag-content"
+                    id="38"
+                  />
+                </section>
+                <h3>
                   RNA Editing
                 </h3>
                 <section
@@ -2569,33 +2591,6 @@ exports[`Entry basic should render main 1`] = `
                     Edited at position 
                     <span>
                       1 
-                      <button
-                        aria-controls="38"
-                        aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
-                        data-testid="evidence-tag-trigger"
-                        type="button"
-                      >
-                        <test-file-stub
-                          height="12"
-                          width="12"
-                        />
-                        <span
-                          class="evidence-tag__label"
-                        >
-                          1 automatic annotation
-                        </span>
-                      </button>
-                      <div
-                        class="evidence-tag-content "
-                        data-testid="evidence-tag-content"
-                        id="38"
-                      />
-                    </span>
-                  </div>
-                  <div>
-                    <span>
-                      value 
                       <button
                         aria-controls="39"
                         aria-expanded="false"
@@ -2617,6 +2612,33 @@ exports[`Entry basic should render main 1`] = `
                         class="evidence-tag-content "
                         data-testid="evidence-tag-content"
                         id="39"
+                      />
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                      value 
+                      <button
+                        aria-controls="40"
+                        aria-expanded="false"
+                        class="svg-colour-unreviewed evidence-tag"
+                        data-testid="evidence-tag-trigger"
+                        type="button"
+                      >
+                        <test-file-stub
+                          height="12"
+                          width="12"
+                        />
+                        <span
+                          class="evidence-tag__label"
+                        >
+                          1 automatic annotation
+                        </span>
+                      </button>
+                      <div
+                        class="evidence-tag-content "
+                        data-testid="evidence-tag-content"
+                        id="40"
                       />
                     </span>
                   </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -1546,6 +1546,28 @@ exports[`Entry view should render 1`] = `
                 >
                   <li>
                     value2
+                    <button
+                      aria-controls="33"
+                      aria-expanded="false"
+                      class="svg-colour-unreviewed evidence-tag"
+                      data-testid="evidence-tag-trigger"
+                      type="button"
+                    >
+                      <test-file-stub
+                        height="12"
+                        width="12"
+                      />
+                      <span
+                        class="evidence-tag__label"
+                      >
+                        1 automatic annotation
+                      </span>
+                    </button>
+                    <div
+                      class="evidence-tag-content "
+                      data-testid="evidence-tag-content"
+                      id="33"
+                    />
                   </li>
                 </ul>
               </div>
@@ -1618,38 +1640,6 @@ exports[`Entry view should render 1`] = `
         >
           value
           <button
-            aria-controls="33"
-            aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
-            data-testid="evidence-tag-trigger"
-            type="button"
-          >
-            <test-file-stub
-              height="12"
-              width="12"
-            />
-            <span
-              class="evidence-tag__label"
-            >
-              1 automatic annotation
-            </span>
-          </button>
-          <div
-            class="evidence-tag-content "
-            data-testid="evidence-tag-content"
-            id="33"
-          />
-        </div>
-        <h3
-          class="tiny"
-        >
-          Isoform 4 dfs
-        </h3>
-        <div
-          class="text-block"
-        >
-          value
-          <button
             aria-controls="34"
             aria-expanded="false"
             class="svg-colour-unreviewed evidence-tag"
@@ -1670,6 +1660,38 @@ exports[`Entry view should render 1`] = `
             class="evidence-tag-content "
             data-testid="evidence-tag-content"
             id="34"
+          />
+        </div>
+        <h3
+          class="tiny"
+        >
+          Isoform 4 dfs
+        </h3>
+        <div
+          class="text-block"
+        >
+          value
+          <button
+            aria-controls="35"
+            aria-expanded="false"
+            class="svg-colour-unreviewed evidence-tag"
+            data-testid="evidence-tag-trigger"
+            type="button"
+          >
+            <test-file-stub
+              height="12"
+              width="12"
+            />
+            <span
+              class="evidence-tag__label"
+            >
+              1 automatic annotation
+            </span>
+          </button>
+          <div
+            class="evidence-tag-content "
+            data-testid="evidence-tag-content"
+            id="35"
           />
         </div>
         <div
@@ -2201,39 +2223,6 @@ exports[`Entry view should render 1`] = `
           </a>
            differs from that shown. Reason: Erroneous gene model prediction Text note
           <button
-            aria-controls="35"
-            aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
-            data-testid="evidence-tag-trigger"
-            type="button"
-          >
-            <test-file-stub
-              height="12"
-              width="12"
-            />
-            <span
-              class="evidence-tag__label"
-            >
-              1 automatic annotation
-            </span>
-          </button>
-          <div
-            class="evidence-tag-content "
-            data-testid="evidence-tag-content"
-            id="35"
-          />
-        </section>
-        <h3>
-          Mass Spectrometry
-        </h3>
-        <section
-          class="text-block"
-        >
-          <h3>
-            isoform 1
-          </h3>
-          Molecular mass is 2.1 Da. Determined by LSI. note value
-          <button
             aria-controls="36"
             aria-expanded="false"
             class="svg-colour-unreviewed evidence-tag"
@@ -2257,6 +2246,39 @@ exports[`Entry view should render 1`] = `
           />
         </section>
         <h3>
+          Mass Spectrometry
+        </h3>
+        <section
+          class="text-block"
+        >
+          <h3>
+            isoform 1
+          </h3>
+          Molecular mass is 2.1 Da. Determined by LSI. note value
+          <button
+            aria-controls="37"
+            aria-expanded="false"
+            class="svg-colour-unreviewed evidence-tag"
+            data-testid="evidence-tag-trigger"
+            type="button"
+          >
+            <test-file-stub
+              height="12"
+              width="12"
+            />
+            <span
+              class="evidence-tag__label"
+            >
+              1 automatic annotation
+            </span>
+          </button>
+          <div
+            class="evidence-tag-content "
+            data-testid="evidence-tag-content"
+            id="37"
+          />
+        </section>
+        <h3>
           RNA Editing
         </h3>
         <section
@@ -2266,33 +2288,6 @@ exports[`Entry view should render 1`] = `
             Edited at position 
             <span>
               1 
-              <button
-                aria-controls="37"
-                aria-expanded="false"
-                class="svg-colour-unreviewed evidence-tag"
-                data-testid="evidence-tag-trigger"
-                type="button"
-              >
-                <test-file-stub
-                  height="12"
-                  width="12"
-                />
-                <span
-                  class="evidence-tag__label"
-                >
-                  1 automatic annotation
-                </span>
-              </button>
-              <div
-                class="evidence-tag-content "
-                data-testid="evidence-tag-content"
-                id="37"
-              />
-            </span>
-          </div>
-          <div>
-            <span>
-              value 
               <button
                 aria-controls="38"
                 aria-expanded="false"
@@ -2314,6 +2309,33 @@ exports[`Entry view should render 1`] = `
                 class="evidence-tag-content "
                 data-testid="evidence-tag-content"
                 id="38"
+              />
+            </span>
+          </div>
+          <div>
+            <span>
+              value 
+              <button
+                aria-controls="39"
+                aria-expanded="false"
+                class="svg-colour-unreviewed evidence-tag"
+                data-testid="evidence-tag-trigger"
+                type="button"
+              >
+                <test-file-stub
+                  height="12"
+                  width="12"
+                />
+                <span
+                  class="evidence-tag__label"
+                >
+                  1 automatic annotation
+                </span>
+              </button>
+              <div
+                class="evidence-tag-content "
+                data-testid="evidence-tag-content"
+                id="39"
               />
             </span>
           </div>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -81,7 +81,7 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
   return (
     <>
       <h3>
-        {disease?.diseaseId || 'No disease ID'}
+        {disease?.diseaseId || <em>No disease ID</em>}
         {disease?.acronym && ` (${disease?.acronym})`}
       </h3>
       <span className="text-block">{evidenceNodes}</span>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -23,23 +23,15 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
   accession,
 }) => {
   const { disease, note } = comment;
-  if (!disease) {
+
+  if (!disease && !note) {
     return null;
   }
-  const {
-    diseaseId,
-    acronym = '',
-    evidences,
-    description,
-    diseaseCrossReference,
-  } = disease;
-  if (!diseaseId) {
-    return null;
-  }
+
   const infoData = [];
 
-  const evidenceNodes = evidences && (
-    <UniProtKBEvidenceTag evidences={evidences} />
+  const evidenceNodes = disease?.evidences && (
+    <UniProtKBEvidenceTag evidences={disease.evidences} />
   );
 
   if (note) {
@@ -59,31 +51,34 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
     }
   }
 
-  if (description) {
+  if (disease?.description) {
     infoData.push({
       title: 'Description',
-      content: description,
+      content: disease.description,
     });
   }
 
-  if (diseaseCrossReference) {
-    const { database, id } = diseaseCrossReference;
+  if (disease?.diseaseCrossReference) {
+    const { database, id } = disease.diseaseCrossReference;
     if (database && id && databaseToDatabaseInfo[database]) {
       infoData.push({
         title: 'See also',
         content: (
           <XRef
             database={database}
-            xref={diseaseCrossReference}
+            xref={disease.diseaseCrossReference}
             primaryAccession={accession}
           />
         ),
       });
     }
   }
+
   return (
     <>
-      <h3>{`${diseaseId} ${acronym && `(${acronym})`}`}</h3>
+      <h3>{`${disease?.diseaseId || 'No disease ID'} ${
+        disease?.acronym || ''
+      }`}</h3>
       <span className="text-block">{evidenceNodes}</span>
       <InfoList infoData={infoData} />
     </>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -82,7 +82,7 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
   return (
     <>
       <h3>{`${disease?.diseaseId || 'No disease ID'} ${
-        disease?.acronym || ''
+        `(${disease?.acronym})` || ''
       }`}</h3>
       <span className="text-block">{evidenceNodes}</span>
       <InfoList infoData={infoData} />

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -78,12 +78,12 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
       });
     }
   }
-
   return (
     <>
-      <h3>{`${disease?.diseaseId || 'No disease ID'} ${
-        `(${disease?.acronym})` || ''
-      }`}</h3>
+      <h3>
+        {disease?.diseaseId || 'No disease ID'}
+        {disease?.acronym && ` (${disease?.acronym})`}
+      </h3>
       <span className="text-block">{evidenceNodes}</span>
       <InfoList infoData={infoData} />
     </>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -43,7 +43,12 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
           <ExpandableList descriptionString="notes">
             {texts.map((text, index) => (
               // eslint-disable-next-line react/no-array-index-key
-              <Fragment key={index}>{text.value}</Fragment>
+              <Fragment key={index}>
+                {text.value}
+                {text.evidences && (
+                  <UniProtKBEvidenceTag evidences={text.evidences} />
+                )}
+              </Fragment>
             ))}
           </ExpandableList>
         ),

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -429,6 +429,28 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_disease
           >
             <li>
               value2
+              <button
+                aria-controls="1"
+                aria-expanded="false"
+                class="svg-colour-unreviewed evidence-tag"
+                data-testid="evidence-tag-trigger"
+                type="button"
+              >
+                <test-file-stub
+                  height="12"
+                  width="12"
+                />
+                <span
+                  class="evidence-tag__label"
+                >
+                  1 automatic annotation
+                </span>
+              </button>
+              <div
+                class="evidence-tag-content "
+                data-testid="evidence-tag-content"
+                id="1"
+              />
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Purpose
Show disease comments which consist of only a note ([Jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-26305))

## Approach

- Also show comments which contain only a note.
- Followed the structure of the data (and the current site) and listed associated publications next to the notes.

## Testing
Update snapshots

## How to view PR effects
As the jira states P02511 has a disease comment consisting of only a note

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why