### PR TITLE
2021 13 schema updates uniprotkb

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 83.96,
-        "statements": 83.88,
-        "functions": 83.67,
-        "branches": 73.38
+        "lines": 83.92,
+        "statements": 83.84,
+        "functions": 83.62,
+        "branches": 73.32
       }
     },
     "transform": {

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -136,7 +136,7 @@ export const allSearchResultLocations = `/:namespace(${Object.keys(
   searchableNamespaceLabels
 ).join('|')})`;
 
-// "/:namespace(uniprotkb|uniparc|........)/accession"
+// "/:namespace(uniprotkb|uniparc|........)/:accession"
 export const allEntryPages = `/:namespace(${Object.keys(
   searchableNamespaceLabels
 ).join('|')})/:accession`;

--- a/src/service-worker/__tests__/url-patterns.spec.ts
+++ b/src/service-worker/__tests__/url-patterns.spec.ts
@@ -54,10 +54,10 @@ describe('URL patterns for service worker caching', () => {
       patterns.uniprotAPIs
     );
     expect(
-      'https://wwwdev.ebi.ac.uk/uniprot/beta/api/uniprotkb/accession/A1L3X0'
+      'https://wwwdev.ebi.ac.uk/uniprot/beta/api/uniprotkb/A1L3X0'
     ).toMatch(patterns.uniprotAPIs);
-    expect(
-      'https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/accession/A1L3X0'
-    ).toMatch(patterns.uniprotAPIs);
+    expect('https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/A1L3X0').toMatch(
+      patterns.uniprotAPIs
+    );
   });
 });

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -177,7 +177,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
       <a
         class="button tertiary"
         download=""
