### PR TITLE
Missing sequence info

### DIFF
--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -437,6 +437,8 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
     return null;
   }
 
+  const infoListComponent = <InfoList infoData={sequenceInfoData} columns />;
+
   const canonicalComponent = (
     <SequenceInfo
       isoformId={accession}
@@ -447,7 +449,12 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
   );
 
   if (!data.alternativeProducts && data.sequence) {
-    return canonicalComponent;
+    return (
+      <>
+        {infoListComponent}
+        {canonicalComponent}
+      </>
+    );
   }
 
   if (!data.alternativeProducts) {
@@ -479,7 +486,7 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
         {/* Missing Add to basket */}
       </div>
 
-      <InfoList infoData={sequenceInfoData} columns />
+      {infoListComponent}
       <IsoformView
         alternativeProducts={data.alternativeProducts}
         canonicalComponent={canonicalComponent}

--- a/src/shared/components/entry/SequenceView.tsx
+++ b/src/shared/components/entry/SequenceView.tsx
@@ -421,6 +421,11 @@ export const IsoformView = ({
 };
 
 const SequenceView = ({ accession, data }: SequenceViewProps) => {
+  // Every entry should have a sequence
+  if (!data.sequence) {
+    return null;
+  }
+
   const sequenceInfoData = [
     {
       title: 'Sequence status',
@@ -431,11 +436,6 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
       content: data.processing,
     },
   ];
-
-  // Every entry should have a sequence
-  if (!data.sequence) {
-    return null;
-  }
 
   const infoListComponent = <InfoList infoData={sequenceInfoData} columns />;
 
@@ -448,17 +448,13 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
     />
   );
 
-  if (!data.alternativeProducts && data.sequence) {
+  if (!data.alternativeProducts) {
     return (
       <>
         {infoListComponent}
         {canonicalComponent}
       </>
     );
-  }
-
-  if (!data.alternativeProducts) {
-    return null;
   }
 
   const allIsoformIds = data.alternativeProducts.isoforms
@@ -485,7 +481,6 @@ const SequenceView = ({ accession, data }: SequenceViewProps) => {
         />
         {/* Missing Add to basket */}
       </div>
-
       {infoListComponent}
       <IsoformView
         alternativeProducts={data.alternativeProducts}

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -6217,6 +6217,42 @@ exports[`Entry view should render for non-human entry 1`] = `
       <div
         class="card__content"
       >
+        <ul
+          class="info-list info-list--columns"
+        >
+          <li>
+            <div
+              class="decorated-list-item"
+            >
+              <div
+                class="decorated-list-item__title tiny"
+              >
+                Sequence status
+              </div>
+              <div
+                class="decorated-list-item__content"
+              >
+                Complete
+              </div>
+            </div>
+          </li>
+          <li>
+            <div
+              class="decorated-list-item"
+            >
+              <div
+                class="decorated-list-item__title tiny"
+              >
+                Sequence processing
+              </div>
+              <div
+                class="decorated-list-item__content"
+              >
+                The displayed sequence is further processed into a mature form.
+              </div>
+            </div>
+          </li>
+        </ul>
         <section
           class="sequence-container"
         >


### PR DESCRIPTION
## Purpose
[Sequence section should include the sequence status (fragment or not)](https://www.ebi.ac.uk/panda/jira/browse/TRM-27039)

## Approach
* Return `null` if no sequence
* Return `infoListComponent` and `canonicalComponent` if no `alternativeProducts`
* Return everything otherwise

## View the changes
http://localhost:8080/uniprotkb/C0HJU3/entry#sequence

## Testing
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
