### PR TITLE
Kanban missing publication info

### DIFF
--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5036,6 +5036,11 @@ exports[`EntryMain view should render 1`] = `
                         class="publication__authors"
                       >
                         <a
+                          href="/uniprotkb?query=lit_author:\\"Baylor College of Medicine Human Genome Sequencing Center Sequence Production Team\\""
+                        >
+                          Baylor College of Medicine Human Genome Sequencing Center Sequence Production Team
+                        </a>
+                        <a
                           href="/uniprotkb?query=lit_author:\\"Scherer S.E.\\""
                         >
                           Scherer S.E.

--- a/src/supporting-data/citations/adapters/citationsConverter.ts
+++ b/src/supporting-data/citations/adapters/citationsConverter.ts
@@ -113,6 +113,7 @@ export const formatCitationData = (citation: Citation) => {
     publicationDate: citation.publicationDate,
     doiId: doiXref?.id,
     submissionDatabase: citation?.submissionDatabase,
+    citationType: citation?.citationType,
     locator: citation?.locator,
   };
   return { pubmedId, journalInfo };

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -74,7 +74,7 @@ export const getLocatorUrl = (
 };
 
 const getChoppedAuthorLists = (authors: string[], limit: number) => {
-  const cutoff = authors.length > limit ? authors.length : limit;
+  const cutoff = Math.max(authors.length, limit);
 
   const displayedAuthors = authors.slice(0, limit - 1);
   const hiddenAuthors = authors.slice(limit - 1, cutoff - 1);

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -12,6 +12,7 @@ import {
   ExternalLink,
   EllipsisReveal,
 } from 'franklin-sites';
+import { capitalize } from 'lodash-es';
 import { SetOptional } from 'type-fest';
 
 import { Location, LocationToPath } from '../../../app/config/urls';
@@ -25,6 +26,7 @@ import cleanText, {
 
 import {
   CitationsAPIModel,
+  CitationType,
   formatCitationData,
 } from '../adapters/citationsConverter';
 
@@ -160,6 +162,7 @@ type JournalInfoProps = {
     volume?: string;
     doiId?: string;
     submissionDatabase?: string;
+    citationType?: CitationType;
     locator?: string;
   };
 };
@@ -173,6 +176,7 @@ export const JournalInfo: FC<JournalInfoProps> = ({
     volume,
     doiId,
     submissionDatabase,
+    citationType,
     locator,
   },
 }) => {
@@ -198,8 +202,16 @@ export const JournalInfo: FC<JournalInfoProps> = ({
     );
   }
 
+  const noDisplayCitationTypes: CitationType[] = [
+    'UniProt indexed literatures',
+    'journal article',
+  ];
+
   const content = (
     <>
+      {citationType && !noDisplayCitationTypes.includes(citationType) && (
+        <div className="tiny">{capitalize(citationType)}</div>
+      )}
       {name} {volume}
       {volume && page && ':'}
       {page}

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -31,7 +31,8 @@ import {
 import '../../../shared/styles/literature-citation.scss';
 
 type AuthorProps = {
-  authors: string[];
+  authors?: string[];
+  authoringGroup?: string[];
   limit?: number;
 };
 
@@ -70,15 +71,30 @@ export const getLocatorUrl = (
   }
 };
 
-const Authors: FC<AuthorProps> = ({ authors, limit = 10 }) => {
+const getChoppedAuthorLists = (authors: string[], limit: number) => {
   const cutoff = authors.length > limit ? authors.length : limit;
 
   const displayedAuthors = authors.slice(0, limit - 1);
   const hiddenAuthors = authors.slice(limit - 1, cutoff - 1);
   const lastAuthor = authors.slice(cutoff - 1);
+  return { displayedAuthors, hiddenAuthors, lastAuthor };
+};
+
+const Authors: FC<AuthorProps> = ({ authors, authoringGroup, limit = 10 }) => {
+  const { displayedAuthors, hiddenAuthors, lastAuthor } = getChoppedAuthorLists(
+    authors || [],
+    limit
+  );
 
   return (
     <div className="publication__authors">
+      {authoringGroup?.map((group, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Fragment key={index}>
+          {index !== 0 && ', '}
+          <Link to={getLinkToAuthor(group)}>{group}</Link>
+        </Fragment>
+      ))}
       {displayedAuthors.map((author, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <Fragment key={index}>
@@ -88,7 +104,7 @@ const Authors: FC<AuthorProps> = ({ authors, limit = 10 }) => {
       ))}
       {hiddenAuthors.length > 0 && (
         <EllipsisReveal>
-          {hiddenAuthors.map((author, index) => (
+          {hiddenAuthors?.map((author, index) => (
             // eslint-disable-next-line react/no-array-index-key
             <Fragment key={index}>
               , <Link to={getLinkToAuthor(author)}>{author}</Link>
@@ -306,7 +322,7 @@ const LiteratureCitation: FC<
   ...props
 }) => {
   const { citation, statistics } = data;
-  const { title, authors, literatureAbstract } = citation;
+  const { title, authors, literatureAbstract, authoringGroup } = citation;
   const { pubmedId, journalInfo } = formatCitationData(citation);
 
   return (
@@ -322,9 +338,11 @@ const LiteratureCitation: FC<
             },
             title || <em>No title available.</em>
           )}
-          {authors?.length && (
-            <Authors authors={authors} limit={displayAll ? +Infinity : 10} />
-          )}
+          <Authors
+            authors={authors}
+            authoringGroup={authoringGroup}
+            limit={displayAll ? +Infinity : 10}
+          />
           {literatureAbstract && (
             <Abstract abstract={literatureAbstract} open={displayAll} />
           )}

--- a/src/supporting-data/citations/components/LiteratureCitation.tsx
+++ b/src/supporting-data/citations/components/LiteratureCitation.tsx
@@ -106,7 +106,7 @@ const Authors: FC<AuthorProps> = ({ authors, authoringGroup, limit = 10 }) => {
       ))}
       {hiddenAuthors.length > 0 && (
         <EllipsisReveal>
-          {hiddenAuthors?.map((author, index) => (
+          {hiddenAuthors.map((author, index) => (
             // eslint-disable-next-line react/no-array-index-key
             <Fragment key={index}>
               , <Link to={getLinkToAuthor(author)}>{author}</Link>


### PR DESCRIPTION
## Purpose
Address multiple issues:
1. https://www.ebi.ac.uk/panda/jira/browse/TRM-27060
2. https://www.ebi.ac.uk/panda/jira/browse/TRM-27046
3. https://www.ebi.ac.uk/panda/jira/browse/TRM-27045
4. https://www.ebi.ac.uk/panda/jira/browse/TRM-27055

## Approach
- When the citation type is not one of the main types, display it on the right above the date information.
- Group comment types and display them all. Add search link for "Strain".
- Display `authorGroup` in Authors component if it's there

## Testing

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
