### PR TITLE
Parse publication cited for to include BLAST links

### DIFF
--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -236,3 +236,6 @@ export const getURLToJobWithData = (
   `${jobTypeToPath(jobType)}?ids=${primaryAccession}${
     options ? `[${options.start}-${options.end}]` : ''
   }`;
+
+export const getBLASTURL = (primaryAccession: string, position?: string) =>
+  `${LocationToPath[Location.Blast]}?ids=${primaryAccession}[${position}]`;

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -236,6 +236,3 @@ export const getURLToJobWithData = (
   `${jobTypeToPath(jobType)}?ids=${primaryAccession}${
     options ? `[${options.start}-${options.end}]` : ''
   }`;
-
-export const getBLASTURL = (primaryAccession: string, position?: string) =>
-  `${LocationToPath[Location.Blast]}?ids=${primaryAccession}[${position}]`;

--- a/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`deepFindAllByKey addBlastLinksToFreeText should generate parse the text and generate link 1`] = `
-Array [
-  Array [
-    "SOME TEXT ",
-    <Link
-      to="/blast?ids=UP_ACCESSION[10-34]"
-    >
-      10-34
-    </Link>,
-    "",
-  ],
-]
-`;
-
 exports[`deepFindAllByKey addBlastLinksToFreeText should handle no positions 1`] = `
 Array [
   Array [

--- a/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deepFindAllByKey addBlastLinksToFreeText should generate parse the text and generate link 1`] = `
+Array [
+  Array [
+    "SOME TEXT ",
+    <Link
+      to="/blast?ids=UP_ACCESSION[10-34]"
+    >
+      10-34
+    </Link>,
+    "",
+  ],
+]
+`;
+
+exports[`deepFindAllByKey addBlastLinksToFreeText should handle no positions 1`] = `
+Array [
+  Array [
+    "SOME TEXT",
+  ],
+]
+`;
+
+exports[`deepFindAllByKey addBlastLinksToFreeText should handle positions at the beggining 1`] = `
+Array [
+  Array [
+    "",
+    <Link
+      to="/blast?ids=UP_ACCESSION[10-34]"
+    >
+      10-34
+    </Link>,
+    " SOME TEXT",
+  ],
+]
+`;
+
+exports[`deepFindAllByKey addBlastLinksToFreeText should handle positions at the end 1`] = `
+Array [
+  Array [
+    "SOME TEXT ",
+    <Link
+      to="/blast?ids=UP_ACCESSION[10-34]"
+    >
+      10-34
+    </Link>,
+    "",
+  ],
+]
+`;

--- a/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/src/shared/utils/__tests__/__snapshots__/utils.spec.ts.snap
@@ -11,7 +11,6 @@ Array [
 exports[`deepFindAllByKey addBlastLinksToFreeText should handle positions at the beggining 1`] = `
 Array [
   Array [
-    "",
     <Link
       to="/blast?ids=UP_ACCESSION[10-34]"
     >
@@ -31,7 +30,6 @@ Array [
     >
       10-34
     </Link>,
-    "",
   ],
 ]
 `;

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   formatPercentage,
   isSameEntry,
   deepFindAllByKey,
+  addBlastLinksToFreeText,
 } from '../utils';
 
 describe('Model Utils', () => {
@@ -176,5 +177,28 @@ describe('deepFindAllByKey', () => {
         deepFindAllByKey([{ a: 1 }, { b: { c: { d: { a: 2 } } } }], 'z')
       )
     ).toEqual([]);
+  });
+
+  describe('addBlastLinksToFreeText', () => {
+    it('should handle positions at the beggining', () => {
+      const result = addBlastLinksToFreeText(
+        ['10-34 SOME TEXT'],
+        'UP_ACCESSION'
+      );
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should handle positions at the end', () => {
+      const result = addBlastLinksToFreeText(
+        ['SOME TEXT 10-34'],
+        'UP_ACCESSION'
+      );
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should handle no positions', () => {
+      const result = addBlastLinksToFreeText(['SOME TEXT'], 'UP_ACCESSION');
+      expect(result).toMatchSnapshot();
+    });
   });
 });

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -1,4 +1,6 @@
+import { Link } from 'react-router-dom';
 import { RequireAtLeastOne } from 'type-fest';
