### PR TITLE
Isoform section

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "global": {
         "lines": 82.16,
         "statements": 81.94,
-        "functions": 82.41,
+        "functions": 82.38,
         "branches": 69.6
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "global": {
         "lines": 82.16,
         "statements": 81.94,
-        "functions": 82.38,
+        "functions": 82.37,
         "branches": 69.6
       }
     },

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -122,11 +122,13 @@ const firstIsoformRE = /-1$/;
 
 type IsoformInfoProps = {
   isoformData: Isoform;
+  canonicalAccession: string;
   isoformNotes?: IsoformNotes;
 };
 
 export const IsoformInfo = ({
   isoformData,
+  canonicalAccession,
   isoformNotes,
 }: IsoformInfoProps) => {
   const regex = new RegExp(isoformData.name.value, 'gi');
@@ -182,6 +184,12 @@ export const IsoformInfo = ({
           {isoformData.varSeqs.map(
             ({ location, alternativeSequence, evidences }) => (
               <li key={`${location.start.value}-${location.end.value}`}>
+                <Link
+                  to={{
+                    pathname: LocationToPath[Location.Blast],
+                    search: `ids=${canonicalAccession}[${location.start.value}-${location.end.value}]`,
+                  }}
+                >{`${location.start.value}-${location.end.value}: `}</Link>
                 {`${location.start.value}-${location.end.value}: `}
                 {alternativeSequence && alternativeSequence.originalSequence ? (
                   <span className={styles.modifications}>{`${
@@ -380,7 +388,11 @@ export const IsoformView = ({
     isoformsNode = isoforms.map((isoform) =>
       isIsoformPage && isoform.isoformIds[0] !== accession ? null : (
         <Fragment key={isoform.isoformIds.join('')}>
-          <IsoformInfo isoformData={isoform} isoformNotes={isoformNotes} />
+          <IsoformInfo
+            isoformData={isoform}
+            canonicalAccession={canonical}
+            isoformNotes={isoformNotes}
+          />
           {includeSequences && isoform.isoformSequenceStatus !== 'External' && (
             <>
               {isIsoformPage ||

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -109,6 +109,8 @@ export const SequenceInfo: FC<{
   );
 };
 
+const firstIsoformRE = /-1$/;
+
 export const IsoformInfo: FC<{
   isoformData: Isoform;
   canonicalAccession: string;
@@ -135,6 +137,34 @@ export const IsoformInfo: FC<{
     {
       title: 'Note',
       content: note && <FreeTextView comments={note} showMolecule={false} />,
+    },
+    {
+      title: 'See also',
+      content: (
+        <>
+          sequence in{' '}
+          <Link
+            to={{
+              pathname: LocationToPath[Location.UniParcResults],
+              search: `query=(isoform:${isoformData.isoformIds[0]})&direct`,
+            }}
+          >
+            UniParc
+          </Link>{' '}
+          or clusters in{' '}
+          <Link
+            to={{
+              pathname: LocationToPath[Location.UniRefResults],
+              search: `query=(uniprot_id:${isoformData.isoformIds[0].replace(
+                firstIsoformRE,
+                ''
+              )})`,
+            }}
+          >
+            UniRef
+          </Link>
+        </>
+      ),
     },
     {
       title: 'Differences from canonical',

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -367,7 +367,7 @@ export const IsoformView = ({
         {isIsoformPage && (
           <>
             {' '}
-            To see the canonical entry page, see{' '}
+            For the canonical entry page see{' '}
             <Link to={getEntryPath(Namespace.uniprotkb, canonical)}>
               {canonical}
             </Link>

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, ReactNode, useState } from 'react';
 import {
   InfoList,
   Sequence,
@@ -356,31 +356,32 @@ export const IsoformView = ({
   const canonical = accession.split('-')[0];
   const isIsoformPage = accession !== canonical;
 
-  let isoformCountNode;
+  const notes: ReactNode[] = [];
   if (isoforms && events) {
-    isoformCountNode = (
-      <p>
+    notes.push(
+      <Fragment key="this entry describes...">
         {`This entry describes ${isIsoformPage ? 'one of the' : ''} `}
         <strong>{isoforms.length}</strong>
         {` isoforms produced by `}
-        <strong>{events.join(' & ')}</strong>.
-        {isIsoformPage && (
-          <>
-            {' '}
-            For the canonical entry page see{' '}
-            <Link to={getEntryPath(Namespace.uniprotkb, canonical)}>
-              {canonical}
-            </Link>
-          </>
-        )}
-      </p>
+        <strong>{events.join(' & ')}</strong>.{' '}
+      </Fragment>
     );
+    if (isIsoformPage) {
+      notes.push(
+        <Fragment key="canonical link">
+          For the canonical entry page see{' '}
+          <Link to={getEntryPath(Namespace.uniprotkb, canonical)}>
+            {canonical}
+          </Link>
+          .{' '}
+        </Fragment>
+      );
+    }
   }
-
-  let notesNode;
-  const texts = alternativeProducts.note?.texts;
-  if (texts) {
-    notesNode = <p>{texts.map((text) => text.value).join(' ')}</p>;
+  for (const [index, { value }] of (
+    alternativeProducts.note?.texts || []
+  ).entries()) {
+    notes.push(<Fragment key={index}>{value}</Fragment>);
   }
 
   let isoformsNode;
@@ -413,8 +414,7 @@ export const IsoformView = ({
   }
   return (
     <>
-      {isoformCountNode}
-      {notesNode}
+      {notes && <p>{notes}</p>}
       {isoformsNode}
     </>
   );

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, FC } from 'react';
+import { Fragment, useState } from 'react';
 import {
   InfoList,
   Sequence,
@@ -53,12 +53,19 @@ type SequenceViewProps = {
   data: SequenceUIModel;
 };
 
-export const SequenceInfo: FC<{
+type SequenceInfoProps = {
   isoformId: string;
   isoformSequence?: SequenceData;
   lastUpdateDate?: string | null;
   isCanonical?: boolean;
-}> = ({ isoformId, isoformSequence, lastUpdateDate, isCanonical = false }) => {
+};
+
+export const SequenceInfo = ({
+  isoformId,
+  isoformSequence,
+  lastUpdateDate,
+  isCanonical = false,
+}: SequenceInfoProps) => {
   const [isoformToFetch, setIsoformToFetch] = useState<string>();
 
   const history = useHistory();
@@ -111,11 +118,17 @@ export const SequenceInfo: FC<{
 
 const firstIsoformRE = /-1$/;
 
-export const IsoformInfo: FC<{
+type IsoformInfoProps = {
   isoformData: Isoform;
   canonicalAccession: string;
   isoformNotes?: IsoformNotes;
-}> = ({ isoformData, canonicalAccession, isoformNotes }) => {
+};
+
+export const IsoformInfo = ({
+  isoformData,
+  canonicalAccession,
+  isoformNotes,
+}: IsoformInfoProps) => {
   let note;
   const regex = new RegExp(isoformData.name.value, 'gi');
   for (const key in isoformNotes) {
@@ -151,7 +164,7 @@ export const IsoformInfo: FC<{
           >
             UniParc
           </Link>{' '}
-          or clusters in{' '}
+          or sequence clusters in{' '}
           <Link
             to={{
               pathname: LocationToPath[Location.UniRefResults],
@@ -244,9 +257,11 @@ export const IsoformInfo: FC<{
   );
 };
 
-export const SequenceCautionView: FC<{
+export const SequenceCautionView = ({
+  data,
+}: {
   data: SequenceCautionComment[];
-}> = ({ data }) => (
+}) => (
   <>
     {data.map(({ sequence, sequenceCautionType, note, evidences }) => (
       <section
@@ -263,9 +278,11 @@ export const SequenceCautionView: FC<{
   </>
 );
 
-export const MassSpectrometryView: FC<{
+export const MassSpectrometryView = ({
+  data,
+}: {
   data: MassSpectrometryComment[];
-}> = ({ data }) => (
+}) => (
   <>
     {data.map((item) => (
       <section className="text-block" key={`${item.molWeight}${item.method}`}>
@@ -281,7 +298,7 @@ export const MassSpectrometryView: FC<{
   </>
 );
 
-export const RNAEditingView: FC<{ data: RNAEditingComment[] }> = ({ data }) => (
+export const RNAEditingView = ({ data }: { data: RNAEditingComment[] }) => (
   <>
     {data.map((item) => (
       <section
@@ -318,19 +335,21 @@ export const RNAEditingView: FC<{ data: RNAEditingComment[] }> = ({ data }) => (
   </>
 );
 
-export const IsoformView: FC<{
+type IsoformViewProps = {
   alternativeProducts: AlternativeProductsComment;
   canonicalComponent?: JSX.Element;
   includeSequences?: boolean;
   canonicalAccession: string;
   isoformNotes?: IsoformNotes;
-}> = ({
+};
+
+export const IsoformView = ({
   alternativeProducts,
   canonicalComponent,
   includeSequences = true,
   canonicalAccession,
   isoformNotes,
-}) => {
+}: IsoformViewProps) => {
   let isoformCountNode;
   const { isoforms, events } = alternativeProducts;
   if (isoforms && events) {
@@ -384,7 +403,7 @@ export const IsoformView: FC<{
   );
 };
 
-const SequenceView: FC<SequenceViewProps> = ({ accession, data }) => {
+const SequenceView = ({ accession, data }: SequenceViewProps) => {
   const sequenceInfoData = [
     {
       title: 'Sequence status',

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -155,7 +155,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
           >
             UniParc
           </a>
-           or clusters in 
+           or sequence clusters in 
           <a
             href="/uniref?query=(uniprot_id:P05067)"
           >
@@ -493,7 +493,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
           >
             UniParc
           </a>
-           or clusters in 
+           or sequence clusters in 
           <a
             href="/uniref?query=(uniprot_id:P05067-2)"
           >

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -143,6 +143,37 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
           <h5
             class="bold"
           >
+            See also
+          </h5>
+        </div>
+        <div
+          class="decorated-list-item__content"
+        >
+          sequence in 
+          <a
+            href="/uniparc?query=(isoform:P05067-1)&direct"
+          >
+            UniParc
+          </a>
+           or clusters in 
+          <a
+            href="/uniref?query=(uniprot_id:P05067)"
+          >
+            UniRef
+          </a>
+        </div>
+      </div>
+    </li>
+    <li>
+      <div
+        class="decorated-list-item decorated-list-item--compact"
+      >
+        <div
+          class="decorated-list-item__title"
+        >
+          <h5
+            class="bold"
+          >
             Note
           </h5>
         </div>
@@ -437,6 +468,37 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
           class="decorated-list-item__content"
         >
           PreA4 770-2
+        </div>
+      </div>
+    </li>
+    <li>
+      <div
+        class="decorated-list-item decorated-list-item--compact"
+      >
+        <div
+          class="decorated-list-item__title"
+        >
+          <h5
+            class="bold"
+          >
+            See also
+          </h5>
+        </div>
+        <div
+          class="decorated-list-item__content"
+        >
+          sequence in 
+          <a
+            href="/uniparc?query=(isoform:P05067-2)&direct"
+          >
+            UniParc
+          </a>
+           or clusters in 
+          <a
+            href="/uniref?query=(uniprot_id:P05067-2)"
+          >
+            UniRef
+          </a>
         </div>
       </div>
     </li>

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -65,7 +65,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
     </li>
   </ul>
   <p>
-    This entry describes 
+    This entry describes  
     <strong>
       2
     </strong>

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -73,10 +73,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
     <strong>
       event 1 & event 2
     </strong>
-    .
-  </p>
-  <p>
-    some text
+    . some text
   </p>
   <h3
     id="Isoform_APP770"

--- a/src/shared/components/entry/styles/sequence-view.module.css
+++ b/src/shared/components/entry/styles/sequence-view.module.css
@@ -1,0 +1,4 @@
+.modifications {
+  font-family: monospace;
+  word-break: break-word;
+}

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -35,6 +35,10 @@ declare module '*.module.scss' {
   const classes: { [key: string]: string };
   export default classes;
 }
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
 
 // Just for one test file
 declare module 'react-beautiful-dnd-test-utils';

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -3153,10 +3153,7 @@ exports[`Entry basic should render main 1`] = `
                     <strong>
                       Alternative initiation
                     </strong>
-                    .
-                  </p>
-                  <p>
-                    value1
+                    . value1
                   </p>
                   <h3
                     id="Isoform_name"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -3228,7 +3228,7 @@ exports[`Entry basic should render main 1`] = `
                           >
                             UniParc
                           </a>
-                           or clusters in 
+                           or sequence clusters in 
                           <a
                             href="/uniref?query=(uniprot_id:isoID1)"
                           >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -3145,7 +3145,7 @@ exports[`Entry basic should render main 1`] = `
                     </li>
                   </ul>
                   <p>
-                    This entry describes 
+                    This entry describes  
                     <strong>
                       1
                     </strong>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -3216,6 +3216,37 @@ exports[`Entry basic should render main 1`] = `
                           <h5
                             class="bold"
                           >
+                            See also
+                          </h5>
+                        </div>
+                        <div
+                          class="decorated-list-item__content"
+                        >
+                          sequence in 
+                          <a
+                            href="/uniparc?query=(isoform:isoID1)&direct"
+                          >
+                            UniParc
+                          </a>
+                           or clusters in 
+                          <a
+                            href="/uniref?query=(uniprot_id:isoID1)"
+                          >
+                            UniRef
+                          </a>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        class="decorated-list-item decorated-list-item--compact"
+                      >
+                        <div
+                          class="decorated-list-item__title"
+                        >
+                          <h5
+                            class="bold"
+                          >
                             Note
                           </h5>
                         </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2791,6 +2791,37 @@ exports[`Entry view should render 1`] = `
                 <h5
                   class="bold"
                 >
+                  See also
+                </h5>
+              </div>
+              <div
+                class="decorated-list-item__content"
+              >
+                sequence in 
+                <a
+                  href="/uniparc?query=(isoform:isoID1)&direct"
+                >
+                  UniParc
+                </a>
+                 or clusters in 
+                <a
+                  href="/uniref?query=(uniprot_id:isoID1)"
+                >
+                  UniRef
+                </a>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div
+              class="decorated-list-item decorated-list-item--compact"
+            >
+              <div
+                class="decorated-list-item__title"
+              >
+                <h5
+                  class="bold"
+                >
                   Note
                 </h5>
               </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2728,10 +2728,7 @@ exports[`Entry view should render 1`] = `
           <strong>
             Alternative initiation
           </strong>
-          .
-        </p>
-        <p>
-          value1
+          . value1
         </p>
         <h3
           id="Isoform_name"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2803,7 +2803,7 @@ exports[`Entry view should render 1`] = `
                 >
                   UniParc
                 </a>
-                 or clusters in 
+                 or sequence clusters in 
                 <a
                   href="/uniref?query=(uniprot_id:isoID1)"
                 >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2720,7 +2720,7 @@ exports[`Entry view should render 1`] = `
           </li>
         </ul>
         <p>
-          This entry describes 
+          This entry describes  
           <strong>
             1
           </strong>

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -339,7 +339,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ccAlternativeProducts, {
         <IsoformView
           alternativeProducts={alternativeProducts}
           includeSequences={false}
-          canonicalAccession={data.primaryAccession}
+          accession={data.primaryAccession}
         />
       )
     );

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -127,10 +127,7 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_alterna
     <strong>
       Alternative initiation
     </strong>
-    .
-  </p>
-  <p>
-    value1
+    . value1
   </p>
   <h3
     id="Isoform_name"

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -190,6 +190,37 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_alterna
           <h5
             class="bold"
           >
+            See also
+          </h5>
+        </div>
+        <div
+          class="decorated-list-item__content"
+        >
+          sequence in 
+          <a
+            href="/uniparc?query=(isoform:isoID1)&direct"
+          >
+            UniParc
+          </a>
+           or clusters in 
+          <a
+            href="/uniref?query=(uniprot_id:isoID1)"
+          >
+            UniRef
+          </a>
+        </div>
+      </div>
+    </li>
+    <li>
+      <div
+        class="decorated-list-item decorated-list-item--compact"
+      >
+        <div
+          class="decorated-list-item__title"
+        >
+          <h5
+            class="bold"
+          >
             Note
           </h5>
         </div>

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -202,7 +202,7 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_alterna
           >
             UniParc
           </a>
-           or clusters in 
+           or sequence clusters in 
           <a
             href="/uniref?query=(uniprot_id:isoID1)"
           >

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -119,7 +119,7 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_allerge
 exports[`UniProtKBColumnConfiguration component should render column "cc_alternative_products": cc_alternative_products 1`] = `
 <DocumentFragment>
   <p>
-    This entry describes 
+    This entry describes  
     <strong>
       1
     </strong>


### PR DESCRIPTION
## Purpose
Modifications to the Isoforms sections https://www.ebi.ac.uk/panda/jira/browse/TRM-26879 & https://www.ebi.ac.uk/panda/jira/browse/TRM-26631

## Approach
- When on isoform page, display only the isoform sequence, opened
  - Added a quick link back to the canonical
- Added link to UniParc and UniRef for each isoform

## Testing
Updated snapshots & checked on canonical page and corresponding isoform pages

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
