### PR TITLE
Kanban ac accession

### DIFF
--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -20,7 +20,7 @@ import { addMessage } from '../../messages/state/messagesActions';
 import apiUrls from '../../shared/config/apiUrls';
 
 import entryToFASTAWithHeaders from '../../shared/utils/entryToFASTAWithHeaders';
-import { uniProtKBAccessionRE } from '../../uniprotkb/utils';
+import { reUniProtKBAccession } from '../../uniprotkb/utils';
 import fetchData from '../../shared/utils/fetchData';
 import * as logging from '../../shared/utils/logging';
 
@@ -47,7 +47,7 @@ const getURLForAccessionOrID = (input: string) => {
   }
 
   // UniProtKB accession
-  if (uniProtKBAccessionRE.test(cleanedInput)) {
+  if (reUniProtKBAccession.test(cleanedInput)) {
     return apiUrls.entry(cleanedInput, Namespace.uniprotkb);
   }
 

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -20,7 +20,7 @@ import { addMessage } from '../../messages/state/messagesActions';
 import apiUrls from '../../shared/config/apiUrls';
 
 import entryToFASTAWithHeaders from '../../shared/utils/entryToFASTAWithHeaders';
-import { uniProtKBAccessionRegEx } from '../../uniprotkb/utils';
+import { uniProtKBAccessionRE } from '../../uniprotkb/utils';
 import fetchData from '../../shared/utils/fetchData';
 import * as logging from '../../shared/utils/logging';
 
@@ -47,7 +47,7 @@ const getURLForAccessionOrID = (input: string) => {
   }
 
   // UniProtKB accession
-  if (uniProtKBAccessionRegEx.test(cleanedInput)) {
+  if (uniProtKBAccessionRE.test(cleanedInput)) {
     return apiUrls.entry(cleanedInput, Namespace.uniprotkb);
   }
 

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3110,7 +3110,9 @@ exports[`Entry view should render for non-human entry 1`] = `
           >
             P0DTR5
           </a>
-          ). Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction.
+          ).
+          <br />
+          Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction
           <button
             aria-controls="0"
             aria-expanded="false"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3104,7 +3104,13 @@ exports[`Entry view should render for non-human entry 1`] = `
         <div
           class="text-block"
         >
-          One of an enzyme pair that work together to convert the A antigen to the H antigen of the O blood type, which together release galactosamine. Catalyzes the first step in the conversion, generating the substrate for the subsequent enzyme (FpGalNase, AC P0DTR5). Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction.
+          One of an enzyme pair that work together to convert the A antigen to the H antigen of the O blood type, which together release galactosamine. Catalyzes the first step in the conversion, generating the substrate for the subsequent enzyme (FpGalNase, AC 
+          <a
+            href="/uniprotkb/P0DTR5"
+          >
+            P0DTR5
+          </a>
+           Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction.
           <button
             aria-controls="0"
             aria-expanded="false"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -3110,7 +3110,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           >
             P0DTR5
           </a>
-           Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction.
+          ). Works on many different A antigen subtypes. Glu-90 probably activates a nucleophilic water molecule to start the deacetylation reaction.
           <button
             aria-controls="0"
             aria-expanded="false"

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
 import { getEntryPath, getEntryPathFor } from '../../../app/config/urls';
-import { uniProtKBAccessionRegEx } from '../../utils';
+import { acRE, uniProtKBAccessionRE } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
 import { FreeTextComment, TextWithEvidence } from '../../types/commentTypes';
@@ -21,83 +21,77 @@ const needsNewLineRE = /^\).\s+/;
 
 const getEntryPathForCitation = getEntryPathFor(Namespace.citations);
 
-export const ACCommentView = ({ string }: { string: string }) => {
+export const ACCommentView = ({ string }: { string: string }) => (
   // This replaces any occurrences of "AC <accession>" with "AC "<link to the accession>
-  const acRE = new RegExp(`(AC ${uniProtKBAccessionRegEx.source})`, 'i');
-  return (
-    <>
-      {string.split(acRE).map((part, index, { length }) => {
-        const accession = part.match(uniProtKBAccessionRegEx)?.[0];
-        if (acRE.test(part) && accession) {
-          return (
-            // eslint-disable-next-line react/no-array-index-key
-            <Fragment key={index}>
-              {`AC `}
-              <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
-                {accession}
-              </Link>
-            </Fragment>
-          );
-        }
-        if (index + 1 === length && !part.endsWith('.')) {
-          return `${part}.`;
-        }
-        return part;
-      })}
-    </>
-  );
-};
+  <>
+    {string.split(acRE).map((part, index, { length }) => {
+      const accession = part.match(uniProtKBAccessionRE)?.[0];
+      if (acRE.test(part) && accession) {
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={index}>
+            {`AC `}
+            <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
+              {accession}
+            </Link>
+          </Fragment>
+        );
+      }
+      if (index + 1 === length && !part.endsWith('.')) {
+        return `${part}.`;
+      }
+      return part;
+    })}
+  </>
+);
 
 type TextViewProps = { comments: TextWithEvidence[]; noEvidence?: boolean };
 