+import { getBLASTURL } from '../../app/config/urls';
 
 export const formatPercentage = (n: number, maximumFractionDigits = 1) =>
   `${n.toLocaleString('en-US', {
@@ -108,3 +110,24 @@ export function* deepFindAllByKey<T = string>(
     }
   }
 }
+
+export const addBlastLinksToFreeText = (
+  texts: string[],
+  primaryAccession: string
+) =>
+  texts.map((text) => {
+    const splitText = text.split(/(\d+-\d+)/);
+    return splitText.map((splitItem, i) => {
+      if (i % 2 === 1) {
+        return (
+          <Link
+            to={getBLASTURL(primaryAccession, splitItem)}
+            key={`${splitItem}`}
+          >
+            {splitItem}
+          </Link>
+        );
+      }
+      return splitItem;
+    });
+  });

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -118,21 +118,23 @@ export const addBlastLinksToFreeText = (
 ) =>
   texts.map((text) => {
     const splitText = text.split(/(\d+-\d+)/);
-    return splitText.map((splitItem, i) => {
-      if (i % 2 === 1) {
-        const range = splitItem.split('-');
-        return (
-          <Link
-            to={getURLToJobWithData(JobTypes.BLAST, primaryAccession, {
-              start: +range[0],
-              end: +range[1],
-            })}
-            key={splitItem}
-          >
-            {splitItem}
-          </Link>
-        );
-      }
-      return splitItem;
-    });
+    return splitText
+      .map((splitItem, i) => {
+        if (i % 2 === 1) {
+          const range = splitItem.split('-');
+          return (
+            <Link
+              to={getURLToJobWithData(JobTypes.BLAST, primaryAccession, {
+                start: +range[0],
+                end: +range[1],
+              })}
+              key={splitItem}
+            >
+              {splitItem}
+            </Link>
+          );
+        }
+        return splitItem;
+      })
+      .filter((item) => item);
   });

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { RequireAtLeastOne } from 'type-fest';
-import { getBLASTURL } from '../../app/config/urls';
+import { getURLToJobWithData } from '../../app/config/urls';
+import { JobTypes } from '../../tools/types/toolsJobTypes';
 
 export const formatPercentage = (n: number, maximumFractionDigits = 1) =>
   `${n.toLocaleString('en-US', {
@@ -119,9 +120,13 @@ export const addBlastLinksToFreeText = (
     const splitText = text.split(/(\d+-\d+)/);
     return splitText.map((splitItem, i) => {
       if (i % 2 === 1) {
+        const range = splitItem.split('-');
         return (
           <Link
-            to={getBLASTURL(primaryAccession, splitItem)}
+            to={getURLToJobWithData(JobTypes.BLAST, primaryAccession, {
+              start: +range[0],
+              end: +range[1],
+            })}
             key={`${splitItem}`}
           >
             {splitItem}

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -127,7 +127,7 @@ export const addBlastLinksToFreeText = (
               start: +range[0],
               end: +range[1],
             })}
-            key={`${splitItem}`}
+            key={splitItem}
           >
             {splitItem}
           </Link>

--- a/src/uniprotkb/components/entry/EntryPublications.tsx
+++ b/src/uniprotkb/components/entry/EntryPublications.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, useMemo } from 'react';
+import { FC, useState, useEffect, useMemo, Fragment } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   Card,
@@ -31,6 +31,7 @@ import {
 } from '../../../supporting-data/citations/adapters/citationsConverter';
 import { Namespace } from '../../../shared/types/namespaces';
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
+import { addBlastLinksToFreeText } from '../../../shared/utils/utils';
 
 const PublicationReference: FC<{ reference: Reference; accession: string }> = ({
   reference,
@@ -92,7 +93,17 @@ const PublicationReference: FC<{ reference: Reference; accession: string }> = ({
     },
     {
       title: 'Cited for',
-      content: referencePositions?.join(', '),
+      content:
+        referencePositions &&
+        addBlastLinksToFreeText(referencePositions, accession).map(
+          (item, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={i}>
+              {i > 0 && ', '}
+              {item}
+            </Fragment>
+          )
+        ),
     },
     {
       title: 'Tissue',

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3788,15 +3788,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="22"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[126-126]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="126"
@@ -3872,15 +3864,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="24"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[278-278]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="278"
@@ -3956,15 +3940,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="26"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[87-87]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="87"
@@ -4040,15 +4016,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="28"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[123-123]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="123"
@@ -4124,15 +4092,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="30"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[236-236]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="236"
@@ -4892,15 +4852,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="44"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[90-90]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="90"
@@ -4954,15 +4906,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="45"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[125-125]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="125"
@@ -5016,15 +4960,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="46"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[126-126]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="126"
@@ -5078,15 +5014,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="47"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[278-278]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="278"
@@ -5140,15 +5068,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       id="48"
                     />
                   </td>
-                  <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[341-341]"
-                      title="BLAST the sequence corresponding to this feature"
-                    >
-                      BLAST
-                    </a>
-                  </td>
+                  <td />
                 </tr>
                 <tr
                   data-end="341"

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -124,17 +124,23 @@ const UniProtKBFeaturesView = ({
               </td>
               <td>
                 {/* Not using React Router link as this is copied into the table DOM */}
-                <Button
-                  element="a"
-                  variant="tertiary"
-                  title="BLAST the sequence corresponding to this feature"
-                  href={getURLToJobWithData(JobTypes.BLAST, primaryAccession, {
-                    start: feature.start,
-                    end: feature.end,
-                  })}
-                >
-                  BLAST
-                </Button>
+                {feature.end - feature.start >= 3 && (
+                  <Button
+                    element="a"
+                    variant="tertiary"
+                    title="BLAST the sequence corresponding to this feature"
+                    href={getURLToJobWithData(
+                      JobTypes.BLAST,
+                      primaryAccession,
+                      {
+                        start: feature.start,
+                        end: feature.end,
+                      }
+                    )}
+                  >
+                    BLAST
+                  </Button>
+                )}
                 {/* <Button>Add</Button> */}
               </td>
             </tr>


### PR DESCRIPTION
## Purpose
Add link to BLAST with subsequence in Publication cited for text. See http://localhost:8080/uniprotkb/P25719/publications

## Approach
Check for matching regex and replace text

## Testing
Adding checks for Regex function

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
