### PR TITLE
changes to customise columns sliding panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coverageThreshold": {
       "global": {
         "lines": 83.44,
-        "statements": 83.41,
+        "statements": 83.4,
         "functions": 83.74,
         "branches": 73.08
       }

--- a/src/shared/components/action-buttons/CustomiseButton.tsx
+++ b/src/shared/components/action-buttons/CustomiseButton.tsx
@@ -28,7 +28,7 @@ const CustomiseButton = () => {
             className={styles['customise-table-panel']}
           >
             <ErrorBoundary>
-              <CustomiseTable onSave={() => setDisplayCustomisePanel(false)} />
+              <CustomiseTable onClose={() => setDisplayCustomisePanel(false)} />
             </ErrorBoundary>
           </SlidingPanel>
         </Suspense>

--- a/src/shared/components/action-buttons/CustomiseButton.tsx
+++ b/src/shared/components/action-buttons/CustomiseButton.tsx
@@ -5,6 +5,8 @@ import ErrorBoundary from '../error-component/ErrorBoundary';
 
 import lazy from '../../utils/lazy';
 
+import styles from './styles/customise-button.module.scss';
+
 const CustomiseTable = lazy(
   () =>
     import(
@@ -23,6 +25,7 @@ const CustomiseButton = () => {
             title="Customize Data"
             position="left"
             onClose={() => setDisplayCustomisePanel(false)}
+            className={styles['customise-table-panel']}
           >
             <ErrorBoundary>
               <CustomiseTable onSave={() => setDisplayCustomisePanel(false)} />

--- a/src/shared/components/action-buttons/styles/customise-button.module.scss
+++ b/src/shared/components/action-buttons/styles/customise-button.module.scss
@@ -1,0 +1,4 @@
+.customise-table-panel > :global(.sliding-panel__content) {
+  // Override style from sliding panel as defined in franklin
+  padding-top: 0;
+}

--- a/src/shared/components/column-select/ColumnSelect.tsx
+++ b/src/shared/components/column-select/ColumnSelect.tsx
@@ -47,6 +47,7 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
   onChange,
   namespace,
   isEntryPage,
+  children,
 }) => {
   const primaryKeyColumns = nsToPrimaryKeyColumns(namespace, isEntryPage);
 
@@ -135,16 +136,19 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
   });
 
   return (
-    <div className="column-select">
-      <ColumnSelectDragDrop
-        columns={fieldDataForSelectedColumns}
-        onDragDrop={handleDragDrop}
-        onRemove={handleSelect}
-      />
-      {tabs.length ? (
-        <Tabs className={sticky['sticky-tabs-container']}>{tabs}</Tabs>
-      ) : undefined}
-    </div>
+    <>
+      <div className="column-select">
+        <ColumnSelectDragDrop
+          columns={fieldDataForSelectedColumns}
+          onDragDrop={handleDragDrop}
+          onRemove={handleSelect}
+        />
+        {tabs.length ? (
+          <Tabs className={sticky['sticky-tabs-container']}>{tabs}</Tabs>
+        ) : undefined}
+      </div>
+      {children}
+    </>
   );
 };
 

--- a/src/shared/components/column-select/ColumnSelect.tsx
+++ b/src/shared/components/column-select/ColumnSelect.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useMemo } from 'react';
-import { AccordionSearch, Tabs, Tab, Loader, Button } from 'franklin-sites';
+import { AccordionSearch, Tabs, Tab, Loader } from 'franklin-sites';
 import { difference } from 'lodash-es';
 
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
@@ -11,7 +11,6 @@ import apiUrls from '../../config/apiUrls';
 import {
   Column,
   nsToPrimaryKeyColumns,
-  nsToDefaultColumns,
   nsToColumnConfig,
 } from '../../config/columns';
 
@@ -33,6 +32,7 @@ import {
   ColumnSelectTab,
 } from '../../../uniprotkb/types/resultsTypes';
 
+import '../../styles/sticky.scss';
 import './styles/column-select.scss';
 
 type ColumnSelectProps = {
@@ -49,7 +49,6 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
   isEntryPage,
 }) => {
   const primaryKeyColumns = nsToPrimaryKeyColumns(namespace, isEntryPage);
-  const defaultColumns = nsToDefaultColumns(namespace, isEntryPage);
 
   // remove the entry field from the choices as this must always be present
   // in the url fields parameter when making the search request ie
@@ -86,7 +85,7 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
     [handleChange, removableSelectedColumns]
   );
 
