### PR TITLE
2021 15 slim sets  correct evidence

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -574,7 +574,7 @@ exports[`Entry basic should render main 1`] = `
                       <button
                         aria-controls="5"
                         aria-expanded="false"
-                        class="svg-colour-reviewed evidence-tag"
+                        class="svg-colour-unreviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -597,7 +597,7 @@ exports[`Entry basic should render main 1`] = `
                     <button
                       aria-controls="6"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -635,7 +635,7 @@ exports[`Entry basic should render main 1`] = `
                         <button
                           aria-controls="7"
                           aria-expanded="false"
-                          class="svg-colour-reviewed evidence-tag"
+                          class="svg-colour-unreviewed evidence-tag"
                           data-testid="evidence-tag-trigger"
                           type="button"
                         >
@@ -667,7 +667,7 @@ exports[`Entry basic should render main 1`] = `
                       <button
                         aria-controls="8"
                         aria-expanded="false"
-                        class="svg-colour-reviewed evidence-tag"
+                        class="svg-colour-unreviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -698,7 +698,7 @@ exports[`Entry basic should render main 1`] = `
                     <button
                       aria-controls="9"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -728,7 +728,7 @@ exports[`Entry basic should render main 1`] = `
                     <button
                       aria-controls="10"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -758,7 +758,7 @@ exports[`Entry basic should render main 1`] = `
                     <button
                       aria-controls="11"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -869,7 +869,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="12"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -911,7 +911,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="13"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -953,7 +953,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="14"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -999,7 +999,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="15"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1022,7 +1022,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="16"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1071,7 +1071,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="17"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1094,7 +1094,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="18"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1121,7 +1121,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="19"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1144,7 +1144,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="20"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1193,7 +1193,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="21"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1237,7 +1237,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="22"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -1283,7 +1283,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="23"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1331,7 +1331,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="24"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1384,7 +1384,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="25"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -1426,7 +1426,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="26"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -1468,7 +1468,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="27"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -1514,7 +1514,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="28"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1537,7 +1537,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="29"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1582,7 +1582,7 @@ exports[`Entry basic should render main 1`] = `
                           <button
                             aria-controls="30"
                             aria-expanded="false"
-                            class="svg-colour-reviewed evidence-tag"
+                            class="svg-colour-unreviewed evidence-tag"
                             data-testid="evidence-tag-trigger"
                             type="button"
                           >
@@ -1628,7 +1628,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="31"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >
@@ -1676,7 +1676,7 @@ exports[`Entry basic should render main 1`] = `
                               <button
                                 aria-controls="32"
                                 aria-expanded="false"
-                                class="svg-colour-reviewed evidence-tag"
+                                class="svg-colour-unreviewed evidence-tag"
                                 data-testid="evidence-tag-trigger"
                                 type="button"
                               >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -243,7 +243,7 @@ exports[`Entry view should render 1`] = `
             <button
               aria-controls="4"
               aria-expanded="false"
-              class="svg-colour-reviewed evidence-tag"
+              class="svg-colour-unreviewed evidence-tag"
               data-testid="evidence-tag-trigger"
               type="button"
             >
@@ -266,7 +266,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="5"
             aria-expanded="false"
-            class="svg-colour-reviewed evidence-tag"
+            class="svg-colour-unreviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -304,7 +304,7 @@ exports[`Entry view should render 1`] = `
               <button
                 aria-controls="6"
                 aria-expanded="false"
-                class="svg-colour-reviewed evidence-tag"
+                class="svg-colour-unreviewed evidence-tag"
                 data-testid="evidence-tag-trigger"
                 type="button"
               >
