### PR TITLE
no link to results page when no results

### DIFF
--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -163,10 +163,9 @@ const NiceStatus = ({ job, jobLink }: NiceStatusProps) => {
     case Status.NOT_FOUND:
       return <>Job not found on the server</>;
     case Status.FINISHED: {
-      const status = jobLink ? (
-        // eslint-disable-next-line uniprot-website/use-config-location
-        <Link to={jobLink}>Completed</Link>
-      ) : null;
+      if (!jobLink) {
+        return null;
+      }
       // either a BLAST or ID Mapping job could have those
       if ('data' in job && job.data && 'hits' in job.data) {
         const actualHits = job.data.hits;
@@ -183,11 +182,16 @@ const NiceStatus = ({ job, jobLink }: NiceStatusProps) => {
           const hitText = pluralise('hit', actualHits);
           return (
             <>
-              {status}{' '}
+              {actualHits === 0 ? (
+                <span>Completed</span>
+              ) : (
+                // eslint-disable-next-line uniprot-website/use-config-location
+                <Link to={jobLink}>Completed</Link>
+              )}{' '}
               <span
                 title={`${actualHits} ${hitText} results found instead of the requested ${expectedHits}`}
               >
-                ({job.data.hits} {hitText})
+                ({actualHits} {hitText})
               </span>
               <Seen job={job} />
             </>
@@ -196,7 +200,8 @@ const NiceStatus = ({ job, jobLink }: NiceStatusProps) => {
       }
       return (
         <>
-          {status}
+          {/* eslint-disable-next-line uniprot-website/use-config-location */}
+          <Link to={jobLink}>Completed</Link>
           <Seen job={job} />
         </>
       );
@@ -358,9 +363,12 @@ const Row = memo(({ job, hasExpired }: RowProps) => {
     );
   }, [job.status]);
 
+  const noResults =
+    'data' in job && job.data && 'hits' in job.data && job.data.hits === 0;
+
   return (
     <Card
-      to={jobLink}
+      to={noResults ? undefined : jobLink}
       ref={ref}
       className={bem({
         b: 'card',

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -191,7 +191,7 @@ const NiceStatus = ({ job, jobLink }: NiceStatusProps) => {
               <span
                 title={`${actualHits} ${hitText} results found instead of the requested ${expectedHits}`}
               >
-                ({actualHits ? `${actualHits} ${hitText}` : 'No results found'})
+                ({actualHits ? `${actualHits} ${hitText}` : 'no results found'})
               </span>
               <Seen job={job} />
             </>

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -191,7 +191,7 @@ const NiceStatus = ({ job, jobLink }: NiceStatusProps) => {
               <span
                 title={`${actualHits} ${hitText} results found instead of the requested ${expectedHits}`}
               >
-                ({actualHits} {hitText})
+                ({actualHits ? `${actualHits} ${hitText}` : 'No results found'})
               </span>
               <Seen job={job} />
             </>

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -156,17 +156,7 @@ const getCheckJobStatus =
 
         const now = Date.now();
 
-        const hits: string = response.headers['x-total-records'];
-
-        if (!hits) {
-          dispatch(
-            updateJob(job.internalID, {
-              timeLastUpdate: now,
-              status: Status.FAILURE,
-            })
-          );
-          throw new Error('There was no valid results for this job');
-        }
+        const hits: string = response.headers['x-total-records'] || '0';
 
         dispatch(
           updateJob(job.internalID, {

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -187,7 +187,9 @@ const getCheckJobStatus =
             data: { hits },
           })
         );
-        dispatch(addMessage(getJobMessage({ job: currentStateOfJob })));
+        dispatch(
+          addMessage(getJobMessage({ job: currentStateOfJob, nHits: hits }))
+        );
       } else {
         // Align
         const now = Date.now();

--- a/src/tools/utils/index.tsx
+++ b/src/tools/utils/index.tsx
@@ -162,7 +162,7 @@ export const getJobMessage = ({
   }
 
   let location: LocationDescriptor<LocationStateFromJobLink> | undefined;
-  if ('remoteID' in job && job.remoteID) {
+  if ('remoteID' in job && job.remoteID && nHits !== 0) {
     location = {
       pathname: generatePath(jobTypeToPath(job.type, true), {
         id: job.remoteID,
@@ -181,7 +181,7 @@ export const getJobMessage = ({
     content: (
       <>
         {job.type} job{' '}
-        {location ? <Link to={location}>{jobName}</Link> : { jobName }}
+        {location ? <Link to={location}>{jobName}</Link> : jobName}
         {` finished${hitsMessage}`}
       </>
     ),


### PR DESCRIPTION
## Purpose
Don't let the user go to a results page if there are no results https://www.ebi.ac.uk/panda/jira/browse/TRM-26302 & https://www.ebi.ac.uk/panda/jira/browse/TRM-26345

## Approach
Remove links in the status text, the result card, and the popup

## Testing
Manual testing with P05635 to Allergome (ID Mapping), and P80488 (BLAST)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
