### PR TITLE
2021 11 structure table bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "protvista-msa": "3.2.16",
     "protvista-navigation": "3.2.14",
     "protvista-sequence": "3.2.14",
-    "protvista-structure": "3.3.1",
     "protvista-tooltip": "3.1.2",
     "protvista-track": "3.2.14",
     "protvista-uniprot": "2.7.4",

--- a/src/shared/styles/_settings.scss
+++ b/src/shared/styles/_settings.scss
@@ -2,7 +2,7 @@ $gutter-size: 1rem;
 
 $z-index-low: 2000;
 $z-index-medium: 5000;
-$z-index-high: 9000;
+$z-index-high: 40000;
 
 $action-buttons-height: 2.5rem;
 

--- a/src/types/protvista-structure.d.ts
+++ b/src/types/protvista-structure.d.ts
@@ -3,6 +3,6 @@ declare module 'protvista-structure';
 
 declare namespace JSX {
   interface IntrinsicElements {
-    'protvista-structure': any;
+    'protvista-uniprot-structure': any;
   }
 }

--- a/src/types/protvista-structure.d.ts
+++ b/src/types/protvista-structure.d.ts
@@ -1,8 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare module 'protvista-structure';
-
-declare namespace JSX {
-  interface IntrinsicElements {
-    'protvista-uniprot-structure': any;
-  }
-}

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -4,5 +4,6 @@ declare module 'protvista-uniprot';
 declare namespace JSX {
   interface IntrinsicElements {
     'protvista-uniprot': any;
+    'protvista-uniprot-structure': any;
   }
 }

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3351,15 +3351,9 @@ exports[`Entry view should render for non-human entry 1`] = `
         <protvista-manager
           attributes="pdb-id"
         >
-          <protvista-structure
+          <protvista-uniprot-structure
             accession="P0DTR4"
             structureid="6N1A"
-          />
-          <protvista-datatable
-            filter-scroll="true"
-            nodeselect="true"
-            noscrolltorow="true"
-            selectedid="6N1A"
           />
         </protvista-manager>
         <h3>

--- a/src/uniprotkb/components/protein-data-views/PDBView.tsx
+++ b/src/uniprotkb/components/protein-data-views/PDBView.tsx
@@ -136,13 +136,9 @@ const PDBView: FC<{
   const firstId = sortedIds && sortedIds.length ? sortedIds[0] : '';
   return (
     <protvista-manager attributes="pdb-id">
-      <protvista-structure structureid={firstId} accession={primaryAccession} />
-      <protvista-datatable
-        ref={setTableData}
-        selectedId={firstId}
-        noScrollToRow
-        noDeselect
-        filter-scroll
+      <protvista-uniprot-structure
+        structureid={firstId}
+        accession={primaryAccession}
       />
     </protvista-manager>
   );

--- a/src/uniprotkb/components/protein-data-views/PDBView.tsx
+++ b/src/uniprotkb/components/protein-data-views/PDBView.tsx
@@ -89,9 +89,9 @@ const PDBView: FC<{
     /* istanbul ignore next */
     () =>
       import(
-        /* webpackChunkName: "protvista-structure" */ 'protvista-structure'
-      ),
-    'protvista-structure'
+        /* webpackChunkName: "protvista-uniprot" */ 'protvista-uniprot'
+      ).then((module) => ({ default: module.ProtvistaUniprotStructure })),
+    'protvista-uniprot-structure'
   );
   const managerDefined = useCustomElement(
     /* istanbul ignore next */


### PR DESCRIPTION
## Purpose
[PDB structure viewer not loading structures on row click](https://www.ebi.ac.uk/panda/jira/browse/TRM-26476)

## Approach
- Replicate Covid portal changes where `protvista-uniprot-structure` is used
- Had to bump `$z-index-high` to `40000`
- Removed `protvista-structure`

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
