### PR TITLE
disable forms when empty

### DIFF
--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -103,7 +103,7 @@ const AlignForm = () => {
   const initialFormValues = useInitialFormParameters(defaultFormValues);
 
   // used when the form submission needs to be disabled
-  const [submitDisabled, setSubmitDisabled] = useState(false);
+  const [submitDisabled, setSubmitDisabled] = useState(true);
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
   // flag to see if the user manually changed the title
@@ -220,7 +220,7 @@ const AlignForm = () => {
       setSubmitDisabled(
         parsedSequences.length > ALIGN_LIMIT ||
           parsedSequences.some((parsedSequence) => !parsedSequence.valid) ||
-          parsedSequences.length === 1
+          parsedSequences.length <= 1
       );
     },
     [jobNameEdited]

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -130,7 +130,7 @@ const BlastForm = () => {
   const initialFormValues = useInitialFormParameters(defaultFormValues);
 
   // used when the form submission needs to be disabled
-  const [submitDisabled, setSubmitDisabled] = useState(false);
+  const [submitDisabled, setSubmitDisabled] = useState(true);
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
   // flag to see if the user manually changed the title

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -513,6 +513,7 @@ exports[`BlastForm test Renders the form 1`] = `
           />
           <button
             class="button primary"
+            disabled=""
             type="submit"
           >
             Run BLAST

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -246,6 +246,8 @@ const IDMappingForm = () => {
     });
   };
 
+  useEffect(() => setSubmitDisabled(textIDs.trim().length === 0), [textIDs]);
+
   useTextFileInput({
     inputRef: fileInputRef,
     onFileContent: setTextIDs,

--- a/src/tools/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
+++ b/src/tools/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
@@ -116,6 +116,7 @@ exports[`IDMappingForm test Renders the form 1`] = `
           />
           <button
             class="button primary"
+            disabled=""
             type="submit"
           >
             Map  IDs

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -100,7 +100,7 @@ const PeptideSearchForm = () => {
   const initialFormValues = useInitialFormParameters(defaultFormValues);
 
   // used when the form submission needs to be disabled
-  const [submitDisabled, setSubmitDisabled] = useState(false);
+  const [submitDisabled, setSubmitDisabled] = useState(true);
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
   // flag to see if the user manually changed the title
@@ -250,7 +250,8 @@ const PeptideSearchForm = () => {
 
   useEffect(() => {
     setSubmitDisabled(
-      parsedSequences.length > PEPTIDE_SEARCH_LIMIT ||
+      parsedSequences.length === 0 ||
+        parsedSequences.length > PEPTIDE_SEARCH_LIMIT ||
         parsedSequences.some((parsedSequence) => parsedSequence.length < 2)
     );
   }, [parsedSequences]);


### PR DESCRIPTION
## Purpose
Disable forms when the text input is empty. https://www.ebi.ac.uk/panda/jira/browse/TRM-26157

## Approach
Disable by default, adjust conditions to disable in the useEffect of each form.

## Testing
 - Updated snapshots
 - Manually made sure the forms were disabled by default, enabled when in the right conditions, re-disabled when returning to empty text content. And also, checked that they weren't disabled by default when resubmitting an existing job.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