@@ -336,7 +336,7 @@ exports[`Entry view should render 1`] = `
             <button
               aria-controls="7"
               aria-expanded="false"
-              class="svg-colour-reviewed evidence-tag"
+              class="svg-colour-unreviewed evidence-tag"
               data-testid="evidence-tag-trigger"
               type="button"
             >
@@ -367,7 +367,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="8"
             aria-expanded="false"
-            class="svg-colour-reviewed evidence-tag"
+            class="svg-colour-unreviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -397,7 +397,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="9"
             aria-expanded="false"
-            class="svg-colour-reviewed evidence-tag"
+            class="svg-colour-unreviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -427,7 +427,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="10"
             aria-expanded="false"
-            class="svg-colour-reviewed evidence-tag"
+            class="svg-colour-unreviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -547,7 +547,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="11"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -589,7 +589,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="12"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -631,7 +631,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="13"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -677,7 +677,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="14"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -700,7 +700,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="15"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -749,7 +749,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="16"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -772,7 +772,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="17"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -799,7 +799,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="18"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -822,7 +822,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="19"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -871,7 +871,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="20"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -915,7 +915,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="21"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -961,7 +961,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="22"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1009,7 +1009,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="23"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1062,7 +1062,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="24"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1104,7 +1104,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="25"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1146,7 +1146,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="26"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1192,7 +1192,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="27"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1215,7 +1215,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="28"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1260,7 +1260,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="29"
                   aria-expanded="false"
-                  class="svg-colour-reviewed evidence-tag"
+                  class="svg-colour-unreviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1306,7 +1306,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="30"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1354,7 +1354,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="31"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -3365,7 +3365,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <button
                       aria-controls="17"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -5042,7 +5042,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <button
                       aria-controls="50"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -5374,7 +5374,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <button
                       aria-controls="55"
                       aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
+                      class="svg-colour-unreviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -34,7 +34,9 @@ export const UniProtEvidenceTagContent: FC<{
 
   return (
     <div>
-      <h5>{evidenceData.label}</h5>
+      <h5>
+        {evidenceData.label} <small>({evidenceData.description})</small>
+      </h5>
       {publicationReferences && (
         <UniProtKBEntryPublications
           pubmedIds={

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
@@ -32,7 +32,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 1`] 
   <button
     aria-controls="0"
     aria-expanded="false"
-    class="svg-colour-reviewed evidence-tag"
+    class="svg-colour-unreviewed evidence-tag"
     data-testid="evidence-tag-trigger"
     type="button"
   >

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`UniProtKBColumnConfiguration component should render column "absorption
       <button
         aria-controls="0"
         aria-expanded="false"
-        class="svg-colour-reviewed evidence-tag"
+        class="svg-colour-unreviewed evidence-tag"
         data-testid="evidence-tag-trigger"
         type="button"
       >
@@ -40,7 +40,7 @@ exports[`UniProtKBColumnConfiguration component should render column "absorption
     <button
       aria-controls="1"
       aria-expanded="false"
-      class="svg-colour-reviewed evidence-tag"
+      class="svg-colour-unreviewed evidence-tag"
       data-testid="evidence-tag-trigger"
       type="button"
     >
@@ -1417,7 +1417,7 @@ exports[`UniProtKBColumnConfiguration component should render column "kinetics":
         <button
           aria-controls="0"
           aria-expanded="false"
-          class="svg-colour-reviewed evidence-tag"
+          class="svg-colour-unreviewed evidence-tag"
           data-testid="evidence-tag-trigger"
           type="button"
         >
@@ -1449,7 +1449,7 @@ exports[`UniProtKBColumnConfiguration component should render column "kinetics":
       <button
         aria-controls="1"
         aria-expanded="false"
-        class="svg-colour-reviewed evidence-tag"
+        class="svg-colour-unreviewed evidence-tag"
         data-testid="evidence-tag-trigger"
         type="button"
       >
@@ -1654,7 +1654,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ph_depende
     <button
       aria-controls="0"
       aria-expanded="false"
-      class="svg-colour-reviewed evidence-tag"
+      class="svg-colour-unreviewed evidence-tag"
       data-testid="evidence-tag-trigger"
       type="button"
     >
@@ -1723,7 +1723,7 @@ exports[`UniProtKBColumnConfiguration component should render column "redox_pote
     <button
       aria-controls="0"
       aria-expanded="false"
-      class="svg-colour-reviewed evidence-tag"
+      class="svg-colour-unreviewed evidence-tag"
       data-testid="evidence-tag-trigger"
       type="button"
     >
@@ -1854,7 +1854,7 @@ exports[`UniProtKBColumnConfiguration component should render column "temp_depen
     <button
       aria-controls="0"
       aria-expanded="false"
-      class="svg-colour-reviewed evidence-tag"
+      class="svg-colour-unreviewed evidence-tag"
       data-testid="evidence-tag-trigger"
       type="button"
     >

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -149,7 +149,7 @@ export const ecoCodeToData = {
     description: 'Inferred from sequence alignment',
   },
   [ecoCode.ISM]: {
-    manual: true,
+    manual: false,
     label: 'Automatic assertion according to rules',
     description: 'Inferred from sequence model',
     labelRender: rulesCountRenderer,


### PR DESCRIPTION
## Purpose
Some automatic annotation evidence tags were showing a gold ribbon.

## Approach
Update the definition for the corresponding ECO code. Also added the content of the `description` field to the body, as it helps disambiguate some of the tags.

## Testing
Update snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