-  const { loading, data } = useDataApi<ReceivedFieldData>(
+  const { loading, data, progress } = useDataApi<ReceivedFieldData>(
     // No configure endpoint for supporting data
     namespace && mainNamespaces.has(namespace)
       ? apiUrls.resultsFields(namespace, isEntryPage)
@@ -106,7 +105,7 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
   );
 
   if (loading) {
-    return <Loader />;
+    return <Loader progress={progress} />;
   }
 
   const fieldDataForSelectedColumns = getFieldDataForColumns(
@@ -142,14 +141,9 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
         onDragDrop={handleDragDrop}
         onRemove={handleSelect}
       />
-      <Button
-        variant="secondary"
-        onClick={() => onChange(defaultColumns)}
-        data-testid="column-select-reset-button"
-      >
-        Reset to default
-      </Button>
-      {tabs.length ? <Tabs>{tabs}</Tabs> : undefined}
+      {tabs.length ? (
+        <Tabs className="sticky-tabs-container">{tabs}</Tabs>
+      ) : undefined}
     </div>
   );
 };

--- a/src/shared/components/column-select/ColumnSelect.tsx
+++ b/src/shared/components/column-select/ColumnSelect.tsx
@@ -32,7 +32,7 @@ import {
   ColumnSelectTab,
 } from '../../../uniprotkb/types/resultsTypes';
 
