### PR TITLE
Subcell section handle lack of data

### DIFF
--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -47,6 +47,7 @@ import uniProtKbConverter, {
   UniProtkbAPIModel,
 } from '../../adapters/uniProtkbConverter';
 import generatePageTitle from '../../adapters/generatePageTitle';
+import { subcellularLocationSectionHasContent } from './SubcellularLocationSection';
 
 import {
   LocationToPath,
@@ -58,6 +59,7 @@ import {
   searchableNamespaceLabels,
 } from '../../../shared/types/namespaces';
 import { EntryType } from '../../../shared/components/entry/EntryTypeIcon';
+import { SubcellularLocationUIModel } from '../../adapters/subcellularLocationConverter';
 
 import helper from '../../../shared/styles/helper.module.scss';
 import sticky from '../../../shared/styles/sticky.module.scss';
@@ -153,6 +155,13 @@ const Entry: FC = () => {
             break;
           case EntrySection.SimilarProteins:
             disabled = false;
+            break;
+          case EntrySection.SubCellularLocation:
+            disabled = !subcellularLocationSectionHasContent(
+              transformedData[
+                'subcellular-location'
+              ] as SubcellularLocationUIModel
+            );
             break;
           default:
             disabled = !hasContent(transformedData[nameAndId.id]);

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -59,7 +59,6 @@ import {
   searchableNamespaceLabels,
 } from '../../../shared/types/namespaces';
 import { EntryType } from '../../../shared/components/entry/EntryTypeIcon';
-import { SubcellularLocationUIModel } from '../../adapters/subcellularLocationConverter';
 
 import helper from '../../../shared/styles/helper.module.scss';
 import sticky from '../../../shared/styles/sticky.module.scss';
@@ -158,9 +157,7 @@ const Entry: FC = () => {
             break;
           case EntrySection.SubCellularLocation:
             disabled = !subcellularLocationSectionHasContent(
-              transformedData[
-                'subcellular-location'
-              ] as SubcellularLocationUIModel
+              transformedData['subcellular-location']
             );
             break;
           default:

--- a/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
+++ b/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export const subcellularLocationSectionHasContent = (
   data: SubcellularLocationUIModel
-) => hasContent(pick(data, ['commentsData', 'featuresData']));
+) => hasContent(pick(data, ['commentsData', 'featuresData', 'goXrefs']));
 
 const SubcellularLocationSection = ({ data, sequence }: Props) => {
   if (!subcellularLocationSectionHasContent(data)) {

--- a/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
+++ b/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
@@ -1,3 +1,4 @@
+import { pick } from 'lodash-es';
 import { Card } from 'franklin-sites';
 
 import EntrySection, {
@@ -16,8 +17,12 @@ type Props = {
   sequence: string;
 };
 
+export const subcellularLocationSectionHasContent = (
+  data: SubcellularLocationUIModel
+) => hasContent(pick(data, ['commentsData', 'featuresData']));
+
 const SubcellularLocationSection = ({ data, sequence }: Props) => {
-  if (!hasContent(data)) {
+  if (!subcellularLocationSectionHasContent(data)) {
     return null;
   }
 

--- a/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
+++ b/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
@@ -1,4 +1,3 @@
-import { pick } from 'lodash-es';
 import { Card } from 'franklin-sites';
 
 import EntrySection, {
@@ -17,9 +16,17 @@ type Props = {
   sequence: string;
 };
 
-export const subcellularLocationSectionHasContent = (
-  data: SubcellularLocationUIModel
-) => hasContent(pick(data, ['commentsData', 'featuresData', 'goXrefs']));
+export const subcellularLocationSectionHasContent = <
+  T extends Record<string | number | symbol, unknown>
+>(
+  data?: T
+) => {
+  if (!data) {
+    return false;
+  }
+  const { commentsData, featuresData, goXrefs } = data;
+  return hasContent({ commentsData, featuresData, goXrefs });
+};
 
 const SubcellularLocationSection = ({ data, sequence }: Props) => {
   if (!subcellularLocationSectionHasContent(data)) {

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -2236,19 +2236,7 @@ exports[`Entry basic should render main 1`] = `
                       </div>
                       <div
                         style="display: none;"
-                      >
-                        <template
-                          id="sibSwissBioPicsStyle"
-                        />
-                        <div
-                          id="fakeContent"
-                        />
-                        <sib-swissbiopics-sl-go-54
-                          contentid="fakeContent"
-                          gos=""
-                          taxid="9606"
-                        />
-                      </div>
+                      />
                     </div>
                   </div>
                 </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -4597,26 +4597,6 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="subcellular-location"
-  >
-    <div
-      class="card__container"
-    >
-      <div
-        class="card__header card__header--with-separator"
-      >
-        <h2>
-          Subcellular Location
-        </h2>
-      </div>
-      <div
-        class="card__content"
-      />
-    </div>
-  </section>
-  <section
-    class="card"
-    data-entry-section="true"
     id="phenotypes"
   >
     <div

--- a/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
@@ -303,7 +303,7 @@ const SubCellViz: FC<Props> = memo(
           font-size: 0;
           font-weight: normal;
         }
-       .subcell_name {
+        .subcell_name {
           display: none;
         }
         .subcell_description {

--- a/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubCellViz.tsx
@@ -303,11 +303,7 @@ const SubCellViz: FC<Props> = memo(
           font-size: 0;
           font-weight: normal;
         }
-        #swissbiopic > h1::after {
-          font-size: 1rem;
-          content: 'No specific UniProt annotations available regarding subcellular location';
-        }
-        .subcell_name {
+       .subcell_name {
           display: none;
         }
         .subcell_description {

--- a/src/uniprotkb/components/protein-data-views/styles/subcellular-location-go-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/subcellular-location-go-view.module.scss
@@ -7,4 +7,5 @@
     background-color: $colour-platinum;
     margin-bottom: 0.25rem;
   }
+  margin-bottom: 0.75rem;
 }


### PR DESCRIPTION
## Purpose

- [Subcellular location card present in entry without subcell info](https://www.ebi.ac.uk/panda/jira/browse/TRM-26645)
- [Display subcellular annotation info even if there is no subcellular location visualisation](https://www.ebi.ac.uk/panda/jira/browse/TRM-26974)
- [Subcellviz: Handle case where there is no data to display](https://www.ebi.ac.uk/panda/jira/browse/TRM-26822)

## Approach
- Create `subcellularLocationSectionHasContent` to determine if there is any content to render
- If no locations or it's a virus-related entry but does have notes, return these
- If no locations or notes, return message indicating this (this used to be done by within CSS)
- If nothing for the UniProt tab but there is something for the GO tab, make GO tab the initial default selected

**Note**: Marija has viewed the changes and is happy with the UI side of things

## View changes
Examples for different cases:
```
P05067      lots of UniProt & GO data
P11926      only GO data
Q00733      only notes
A0A2K3DA85  no data
```

## Testing
Updated unit tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