-        href="/<testing>/api/uniprotkb/accession/P05067.fasta"
+        href="/<testing>/api/uniprotkb/P05067.fasta"
       >
         <test-file-stub />
         Download

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -108,7 +108,7 @@ const apiUrls = {
     joinUrl(apiPrefix, '/genecentric/', accession),
   idMappingFields: joinUrl(apiPrefix, '/configure/idmapping/fields'),
   entry: (id: string | undefined, namespace: Namespace) =>
-    id && joinUrl(apiPrefix, `/${namespace}/`, id),
+    id && joinUrl(apiPrefix, namespace, id),
   sequenceFasta: (accession: string) =>
     `${apiUrls.entry(accession, Namespace.uniprotkb)}.fasta`,
   entryDownload: (

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -126,7 +126,7 @@ const apiUrls = {
           fileFormatToUrlParameter[format]
         }`,
   entryPublications: (accession: string) =>
-    joinUrl(apiPrefix, '/uniprotkb/', accession, '/publications'),
+    joinUrl(apiPrefix, 'uniprotkb', accession, '/publications'),
   taxonomySuggester: 'suggester?dict=taxonomy&query=?',
   organismSuggester: 'suggester?dict=organism&query=?',
 

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -108,15 +108,7 @@ const apiUrls = {
     joinUrl(apiPrefix, '/genecentric/', accession),
   idMappingFields: joinUrl(apiPrefix, '/configure/idmapping/fields'),
   entry: (id: string | undefined, namespace: Namespace) =>
-    id &&
-    joinUrl(
-      apiPrefix,
-      // NOTE: The inclusion of /accession/ subpath for uniprotkb is going to be reviewed by backend
-      // and potentially removed to bring it in line with the other namespaces
-      // NOTE: uniparc entry isn't working/deployed yet
-      `/${namespace}/${namespace === Namespace.uniprotkb ? 'accession/' : ''}`,
-      id
-    ),
+    id && joinUrl(apiPrefix, `/${namespace}/`, id),
   sequenceFasta: (accession: string) =>
     `${apiUrls.entry(accession, Namespace.uniprotkb)}.fasta`,
   entryDownload: (
@@ -134,7 +126,7 @@ const apiUrls = {
           fileFormatToUrlParameter[format]
         }`,
   entryPublications: (accession: string) =>
-    joinUrl(apiPrefix, '/uniprotkb/accession', accession, '/publications'),
+    joinUrl(apiPrefix, '/uniprotkb/', accession, '/publications'),
   taxonomySuggester: 'suggester?dict=taxonomy&query=?',
   organismSuggester: 'suggester?dict=organism&query=?',
 

--- a/src/shared/config/testingApiUrls.ts
+++ b/src/shared/config/testingApiUrls.ts
@@ -1,41 +1,56 @@
+/* eslint-disable no-console */
 // TODO: eventually delete this file
 import urlJoin from 'url-join';
 import { apiPrefix } from './apiUrls';
 
 // set to true if testing new API changes
-const apiTesting = false;
+const apiTesting = true;
+
+if (apiTesting) {
+  console.warn('❗❗❗ USING API TESTING ENDPOINT - DO NOT USE IN PRODUCTION');
+}
 
 const joinUrlForApiTesting = (prefix: string, ...paths: string[]) => {
   // Due to the way the API is served it's impossible to unify all of the testing servers to a single domain:port.
   // The map below encodes the various namespace/path combinations in the confluence document:
   // https://www.ebi.ac.uk/seqdb/confluence/display/UniProt/Managing+RESTful+Services#ManagingRESTfulServices-ProteomeandGenecentricServices
   // Guoying has remarked that this is temporary until we have k8s production servers live then wwwdev will be the new testing VM
-  const apiTestingProtocolDomain = 'http://wp-np2-be';
+  const apiTestingProtocolDomain = (port: number) =>
+    `http://hx-rke-wp-webadmin-02-worker-1.caas.ebi.ac.uk:${port}/uniprot/beta/api`;
   const endpointToPort = {
-    uniprotkb: 8090,
-    uniref: 8091,
-    uniparc: 8093,
-    proteomes: 8092,
+    uniprotkb: 32545,
+    uniref: 30157,
+    uniparc: 30092,
+    proteomes: 31114,
+    unisave: 30157,
     // supporting data
-    taxonomy: 8095,
-    keywords: 8095,
-    citations: 8095,
-    diseases: 8095,
-    database: 8095,
-    locations: 8095,
+    taxonomy: 9606,
+    keywords: 9606,
+    citations: 9606,
+    diseases: 9606,
+    database: 9606,
+    locations: 9606,
+    // tools
+    idmapping: 30361,
     // other
+    help: 31684,
     genecentric: 8092,
+    arba: 32137,
+    unirule: 32137,
+    configure: 30510,
   };
-  const defaultEndpointToPort = 8095; // default to 8095 for all support data and configure
+  const defaultEndpointToPort = 9606; // default for all support data
   let newPrefix = prefix;
   if (apiTesting && prefix === apiPrefix && paths?.[0]) {
     // joinUrl(apiPrefix, `/${namespace}/search`),
-    const endpoint = paths[0].split('/').filter(Boolean)[0];
-    if (endpoint) {
-      const port =
-        endpointToPort[endpoint as keyof typeof endpointToPort] ||
-        defaultEndpointToPort;
-      newPrefix = `${apiTestingProtocolDomain}:${port}`;
+    const endpoint = paths[0]
+      .split('/')
+      .filter(Boolean)[0] as keyof typeof endpointToPort;
+    if (endpoint && endpoint in endpointToPort) {
+      const port = endpointToPort[endpoint] || defaultEndpointToPort;
+      newPrefix = apiTestingProtocolDomain(port);
+    } else {
+      console.error(`${endpoint} not in endpointToPort mapping`);
     }
   }
   return urlJoin(newPrefix, ...paths);

--- a/src/shared/config/testingApiUrls.ts
+++ b/src/shared/config/testingApiUrls.ts
@@ -4,7 +4,7 @@ import urlJoin from 'url-join';
 import { apiPrefix } from './apiUrls';
 
 // set to true if testing new API changes
-const apiTesting = true;
+const apiTesting = false;
 
 if (apiTesting) {
   console.warn('❗❗❗ USING API TESTING ENDPOINT - DO NOT USE IN PRODUCTION');

--- a/src/shared/utils/__tests__/getFASTAFromAccession.spec.ts
+++ b/src/shared/utils/__tests__/getFASTAFromAccession.spec.ts
@@ -23,15 +23,15 @@ describe('getFASTAFromAccession', () => {
   });
 
   it('should throw if protein not existing', async () => {
-    mock.onGet(/api\/uniprotkb\/accession\/O00000$/).reply(404, {
-      url: 'http://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/accession/O00000',
+    mock.onGet(/api\/uniprotkb\/O00000$/).reply(404, {
+      url: 'http://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/O00000',
       messages: ['Resource not found'],
     });
     await expect(getFASTAFromAccession('O00000')).rejects.toThrow();
   });
 
   it('should handle UniProtKB entry', async () => {
-    mock.onGet(/api\/uniprotkb\/accession\/P05067$/).reply(200, mockUniProtKB);
+    mock.onGet(/api\/uniprotkb\/P05067$/).reply(200, mockUniProtKB);
     await expect(getFASTAFromAccession('P05067')).resolves.toMatchSnapshot();
   });
 

--- a/src/supporting-data/citations/adapters/citationsConverter.ts
+++ b/src/supporting-data/citations/adapters/citationsConverter.ts
@@ -113,6 +113,7 @@ export const formatCitationData = (citation: Citation) => {
     publicationDate: citation.publicationDate,
     doiId: doiXref?.id,
     submissionDatabase: citation?.submissionDatabase,
+    locator: citation?.locator,
   };
   return { pubmedId, journalInfo };
 };

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -50,7 +50,7 @@ export const getLocatorUrl = (
   }
   switch (name) {
     case 'Plant Gene Register':
-      return `${PGR_URL}${locator}`;
+      return `${PGR_URL}${locator}.html`;
     case "Worm Breeder's Gazette": {
       const regex = /(\d+)\((\d+)\):(\d+)/;
       const matches = locator?.match(regex);

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -37,6 +37,36 @@ const getLinkToAuthor = (author: string) => ({
   search: `query=lit_author:"${author}"`,
 });
 
+const WORM_BREEDERS_GAZETTE_URL = 'http://www.wormbook.org/wli/';
+// const ARVO_URL = 'http://iovs.arvojournals.org/article.aspx?articleid=';
+const PGR_URL = 'https://www.ebi.ac.uk/~textman/pgr-htdocs/pgr/';
+
+export const getLocatorUrl = (
+  locator?: string,
+  name?: 'Plant Gene Register' | "Worm Breeder's Gazette" | string
+) => {
+  if (!locator || !name) {
+    return null;
+  }
+  switch (name) {
+    case 'Plant Gene Register':
+      return `${PGR_URL}${locator}`;
+    case "Worm Breeder's Gazette": {
+      const regex = /(\d+)\((\d+)\):(\d+)/;
+      const matches = locator?.match(regex);
+      if (!matches) {
+        return null;
+      }
+      const issue = matches[1];
+      const volume = matches[2];
+      const page = matches[3];
+      return `${WORM_BREEDERS_GAZETTE_URL}wbg${issue}.${volume}p${page}/`;
+    }
+    default:
+      return null;
+  }
+};
+
 const Authors: FC<AuthorProps> = ({ authors, limit = 10 }) => {
   const cutoff = authors.length > limit ? authors.length : limit;
 
@@ -106,6 +136,7 @@ type JournalInfoProps = {
     volume?: string;
     doiId?: string;
     submissionDatabase?: string;
+    locator?: string;
   };
 };
 
@@ -118,6 +149,7 @@ export const JournalInfo: FC<JournalInfoProps> = ({
     volume,
     doiId,
     submissionDatabase,
+    locator,
   },
 }) => {
   const name = journal || doiId;
@@ -152,11 +184,13 @@ export const JournalInfo: FC<JournalInfoProps> = ({
     </>
   );
 
-  if (!doiId) {
+  const url = doiId ? externalUrls.DOI(doiId) : getLocatorUrl(locator, name);
+
+  if (!url) {
     return content;
   }
 
-  return <ExternalLink url={externalUrls.DOI(doiId)}>{content}</ExternalLink>;
+  return <ExternalLink url={url}>{content}</ExternalLink>;
 };
 
 type StatisticsProps = {

--- a/src/supporting-data/citations/components/__tests__/LiteratureCitation.spec.tsx
+++ b/src/supporting-data/citations/components/__tests__/LiteratureCitation.spec.tsx
@@ -2,7 +2,7 @@ import { screen, fireEvent } from '@testing-library/react';
 
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
-import LiteratureCitation from '../LiteratureCitation';
+import LiteratureCitation, { getLocatorUrl } from '../LiteratureCitation';
 
 import { CitationsAPIModel } from '../../adapters/citationsConverter';
 
@@ -50,5 +50,24 @@ describe('Publication component', () => {
       <LiteratureCitation data={literatureCitationData['CI-5GBDQ6B103N1E']} />
     );
     expect(screen.getByText(/Submitted to/)).toBeInTheDocument();
+  });
+});
+
+describe('Publication component url', () => {
+  test('Plant Gene Register', () => {
+    const url = getLocatorUrl('PGR98-023', 'Plant Gene Register');
+    expect(url).toEqual(
+      'https://www.ebi.ac.uk/~textman/pgr-htdocs/pgr/PGR98-023'
+    );
+  });
+
+  test("Worm Breeder's Gazette", () => {
+    const url = getLocatorUrl('14(2):46', "Worm Breeder's Gazette");
+    expect(url).toEqual('http://www.wormbook.org/wli/wbg14.2p46/');
+  });
+
+  test("Wrong locator for Worm Breeder's", () => {
+    const url = getLocatorUrl('', "Worm Breeder's Gazette");
+    expect(url).toBeNull();
   });
 });

--- a/src/supporting-data/citations/components/__tests__/LiteratureCitation.spec.tsx
+++ b/src/supporting-data/citations/components/__tests__/LiteratureCitation.spec.tsx
@@ -57,7 +57,7 @@ describe('Publication component url', () => {
   test('Plant Gene Register', () => {
     const url = getLocatorUrl('PGR98-023', 'Plant Gene Register');
     expect(url).toEqual(
-      'https://www.ebi.ac.uk/~textman/pgr-htdocs/pgr/PGR98-023'
+      'https://www.ebi.ac.uk/~textman/pgr-htdocs/pgr/PGR98-023.html'
     );
   });
 

--- a/src/uniprotkb/components/entry/__tests__/__mocks__/entryPublicationsData.ts
+++ b/src/uniprotkb/components/entry/__tests__/__mocks__/entryPublicationsData.ts
@@ -6,7 +6,7 @@ type Payload = {
   results: Partial<CitationsAPIModel>[];
 };
 
-// api/uniprotkb/accession/O43865/publications?facets=types%2Ccategories%2Cis_large_scale
+// api/uniprotkb/O43865/publications?facets=types%2Ccategories%2Cis_large_scale
 const mock: Payload = {
   facets: [
     {

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -4157,7 +4157,7 @@ exports[`Entry view should render for non-human entry 1`] = `
             <a
               class="button tertiary"
               download=""
-              href="/<testing>/api/uniprotkb/accession/P0DTR4.fasta"
+              href="/<testing>/api/uniprotkb/P0DTR4.fasta"
             >
               <test-file-stub />
               Download


### PR DESCRIPTION
## Purpose
- Check model changes for UniProtKB
- Update new url path without `/accession`
- Handle `locator` field in Citations

## Approach
- There were no changes to the model
- All paths were updated and test cases updated. Checked in browser.
- Managed to dig up the old code from uuw to see how the urls corresponding to `locator` were handled and translated the logic. In the process, realised that ARVO was missing, Leo is looking into that and will create a subsequent Jira.

## Testing
Added a test to check the generation of the url was correct.
Examples to try: O64948, P98060

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