-import '../../styles/sticky.scss';
+import sticky from '../../styles/sticky.module.scss';
 import './styles/column-select.scss';
 
 type ColumnSelectProps = {
@@ -142,7 +142,7 @@ const ColumnSelect: FC<ColumnSelectProps> = ({
         onRemove={handleSelect}
       />
       {tabs.length ? (
-        <Tabs className="sticky-tabs-container">{tabs}</Tabs>
+        <Tabs className={sticky['sticky-tabs-container']}>{tabs}</Tabs>
       ) : undefined}
     </div>
   );

--- a/src/shared/components/column-select/__tests__/ColumnSelect.spec.tsx
+++ b/src/shared/components/column-select/__tests__/ColumnSelect.spec.tsx
@@ -11,7 +11,6 @@ import ColumnSelect from '../ColumnSelect';
 
 import { Namespace } from '../../../types/namespaces';
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
-import { nsToDefaultColumns } from '../../../config/columns';
 
 import { SearchResultsLocations } from '../../../../app/config/urls';
 
@@ -49,12 +48,12 @@ describe('ColumnSelect component', () => {
     jest.clearAllMocks();
   });
 
-  test('should render', () => {
+  it('should render', () => {
     const { asFragment } = rendered;
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('should call to get field data and have the correct number of "data" list items', () => {
+  it('should call to get field data and have the correct number of "data" list items', () => {
     const items = screen.getAllByTestId('accordion-search-list-item');
     // Only "data" (ie not DB links) are visible so only count these and
     // subtract one for the accession column which shouldn't be listed as the
@@ -68,7 +67,7 @@ describe('ColumnSelect component', () => {
     expect(items.length).toBe(nDataListItems - 1);
   });
 
-  test('should call onChange when unselected item is clicked and do so with selected columns and new item', () => {
+  it('should call onChange when unselected item is clicked and do so with selected columns and new item', () => {
     const item = screen.getByText('Gene Names');
     fireEvent.click(item);
     expect(onChange).toHaveBeenCalledWith([
@@ -77,7 +76,7 @@ describe('ColumnSelect component', () => {
     ]);
   });
 
-  test('should call onChange when already selected item is clicked and do so with selected columns without clicked item', () => {
+  it('should call onChange when already selected item is clicked and do so with selected columns without clicked item', () => {
     // Getting the 2nd item as the 1st one is the drag-and-drop button
     const item = screen.getAllByText('Protein existence')[1];
     fireEvent.click(item);
@@ -86,13 +85,7 @@ describe('ColumnSelect component', () => {
     );
   });
 
-  test('should call onChange with default columns when "Reset to default" button clicked', () => {
-    const button = screen.getByText('Reset to default');
-    fireEvent.click(button);
-    expect(onChange).toHaveBeenCalledWith(nsToDefaultColumns(namespace));
-  });
-
-  test('should call onChange with the correct column order when "Protein name" is dragged to the right', async () => {
+  it('should call onChange with the correct column order when "Protein name" is dragged to the right', async () => {
     const dragEl = screen
       .getAllByText('Protein names')[0]
       .closest(DND_DRAGGABLE_DATA_ATTR);

--- a/src/shared/components/column-select/__tests__/__snapshots__/ColumnSelect.spec.tsx.snap
+++ b/src/shared/components/column-select/__tests__/__snapshots__/ColumnSelect.spec.tsx.snap
@@ -49,15 +49,8 @@ exports[`ColumnSelect component should render 1`] = `
         </span>
       </div>
     </div>
-    <button
-      class="button secondary"
-      data-testid="column-select-reset-button"
-      type="button"
-    >
-      Reset to default
-    </button>
     <div
-      class="tabs"
+      class="tabs sticky-tabs-container"
     >
       <div
         class="tabs__header"
@@ -74,7 +67,7 @@ exports[`ColumnSelect component should render 1`] = `
           <div
             class="column-select__tab-title"
           >
-            data
+            Data
             <span
               class="column-select__tab-title__count column-select__tab-title__count--visible bubble--small"
             >
@@ -93,7 +86,7 @@ exports[`ColumnSelect component should render 1`] = `
           <div
             class="column-select__tab-title"
           >
-            links
+            External links
             <span
               class="column-select__tab-title__count column-select__tab-title__count--hidden bubble--small"
             >

--- a/src/shared/components/column-select/styles/column-select-drag-drop.scss
+++ b/src/shared/components/column-select/styles/column-select-drag-drop.scss
@@ -7,7 +7,7 @@
     padding: 0.5rem;
     overflow: auto;
     white-space: nowrap;
-    margin-bottom: 1rem;
+    margin: 1rem 0;
 
     .chip {
       --main-chip-color: #{$colour-sea-blue};

--- a/src/shared/components/column-select/styles/column-select.scss
+++ b/src/shared/components/column-select/styles/column-select.scss
@@ -2,10 +2,6 @@
   margin-bottom: 1rem;
 
   &__tab-title {
-    &:first-letter {
-      text-transform: capitalize;
-    }
-
     &__count {
       margin-left: 0.5rem;
 

--- a/src/shared/components/column-select/utils/__tests__/index.spec.tsx
+++ b/src/shared/components/column-select/utils/__tests__/index.spec.tsx
@@ -7,7 +7,7 @@ import fieldData from './__mocks__/fieldData';
 describe('prepareFieldData', () => {
   test('should return prepared field data', () => {
     expect(prepareFieldData(fieldData)).toEqual({
-      data: [
+      Data: [
         {
           id: 'names_&_taxonomy',
           items: [
@@ -20,7 +20,7 @@ describe('prepareFieldData', () => {
           title: 'Names & Taxonomy',
         },
       ],
-      links: [
+      'External links': [
         {
           id: 'sequence',
           items: [
@@ -38,7 +38,7 @@ describe('prepareFieldData', () => {
 
   test('should exclude column', () => {
     expect(prepareFieldData(fieldData, [UniProtKBColumn.geneNames])).toEqual({
-      links: [
+      'External links': [
         {
           id: 'sequence',
           items: [
@@ -65,7 +65,7 @@ describe('getFieldDataForColumns', () => {
         accordionId: 'names_&_taxonomy',
         itemId: 'gene_names',
         label: 'Gene Names',
-        tabId: 'data',
+        tabId: 'Data',
       },
     ]);
   });
@@ -73,14 +73,14 @@ describe('getFieldDataForColumns', () => {
     expect(
       getFieldDataForColumns([UniProtKBColumn.xrefCcds], {
         ...prepared,
-        data: undefined,
+        Data: undefined,
       })
     ).toEqual([
       {
         accordionId: 'sequence',
         itemId: 'xref_ccds',
         label: 'CCDS',
-        tabId: 'links',
+        tabId: 'External links',
       },
     ]);
   });

--- a/src/shared/components/customise-table/CustomiseTable.tsx
+++ b/src/shared/components/customise-table/CustomiseTable.tsx
@@ -53,19 +53,20 @@ const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
         selectedColumns={columns}
         namespace={namespace}
         isEntryPage={isEntryPage}
-      />
-      <div
-        className={cn(
-          'button-group',
-          'sliding-panel__button-row',
-          sticky['sticky-bottom-right']
-        )}
       >
-        <Button variant="secondary" type="reset">
-          Reset to default
-        </Button>
-        <Button type="submit">Close</Button>
-      </div>
+        <div
+          className={cn(
+            'button-group',
+            'sliding-panel__button-row',
+            sticky['sticky-bottom-right']
+          )}
+        >
+          <Button variant="secondary" type="reset">
+            Reset to default
+          </Button>
+          <Button type="submit">Close</Button>
+        </div>
+      </ColumnSelect>
     </form>
   );
 };

--- a/src/shared/components/customise-table/CustomiseTable.tsx
+++ b/src/shared/components/customise-table/CustomiseTable.tsx
@@ -12,9 +12,6 @@ import { allEntryPages } from '../../../app/config/urls';
 
 import { Namespace } from '../../types/namespaces';
 
-import '../../styles/sticky.scss';
-import './styles/customise-table.scss';
-
 type CustomiseTableProps = {
   onSave: () => void;
 };
@@ -22,11 +19,12 @@ type CustomiseTableProps = {
 const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
   const namespace = useNS() || Namespace.uniprotkb;
   const isEntryPage = Boolean(useRouteMatch(allEntryPages));
+  const defaultColumns = nsToDefaultColumns(namespace, isEntryPage);
   const [columns, setColumns] = useLocalStorage(
     `table columns for ${namespace}${
       isEntryPage ? ' entry page' : ''
     }` as const,
-    nsToDefaultColumns(namespace, isEntryPage)
+    defaultColumns
   );
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -34,10 +32,15 @@ const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
     onSave();
   };
 
+  const handleReset = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setColumns(defaultColumns);
+  };
+
   return (
     <form
       onSubmit={handleSubmit}
-      className="customise-table"
+      onReset={handleReset}
       aria-label={`Customise ${namespace}${
         isEntryPage ? '' : ' result'
       } table columns form`}
@@ -49,6 +52,9 @@ const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
         isEntryPage={isEntryPage}
       />
       <div className="button-group sticky-bottom-right sliding-panel__button-row">
+        <Button variant="secondary" type="reset">
+          Reset to default
+        </Button>
         <Button type="submit">Close</Button>
       </div>
     </form>

--- a/src/shared/components/customise-table/CustomiseTable.tsx
+++ b/src/shared/components/customise-table/CustomiseTable.tsx
@@ -1,6 +1,7 @@
 import { FormEvent } from 'react';
 import { Button } from 'franklin-sites';
 import { useRouteMatch } from 'react-router-dom';
+import cn from 'classnames';
 
 import ColumnSelect from '../column-select/ColumnSelect';
 
@@ -11,6 +12,8 @@ import { nsToDefaultColumns } from '../../config/columns';
 import { allEntryPages } from '../../../app/config/urls';
 
 import { Namespace } from '../../types/namespaces';
+
+import sticky from '../../styles/sticky.module.scss';
 
 type CustomiseTableProps = {
   onSave: () => void;
@@ -51,7 +54,13 @@ const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
         namespace={namespace}
         isEntryPage={isEntryPage}
       />
-      <div className="button-group sticky-bottom-right sliding-panel__button-row">
+      <div
+        className={cn(
+          'button-group',
+          'sliding-panel__button-row',
+          sticky['sticky-bottom-right']
+        )}
+      >
         <Button variant="secondary" type="reset">
           Reset to default
         </Button>

--- a/src/shared/components/customise-table/CustomiseTable.tsx
+++ b/src/shared/components/customise-table/CustomiseTable.tsx
@@ -2,6 +2,7 @@ import { FormEvent } from 'react';
 import { Button } from 'franklin-sites';
 import { useRouteMatch } from 'react-router-dom';
 import cn from 'classnames';
+import { frame } from 'timing-functions';
 
 import ColumnSelect from '../column-select/ColumnSelect';
 
@@ -16,10 +17,10 @@ import { Namespace } from '../../types/namespaces';
 import sticky from '../../styles/sticky.module.scss';
 
 type CustomiseTableProps = {
-  onSave: () => void;
+  onClose: () => void;
 };
 
-const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
+const CustomiseTable = ({ onClose }: CustomiseTableProps) => {
   const namespace = useNS() || Namespace.uniprotkb;
   const isEntryPage = Boolean(useRouteMatch(allEntryPages));
   const defaultColumns = nsToDefaultColumns(namespace, isEntryPage);
@@ -32,12 +33,14 @@ const CustomiseTable = ({ onSave }: CustomiseTableProps) => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onSave();
+    onClose();
   };
 
   const handleReset = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setColumns(defaultColumns);
+    // Have to delay closing otherwise sometimes it doesn't save
+    frame().then(onClose);
   };
 
   return (

--- a/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
+++ b/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
@@ -10,12 +10,15 @@ import CustomiseTable from '../CustomiseTable';
 import '../../../../uniprotkb/components/__mocks__/mockApi';
 
 import customRender from '../../../__test-helpers__/customRender';
+import { nsToDefaultColumns } from '../../../config/columns';
+import { localStorageCache } from '../../../hooks/useLocalStorage';
 
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
 import { SearchResultsLocations } from '../../../../app/config/urls';
 import { Namespace } from '../../../types/namespaces';
 
 const route = SearchResultsLocations[Namespace.uniprotkb];
+const storageKey = `table columns for ${Namespace.uniprotkb}` as const;
 
 describe('CustomiseTable component', () => {
   let rendered: ReturnType<typeof customRender>;
@@ -30,13 +33,19 @@ describe('CustomiseTable component', () => {
     rendered = customRender(<CustomiseTable onSave={onSave} />, {
       route,
       initialLocalStorage: {
-        'table columns for uniprotkb': selectedColumns,
+        [storageKey]: selectedColumns,
       },
     });
     await waitFor(() => screen.getAllByTestId('accordion-search-list-item'));
   });
 
-  test('should render', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    localStorageCache.clear();
+    onSave.mockReset();
+  });
+
+  it('should render', () => {
     const { asFragment } = rendered;
     expect(asFragment()).toMatchSnapshot();
     const selectionChip = screen.getByRole('button', {
@@ -46,12 +55,12 @@ describe('CustomiseTable component', () => {
     expect(selectionChip).toBeInTheDocument();
   });
 
-  test('should call onSave prop corresponding button is pressed', () => {
+  it('should call onSave prop corresponding button is pressed', () => {
     fireEvent.click(screen.getByText('Close'));
     expect(onSave).toHaveBeenCalled();
   });
 
-  test('should remove chip when clicked on', () => {
+  it('should remove chip when clicked on', async () => {
     const selectionChip = screen.getByRole('button', {
       name: 'Protein names',
       hidden: false,
@@ -62,5 +71,62 @@ describe('CustomiseTable component', () => {
     ).not.toBeInTheDocument();
     fireEvent.submit(screen.getByRole('form'));
     expect(onSave).toHaveBeenCalled();
+
+    // Give a chance to write to localStorage before having to do clean-up
+    await waitFor(() =>
+      expect(window.localStorage.getItem(storageKey)).toBe(
+        // Final expected state
+        JSON.stringify([
+          UniProtKBColumn.accession,
+          UniProtKBColumn.proteinExistence,
+        ])
+      )
+    );
+  });
+
+  it('should set and reset correctly', async () => {
+    // checkboxes checked initially
+    const initiallyCheckedCheckboxes = screen.getAllByRole('checkbox', {
+      checked: true,
+    });
+
+    // Expect all fromt the initial test state minus the accession
+    expect(initiallyCheckedCheckboxes).toHaveLength(selectedColumns.length - 1);
+
+    const uncheckedCheckboxes = screen.getAllByRole('checkbox', {
+      checked: false,
+    });
+
+    // Check 2 of the unchecked checkboxes
+    fireEvent.change(uncheckedCheckboxes[0], { target: { checked: true } });
+    fireEvent.change(uncheckedCheckboxes[1], { target: { checked: true } });
+
+    // We should have now 2 more checked checkboxes
+    expect(
+      screen.getAllByRole('checkbox', {
+        checked: true,
+      })
+    ).toHaveLength(initiallyCheckedCheckboxes.length + 2);
+    expect(screen.getAllByRole('checkbox', { checked: true }).length).toBe(
+      initiallyCheckedCheckboxes.length + 2
+    );
+
+    // Reset form to default
+    fireEvent.reset(screen.getByRole('form'));
+
+    const defaultColumns = nsToDefaultColumns(Namespace.uniprotkb);
+    // We should now have the the default checkboxes checked
+    expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(
+      // minus 1 to not count the accession
+      defaultColumns.length - 1
+    );
+
+    // Give a chance to write to localStorage before having to do clean-up
+    await waitFor(() =>
+      expect(window.localStorage.getItem(storageKey)).toBe(
+        // Final expected state
+        JSON.stringify(defaultColumns)
+      )
+    );
   });
 });

--- a/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
+++ b/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
@@ -22,7 +22,7 @@ const storageKey = `table columns for ${Namespace.uniprotkb}` as const;
 
 describe('CustomiseTable component', () => {
   let rendered: ReturnType<typeof customRender>;
-  const onSave = jest.fn();
+  const onClose = jest.fn();
   const selectedColumns = [
     UniProtKBColumn.accession,
     UniProtKBColumn.proteinName,
@@ -30,7 +30,7 @@ describe('CustomiseTable component', () => {
   ];
 
   beforeEach(async () => {
-    rendered = customRender(<CustomiseTable onSave={onSave} />, {
+    rendered = customRender(<CustomiseTable onClose={onClose} />, {
       route,
       initialLocalStorage: {
         [storageKey]: selectedColumns,
@@ -42,7 +42,7 @@ describe('CustomiseTable component', () => {
   afterEach(() => {
     window.localStorage.clear();
     localStorageCache.clear();
-    onSave.mockReset();
+    onClose.mockReset();
   });
 
   it('should render', () => {
@@ -55,9 +55,9 @@ describe('CustomiseTable component', () => {
     expect(selectionChip).toBeInTheDocument();
   });
 
-  it('should call onSave prop corresponding button is pressed', () => {
+  it('should call onClose prop corresponding button is pressed', () => {
     fireEvent.click(screen.getByText('Close'));
-    expect(onSave).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 
   it('should remove chip when clicked on', async () => {
@@ -70,7 +70,7 @@ describe('CustomiseTable component', () => {
       screen.queryByRole('button', { name: 'Protein names', hidden: false })
     ).not.toBeInTheDocument();
     fireEvent.submit(screen.getByRole('form'));
-    expect(onSave).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
 
     // Give a chance to write to localStorage before having to do clean-up
     await waitFor(() =>

--- a/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
+++ b/src/shared/components/customise-table/__tests__/CustomiseTable.spec.tsx
@@ -90,7 +90,7 @@ describe('CustomiseTable component', () => {
       checked: true,
     });
 
-    // Expect all fromt the initial test state minus the accession
+    // Expect all from the initial test state minus the accession
     expect(initiallyCheckedCheckboxes).toHaveLength(selectedColumns.length - 1);
 
     const uncheckedCheckboxes = screen.getAllByRole('checkbox', {

--- a/src/shared/components/customise-table/__tests__/__snapshots__/CustomiseTable.spec.tsx.snap
+++ b/src/shared/components/customise-table/__tests__/__snapshots__/CustomiseTable.spec.tsx.snap
@@ -2303,7 +2303,7 @@ exports[`CustomiseTable component should render 1`] = `
       </div>
     </div>
     <div
-      class="button-group sticky-bottom-right sliding-panel__button-row"
+      class="button-group sliding-panel__button-row sticky-bottom-right"
     >
       <button
         class="button secondary"

--- a/src/shared/components/customise-table/__tests__/__snapshots__/CustomiseTable.spec.tsx.snap
+++ b/src/shared/components/customise-table/__tests__/__snapshots__/CustomiseTable.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`CustomiseTable component should render 1`] = `
 <DocumentFragment>
   <form
     aria-label="Customise uniprotkb result table columns form"
-    class="customise-table"
   >
     <div
       class="column-select"
@@ -53,15 +52,8 @@ exports[`CustomiseTable component should render 1`] = `
           </span>
         </div>
       </div>
-      <button
-        class="button secondary"
-        data-testid="column-select-reset-button"
-        type="button"
-      >
-        Reset to default
-      </button>
       <div
-        class="tabs"
+        class="tabs sticky-tabs-container"
       >
         <div
           class="tabs__header"
@@ -78,7 +70,7 @@ exports[`CustomiseTable component should render 1`] = `
             <div
               class="column-select__tab-title"
             >
-              data
+              Data
               <span
                 class="column-select__tab-title__count column-select__tab-title__count--visible bubble--small"
               >
@@ -97,7 +89,7 @@ exports[`CustomiseTable component should render 1`] = `
             <div
               class="column-select__tab-title"
             >
-              links
+              External links
               <span
                 class="column-select__tab-title__count column-select__tab-title__count--hidden bubble--small"
               >
@@ -2313,6 +2305,12 @@ exports[`CustomiseTable component should render 1`] = `
     <div
       class="button-group sticky-bottom-right sliding-panel__button-row"
     >
+      <button
+        class="button secondary"
+        type="reset"
+      >
+        Reset to default
+      </button>
       <button
         class="button primary"
         type="submit"

--- a/src/shared/components/customise-table/styles/customise-table.scss
+++ b/src/shared/components/customise-table/styles/customise-table.scss
@@ -1,3 +1,0 @@
-.customise-table {
-  padding: 1rem 0;
-}

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, FC, ChangeEvent } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Loader, CodeBlock, Button, LongNumber } from 'franklin-sites';
+import cn from 'classnames';
 
 import ColumnSelect from '../column-select/ColumnSelect';
 
@@ -25,7 +26,7 @@ import {
 import { ContentType, FileFormat } from '../../types/resultsDownload';
 import { Namespace } from '../../types/namespaces';
 
-import '../../styles/sticky.scss';
+import sticky from '../../styles/sticky.module.scss';
 import './styles/download.scss';
 
 export const getPreviewFileFormat = (fileFormat: FileFormat) =>
@@ -263,7 +264,13 @@ const Download: FC<DownloadProps> = ({
             />
           </>
         )}
-      <section className="button-group sliding-panel__button-row sticky-bottom-right">
+      <section
+        className={cn(
+          'button-group',
+          'sliding-panel__button-row',
+          sticky['sticky-bottom-right']
+        )}
+      >
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>

--- a/src/shared/components/entry/styles/entry-page.scss
+++ b/src/shared/components/entry/styles/entry-page.scss
@@ -8,7 +8,7 @@
     scroll-margin-top: calc(#{$header-height} + #{$global-margin * 0.5});
   }
 
-  &.sticky-tabs-container .tabs__header {
+  & .tabs__header {
     margin: 1rem 0.125rem;
     width: calc(100% - 1rem);
   }

--- a/src/shared/styles/sticky.module.scss
+++ b/src/shared/styles/sticky.module.scss
@@ -1,7 +1,7 @@
 @import 'franklin-sites/src/styles/colours';
 
 .sticky-tabs-container {
-  & .tabs__header {
+  & :global(.tabs__header) {
     z-index: 100;
     position: sticky;
     top: 0;

--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -19,6 +19,7 @@ import {
 import { useHistory } from 'react-router-dom';
 import { sleep } from 'timing-functions';
 import { v1 } from 'uuid';
+import cn from 'classnames';
 
 import SequenceSearchLoader, {
   ParsedSequence,
@@ -50,7 +51,7 @@ import {
   MessageLevel,
 } from '../../../messages/types/messagesTypes';
 
-import '../../../shared/styles/sticky.scss';
+import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../styles/ToolsForm.scss';
 
 const ALIGN_LIMIT = 100;
@@ -343,7 +344,9 @@ const AlignForm = () => {
               ))}
             </section>
           </details>
-          <section className="tools-form-section sticky-bottom-right">
+          <section
+            className={cn('tools-form-section', sticky['sticky-bottom-right'])}
+          >
             <section className="button-group tools-form-section__buttons">
               {sending && !reducedMotion && (
                 <>

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -28,7 +28,7 @@ import { AlignResults } from '../../types/alignResults';
 import { JobTypes } from '../../../types/toolsJobTypes';
 import { PublicServerParameters } from '../../types/alignServerParameters';
 
-import '../../../../shared/styles/sticky.scss';
+import sticky from '../../../../shared/styles/sticky.module.scss';
 
 const jobType = JobTypes.ALIGN;
 const urls = toolsURLs(jobType);
@@ -167,7 +167,7 @@ const AlignResult = () => {
   );
 
   return (
-    <SingleColumnLayout className="sticky-tabs-container">
+    <SingleColumnLayout className={sticky['sticky-tabs-container']}>
       <PageIntro title="Align Results" />
       <Tabs active={match.params.subPage}>
         <Tab

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -20,6 +20,7 @@ import {
 import { useHistory } from 'react-router-dom';
 import { sleep } from 'timing-functions';
 import { v1 } from 'uuid';
+import cn from 'classnames';
 
 import AutocompleteWrapper from '../../../query-builder/components/AutocompleteWrapper';
 import SequenceSearchLoader, {
@@ -64,7 +65,7 @@ import {
 } from '../../../messages/types/messagesTypes';
 import { SelectedTaxon } from '../../types/toolsFormData';
 
-import '../../../shared/styles/sticky.scss';
+import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../styles/ToolsForm.scss';
 
 const BLAST_LIMIT = 20;
@@ -519,7 +520,9 @@ const BlastForm = () => {
               ))}
             </section>
           </details>
-          <section className="tools-form-section sticky-bottom-right">
+          <section
+            className={cn('tools-form-section', sticky['sticky-bottom-right'])}
+          >
             <section className="button-group tools-form-section__buttons">
               {sending && !reducedMotion && (
                 <>

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -44,7 +44,7 @@ import { PublicServerParameters } from '../../types/blastServerParameters';
 import { UniProtkbAPIModel } from '../../../../uniprotkb/adapters/uniProtkbConverter';
 
 import helper from '../../../../shared/styles/helper.module.scss';
-import '../../../../shared/styles/sticky.scss';
+import sticky from '../../../../shared/styles/sticky.module.scss';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
@@ -327,7 +327,7 @@ const BlastResult = () => {
         <PageIntro title="BLAST Results" resultsCount={hitsFiltered.length} />
       }
       sidebar={sidebar}
-      className="sticky-tabs-container"
+      className={sticky['sticky-tabs-container']}
     >
       <Tabs
         active={match.params.subPage}

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -7,7 +7,7 @@ import {
   useCallback,
 } from 'react';
 import { useDispatch } from 'react-redux';
-import { v1 } from 'uuid';
+import { useHistory } from 'react-router-dom';
 import {
   PageIntro,
   Message,
@@ -16,7 +16,8 @@ import {
   Loader,
 } from 'franklin-sites';
 import { sleep } from 'timing-functions';
-import { useHistory } from 'react-router-dom';
+import { v1 } from 'uuid';
+import cn from 'classnames';
 
 import AutocompleteWrapper from '../../../query-builder/components/AutocompleteWrapper';
 
@@ -54,7 +55,7 @@ import {
 import { FormParameters } from '../types/idMappingFormParameters';
 import { SelectedTaxon } from '../../types/toolsFormData';
 
-import '../../../shared/styles/sticky.scss';
+import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../styles/ToolsForm.scss';
 
 export type TreeDataNode = {
@@ -413,7 +414,12 @@ const IDMappingForm = () => {
                 </label>
               </section>
             </section>
-            <section className="tools-form-section sticky-bottom-right">
+            <section
+              className={cn(
+                'tools-form-section',
+                sticky['sticky-bottom-right']
+              )}
+            >
               <section className="button-group tools-form-section__buttons">
                 {sending && !reducedMotion && (
                   <>

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -14,6 +14,7 @@ import { Chip, PageIntro, SpinnerIcon } from 'franklin-sites';
 import { useHistory } from 'react-router-dom';
 import { sleep } from 'timing-functions';
 import { v1 } from 'uuid';
+import cn from 'classnames';
 
 import AutocompleteWrapper from '../../../query-builder/components/AutocompleteWrapper';
 
@@ -45,7 +46,7 @@ import {
   MessageLevel,
 } from '../../../messages/types/messagesTypes';
 
-import '../../../shared/styles/sticky.scss';
+import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../styles/ToolsForm.scss';
 
 // just because, no known actual limit
@@ -382,7 +383,9 @@ const PeptideSearchForm = () => {
               ))}
             </section>
           </details>
-          <section className="tools-form-section sticky-bottom-right">
+          <section
+            className={cn('tools-form-section', sticky['sticky-bottom-right'])}
+          >
             <section className="button-group tools-form-section__buttons">
               {sending && !reducedMotion && (
                 <>

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -14,6 +14,7 @@ import {
   Tabs,
   Tab,
 } from 'franklin-sites';
+import cn from 'classnames';
 
 import EntrySection, {
   getEntrySectionNameAndId,
@@ -63,7 +64,7 @@ import { LocationToPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../../shared/types/namespaces';
 import { EntryType } from '../../../shared/components/entry/EntryTypeIcon';
 
-import '../../../shared/styles/sticky.scss';
+import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../../shared/components/entry/styles/entry-page.scss';
 
 export enum TabLocation {
@@ -213,7 +214,7 @@ const Entry: FC = () => {
   return (
     <SideBarLayout
       sidebar={sidebar}
-      className="entry-page sticky-tabs-container"
+      className={cn('entry-page', sticky['sticky-tabs-container'])}
       title={
         <ErrorBoundary>
           <h1 className="big">

--- a/src/uniprotkb/types/resultsTypes.ts
+++ b/src/uniprotkb/types/resultsTypes.ts
@@ -18,8 +18,8 @@ export const getApiSortDirection = (direction: SortDirection) =>
 export type SelectedFacet = { name: string; value: string };
 
 export enum ColumnSelectTab {
-  data = 'data',
-  links = 'links',
+  data = 'Data',
+  links = 'External links',
 }
 
 export type SelectedColumn = {


### PR DESCRIPTION
## Purpose
Modifications needed to the customise column component https://www.ebi.ac.uk/panda/jira/browse/TRM-26084

## Approach
From the jira (some points were out of date):
1. ~Customise columns" in H2 text style~ title was already in the sliding panel title area
2. Change tab name "Links" to "External links" -> in this PR
3. Make the tabs sticky -> in this PR (there were already rules in CSS, but was missing a class to apply it)
4. ~Add placeholder to search bar "Search for columns"~ had already been set recently
5. Move the "Reset to default" button next to the "Close" button, see mockup -> in this PR

## Testing
Move tests around, specifically the on regarding resetting as it changed component

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
