### PR TITLE
Parse query with space and quoations

### DIFF
--- a/src/query-builder/utils/__tests__/__mocks__/clauseQueryTestData.ts
+++ b/src/query-builder/utils/__tests__/__mocks__/clauseQueryTestData.ts
@@ -256,6 +256,20 @@ const testData = [
       },
     ],
   },
+  {
+    description: 'should handle free text query with spaces and quotations',
+    queryString: '"homo sapiens"',
+    clauses: [
+      {
+        id: 0,
+        searchTerm: idToSearchTerm.gene_ontology,
+        queryBits: {
+          All: 'homo sapiens',
+        },
+        logicOperator: 'AND',
+      },
+    ],
+  },
 ] as Array<{ description: string; queryString: string; clauses: Clause[] }>;
 
 export default testData;

--- a/src/query-builder/utils/queryStringProcessor.ts
+++ b/src/query-builder/utils/queryStringProcessor.ts
@@ -35,7 +35,8 @@ export const stringify = (clauses: Clause[] = []): string => {
             // contains ' ' or ':'
             /[ :]/.test(value) &&
             // but isn't of the form '[... TO ...]';
-            !(value.startsWith('[') && value.endsWith(']'));
+            !(value.startsWith('[') && value.endsWith(']')) &&
+            !(value.startsWith('"') && value.endsWith('"'));
           const quote = needsQuotes ? '"' : '';
 
           // free-text search


### PR DESCRIPTION
## Purpose

- When parsing queries with double quotation marks and spaces additional, unneeded, double quotation marks were being added
- [Jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-26348)

## Approach
- Detect if the query starts and ends with `"` and if so, don't add more

## Testing
- Unit test written

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
