### PR TITLE
2021 16 gene names

### DIFF
--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -214,10 +214,10 @@ export const getSubjects = (
   const label =
     geneNamesData?.[0].geneName?.value ||
     geneNamesData?.[0].synonyms?.[0].value ||
-    '';
-  if (!label) {
-    logging.warn('label value unavailable for GO Ribbon');
-  }
+    geneNamesData?.[0].orderedLocusNames?.[0].value ||
+    geneNamesData?.[0].orfNames?.[0].value ||
+    // Can happen, but display something, otherwise it would show ":undefined"
+    '<no gene name>';
 
   let taxon_id: string;
   if (organismData?.taxonId) {

--- a/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
+++ b/src/uniprotkb/components/protein-data-views/ProteinOverviewView.tsx
@@ -52,10 +52,15 @@ const ProteinOverview: FC<{
       <>
         <strong>Gene:</strong>{' '}
         {data.genes
-          .filter((geneName) => geneName.geneName)
           .map(
             (geneName) =>
-              `${geneName.geneName?.value}${
+              `${
+                geneName.geneName?.value ||
+                geneName.orderedLocusNames
+                  ?.map((name) => name.value)
+                  .join(', ') ||
+                geneName.orfNames?.map((name) => name.value).join(', ')
+              }${
                 geneName.synonyms
                   ? ` (${geneName.synonyms
                       ?.map((synonym) => synonym.value)
@@ -63,7 +68,7 @@ const ProteinOverview: FC<{
                   : ''
               }`
           )
-          .join(', ')}
+          .join('; ')}
         {' · '}
       </>
     );


### PR DESCRIPTION
## Purpose
Mainly get gene names from more places in the data
Discovered through https://sentry.io/organizations/uniprot/issues/2817748403/

## Approach
Get gene names from orderedLocusNames or orfNames, to match the current website behaviour
Remove the warning when no gene name, this might happen and is correct

## Testing
Currents tests still running
Check the title of the go ribbon cells (mouse over)
Check the protein overview at the top of a entry page

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Exampe test with:
P05067: no change
Q90023: fix the empty "Gene: " displayed on current beta by using the orderedLocusNames
A0A5K4F3G5: no gene name, correctly not displaying it, no warning raised
You could check with more examples from https://sentry.io/organizations/uniprot/issues/2817748403/tags/transaction/