### PR TITLE
redirect all search pages without a search query to the star search

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -1,5 +1,11 @@
 import { lazy, Suspense, FC, CSSProperties, useEffect, useRef } from 'react';
-import { Router, Route, Switch, RouteChildrenProps } from 'react-router-dom';
+import {
+  Router,
+  Route,
+  Switch,
+  RouteChildrenProps,
+  Redirect,
+} from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { FranklinSite, Loader } from 'franklin-sites';
 import { sleep } from 'timing-functions';
@@ -251,6 +257,11 @@ const ResultsOrLanding =
       <LandingPage {...props} />
     );
 
+// NOTE: remove whenever we start implementing landing pages
+const RedirectToStarSearch = ({ location }: RouteChildrenProps) => (
+  <Redirect to={{ ...location, search: 'query=*' }} />
+);
+
 const App = () => {
   useScrollToTop(history);
   useReloadApp(history);
@@ -346,7 +357,10 @@ const App = () => {
               {/* Result pages */}
               <Route
                 path={allSearchResultLocations}
-                component={GenericResultsPage}
+                component={ResultsOrLanding(
+                  GenericResultsPage,
+                  RedirectToStarSearch
+                )}
               />
               {/* Tools */}
               <Route


### PR DESCRIPTION
## Purpose
Redirect what will be landing pages to the corresponding star search for now https://www.ebi.ac.uk/panda/jira/browse/TRM-26846
This is after realising that some users ended up there sometimes (URL editing?) and would see a no results page

## Approach
Reuse the ResultsOrLanding helper component and point to a Redirect component reusing the current location and replacing the search part of the location

## Testing
Manual testing

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
