### PR TITLE
DB Info Map loading issues

### DIFF
--- a/src/shared/contexts/DatabaseInfoMaps.tsx
+++ b/src/shared/contexts/DatabaseInfoMaps.tsx
@@ -1,4 +1,9 @@
 import { createContext, ReactNode, useEffect, useMemo } from 'react';
+import { Loader } from 'franklin-sites';
+
+import ErrorHandler from '../components/error-pages/ErrorHandler';
+
+import useDataApi from '../hooks/useDataApi';
 
 import {
   DatabaseInfoMaps,
@@ -7,7 +12,6 @@ import {
   isDatabaseColumn,
 } from '../../uniprotkb/utils/database';
 import apiUrls from '../config/apiUrls';
-import useDataApi from '../hooks/useDataApi';
 import * as logging from '../utils/logging';
 
 import { UniProtKBColumn } from '../../uniprotkb/types/columnTypes';
@@ -49,24 +53,32 @@ type DatabaseInfoMapsProviderProps = {
 export const DatabaseInfoMapsProvider = ({
   children,
 }: DatabaseInfoMapsProviderProps) => {
-  const { data: databaseInfo } = useDataApi<DatabaseInfo>(
+  const { data, loading, progress, error, status } = useDataApi<DatabaseInfo>(
     apiUrls.allUniProtKBDatabases
   );
   const databaseInfoMaps = useMemo(
-    () => databaseInfo && getDatabaseInfoMaps(databaseInfo),
-    [databaseInfo]
+    () => data && getDatabaseInfoMaps(data),
+    [data]
   );
 
   useEffect(() => {
     // Sanity check for dynamic database info and static column definition
-    if (process.env.NODE_ENV === 'development' && databaseInfo) {
-      databaseInfoColumnsSanityCheck(databaseInfo);
+    if (process.env.NODE_ENV === 'development' && data) {
+      databaseInfoColumnsSanityCheck(data);
     }
-  }, [databaseInfo]);
+  }, [data]);
 
-  return databaseInfoMaps ? (
+  if (loading) {
+    return <Loader progress={progress} />;
+  }
+
+  if (error || !databaseInfoMaps) {
+    return <ErrorHandler status={status} />;
+  }
+
+  return (
     <DatabaseInfoMapsContext.Provider value={databaseInfoMaps}>
       {children}
     </DatabaseInfoMapsContext.Provider>
-  ) : null;
+  );
 };


### PR DESCRIPTION
## Purpose
Tries to handle the possible reasons behind the complete white page reports in hotjar.
Since loading the db info maps data is blocking to render the whole site, give a UI feedback to the user if anything goes wrong.
(Note that the white page issues might still be caused by other reasons, I'm thinking mainly with network issues when loading the main JS chunks)

## Approach
Most of the time, the user won't have time to notice anything, but:
 - If the network is really slow, displays a Loader component
 - If there's been an issue loading the data, displays an error component

=> At least there's a cue to understand what's going on from the user's point of view => might retry to load, or wait to have a better network

## Testing
Manual testing: devtools network request blocking for `https://rest.uniprot.org/beta/configure/uniprotkb/allDatabases`

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
