### PR TITLE
2021 13 xref any

### DIFF
--- a/src/query-builder/components/__tests__/__mocks__/configureSearchTerms.ts
+++ b/src/query-builder/components/__tests__/__mocks__/configureSearchTerms.ts
@@ -9145,7 +9145,6 @@ const configureSearchTerms = [
             term: 'xref',
             dataType: 'string',
             fieldType: 'general',
-            valuePrefix: 'any-',
           },
         ],
       },

--- a/src/query-builder/utils/__tests__/__snapshots__/parseAndMatchQuery.spec.ts.snap
+++ b/src/query-builder/utils/__tests__/__snapshots__/parseAndMatchQuery.spec.ts.snap
@@ -236,7 +236,7 @@ Array [
 ]
 `;
 
-exports[`query parser and validator with xrefs, one invalid 1`] = `
+exports[`query parser and validator with xrefs, two of which are any 1`] = `
 Array [
   Object {
     "id": 0,
@@ -270,23 +270,18 @@ Array [
       "valuePrefix": "embl-",
     },
   },
-]
-`;
-
-exports[`query parser and validator with xrefs, one invalid 2`] = `
-Array [
   Object {
     "id": 2,
     "logicOperator": "AND",
     "queryBits": Object {
-      "xref": "invalid",
+      "xref": "xyz",
     },
     "searchTerm": Object {
       "dataType": "string",
       "fieldType": "general",
-      "id": "",
+      "id": "xref_any",
       "itemType": "single",
-      "label": "",
+      "label": "Any cross-reference",
       "term": "xref",
     },
   },
@@ -299,9 +294,9 @@ Array [
     "searchTerm": Object {
       "dataType": "string",
       "fieldType": "general",
-      "id": "",
+      "id": "xref_any",
       "itemType": "single",
-      "label": "",
+      "label": "Any cross-reference",
       "term": "xref",
     },
   },

--- a/src/query-builder/utils/__tests__/parseAndMatchQuery.spec.ts
+++ b/src/query-builder/utils/__tests__/parseAndMatchQuery.spec.ts
@@ -17,15 +17,14 @@ describe('query parser and validator', () => {
     expect(invalid).toHaveLength(0);
   });
 
-  test('with xrefs, one invalid', () => {
+  test('with xrefs, two of which are any', () => {
     const [valid, invalid] = parseAndMatchQuery(
-      '(xref:pdb-gluco-fructose) AND (xref:embl-some value) AND (xref:invalid) AND (xref:xyz-value)',
+      '(xref:pdb-gluco-fructose) AND (xref:embl-some value) AND (xref:xyz) AND (xref:xyz-value)',
       searchTermsData
     );
-    expect(valid).toHaveLength(2);
+    expect(valid).toHaveLength(4);
     expect(valid).toMatchSnapshot();
-    expect(invalid).toHaveLength(2);
-    expect(invalid).toMatchSnapshot();
+    expect(invalid).toHaveLength(0);
   });
 
   test('with valid and invalid fields', () => {

--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -88,7 +88,7 @@ const parseAndMatchQuery = (
           matchingXref = matching.find(({ term }) => term === 'xref');
           queryBitsXref = clause.queryBits.xref;
         }
-        if (matchingXref) {
+        if (matchingXref && queryBitsXref) {
           validatedQuery.push({
             ...clause,
             searchTerm: matchingXref,

--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -73,15 +73,26 @@ const parseAndMatchQuery = (
         });
       } else if (clause.searchTerm.term === 'xref') {
         // specific case for crosss-references
-        const [prefix, ...rest] = clause.queryBits.xref.split('-');
-        const matchingXref = matching.find(
-          ({ valuePrefix }) => valuePrefix === `${prefix}-`
-        );
+        let matchingXref;
+        let queryBitsXref;
+        if (clause.queryBits.xref.includes('-')) {
+          // There seems to be a prefix (prefix-foo) here so see if prefix can be found
+          const [prefix, ...rest] = clause.queryBits.xref.split('-');
+          matchingXref = matching.find(
+            ({ valuePrefix }) => valuePrefix === `${prefix}-`
+          );
+          queryBitsXref = rest.join('-');
+        }
+        if (!matchingXref) {
+          // There isn't a prefix or at least one that was found so this is an any xref search eg (xref:X82272)
+          matchingXref = matching.find(({ term }) => term === 'xref');
+          queryBitsXref = clause.queryBits.xref;
+        }
         if (matchingXref) {
           validatedQuery.push({
             ...clause,
             searchTerm: matchingXref,
-            queryBits: { xref: rest.join('-') },
+            queryBits: { xref: queryBitsXref },
           });
         } else {
           // invalid xref prefix


### PR DESCRIPTION
## Purpose
Currently, selecting "Cross-References/Any/Any cross-reference" generates the query `(xref:any-Something)`. It should actually be `(xref:Something)` [[jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-26638)]

## Approach
How does this change address the problem?
- Check if a hyphen exists in the xref queryBit and if so try to extract a valid prefix. If not present, treat as any search eg `xref:foo`
- The [search-fields](https://www.ebi.ac.uk/uniprot/beta/api/configure/uniprotkb/search-fields) will be modified to have `valuePrefix` removed from the `xref_any` item shortly:

```
{
  "id":"xref_group_any",
  "label":"Any",
  "itemType":"group",
  "items":[
    {
      "id":"xref_any",
      "label":"Any cross-reference",
      "itemType":"single",
      "term":"xref",
      "dataType":"string",
      "fieldType":"general",
      "valuePrefix":"any-"       <----------------- this will be removed
    }
  ]
}
```

## Testing
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
