### PR TITLE
Disease link and xref name

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "core-js": "3.19.3",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.175",
+    "franklin-sites": "0.0.176",
     "history": "4.10.1",
     "idb": "7.0.0",
     "interaction-viewer": "3.4.0",

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -2276,7 +2276,11 @@ exports[`Entry basic should render main 1`] = `
                     Involvement in disease
                   </h3>
                   <h4>
-                    DiseaseEntry Id (someAcron)
+                    <a
+                      href="/diseases/DiseaseEntry AC"
+                    >
+                      DiseaseEntry Id (someAcron)
+                    </a>
                   </h4>
                   <span
                     class="text-block"
@@ -2379,6 +2383,7 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__content"
                         >
+                          MIM:
                           <a
                             class="external-link"
                             href="https://www.omim.org/entry/3124"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -1845,7 +1845,11 @@ exports[`Entry view should render 1`] = `
           Involvement in disease
         </h3>
         <h4>
-          DiseaseEntry Id (someAcron)
+          <a
+            href="/diseases/DiseaseEntry AC"
+          >
+            DiseaseEntry Id (someAcron)
+          </a>
         </h4>
         <span
           class="text-block"
@@ -1948,6 +1952,7 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__content"
               >
+                MIM:
                 <a
                   class="external-link"
                   href="https://www.omim.org/entry/3124"

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -1,4 +1,5 @@
 import { Fragment, FC } from 'react';
+import { Link } from 'react-router-dom';
 import { InfoList, ExpandableList } from 'franklin-sites';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
@@ -6,6 +7,8 @@ import { XRef } from './XRefView';
 
 import { DiseaseComment } from '../../types/commentTypes';
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
+import { getEntryPath } from '../../../app/config/urls';
+import { Namespace } from '../../../shared/types/namespaces';
 
 type DiseaseInvolvementEntryProps = {
   comment: DiseaseComment[][0];
@@ -80,11 +83,24 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
       });
     }
   }
+
+  const title = (
+    <>
+      {disease?.diseaseId ? disease.diseaseId : <em>No disease ID</em>}
+      {disease?.acronym && ` (${disease?.acronym})`}
+    </>
+  );
+
   return (
     <>
       <h4>
-        {disease?.diseaseId || <em>No disease ID</em>}
-        {disease?.acronym && ` (${disease?.acronym})`}
+        {disease?.diseaseAccession ? (
+          <Link to={getEntryPath(Namespace.diseases, disease.diseaseAccession)}>
+            {title}
+          </Link>
+        ) : (
+          title
+        )}
       </h4>
       <span className="text-block">{evidenceNodes}</span>
       <InfoList infoData={infoData} />

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -69,16 +69,21 @@ export const DiseaseInvolvementEntry: FC<DiseaseInvolvementEntryProps> = ({
 
   if (disease?.diseaseCrossReference) {
     const { database, id } = disease.diseaseCrossReference;
-    if (database && id && databaseInfoMaps?.databaseToDatabaseInfo[database]) {
+    const databaseInfo =
+      id && database && databaseInfoMaps?.databaseToDatabaseInfo[database];
+    if (databaseInfo) {
       infoData.push({
         title: 'See also',
         content: (
-          <XRef
-            database={database}
-            xref={disease.diseaseCrossReference}
-            primaryAccession={accession}
-            databaseToDatabaseInfo={databaseInfoMaps?.databaseToDatabaseInfo}
-          />
+          <>
+            {`${databaseInfo.displayName}:`}
+            <XRef
+              database={database}
+              xref={disease.diseaseCrossReference}
+              primaryAccession={accession}
+              databaseToDatabaseInfo={databaseInfoMaps?.databaseToDatabaseInfo}
+            />
+          </>
         ),
       });
     }

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
@@ -6,7 +6,11 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
     Involvement in disease
   </h3>
   <h4>
-    Alzheimers (AD)
+    <a
+      href="/diseases/ASDASDAS"
+    >
+      Alzheimers (AD)
+    </a>
   </h4>
   <span
     class="text-block"
@@ -64,7 +68,7 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
         <div
           class="decorated-list-item__content"
         >
-          (
+          EMBL:(
           <a
             class="external-link"
             href="https://www.ebi.ac.uk/ena/data/view/some ref id"

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -387,7 +387,11 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_develop
 exports[`UniProtKBColumnConfiguration component should render column "cc_disease": cc_disease 1`] = `
 <DocumentFragment>
   <h4>
-    DiseaseEntry Id (someAcron)
+    <a
+      href="/diseases/DiseaseEntry AC"
+    >
+      DiseaseEntry Id (someAcron)
+    </a>
   </h4>
   <span
     class="text-block"
@@ -490,6 +494,7 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_disease
         <div
           class="decorated-list-item__content"
         >
+          MIM:
           <a
             class="external-link"
             href="https://www.omim.org/entry/3124"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6255,10 +6255,10 @@ foundation-sites@6.7.4:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.7.4.tgz#495ddb3b7014ae33df3bf7cc1f9fe74b2cfd572e"
   integrity sha512-2QPaZJ0Od0DyklhQyKC3zPbr8AAUXSkr1scZJrQTgj/KTLresuCgUBfi7ft32NlOWhuqVXisjOgTE8N5EPS3cg==
 
-franklin-sites@0.0.175:
-  version "0.0.175"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.175.tgz#9c948e8948da19dc659d9871e49d9b20650d01a2"
-  integrity sha512-a3tfS/QmjaLXzzwtiyLkUqsnY07MY8LXP60NbWlCpFO1M8XiFiIKEFlWuSZ/PflpTzwOUOe27fu6mrtgT8LOqw==
+franklin-sites@0.0.176:
+  version "0.0.176"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.176.tgz#5488a60d7fecd5bb524361fdc38640630571346f"
+  integrity sha512-QZABg9Pg+hsRvOn4AvfTOiHQ9fmNcwEznat2LFxJylkNn47agSAzQodE86rbK3AlZVTHXwlmy65ys+KEfqmkdA==
   dependencies:
     classnames "2.3.1"
     d3 "5.16.0"


### PR DESCRIPTION
## Purpose
[Display OMIM and UniProt's Disease page link in UniProtKB disease section](https://www.ebi.ac.uk/panda/jira/browse/TRM-26261)

## Approach
- Create link
- Add xref name before xref link
- Upgrade franklin

## Testing
- Updated snapshots

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