-export const TextView = ({ comments, noEvidence }: TextViewProps) => {
-  const acRE = new RegExp(`AC ${uniProtKBAccessionRegEx.source}`, 'i');
-  return (
-    <div className="text-block">
-      {comments.map((comment, index) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Fragment key={index}>
-          {comment.value.split(pubMedRE).map((part, index, { length }) => {
-            /** We should get odds plain text, and evens pubmed ID, but we are
-             *  still double-checking just in case */
-            if (pubMedIDRE.test(part)) {
-              // PubMed ID, insert a link
-              return (
-                // eslint-disable-next-line react/no-array-index-key
-                <Link key={index} to={getEntryPathForCitation(part)}>
-                  {part}
-                </Link>
-              );
-            }
-            if (acRE.test(part)) {
-              return <ACCommentView string={part} key="AC" />;
-            }
-            if (needsNewLineRE.test(part)) {
-              // add new line before adding the rest of the plain text
-              return (
-                // eslint-disable-next-line react/no-array-index-key
-                <Fragment key={index}>
-                  ).
-                  <br />
-                  {part.replace(needsNewLineRE, '')}
-                </Fragment>
-              );
-            }
-            // If the last section doesn't end with a period, add it
-            if (index + 1 === length && !part.endsWith('.')) {
-              return `${part}.`;
-            }
-            // use plain text as such
-            return part;
-          })}
-          {!noEvidence && comment.evidences && (
-            <UniProtKBEvidenceTag evidences={comment.evidences} />
-          )}
-        </Fragment>
-      ))}
-    </div>
-  );
-};
+export const TextView = ({ comments, noEvidence }: TextViewProps) => (
+  <div className="text-block">
+    {comments.map((comment, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <Fragment key={index}>
+        {comment.value.split(pubMedRE).map((part, index, { length }) => {
+          /** We should get odds plain text, and evens pubmed ID, but we are
+           *  still double-checking just in case */
+          if (pubMedIDRE.test(part)) {
+            // PubMed ID, insert a link
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Link key={index} to={getEntryPathForCitation(part)}>
+                {part}
+              </Link>
+            );
+          }
+          if (acRE.test(part)) {
+            return <ACCommentView string={part} key="AC" />;
+          }
+          if (needsNewLineRE.test(part)) {
+            // add new line before adding the rest of the plain text
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Fragment key={index}>
+                ).
+                <br />
+                {part.replace(needsNewLineRE, '')}
+              </Fragment>
+            );
+          }
+          // If the last section doesn't end with a period, add it
+          if (index + 1 === length && !part.endsWith('.')) {
+            return `${part}.`;
+          }
+          // use plain text as such
+          return part;
+        })}
+        {!noEvidence && comment.evidences && (
+          <UniProtKBEvidenceTag evidences={comment.evidences} />
+        )}
+      </Fragment>
+    ))}
+  </div>
+);
 
 type FreeTextProps = {
   comments?: FreeTextComment[];

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
-import { getEntryPathFor } from '../../../app/config/urls';
+import { getEntryPath, getEntryPathFor } from '../../../app/config/urls';
+import { uniProtKBAccessionRegEx } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
 import { FreeTextComment, TextWithEvidence } from '../../types/commentTypes';
@@ -20,50 +21,80 @@ const needsNewLineRE = /^\).\s+/;
 
 const getEntryPathForCitation = getEntryPathFor(Namespace.citations);
 
