### PR TITLE
Empty secondary accessions

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3201,24 +3201,6 @@ exports[`Entry view should render for non-human entry 1`] = `
               </div>
             </div>
           </li>
-          <li>
-            <div
-              class="decorated-list-item"
-            >
-              <div
-                class="decorated-list-item__title"
-              >
-                <h5
-                  class="bold"
-                >
-                  Secondary accessions
-                </h5>
-              </div>
-              <div
-                class="decorated-list-item__content"
-              />
-            </div>
-          </li>
         </ul>
       </div>
     </div>

--- a/src/uniprotkb/components/protein-data-views/AccessionsView.tsx
+++ b/src/uniprotkb/components/protein-data-views/AccessionsView.tsx
@@ -3,24 +3,27 @@ import { InfoList, ExpandableList } from 'franklin-sites';
 
 import { NamesAndTaxonomyUIModel } from '../../adapters/namesAndTaxonomyConverter';
 
-const AccessionsView: FC<{ data: NamesAndTaxonomyUIModel }> = ({ data }) => (
-  <InfoList
-    infoData={[
-      {
-        title: `Primary accession`,
-        content: data.primaryAccession,
-      },
-      {
-        title: `Secondary accessions`,
-        content: (
-          <ExpandableList descriptionString="accessions">
-            {data.secondaryAccessions?.map((accession) => (
-              <Fragment key={accession}>{accession}</Fragment>
-            ))}
-          </ExpandableList>
-        ),
-      },
-    ]}
-  />
-);
+const AccessionsView: FC<{ data: NamesAndTaxonomyUIModel }> = ({ data }) => {
+  const secondaryAccessions = data.secondaryAccessions?.map((accession) => (
+    <Fragment key={accession}>{accession}</Fragment>
+  ));
+  return (
+    <InfoList
+      infoData={[
+        {
+          title: `Primary accession`,
+          content: data.primaryAccession,
+        },
+        {
+          title: `Secondary accessions`,
+          content: secondaryAccessions && (
+            <ExpandableList descriptionString="accessions">
+              {secondaryAccessions}
+            </ExpandableList>
+          ),
+        },
+      ]}
+    />
+  );
+};
 export default AccessionsView;


### PR DESCRIPTION
## Purpose
Looking at https://beta.uniprot.org/uniprotkb/A8BQ10/entry I noticed the `Secondary accessions` info list titled rendered without any children

## Approach
Check if there are secondary accessions first. This needs to be handled here as I can't see a reliable way to check for null-like react elements in the `InfoList`.

## Testing
Update snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
