### PR TITLE
Function section tidy up

### DIFF
--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.capitalize {
+  text-transform: capitalize;
+}
+
 // Debug utility to show heading levels
 // @for $i from 1 through 6 {
 //   h#{$i} {

--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -24,10 +24,6 @@
   }
 }
 
-.capitalize {
-  text-transform: capitalize;
-}
-
 // Debug utility to show heading levels
 // @for $i from 1 through 6 {
 //   h#{$i} {

--- a/src/shared/styles/helper.module.scss
+++ b/src/shared/styles/helper.module.scss
@@ -8,3 +8,7 @@
 .no-wrap {
   white-space: nowrap;
 }
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/src/uniprotkb/components/entry/FunctionSection.tsx
+++ b/src/uniprotkb/components/entry/FunctionSection.tsx
@@ -119,7 +119,7 @@ export const CofactorView = ({ cofactors, title }: CofactorViewProps) => {
   }
   return (
     <>
-      {title && <h3>{title}</h3>}
+      {title && <h3 className="capitalize">{title}</h3>}
       {cofactors.map((cofactorComment, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <section className="text-block" key={index}>
@@ -194,10 +194,6 @@ const FunctionSection = ({ data, sequence, primaryAccession }: Props) => {
       />
       <BioPhysicoChemicalPropertiesView
         data={data.bioPhysicoChemicalProperties}
-      />
-      <FreeTextView
-        comments={data.commentsData.get('PATHWAY') as FreeTextComment[]}
-        title="pathway"
       />
       <FreeTextView
         comments={

--- a/src/uniprotkb/components/entry/FunctionSection.tsx
+++ b/src/uniprotkb/components/entry/FunctionSection.tsx
@@ -27,6 +27,8 @@ import {
   FreeTextComment,
 } from '../../types/commentTypes';
 
+import helper from '../../../shared/styles/helper.module.scss';
+
 const GoRibbon = lazy(
   () => import(/* webpackChunkName: "go-ribbon" */ './GoRibbon')
 );
@@ -119,7 +121,7 @@ export const CofactorView = ({ cofactors, title }: CofactorViewProps) => {
   }
   return (
     <>
-      {title && <h3 className="capitalize">{title}</h3>}
+      {title && <h3 className={helper.capitalize}>{title}</h3>}
       {cofactors.map((cofactorComment, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <section className="text-block" key={index}>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -326,7 +326,9 @@ exports[`Entry basic should render main 1`] = `
               <div
                 class="card__content"
               >
-                <h3>
+                <h3
+                  class="capitalize"
+                >
                   catalytic activity
                 </h3>
                 <span
@@ -428,7 +430,9 @@ exports[`Entry basic should render main 1`] = `
                     )
                   </div>
                 </span>
-                <h3>
+                <h3
+                  class="capitalize"
+                >
                   cofactor
                 </h3>
                 <section
@@ -1916,7 +1920,7 @@ exports[`Entry basic should render main 1`] = `
                   </li>
                 </ul>
                 <h3
-                  style="text-transform: capitalize;"
+                  class="capitalize"
                 >
                   disruption phenotype
                 </h3>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -20,7 +20,9 @@ exports[`Entry view should render 1`] = `
       <div
         class="card__content"
       >
-        <h3>
+        <h3
+          class="capitalize"
+        >
           catalytic activity
         </h3>
         <span
@@ -122,7 +124,9 @@ exports[`Entry view should render 1`] = `
             )
           </div>
         </span>
-        <h3>
+        <h3
+          class="capitalize"
+        >
           cofactor
         </h3>
         <section
@@ -1604,7 +1608,7 @@ exports[`Entry view should render 1`] = `
           </li>
         </ul>
         <h3
-          style="text-transform: capitalize;"
+          class="capitalize"
         >
           disruption phenotype
         </h3>
@@ -2453,7 +2457,9 @@ exports[`Entry view should render for non-human entry 1`] = `
             id="0"
           />
         </div>
-        <h3>
+        <h3
+          class="capitalize"
+        >
           catalytic activity
         </h3>
         <span
@@ -2523,7 +2529,9 @@ exports[`Entry view should render for non-human entry 1`] = `
             />
           </div>
         </span>
-        <h3>
+        <h3
+          class="capitalize"
+        >
           cofactor
         </h3>
         <section
@@ -2556,7 +2564,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           </span>
         </section>
         <h3
-          style="text-transform: capitalize;"
+          class="capitalize"
         >
           miscellaneous
         </h3>
@@ -2588,7 +2596,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           />
         </div>
         <h3
-          style="text-transform: capitalize;"
+          class="capitalize"
         >
           biotechnology
         </h3>
@@ -2693,7 +2701,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           />
         </div>
         <h3
-          style="text-transform: capitalize;"
+          class="capitalize"
         >
           activity regulation
         </h3>
@@ -3614,7 +3622,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           />
         </protvista-manager>
         <h3
-          style="text-transform: capitalize;"
+          class="capitalize"
         >
           domain
         </h3>

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -23,6 +23,7 @@ import {
   PhysiologicalReaction,
 } from '../../types/commentTypes';
 
+import helper from '../../../shared/styles/helper.module.scss';
 import './styles/catalytic-activity-view.scss';
 
 // example accessions to view this component: P31937, P0A879
@@ -210,7 +211,7 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
   let firstRheaId: number;
   return (
     <>
-      {title && <h3 className="capitalize">{title}</h3>}
+      {title && <h3 className={helper.capitalize}>{title}</h3>}
       {comments.map(({ reaction, physiologicalReactions }) => {
         if (!reaction) {
           return null;

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -210,7 +210,7 @@ const CatalyticActivityView: FC<CatalyticActivityProps> = ({
   let firstRheaId: number;
   return (
     <>
-      {title && <h3>{title}</h3>}
+      {title && <h3 className="capitalize">{title}</h3>}
       {comments.map(({ reaction, physiologicalReactions }) => {
         if (!reaction) {
           return null;

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -90,7 +90,7 @@ const FreeTextView: FC<FreeTextProps> = ({
 
   return (
     <>
-      {title && <h3 style={{ textTransform: 'capitalize' }}>{title}</h3>}
+      {title && <h3 className="capitalize">{title}</h3>}
       {freeTextData}
     </>
   );

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -8,6 +8,8 @@ import { getEntryPathFor } from '../../../app/config/urls';
 import { Namespace } from '../../../shared/types/namespaces';
 import { FreeTextComment, TextWithEvidence } from '../../types/commentTypes';
 
+import helper from '../../../shared/styles/helper.module.scss';
+
 const pubMedIDRE = /\d{7,8}/;
 // Capturing group will allow split to conserve that bit in the split parts
 /** NOTE:
@@ -90,7 +92,7 @@ const FreeTextView: FC<FreeTextProps> = ({
 
   return (
     <>
-      {title && <h3 className="capitalize">{title}</h3>}
+      {title && <h3 className={helper.capitalize}>{title}</h3>}
       {freeTextData}
     </>
   );

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`CatalyticActivityView component should render catalytic activity 1`] = `
 <DocumentFragment>
-  <h3>
+  <h3
+    class="capitalize"
+  >
     Catalytic activity
   </h3>
   <span


### PR DESCRIPTION
## Purpose

1. Duplicate pathway notes in function section
2. Inconsistent title casing

## Approach

1. Removed one
2. Created an app level `capitalize` class and used this instead of inline styles

## Testing
Snapshot updates

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
