### PR TITLE
useTextFileInput: reset input ref to handle the case that a user loads the same file twice

### DIFF
--- a/src/shared/hooks/useTextFileInput.ts
+++ b/src/shared/hooks/useTextFileInput.ts
@@ -34,39 +34,47 @@ const useTextFileInput = ({
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
-  const handleNewFile = useCallback((file?: File) => {
-    if (!file) {
-      return;
-    }
-    let didCancel = false;
+  const handleNewFile = useCallback(
+    (file?: File) => {
+      if (!file) {
+        return;
+      }
+      let didCancel = false;
 
-    const fr = new FileReader();
-    fr.onload = () => {
-      if (!didCancel) {
-        const text = fr.result as string;
-        const NumberOKCharacters = text.match(writableRE)?.length ?? 0;
-        if (NumberOKCharacters / text.length < 0.9) {
-          // more than 90% of characters are not writable, bail
-          onErrorRef.current?.(
-            new TypeError(
-              `The file "${file.name}" doesn't appear to be in the correct format. It needs to be a plain text file.`
-            )
-          );
-        } else {
-          onFileContentRef.current(text);
+      const fr = new FileReader();
+      fr.onload = () => {
+        if (!didCancel) {
+          const text = fr.result as string;
+          const NumberOKCharacters = text.match(writableRE)?.length ?? 0;
+          if (NumberOKCharacters / text.length < 0.9) {
+            // more than 90% of characters are not writable, bail
+            onErrorRef.current?.(
+              new TypeError(
+                `The file "${file.name}" doesn't appear to be in the correct format. It needs to be a plain text file.`
+              )
+            );
+          } else {
+            onFileContentRef.current(text);
+            // Reset input ref to handle the case that a user loads the same file twice
+            if (inputRef?.current) {
+              // eslint-disable-next-line no-param-reassign
+              inputRef.current.value = '';
+            }
+          }
         }
-      }
-    };
-    fr.readAsText(file);
+      };
+      fr.readAsText(file);
 
-    // eslint-disable-next-line consistent-return
-    return () => {
-      didCancel = true;
-      if (fr) {
-        fr.abort();
-      }
-    };
-  }, []);
+      // eslint-disable-next-line consistent-return
+      return () => {
+        didCancel = true;
+        if (fr) {
+          fr.abort();
+        }
+      };
+    },
+    [inputRef]
+  );
 
   const handleDrop = useCallback(
     (files: FileList) => {


### PR DESCRIPTION
## Purpose
Bug fix: useTextFileInput unresponsive to loading same file twice [[jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-26469)]

## Approach
`inputRef.current.value = ''` inside the hook

## Testing
none

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
