### PR TITLE
Subcell viz membranes

### DIFF
--- a/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
@@ -12,6 +12,8 @@ import './styles/sub-cell-viz.scss';
 /*
   The logic implemented here to get our data into @swissprot/swissbiopics-visualizer has been lifted
   from the source code at http://sp.sib.swiss/scripts/uniprot_entry-bundle.js with some modifications
+
+  Good membrane example: A1L3X0
 */
 
 const shapes = [
@@ -133,8 +135,6 @@ type Props = RequireExactlyOne<
   'uniProtLocationIds' | 'goLocationIds'
 >;
 
-// TODO: add additional GO template which will also require GO term data
-// TODO: handle this case as seen in the source code 'svg .membranes .membrane.subcell_present' eg A1L3X0 doesn't work
 const SubCellViz: FC<Props> = memo(
   ({ uniProtLocationIds, goLocationIds, taxonId, children }) => {
     const instanceName = useRef(

--- a/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
@@ -66,16 +66,15 @@ const getGoTermClassNames = (locationGroup: Element) =>
     .filter((className) => className.startsWith('GO'))
     .map((goId) => `.${goId}`);
 
-const getUniProtTextSelectors = (subcellularPresentSVG: Element) =>
-  [
-    `#${subcellularPresentSVG.id}term`,
-    ...Array.from(subcellularPresentSVG.classList)
-      .map((className: string) => {
-        const id = className.match(reMpPart)?.groups?.id;
-        return id && `#${id}term`;
-      })
-      .filter(Boolean),
-  ] as string[];
+const getUniProtTextSelectors = (subcellularPresentSVG: Element): string[] => [
+  `#${subcellularPresentSVG.id}term`,
+  ...Array.from(subcellularPresentSVG.classList)
+    .map((className: string) => {
+      const id = className.match(reMpPart)?.groups?.id;
+      return id && `#${id}term`;
+    })
+    .filter((sel: string | undefined): sel is string => Boolean(sel)),
+];
 
 const attachTooltips = (
   locationGroup: Element,

--- a/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
@@ -197,6 +197,7 @@ const SubCellViz: FC<Props> = memo(
       );
       const shadowRoot = instance?.shadowRoot;
       const onSvgLoaded = () => {
+        console.log(uniProtLocationIds);
         const tabsHeaderHeight =
           document.querySelector('.tabs__header')?.clientHeight;
         const pictureTop = tabsHeaderHeight
@@ -222,6 +223,12 @@ const SubCellViz: FC<Props> = memo(
         }
         .subcell_description {
           display: none;
+        }
+
+        svg .mp_SL0097 .coloured {
+          stroke: black !important;
+          fill: #abc7d6 !important;
+          fill-opacity: 1 !important;
         }
       `;
         const style = document.createElement('style');
@@ -298,7 +305,7 @@ const SubCellViz: FC<Props> = memo(
       return () => {
         shadowRoot?.removeEventListener('svgloaded', onSvgLoaded);
       };
-    }, [uniProtLocationIds?.length]);
+    }, [uniProtLocationIds]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const Instance = (props: any) => <instanceName.current {...props} />;


### PR DESCRIPTION
## Purpose
Handle locations which are membranes or "part". [[Jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-25569)]

## Approach

- From seen locations extract classnames that start with `mp_` or `part_` and convert these into IDs.
- Apply styles with selector `[class*="mp_"] .coloured, svg [class*="part_"] .coloured`

## Testing
None

## View changes
Accession A1L3X0 is a good example.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
