### PR TITLE
Add redirect if missing 'KW-'

### DIFF
--- a/src/supporting-data/keywords/components/entry/Entry.tsx
+++ b/src/supporting-data/keywords/components/entry/Entry.tsx
@@ -1,4 +1,5 @@
-import { RouteChildrenProps } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useHistory, RouteChildrenProps } from 'react-router-dom';
 import { Loader, Card, InfoList } from 'franklin-sites';
 import cn from 'classnames';
 
@@ -23,6 +24,7 @@ import KeywordsColumnConfiguration, {
 
 import helper from '../../../../shared/styles/helper.module.scss';
 import entryPageStyles from '../../../shared/styles/entry-page.module.scss';
+import { getEntryPathFor } from '../../../../app/config/urls';
 
 const columns = [
   KeywordsColumn.definition,
@@ -35,7 +37,17 @@ const columns = [
 ];
 
 const KeywordsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
+  const history = useHistory();
   const accession = props.match?.params.accession;
+
+  useEffect(() => {
+    // If accession is a number only, add KW- prefix
+    if (accession?.match(/^\d+$/)) {
+      history.push({
+        pathname: getEntryPathFor(Namespace.keywords)(`KW-${accession}`),
+      });
+    }
+  }, [accession, history]);
 
   const { data, loading, error, status, progress, isStale } =
     useDataApiWithStale<KeywordsAPIModel>(

--- a/src/supporting-data/keywords/components/entry/Entry.tsx
+++ b/src/supporting-data/keywords/components/entry/Entry.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
-import { useHistory, RouteChildrenProps } from 'react-router-dom';
 import { Loader, Card, InfoList } from 'franklin-sites';
 import cn from 'classnames';
+
+import { RouteChildrenProps } from 'react-router-dom';
 
 import HTMLHead from '../../../../shared/components/HTMLHead';
 import SingleColumnLayout from '../../../../shared/components/layouts/SingleColumnLayout';
@@ -36,15 +37,21 @@ const columns = [
   KeywordsColumn.links,
 ];
 
-const KeywordsEntry = (props: RouteChildrenProps<{ accession: string }>) => {
-  const history = useHistory();
-  const accession = props.match?.params.accession;
+const reNumber = /^\d+$/;
+
+const KeywordsEntry = ({
+  match,
+  history,
+}: RouteChildrenProps<{ accession: string }>) => {
+  const accession = match?.params.accession;
 
   useEffect(() => {
     // If accession is a number only, add KW- prefix
-    if (accession?.match(/^\d+$/)) {
+    if (accession && reNumber.test(accession)) {
       history.push({
-        pathname: getEntryPathFor(Namespace.keywords)(`KW-${accession}`),
+        pathname: getEntryPathFor(Namespace.keywords)(
+          `KW-${accession.padStart(4, '0')}`
+        ),
       });
     }
   }, [accession, history]);

--- a/src/supporting-data/keywords/components/entry/Entry.tsx
+++ b/src/supporting-data/keywords/components/entry/Entry.tsx
@@ -12,6 +12,7 @@ import { MapToDropdown } from '../../../../shared/components/MapTo';
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 
 import apiUrls from '../../../../shared/config/apiUrls';
+import { getEntryPathFor } from '../../../../app/config/urls';
 
 import {
   Namespace,
@@ -24,7 +25,6 @@ import KeywordsColumnConfiguration, {
 
 import helper from '../../../../shared/styles/helper.module.scss';
 import entryPageStyles from '../../../shared/styles/entry-page.module.scss';
-import { getEntryPathFor } from '../../../../app/config/urls';
 
 const columns = [
   KeywordsColumn.definition,


### PR DESCRIPTION
## Purpose
Other resources link to UniProt keywords by using an old format, without the `KW-` prefix.

## Approach
If the submitted accession is ony made of numbers, update the location by adding `KW-` to the number.

## Testing
N/A

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
