### PR TITLE
Always display structure viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 82.56,
-        "statements": 82.35,
-        "functions": 82.92,
-        "branches": 69.95
+        "lines": 82.3,
+        "statements": 82.08,
+        "functions": 82.6,
+        "branches": 69.65
       }
     },
     "transform": {

--- a/src/uniprotkb/components/entry/StructureSection.tsx
+++ b/src/uniprotkb/components/entry/StructureSection.tsx
@@ -7,9 +7,8 @@ import EntrySection, {
 import { UIModel } from '../../adapters/sectionConverter';
 import FeaturesView from '../protein-data-views/UniProtKBFeaturesView';
 import XRefView from '../protein-data-views/XRefView';
-import PDBView from '../protein-data-views/PDBView';
+import StructureView from '../protein-data-views/StructureView';
 
-import { hasContent } from '../../../shared/utils/utils';
 import { entrySectionToDatabaseCategoryOrder } from '../../config/database';
 
 import {
@@ -31,9 +30,7 @@ const StructureSection = ({
   sequence,
   crc64,
 }: Props) => {
-  if (!hasContent(data)) {
-    return null;
-  }
+  // NOTE: do not check if content is there or not, always display because of AF
   const { arrayStructureDatabases, otherDatabases } = groupBy(
     data.xrefData,
     ({ category }) =>
@@ -45,22 +42,14 @@ const StructureSection = ({
   // Need to save these as we want to display them in the xrefs section
   const nonPDBDatabases = otherDatabases || [];
 
-  let PDBViewNode;
   const structureDatabases =
     arrayStructureDatabases &&
     arrayStructureDatabases.length === 1 &&
     arrayStructureDatabases[0];
   if (structureDatabases) {
-    const { PDBDatabase, otherStructureDatabases } =
-      partitionStructureDatabases(structureDatabases.databases);
-    if (PDBDatabase && PDBDatabase.xrefs.length) {
-      PDBViewNode = (
-        <PDBView
-          xrefs={PDBDatabase.xrefs}
-          primaryAccession={primaryAccession}
-        />
-      );
-    }
+    const { otherStructureDatabases } = partitionStructureDatabases(
+      structureDatabases.databases
+    );
     const nonPDBStructureDatabases: XrefUIModel = {
       category: DatabaseCategory.STRUCTURE,
       databases: otherStructureDatabases,
@@ -95,7 +84,7 @@ const StructureSection = ({
       id={EntrySection.Structure}
       data-entry-section
     >
-      {PDBViewNode}
+      <StructureView primaryAccession={primaryAccession} />
       <FeaturesView features={data.featuresData} sequence={sequence} />
       {XrefViewNode}
     </Card>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -2774,6 +2774,9 @@ exports[`Entry basic should render main 1`] = `
                 <div
                   class="card__content"
                 >
+                  <protvista-uniprot-structure
+                    accession="P21802"
+                  />
                   <h3>
                     3D structure databases
                   </h3>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2349,6 +2349,9 @@ exports[`Entry view should render 1`] = `
       <div
         class="card__content"
       >
+        <protvista-uniprot-structure
+          accession="P21802"
+        />
         <h3>
           3D structure databases
         </h3>
@@ -5133,14 +5136,9 @@ exports[`Entry view should render for non-human entry 1`] = `
       <div
         class="card__content"
       >
-        <protvista-manager
-          attributes="pdb-id"
-        >
-          <protvista-uniprot-structure
-            accession="P0DTR4"
-            structureid="6N1A"
-          />
-        </protvista-manager>
+        <protvista-uniprot-structure
+          accession="P0DTR4"
+        />
         <h3>
           3D structure databases
         </h3>

--- a/src/uniprotkb/components/protein-data-views/PDBView.tsx
+++ b/src/uniprotkb/components/protein-data-views/PDBView.tsx
@@ -41,23 +41,13 @@ export type ProtvistaPDB = {
 
 const PDBView: FC<{
   xrefs: Xref[];
-  noStructure?: boolean;
-  primaryAccession?: string;
-}> = ({ xrefs, noStructure = false, primaryAccession }) => {
-  const structureDefined = useCustomElement(
-    /* istanbul ignore next */
-    () =>
-      import(
-        /* webpackChunkName: "protvista-uniprot" */ 'protvista-uniprot'
-      ).then((module) => ({ default: module.ProtvistaUniprotStructure })),
-    'protvista-uniprot-structure'
-  );
-  const managerDefined = useCustomElement(
-    /* istanbul ignore next */
-    () =>
-      import(/* webpackChunkName: "protvista-manager" */ 'protvista-manager'),
-    'protvista-manager'
-  );
+}> = ({ xrefs }) => {
+  /**
+   * Note: this view is duplicated in protvista-uniprot-structure
+   * This is because the AF data is not currently available as part of the entry
+   * Eventually it might make sense to just use protvista-structure and
+   * protvista-datatable.
+   */
   const datatableDefined = useCustomElement(
     /* istanbul ignore next */
     () =>
@@ -66,73 +56,59 @@ const PDBView: FC<{
       ),
     'protvista-datatable'
   );
-  const ceDefined = structureDefined && managerDefined && datatableDefined;
 
   const data = processData(xrefs);
 
-  if (!ceDefined) {
+  if (!datatableDefined) {
     return <Loader />;
   }
 
-  if (noStructure) {
-    return (
-      <protvista-datatable>
-        <table>
-          <thead>
-            <tr>
-              <th>PDB Entry</th>
-              <th>Method</th>
-              <th>Resolution</th>
-              <th>Chain</th>
-              <th>Positions</th>
-              <th>Links</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.map(
-              (d) =>
-                d && (
-                  <tr key={d.id}>
-                    <td>{d.id}</td>
-                    <td>{d.method}</td>
-                    <td>{d.resolution?.replace('A', 'Å')}</td>
-                    <td>{d.chain}</td>
-                    <td>{d.positions}</td>
-                    <td>
-                      {PDBMirrorsInfo.map(({ displayName, uriLink }) =>
-                        d.id && uriLink ? (
-                          <ExternalLink
-                            url={processUrlTemplate(uriLink, { id: d.id })}
-                          >
-                            {displayName}
-                          </ExternalLink>
-                        ) : (
-                          { displayName }
-                        )
-                      ).reduce((prev, curr) => (
-                        <>
-                          {prev} · {curr}
-                        </>
-                      ))}
-                    </td>
-                  </tr>
-                )
-            )}
-          </tbody>
-        </table>
-      </protvista-datatable>
-    );
-  }
-
-  const sortedIds = xrefs.map(({ id }) => id).sort();
-  const firstId = sortedIds && sortedIds.length ? sortedIds[0] : '';
   return (
-    <protvista-manager attributes="pdb-id">
-      <protvista-uniprot-structure
-        structureid={firstId}
-        accession={primaryAccession}
-      />
-    </protvista-manager>
+    <protvista-datatable>
+      <table>
+        <thead>
+          <tr>
+            <th>PDB Entry</th>
+            <th>Method</th>
+            <th>Resolution</th>
+            <th>Chain</th>
+            <th>Positions</th>
+            <th>Links</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(
+            (d) =>
+              d && (
+                <tr key={d.id}>
+                  <td>{d.id}</td>
+                  <td>{d.method}</td>
+                  <td>{d.resolution?.replace('A', 'Å')}</td>
+                  <td>{d.chain}</td>
+                  <td>{d.positions}</td>
+                  <td>
+                    {PDBMirrorsInfo.map(({ displayName, uriLink }) =>
+                      d.id && uriLink ? (
+                        <ExternalLink
+                          url={processUrlTemplate(uriLink, { id: d.id })}
+                        >
+                          {displayName}
+                        </ExternalLink>
+                      ) : (
+                        { displayName }
+                      )
+                    ).reduce((prev, curr) => (
+                      <>
+                        {prev} · {curr}
+                      </>
+                    ))}
+                  </td>
+                </tr>
+              )
+          )}
+        </tbody>
+      </table>
+    </protvista-datatable>
   );
 };
 

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -1,0 +1,21 @@
+import { Loader } from 'franklin-sites';
+
+import useCustomElement from '../../../shared/hooks/useCustomElement';
+
+const StructureView = ({ primaryAccession }: { primaryAccession: string }) => {
+  const structureDefined = useCustomElement(
+    /* istanbul ignore next */
+    () =>
+      import(
+        /* webpackChunkName: "protvista-uniprot" */ 'protvista-uniprot'
+      ).then((module) => ({ default: module.ProtvistaUniprotStructure })),
+    'protvista-uniprot-structure'
+  );
+
+  if (!structureDefined) {
+    return <Loader />;
+  }
+  return <protvista-uniprot-structure accession={primaryAccession} />;
+};
+
+export default StructureView;

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -354,7 +354,7 @@ const StructureXRefsGroupedByCategory: FC<StructureXRefsGroupedByCategoryProps> 
       partitionStructureDatabases(databases);
     let PDBViewNode;
     if (PDBDatabase && PDBDatabase.xrefs.length) {
-      PDBViewNode = <PDBView xrefs={PDBDatabase.xrefs} noStructure />;
+      PDBViewNode = <PDBView xrefs={PDBDatabase.xrefs} />;
     }
     return (
       <>


### PR DESCRIPTION
## Purpose
With AF, every single entry will eventually have structures to display. Currently we are only displaying the structure if PDB information is available.

## Approach
Always display the structure, and use the protvista-uniprot-structure component. Kept the PDBView component datatable only as it's still used for xrefs, and added a comment .

## Testing
Update snapshots.
Had to bump down the coverage as some of the component display is now handled in the web components.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
