### PR TITLE
Panproteome

### DIFF
--- a/src/app/components/home-page/UniProtData.tsx
+++ b/src/app/components/home-page/UniProtData.tsx
@@ -6,6 +6,7 @@ import cn from 'classnames';
 import colors from '../../../../node_modules/franklin-sites/src/styles/colours.json';
 
 import { LocationToPath, Location } from '../../config/urls';
+import ftpUrls from '../../../shared/config/ftpUrls';
 
 import FTPIllustration from '../../../images/ftp_illustration.svg';
 import ProgrammaticIllustration from '../../../images/programmatic_illustration.svg';
@@ -31,7 +32,7 @@ const UniProtData = () => (
       className="uniprot-grid-cell--span-3"
       backgroundImage={<FTPIllustration />}
       backgroundColor={colors.independence}
-      url="https://ftp.uniprot.org/pub/databases/uniprot/"
+      url={ftpUrls.uniprot}
       gradient
     >
       Download UniProt release data

--- a/src/proteomes/adapters/proteomesConverter.ts
+++ b/src/proteomes/adapters/proteomesConverter.ts
@@ -88,12 +88,16 @@ export type ProteomesAPIModel = {
   proteinCount: number; // use this in the results table - calculated sum of the components proteinCount: components.reduce((total, { proteinCount }) => proteinCount + total, 0)
 };
 
-export type ProteomesUIModel = ProteomesAPIModel & {
-  // any addition/change by the converter
+export type ProteomesUIModel = Omit<ProteomesAPIModel, 'panproteome'> & {
+  panproteome: ProteomesAPIModel['panproteome'] | ProteomesAPIModel;
 };
 
-const proteomesConverter = (data: ProteomesAPIModel): ProteomesUIModel => ({
+const proteomesConverter = (
+  data: ProteomesAPIModel,
+  ppData?: ProteomesAPIModel
+): ProteomesUIModel => ({
   ...data,
+  panproteome: ppData || data.panproteome,
 });
 
 export default proteomesConverter;

--- a/src/proteomes/adapters/proteomesConverter.ts
+++ b/src/proteomes/adapters/proteomesConverter.ts
@@ -94,10 +94,10 @@ export type ProteomesUIModel = Omit<ProteomesAPIModel, 'panproteome'> & {
 
 const proteomesConverter = (
   data: ProteomesAPIModel,
-  ppData?: ProteomesAPIModel
+  panProteomeData?: ProteomesAPIModel
 ): ProteomesUIModel => ({
   ...data,
-  panproteome: ppData || data.panproteome,
+  panproteome: panProteomeData || data.panproteome,
 });
 
 export default proteomesConverter;

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -37,21 +37,24 @@ const Entry = () => {
     apiUrls.entry(accession, Namespace.proteomes)
   );
 
-  const ppData = useDataApi<ProteomesAPIModel>(
+  const panProteomeData = useDataApi<ProteomesAPIModel>(
     mainData.data?.panproteome && mainData.data.panproteome !== mainData.data.id
       ? apiUrls.entry(mainData.data.panproteome, Namespace.proteomes)
       : null
   );
 
-  if (mainData.loading || ppData.loading || !mainData.data) {
-    return <Loader progress={mainData.progress || ppData.progress} />;
+  if (mainData.loading || panProteomeData.loading || !mainData.data) {
+    return <Loader progress={mainData.progress || panProteomeData.progress} />;
   }
 
-  if (mainData.error || ppData.error || !accession || !mainData.data) {
-    return <ErrorHandler status={mainData.status || ppData.status} />;
+  if (mainData.error || panProteomeData.error || !accession || !mainData.data) {
+    return <ErrorHandler status={mainData.status || panProteomeData.status} />;
   }
 
-  const transformedData = proteomesConverter(mainData.data, ppData.data);
+  const transformedData = proteomesConverter(
+    mainData.data,
+    panProteomeData.data
+  );
 
   return (
     <SingleColumnLayout className="entry-page">

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -19,11 +19,6 @@ import { ProteomesUIModel } from '../../adapters/proteomesConverter';
 
 import '../styles/overview.scss';
 
-type Item = {
-  title: JSX.Element;
-  content: JSX.Element;
-};
-
 export const Overview = ({ data }: { data: ProteomesUIModel }) => {
   const infoData = useMemo(() => {
     const renderColumnAsInfoListItem = (column: ProteomesColumn) => {
@@ -100,9 +95,9 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
           ),
       },
       renderColumnAsInfoListItem(ProteomesColumn.genomeRepresentation),
-      data.panproteome && {
+      {
         title: 'Pan proteome',
-        content: (
+        content: data.panproteome && (
           <PanProteome
             panproteome={data.panproteome}
             id={data.id}
@@ -122,7 +117,7 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
           </div>
         ),
       },
-    ].filter((item): item is Item => Boolean(item));
+    ];
   }, [data]);
 
   return (

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -97,13 +97,7 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
       renderColumnAsInfoListItem(ProteomesColumn.genomeRepresentation),
       {
         title: 'Pan proteome',
-        content: data.panproteome && (
-          <PanProteome
-            panproteome={data.panproteome}
-            id={data.id}
-            taxonomy={data.taxonomy}
-          />
-        ),
+        content: data.panproteome && <PanProteome proteome={data} />,
       },
       renderColumnAsInfoListItem(ProteomesColumn.cpd),
       {

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -42,14 +42,14 @@ type PanProteomeProps = SetRequired<
   'panproteome'
 >;
 
-export const Panproteome = ({
+export const PanProteome = ({
   panproteome,
   id,
   taxonomy,
 }: PanProteomeProps) => {
-  const entryIsPanproteome = id === panproteome;
-  const { data: panproteomeData, loading } = useDataApi<ProteomesAPIModel>(
-    entryIsPanproteome ? null : apiUrls.entry(id, Namespace.proteomes)
+  const entryIsPanProteome = id === panproteome;
+  const { data: panProteomeData, loading } = useDataApi<ProteomesAPIModel>(
+    entryIsPanProteome ? null : apiUrls.entry(id, Namespace.proteomes)
   );
 
   if (loading) {
@@ -57,11 +57,15 @@ export const Panproteome = ({
   }
 
   const name =
-    (entryIsPanproteome && taxonomy?.scientificName) ||
-    panproteomeData?.taxonomy.scientificName ||
+    (entryIsPanProteome && taxonomy?.scientificName) ||
+    panProteomeData?.taxonomy.scientificName ||
     panproteome;
-
-  return <>{`This proteome is part of the ${name} pan proteome (fasta)`}</>;
+  return (
+    <>
+      {`This proteome is part of the ${name} pan proteome (`}
+      <a href={ftpUrls.panProteomes(panproteome)}>FASTA</a>)
+    </>
+  );
 };
 
 export const Overview = ({ data }: { data: ProteomesUIModel }) => {
@@ -143,7 +147,7 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
       data.panproteome && {
         title: 'Pan proteome',
         content: (
-          <Panproteome
+          <PanProteome
             panproteome={data.panproteome}
             id={data.id}
             taxonomy={data.taxonomy}

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -1,12 +1,5 @@
 import { useMemo } from 'react';
-import {
-  Card,
-  InfoList,
-  ExternalLink,
-  LongNumber,
-  Loader,
-} from 'franklin-sites';
-import { SetRequired } from 'type-fest';
+import { Card, InfoList, ExternalLink, LongNumber } from 'franklin-sites';
 
 import HTMLHead from '../../../shared/components/HTMLHead';
 import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
@@ -14,58 +7,21 @@ import { EntryTypeIcon } from '../../../shared/components/entry/EntryTypeIcon';
 import BuscoView from '../BuscoView';
 import BuscoLegend from '../BuscoLegend';
 import BuscoAbbr from '../BuscoAbbr';
-
-import useDataApi from '../../../shared/hooks/useDataApi';
+import { PanProteome } from './PanProteome';
 
 import parseDate from '../../../shared/utils/parseDate';
 import ftpUrls from '../../../shared/config/ftpUrls';
 import ProteomesColumnConfiguration, {
   ProteomesColumn,
 } from '../../config/ProteomesColumnConfiguration';
-import apiUrls from '../../../shared/config/apiUrls';
 
-import {
-  ProteomesAPIModel,
-  ProteomesUIModel,
-} from '../../adapters/proteomesConverter';
+import { ProteomesUIModel } from '../../adapters/proteomesConverter';
 
 import '../styles/overview.scss';
-import { Namespace } from '../../../shared/types/namespaces';
 
 type Item = {
   title: JSX.Element;
   content: JSX.Element;
-};
-
-type PanProteomeProps = SetRequired<
-  Pick<ProteomesUIModel, 'panproteome' | 'id' | 'taxonomy'>,
-  'panproteome'
->;
-
-export const PanProteome = ({
-  panproteome,
-  id,
-  taxonomy,
-}: PanProteomeProps) => {
-  const entryIsPanProteome = id === panproteome;
-  const { data: panProteomeData, loading } = useDataApi<ProteomesAPIModel>(
-    entryIsPanProteome ? null : apiUrls.entry(id, Namespace.proteomes)
-  );
-
-  if (loading) {
-    return <Loader />;
-  }
-
-  const name =
-    (entryIsPanProteome && taxonomy?.scientificName) ||
-    panProteomeData?.taxonomy.scientificName ||
-    panproteome;
-  return (
-    <>
-      {`This proteome is part of the ${name} pan proteome (`}
-      <a href={ftpUrls.panProteomes(panproteome)}>FASTA</a>)
-    </>
-  );
 };
 
 export const Overview = ({ data }: { data: ProteomesUIModel }) => {

--- a/src/proteomes/components/entry/PanProteome.tsx
+++ b/src/proteomes/components/entry/PanProteome.tsx
@@ -1,4 +1,3 @@
-import { Loader } from 'franklin-sites';
 import cn from 'classnames';
 import { SetRequired } from 'type-fest';
 

--- a/src/proteomes/components/entry/PanProteome.tsx
+++ b/src/proteomes/components/entry/PanProteome.tsx
@@ -25,6 +25,7 @@ export const PanProteome = ({
   taxonomy,
 }: PanProteomeProps) => {
   const entryIsPanProteome = id === panproteome;
+
   const { data: panProteomeData, loading } = useDataApi<ProteomesAPIModel>(
     entryIsPanProteome ? null : apiUrls.entry(id, Namespace.proteomes)
   );

--- a/src/proteomes/components/entry/PanProteome.tsx
+++ b/src/proteomes/components/entry/PanProteome.tsx
@@ -1,0 +1,58 @@
+import { Loader } from 'franklin-sites';
+import cn from 'classnames';
+import { SetRequired } from 'type-fest';
+
+import useDataApi from '../../../shared/hooks/useDataApi';
+
+import apiUrls from '../../../shared/config/apiUrls';
+import ftpUrls from '../../../shared/config/ftpUrls';
+
+import {
+  ProteomesUIModel,
+  ProteomesAPIModel,
+} from '../../adapters/proteomesConverter';
+import { Namespace } from '../../../shared/types/namespaces';
+
+import styles from '../../../shared/styles/blur-loading.module.scss';
+
+type PanProteomeProps = SetRequired<
+  Pick<ProteomesUIModel, 'panproteome' | 'id' | 'taxonomy'>,
+  'panproteome'
+>;
+
+export const PanProteome = ({
+  panproteome,
+  id,
+  taxonomy,
+}: PanProteomeProps) => {
+  const entryIsPanProteome = id === panproteome;
+  const { data: panProteomeData, loading } = useDataApi<ProteomesAPIModel>(
+    entryIsPanProteome ? null : apiUrls.entry(id, Namespace.proteomes)
+  );
+
+  const name =
+    // If loading, use current proteomes scientificName as a placeholder
+    ((loading || entryIsPanProteome) && taxonomy?.scientificName) ||
+    // At this point, the entry is not the pan proteome so try the loaded data
+    panProteomeData?.taxonomy.scientificName ||
+    // As a last resort fall back on the panproteome ID which we know must exist
+    panproteome;
+
+  return (
+    <>
+      {'This proteome is part of the '}
+      <span className={styles['blur-loading']}>
+        <span
+          className={cn(
+            { [styles['blur-loading__placeholder']]: loading },
+            styles['blur-loading__item']
+          )}
+        >
+          {name}
+        </span>
+      </span>
+      {' pan proteome ('}
+      <a href={ftpUrls.panProteomes(panproteome)}>FASTA</a>)
+    </>
+  );
+};

--- a/src/proteomes/components/entry/__tests__/PanProteome.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/PanProteome.spec.tsx
@@ -1,0 +1,60 @@
+import { screen } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
+
+import { PanProteome } from '../PanProteome';
+
+const mock = new MockAdapter(axios);
+
+describe('PanProteome', () => {
+  it('should immediately render pan-proteome name if entry is pan proteome and with link', () => {
+    const { asFragment } = customRender(
+      <PanProteome
+        panproteome="UP1"
+        id="UP1"
+        taxonomy={{ taxonId: 12345, scientificName: 'Some Name' }}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByRole('link', { name: 'FASTA' })).toBeInTheDocument();
+    expect(screen.getByText('Some Name')).toBeInTheDocument();
+  });
+  it('should request pan-proteome data if different to entry, temporarily display name from props and display pan-proteome name once loaded', async () => {
+    mock.onGet().reply(200, {
+      id: 'UP2',
+      taxonomy: {
+        scientificName: 'Another Name',
+      },
+    });
+    customRender(
+      <PanProteome
+        panproteome="UP1"
+        id="UP2"
+        taxonomy={{ taxonId: 12345, scientificName: 'Some Name' }}
+      />
+    );
+    let name = screen.getByText('Some Name');
+    expect(name).toBeInTheDocument();
+    name = await screen.findByText('Another Name');
+    expect(name).toBeInTheDocument();
+  });
+  it('should request pan-proteome data if different to entry and display pan-proteome ID if scientific name not in response data', async () => {
+    mock.onGet().reply(200, {
+      id: 'UP2',
+      taxonomy: {},
+    });
+    customRender(
+      <PanProteome
+        panproteome="UP1"
+        id="UP2"
+        taxonomy={{ taxonId: 12345, scientificName: 'Some Name' }}
+      />
+    );
+    let name = screen.getByText('Some Name');
+    expect(name).toBeInTheDocument();
+    name = await screen.findByText('UP1');
+    expect(name).toBeInTheDocument();
+  });
+});

--- a/src/proteomes/components/entry/__tests__/__snapshots__/PanProteome.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/PanProteome.spec.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PanProteome should immediately render pan-proteome name if entry is pan proteome and with link 1`] = `
+<DocumentFragment>
+  This proteome is part of the 
+  <span
+    class="blur-loading"
+  >
+    <span
+      class="blur-loading__item"
+    >
+      Some Name
+    </span>
+  </span>
+   pan proteome (
+  <a
+    href="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/pan_proteomes/UP1.fasta.gz"
+  >
+    FASTA
+  </a>
+  )
+</DocumentFragment>
+`;

--- a/src/proteomes/components/entry/__tests__/__snapshots__/PanProteome.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/PanProteome.spec.tsx.snap
@@ -1,17 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PanProteome should immediately render pan-proteome name if entry is pan proteome and with link 1`] = `
+exports[`PanProteome should render a link to FASTA, when is a panproteome 1`] = `
+<DocumentFragment>
+  This proteome is part of the Homo sapiens pan proteome (
+  <a
+    href="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/pan_proteomes/UP000005640.fasta.gz"
+  >
+    FASTA
+  </a>
+  )
+</DocumentFragment>
+`;
+
+exports[`PanProteome should render a link to entry and a link to FASTA, when is part of a panproteome 1`] = `
 <DocumentFragment>
   This proteome is part of the 
-  <span
-    class="blur-loading"
+  <a
+    href="/proteomes/UP1"
   >
-    <span
-      class="blur-loading__item"
-    >
-      Some Name
-    </span>
-  </span>
+    Homo sapiens
+  </a>
    pan proteome (
   <a
     href="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/pan_proteomes/UP1.fasta.gz"

--- a/src/proteomes/config/ProteomesColumnConfiguration.tsx
+++ b/src/proteomes/config/ProteomesColumnConfiguration.tsx
@@ -13,7 +13,10 @@ import { getEntryPath, LocationToPath, Location } from '../../app/config/urls';
 import abbreviationToTitle from '../../shared/config/abbreviations';
 
 import { Namespace } from '../../shared/types/namespaces';
-import { ProteomesAPIModel } from '../adapters/proteomesConverter';
+import {
+  ProteomesAPIModel,
+  ProteomesUIModel,
+} from '../adapters/proteomesConverter';
 import { ColumnConfiguration } from '../../shared/types/columnConfiguration';
 import { UniProtKBColumn } from '../../uniprotkb/types/columnTypes';
 
@@ -46,7 +49,7 @@ export const primaryKeyColumns = [ProteomesColumn.upid];
 
 export const ProteomesColumnConfiguration: ColumnConfiguration<
   ProteomesColumn,
-  ProteomesAPIModel
+  ProteomesAPIModel | ProteomesUIModel
 > = new Map();
 
 // COLUMN RENDERERS BELOW

--- a/src/proteomes/config/__tests__/ProteomesColumnConfiguration.spec.tsx
+++ b/src/proteomes/config/__tests__/ProteomesColumnConfiguration.spec.tsx
@@ -3,7 +3,6 @@ import ProteomesColumnConfiguration, {
 } from '../ProteomesColumnConfiguration';
 
 import proteomesConverter, {
-  ProteomesAPIModel,
   ProteomesUIModel,
 } from '../../adapters/proteomesConverter';
 import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
@@ -15,7 +14,7 @@ jest.mock('../../../tools/utils/storage');
 const transformedData: ProteomesUIModel = proteomesConverter(data);
 
 describe('ProteomesColumnConfiguration component', () => {
-  testColumnConfiguration<ProteomesColumn, ProteomesAPIModel>(
+  testColumnConfiguration<ProteomesColumn, ProteomesUIModel>(
     ProteomesColumnConfiguration,
     transformedData
   );

--- a/src/shared/components/layouts/ReleaseInfo.tsx
+++ b/src/shared/components/layouts/ReleaseInfo.tsx
@@ -10,6 +10,7 @@ import { getLocationEntryPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../types/namespaces';
 
 import helper from '../../styles/helper.module.scss';
+import blurLoading from '../../styles/blur-loading.module.scss';
 import './styles/release-info.scss';
 
 const fetchOptions: { method: Method } = { method: 'HEAD' };
@@ -26,10 +27,16 @@ const ReleaseInfo = () => {
   const releaseNumber = headers?.['x-release-number'];
 
   return (
-    <span className={cn('release-info', helper['no-wrap'])}>
+    <span
+      className={cn(
+        'release-info',
+        helper['no-wrap'],
+        blurLoading['blur-loading__item']
+      )}
+    >
       <span
         className={cn(
-          { 'release-info__placeholder': !releaseNumber },
+          { [blurLoading['blur-loading__placeholder']]: !releaseNumber },
           'release-info__release_number'
         )}
       >

--- a/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
+++ b/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
@@ -66,10 +66,10 @@ exports[`HomePage component should render 1`] = `
         class="stats-release"
       >
         <span
-          class="release-info no-wrap"
+          class="release-info no-wrap blur-loading__item"
         >
           <span
-            class="release-info__placeholder release-info__release_number"
+            class="blur-loading__placeholder release-info__release_number"
           >
             Release 2021_00
           </span>

--- a/src/shared/components/layouts/styles/release-info.scss
+++ b/src/shared/components/layouts/styles/release-info.scss
@@ -1,15 +1,3 @@
-.release-info {
-  &__release_number {
-    transition: filter linear 0.25s;
-    filter: blur(0);
-  }
-
-  &__placeholder {
-    will-change: filter;
-    filter: blur(0.1rem);
-  }
-}
-
 header .release-info {
   float: right;
 }

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -1,10 +1,21 @@
 import { capitalize } from 'lodash-es';
+import joinUrl from 'url-join';
+
+const ftpPrefix = 'https://ftp.uniprot.org';
 
 const ftpUrls = {
   referenceProteomes: (id: string, superkingdom: string, taxonId: number) =>
-    `https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/reference_proteomes/${capitalize(
-      superkingdom
-    )}/${id}/${id}_${taxonId}.fasta.gz`,
+    joinUrl(
+      ftpPrefix,
+      `/pub/databases/uniprot/current_release/knowledgebase/reference_proteomes/${capitalize(
+        superkingdom
+      )}/${id}/${id}_${taxonId}.fasta.gz`
+    ),
+  panProteomes: (id: string) =>
+    joinUrl(
+      ftpPrefix,
+      `/pub/databases/uniprot/current_release/knowledgebase/pan_proteomes/${id}.fasta.gz`
+    ),
 };
 
 export default ftpUrls;

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -1,20 +1,21 @@
 import { capitalize } from 'lodash-es';
 import joinUrl from 'url-join';
 
-const ftpPrefix = 'https://ftp.uniprot.org';
+const ftpUniProt = 'https://ftp.uniprot.org/pub/databases/uniprot/';
 
 const ftpUrls = {
+  uniprot: ftpUniProt,
   referenceProteomes: (id: string, superkingdom: string, taxonId: number) =>
     joinUrl(
-      ftpPrefix,
-      `/pub/databases/uniprot/current_release/knowledgebase/reference_proteomes/${capitalize(
+      ftpUniProt,
+      `/current_release/knowledgebase/reference_proteomes/${capitalize(
         superkingdom
       )}/${id}/${id}_${taxonId}.fasta.gz`
     ),
   panProteomes: (id: string) =>
     joinUrl(
-      ftpPrefix,
-      `/pub/databases/uniprot/current_release/knowledgebase/pan_proteomes/${id}.fasta.gz`
+      ftpUniProt,
+      `/current_release/knowledgebase/pan_proteomes/${id}.fasta.gz`
     ),
 };
 

--- a/src/shared/styles/blur-loading.module.scss
+++ b/src/shared/styles/blur-loading.module.scss
@@ -1,0 +1,11 @@
+.blur-loading {
+  &__item {
+    transition: filter linear 0.25s;
+    filter: blur(0);
+  }
+
+  &__placeholder {
+    will-change: filter;
+    filter: blur(0.1rem);
+  }
+}


### PR DESCRIPTION
## Purpose
[Missing link to pan proteome in Proteome entry Overview](https://www.ebi.ac.uk/panda/jira/browse/TRM-27062)

## Approach
- If `panproteome` is provided, check to see if it matches the current entry. If so, use that. If not, load the corresponding `panproteome` entry.
- Handle loading state at the same place as the rest of the entry (Loader on the main area of the page)
- Added more ftp config

## Outstanding questions
I have made a few assumptions as there wasn't enough people to discuss the following questions:
- ~If a `panproteome` ID is present is it ever different to the the current entry ID? If so, what is an example?~
  - UP000000211 & UP000000532
- ~Should we create a link to the pan proteome entry page (if different) as well as just the FASTA FTP download link?~
  - Yes, like in the current website

## To view
- http://localhost:8080/proteomes/UP000000265
- http://localhost:8080/proteomes/UP000001570

## Testing
- Unit and snapshots

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