+export const ACCommentView = ({ string }: { string: string }) => {
+  // This replaces any occurrences of "AC <accession>" with "AC "<link to the accession>
+  const stringTokens = string.split(' ');
+  const nodeTokens: ReactNode[] = new Array(stringTokens.length);
+  for (let i = 0; i < stringTokens.length; i += 1) {
+    const accession = stringTokens[i].match(uniProtKBAccessionRegEx)?.[0];
+    nodeTokens[i] =
+      i > 0 && stringTokens[i - 1] === 'AC' && accession ? (
+        <Link key={i} to={getEntryPath(Namespace.uniprotkb, accession)}>
+          {accession}
+        </Link>
+      ) : (
+        stringTokens[i]
+      );
+  }
+  const lastIndex = stringTokens.length - 1;
+  if (!stringTokens[lastIndex].endsWith('.')) {
+    nodeTokens[lastIndex] = (
+      <Fragment key="last">{nodeTokens[lastIndex]}.</Fragment>
+    );
+  }
+  return <>{nodeTokens.reduce((prev, curr) => [prev, ' ', curr])}</>;
+};
+
 type TextViewProps = { comments: TextWithEvidence[]; noEvidence?: boolean };
 
-export const TextView = ({ comments, noEvidence }: TextViewProps) => (
-  <div className="text-block">
-    {comments.map((comment, index) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <Fragment key={index}>
-        {comment.value.split(pubMedRE).map((part, index, { length }) => {
-          /** We should get odds plain text, and evens pubmed ID, but we are
-           *  still double-checking just in case */
-          if (pubMedIDRE.test(part)) {
-            // PubMed ID, insert a link
-            return (
-              // eslint-disable-next-line react/no-array-index-key
-              <Link key={index} to={getEntryPathForCitation(part)}>
-                {part}
-              </Link>
-            );
-          }
-          if (needsNewLineRE.test(part)) {
-            // add new line before adding the rest of the plain text
-            return (
-              // eslint-disable-next-line react/no-array-index-key
-              <Fragment key={index}>
-                ).
-                <br />
-                {part.replace(needsNewLineRE, '')}
-              </Fragment>
-            );
-          }
-          // If the last section doesn't end with a period, add it
-          if (index + 1 === length && !part.endsWith('.')) {
-            return `${part}.`;
-          }
-          // use plain text as such
-          return part;
-        })}
-        {!noEvidence && comment.evidences && (
-          <UniProtKBEvidenceTag evidences={comment.evidences} />
-        )}
-      </Fragment>
-    ))}
-  </div>
-);
+export const TextView = ({ comments, noEvidence }: TextViewProps) => {
+  const acRE = new RegExp(`AC ${uniProtKBAccessionRegEx.source}`, 'gi');
+  return (
+    <div className="text-block">
+      {comments.map((comment, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Fragment key={index}>
+          {comment.value.split(pubMedRE).map((part, index, { length }) => {
+            /** We should get odds plain text, and evens pubmed ID, but we are
+             *  still double-checking just in case */
+            if (pubMedIDRE.test(part)) {
+              // PubMed ID, insert a link
+              return (
+                // eslint-disable-next-line react/no-array-index-key
+                <Link key={index} to={getEntryPathForCitation(part)}>
+                  {part}
+                </Link>
+              );
+            }
+            if (acRE.test(part)) {
+              return <ACCommentView string={part} key="AC" />;
+            }
+            if (needsNewLineRE.test(part)) {
+              // add new line before adding the rest of the plain text
+              return (
+                // eslint-disable-next-line react/no-array-index-key
+                <Fragment key={index}>
+                  ).
+                  <br />
+                  {part.replace(needsNewLineRE, '')}
+                </Fragment>
+              );
+            }
+            // If the last section doesn't end with a period, add it
+            if (index + 1 === length && !part.endsWith('.')) {
+              return `${part}.`;
+            }
+            // use plain text as such
+            return part;
+          })}
+          {!noEvidence && comment.evidences && (
+            <UniProtKBEvidenceTag evidences={comment.evidences} />
+          )}
+        </Fragment>
+      ))}
+    </div>
+  );
+};
 
 type FreeTextProps = {
   comments?: FreeTextComment[];

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -23,26 +23,24 @@ const getEntryPathForCitation = getEntryPathFor(Namespace.citations);
 
 export const ACCommentView = ({ string }: { string: string }) => {
   // This replaces any occurrences of "AC <accession>" with "AC "<link to the accession>
-  const stringTokens = string.split(' ');
-  const nodeTokens: ReactNode[] = new Array(stringTokens.length);
-  for (let i = 0; i < stringTokens.length; i += 1) {
-    const accession = stringTokens[i].match(uniProtKBAccessionRegEx)?.[0];
-    nodeTokens[i] =
-      i > 0 && stringTokens[i - 1] === 'AC' && accession ? (
+  const tokens = string.split(' ');
+  const nodes: ReactNode[] = new Array(tokens.length);
+  for (let i = 0; i < tokens.length; i += 1) {
+    const accession = tokens[i].match(uniProtKBAccessionRegEx)?.[0];
+    nodes[i] =
+      i > 0 && tokens[i - 1] === 'AC' && accession ? (
         <Link key={i} to={getEntryPath(Namespace.uniprotkb, accession)}>
           {accession}
         </Link>
       ) : (
-        stringTokens[i]
+        tokens[i]
       );
   }
-  const lastIndex = stringTokens.length - 1;
-  if (!stringTokens[lastIndex].endsWith('.')) {
-    nodeTokens[lastIndex] = (
-      <Fragment key="last">{nodeTokens[lastIndex]}.</Fragment>
-    );
+  const lastIndex = tokens.length - 1;
+  if (!tokens[lastIndex].endsWith('.')) {
+    nodes[lastIndex] = <Fragment key="last">{nodes[lastIndex]}.</Fragment>;
   }
-  return <>{nodeTokens.reduce((prev, curr) => [prev, ' ', curr])}</>;
+  return <>{nodes.reduce((prev, curr) => [prev, ' ', curr])}</>;
 };
 
 type TextViewProps = { comments: TextWithEvidence[]; noEvidence?: boolean };

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -4,46 +4,22 @@ import { Link } from 'react-router-dom';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
 import { getEntryPath, getEntryPathFor } from '../../../app/config/urls';
-import { acRE, uniProtKBAccessionRE } from '../../utils';
+import {
+  acRE,
+  pubMedIDRE,
+  pubMedOrACRE,
+  pubMedRE,
+  uniProtKBAccessionRE,
+} from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
 import { FreeTextComment, TextWithEvidence } from '../../types/commentTypes';
 
 import helper from '../../../shared/styles/helper.module.scss';
 
-const pubMedIDRE = /^\d{7,8}$/;
-// Capturing group will allow split to conserve that bit in the split parts
-/** NOTE:
- * Should be using a lookbehind `/(?<=pubmed:)(\d{7,8})/i` but it is not
- * supported in Safari yet. It's OK, we just get more chunks when splitting */
-const pubMedRE = /(pubmed:)(\d{7,8})/i;
 const needsNewLineRE = /^\).\s+/;
 
 const getEntryPathForCitation = getEntryPathFor(Namespace.citations);
-
-export const ACCommentView = ({ string }: { string: string }) => (
-  // This replaces any occurrences of "AC <accession>" with "AC "<link to the accession>
-  <>
-    {string.split(acRE).map((part, index, { length }) => {
-      const accession = part.match(uniProtKBAccessionRE)?.[0];
-      if (acRE.test(part) && accession) {
-        return (
-          // eslint-disable-next-line react/no-array-index-key
-          <Fragment key={index}>
-            {`AC `}
-            <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
-              {accession}
-            </Link>
-          </Fragment>
-        );
-      }
-      if (index + 1 === length && !part.endsWith('.')) {
-        return `${part}.`;
-      }
-      return part;
-    })}
-  </>
-);
 
 type TextViewProps = { comments: TextWithEvidence[]; noEvidence?: boolean };
 
@@ -52,20 +28,35 @@ export const TextView = ({ comments, noEvidence }: TextViewProps) => (
     {comments.map((comment, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <Fragment key={index}>
-        {comment.value.split(pubMedRE).map((part, index, { length }) => {
-          /** We should get odds plain text, and evens pubmed ID, but we are
-           *  still double-checking just in case */
-          if (pubMedIDRE.test(part)) {
+        {comment.value.split(pubMedOrACRE).map((part, index, { length }) => {
+          // Capturing group will allow split to conserve that bit in the split parts
+          // NOTE: pubMedRE and acRE should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
+          // it is not supported in Safari yet. It's OK, we just get more chunks when splitting
+          const pubMedID = part.match(pubMedIDRE)?.[0];
+          if (pubMedRE.test(part) && pubMedID) {
             // PubMed ID, insert a link
+            // eg P05067
             return (
               // eslint-disable-next-line react/no-array-index-key
-              <Link key={index} to={getEntryPathForCitation(part)}>
-                {part}
-              </Link>
+              <Fragment key={index}>
+                PubMed:
+                <Link to={getEntryPathForCitation(pubMedID)}>{pubMedID}</Link>
+              </Fragment>
             );
           }
-          if (acRE.test(part)) {
-            return <ACCommentView string={part} key="AC" />;
+          const accession = part.match(uniProtKBAccessionRE)?.[0];
+          if (acRE.test(part) && accession) {
+            // Replace any occurrences of "AC <accession>" with "AC "<link to accession>
+            // eg A0A075B6S6
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Fragment key={index}>
+                {`AC `}
+                <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
+                  {accession}
+                </Link>
+              </Fragment>
+            );
           }
           if (needsNewLineRE.test(part)) {
             // add new line before adding the rest of the plain text

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -5,11 +5,11 @@ import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
 import { getEntryPath, getEntryPathFor } from '../../../app/config/urls';
 import {
-  acRE,
-  pubMedIDRE,
-  pubMedOrACRE,
-  pubMedRE,
-  uniProtKBAccessionRE,
+  reAC,
+  rePubMedID,
+  rePubMedOrAC,
+  rePubMed,
+  reUniProtKBAccession,
 } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
@@ -28,14 +28,14 @@ export const TextView = ({ comments, noEvidence }: TextViewProps) => (
     {comments.map((comment, index) => (
       // eslint-disable-next-line react/no-array-index-key
       <Fragment key={index}>
-        {comment.value.split(pubMedOrACRE).map((part, index, { length }) => {
+        {comment.value.split(rePubMedOrAC).map((part, index, { length }) => {
           // Capturing group will allow split to conserve that bit in the split parts
-          // NOTE: pubMedRE and acRE should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
+          // NOTE: rePubMed and reAC should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
           // it is not supported in Safari yet. It's OK, we just get more chunks when splitting
-          const pubMedID = part.match(pubMedIDRE)?.[0];
-          if (pubMedRE.test(part) && pubMedID) {
+          const pubMedID = part.match(rePubMedID)?.[0];
+          if (rePubMed.test(part) && pubMedID) {
             // PubMed ID, insert a link
-            // eg P05067
+            // eg A0A075B6S6
             return (
               // eslint-disable-next-line react/no-array-index-key
               <Fragment key={index}>
@@ -44,8 +44,8 @@ export const TextView = ({ comments, noEvidence }: TextViewProps) => (
               </Fragment>
             );
           }
-          const accession = part.match(uniProtKBAccessionRE)?.[0];
-          if (acRE.test(part) && accession) {
+          const accession = part.match(reUniProtKBAccession)?.[0];
+          if (reAC.test(part) && accession) {
             // Replace any occurrences of "AC <accession>" with "AC "<link to accession>
             // eg A0A075B6S6
             return (

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -28,20 +28,21 @@ export const ACCommentView = ({ string }: { string: string }) => {
     <>
       {string.split(acRE).map((part, index, { length }) => {
         const accession = part.match(uniProtKBAccessionRegEx)?.[0];
-        return acRE.test(part) && accession ? (
-          // eslint-disable-next-line react/no-array-index-key
-          <Fragment key={index}>
-            {`AC `}
-            <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
-              {accession}
-            </Link>
-          </Fragment>
-        ) : (
-          // eslint-disable-next-line react/no-array-index-key
-          <Fragment key={index}>
-            {index + 1 === length && !part.endsWith('.') ? `${part}.` : part}
-          </Fragment>
-        );
+        if (acRE.test(part) && accession) {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={index}>
+              {`AC `}
+              <Link to={getEntryPath(Namespace.uniprotkb, accession)}>
+                {accession}
+              </Link>
+            </Fragment>
+          );
+        }
+        if (index + 1 === length && !part.endsWith('.')) {
+          return `${part}.`;
+        }
+        return part;
       })}
     </>
   );

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
-import FreeTextView, { ACCommentView } from '../FreeTextView';
+import FreeTextView from '../FreeTextView';
 
 import freeTextUIData from './__mocks__/freeTextUIData';
 
@@ -53,20 +53,20 @@ describe('FreeText component', () => {
   });
 });
 
-describe('ACCommentView', () => {
-  it('should render link with a single instance of "AC <accession>"', () => {
-    customRender(
-      <ACCommentView string="For an example of a full-length immunoglobulin kappa light chain see AC P0DOX7." />
-    );
-    const links = screen.queryAllByRole('link');
-    expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
-  });
-  it('should render two links with two instances of "AC <accession>"', () => {
-    customRender(<ACCommentView string="See AC P0DOX7 and see AC P05067." />);
-    const links = screen.queryAllByRole('link');
-    expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
-    expect(links[1]).toHaveAttribute('href', '/uniprotkb/P05067');
-  });
-});
+// describe('ACCommentView', () => {
+//   it('should render link with a single instance of "AC <accession>"', () => {
+//     customRender(
+//       <ACCommentView string="For an example of a full-length immunoglobulin kappa light chain see AC P0DOX7." />
+//     );
+//     const links = screen.queryAllByRole('link');
+//     expect(links).toHaveLength(1);
+//     expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
+//   });
+//   it('should render two links with two instances of "AC <accession>"', () => {
+//     customRender(<ACCommentView string="See AC P0DOX7 and see AC P05067." />);
+//     const links = screen.queryAllByRole('link');
+//     expect(links).toHaveLength(2);
+//     expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
+//     expect(links[1]).toHaveAttribute('href', '/uniprotkb/P05067');
+//   });
+// });

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
-import FreeTextView from '../FreeTextView';
+import FreeTextView, { ACCommentView } from '../FreeTextView';
 
 import freeTextUIData from './__mocks__/freeTextUIData';
 
@@ -50,5 +50,23 @@ describe('FreeText component', () => {
     it('should not render evidence tags', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('ACCommentView', () => {
+  it('should render link with a single instance of "AC <accession>"', () => {
+    customRender(
+      <ACCommentView string="For an example of a full-length immunoglobulin kappa light chain see AC P0DOX7." />
+    );
+    const links = screen.queryAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
+  });
+  it('should render two links with two instances of "AC <accession>"', () => {
+    customRender(<ACCommentView string="See AC P0DOX7 and see AC P05067." />);
+    const links = screen.queryAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
+    expect(links[1]).toHaveAttribute('href', '/uniprotkb/P05067');
   });
 });

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -38,6 +38,16 @@ describe('FreeText component', () => {
     });
   });
 
+  describe('Free text CC, with inlined PubMeds and AC<accession>', () => {
+    beforeEach(() => {
+      customRender(<FreeTextView comments={[freeTextUIData[2]]} />);
+    });
+
+    it('should render pubmed and AC links', () => {
+      expect(screen.queryAllByRole('link')).toHaveLength(3);
+    });
+  });
+
   describe('Free text CC, no inlined PubMeds, no evidence tag', () => {
     beforeEach(() => {
       customRender(<FreeTextView comments={[freeTextUIData[0]]} noEvidence />);

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -52,21 +52,3 @@ describe('FreeText component', () => {
     });
   });
 });
-
-// describe('ACCommentView', () => {
-//   it('should render link with a single instance of "AC <accession>"', () => {
-//     customRender(
-//       <ACCommentView string="For an example of a full-length immunoglobulin kappa light chain see AC P0DOX7." />
-//     );
-//     const links = screen.queryAllByRole('link');
-//     expect(links).toHaveLength(1);
-//     expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
-//   });
-//   it('should render two links with two instances of "AC <accession>"', () => {
-//     customRender(<ACCommentView string="See AC P0DOX7 and see AC P05067." />);
-//     const links = screen.queryAllByRole('link');
-//     expect(links).toHaveLength(2);
-//     expect(links[0]).toHaveAttribute('href', '/uniprotkb/P0DOX7');
-//     expect(links[1]).toHaveAttribute('href', '/uniprotkb/P05067');
-//   });
-// });

--- a/src/uniprotkb/components/protein-data-views/__tests__/__mocks__/freeTextUIData.ts
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__mocks__/freeTextUIData.ts
@@ -33,6 +33,15 @@ const mock: FreeTextComment[] = [
       },
     ],
   },
+  {
+    commentType: 'FUNCTION',
+    texts: [
+      {
+        value:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua (PubMed:1234567, PubMed:12345678). Ut enim ad minim veniam, quis AC P05067 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+      },
+    ],
+  },
 ];
 
 export default mock;

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -74,5 +74,6 @@ export const getPropertyValue = (
 
 // The regex that matches uniprot accession. Taken from:
 // https://www.uniprot.org/help/accession_numbers
+// NOTE: modifined to use a non-capturing group with ?:
 export const uniProtKBAccessionRegEx =
-  /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}/i;
+  /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}/i;

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -74,14 +74,14 @@ export const getPropertyValue = (
 
 // The regex that matches uniprot accession. Taken from:
 // https://www.uniprot.org/help/accession_numbers
-// NOTE: modifined to use a non-capturing group with ?:
-export const uniProtKBAccessionRE =
+// NOTE: modified to use a non-capturing group with "?:"
+export const reUniProtKBAccession =
   /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}/i;
 
-export const acRE = new RegExp(`(?:AC ${uniProtKBAccessionRE.source})`, 'i');
-export const pubMedRE = /(?:pubmed:\d{7,8})/i;
-export const pubMedIDRE = /\d{7,8}/;
-export const pubMedOrACRE = new RegExp(
-  `(${pubMedRE.source}|${acRE.source})`,
+export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
+export const rePubMedID = /\d{7,8}/;
+export const rePubMed = new RegExp(`(?:pubmed:${rePubMedID.source})`, 'i');
+export const rePubMedOrAC = new RegExp(
+  `(${rePubMed.source}|${reAC.source})`,
   'i'
 );

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -7,7 +7,6 @@ import {
 import { GeneNamesData } from '../adapters/namesAndTaxonomyConverter';
 
 import { Property, PropertyKey } from '../types/modelTypes';
-import { CommentType } from '../types/commentTypes';
 
 export const hasExternalLinks = (transformedData: UniProtkbUIModel) =>
   UniProtKBEntryConfig.some(({ id }) => {

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -75,5 +75,7 @@ export const getPropertyValue = (
 // The regex that matches uniprot accession. Taken from:
 // https://www.uniprot.org/help/accession_numbers
 // NOTE: modifined to use a non-capturing group with ?:
-export const uniProtKBAccessionRegEx =
+export const uniProtKBAccessionRE =
   /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}/i;
+
+export const acRE = new RegExp(`(AC ${uniProtKBAccessionRE.source})`, 'i');

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -78,4 +78,10 @@ export const getPropertyValue = (
 export const uniProtKBAccessionRE =
   /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}/i;
 
-export const acRE = new RegExp(`(AC ${uniProtKBAccessionRE.source})`, 'i');
+export const acRE = new RegExp(`(?:AC ${uniProtKBAccessionRE.source})`, 'i');
+export const pubMedRE = /(?:pubmed:\d{7,8})/i;
+export const pubMedIDRE = /\d{7,8}/;
+export const pubMedOrACRE = new RegExp(
+  `(${pubMedRE.source}|${acRE.source})`,
+  'i'
+);


### PR DESCRIPTION
## Purpose
[Sequence caution - parse "AC " to create hyperlink](https://www.ebi.ac.uk/panda/jira/browse/TRM-26896)
## Approach
Split caution text by whitespace and iterate to find any instances of an AC preceding an accession and update with link if found.

## Testing
* Snapshots updated
* New unit tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
