### PR TITLE
contextual help - side button & content

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -416,16 +416,16 @@ const App = () => {
               )}
             />
           </Switch>
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary fallback={null}>
-              <ContextualHelp />
-            </ErrorBoundary>
-          </Suspense>
         </Suspense>
       </BaseLayout>
       <ErrorBoundary fallback={null}>
         <GDPR />
       </ErrorBoundary>
+      <Suspense fallback={null}>
+        <ErrorBoundary fallback={null}>
+          <ContextualHelp />
+        </ErrorBoundary>
+      </Suspense>
     </>
   );
 };

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, FC, CSSProperties, useEffect, useRef } from 'react';
+import { lazy, Suspense, FC } from 'react';
 import { Route, Switch, RouteChildrenProps, Redirect } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { Loader } from 'franklin-sites';
@@ -222,32 +222,14 @@ const ResourceNotFoundPage = lazy(
     )
 );
 
-const ContextualHelpHandler = lazy(() =>
+const ContextualHelp = lazy(() =>
   sleep(1000).then(
     () =>
       import(
-        /* webpackChunkName: "contextual-help" */ '../../help/components/contextual/ContextualHelpHandler'
+        /* webpackChunkName: "contextual-help" */ '../../help/components/contextual/ContextualHelp'
       )
   )
 );
-
-const reportBugLinkStyles: CSSProperties = {
-  fontSize: '.8rem',
-  lineHeight: '1rem',
-  padding: '1.5ch',
-  color: '#FFF',
-  backgroundColor: '#126A9F',
-  position: 'fixed',
-  bottom: 'calc(50% - 5ch)',
-  right: 0,
-  borderRadius: '0.5ch 0 0 0.5ch',
-  writingMode: 'vertical-rl',
-  textOrientation: 'sideways',
-  zIndex: 99,
-  opacity: 0,
-  transform: `translateX(100%)`,
-  transition: 'transform ease-out 0.25s',
-};
 
 // Helper component to render a landing page or the results page depending on
 // the presence of absence of a querystring
@@ -268,23 +250,6 @@ const RedirectToStarSearch = ({ location }: RouteChildrenProps) => (
 const App = () => {
   useScrollToTop(history);
   useReloadApp(history);
-
-  const feedbackRef = useRef<HTMLAnchorElement>(null);
-
-  useEffect(() => {
-    sleep(3000).then(() => {
-      // If there's already Hotjar's feedback, don't do anything
-      if (document.querySelector('._hj_feedback_container')) {
-        return;
-      }
-      if (!feedbackRef.current) {
-        return;
-      }
-      feedbackRef.current.tabIndex = 0;
-      feedbackRef.current.style.opacity = '1';
-      feedbackRef.current.style.transform = 'translateX(0)';
-    });
-  });
 
   return (
     <>
@@ -453,7 +418,7 @@ const App = () => {
           </Switch>
           <Suspense fallback={<Loader />}>
             <ErrorBoundary fallback={null}>
-              <ContextualHelpHandler />
+              <ContextualHelp />
             </ErrorBoundary>
           </Suspense>
         </Suspense>
@@ -461,16 +426,6 @@ const App = () => {
       <ErrorBoundary fallback={null}>
         <GDPR />
       </ErrorBoundary>
-      <a
-        style={reportBugLinkStyles}
-        target="_blank"
-        href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
-        rel="noopener noreferrer"
-        tabIndex={-1}
-        ref={feedbackRef}
-      >
-        Feedback
-      </a>
     </>
   );
 };

--- a/src/help/components/contextual/ContextualHelp.tsx
+++ b/src/help/components/contextual/ContextualHelp.tsx
@@ -16,7 +16,7 @@ import {
 const ContextualHelp = () => {
   const history = useHistory();
   const [articleId, setArticleId] = useState<string | undefined>(undefined);
-  const [displayButton, setDisplayButton] = useState(false);
+  const [displayButton, setDisplayButton] = useState<boolean | undefined>();
   // Needs to match the height value in the contextual-help stylesheet
   const smallScreen = useMatchMedia('only screen and (max-height: 35em)');
 
@@ -36,8 +36,8 @@ const ContextualHelp = () => {
             getLocationEntryPath(Location.HelpEntry, element.dataset.articleId)
           );
         } else {
-          setDisplayButton(false);
           setArticleId(element.dataset.articleId);
+          setDisplayButton(false);
         }
       }
     };
@@ -58,11 +58,16 @@ const ContextualHelp = () => {
     }
   }, []);
 
-  const handleButtonClick = useCallback<
-    MouseEventHandler<HTMLButtonElement>
-  >(() => {
-    setDisplayButton(false);
-  }, []);
+  const handleButtonClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(
+    (event) => {
+      if (event.metaKey || event.ctrlKey) {
+        return; // default behaviour of opening a new tab
+      }
+      event.preventDefault();
+      setDisplayButton(false);
+    },
+    []
+  );
 
   useEffect(() => {
     frame().then(() => {
@@ -71,15 +76,13 @@ const ContextualHelp = () => {
     });
   }, []);
 
-  // TODO: return button and panel
-  // Probably shouldn't rely on articleId to display panel
   return (
     <>
-      {!displayButton && shouldBeVisible && (
+      {displayButton === false && shouldBeVisible && (
         <ContextualHelpContainer articleId={articleId} onClose={handleClose} />
       )}
       <SideButtons
-        displayHelp={shouldBeVisible && displayButton && !smallScreen}
+        displayHelp={shouldBeVisible && !!displayButton && !smallScreen}
         onClick={handleButtonClick}
       />
     </>

--- a/src/help/components/contextual/ContextualHelp.tsx
+++ b/src/help/components/contextual/ContextualHelp.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import { useRouteMatch, useHistory } from 'react-router-dom';
+import { frame } from 'timing-functions';
 
 import ContextualHelpContainer from './ContextualHelpContainer';
+import SideButtons from './SideButtons';
 
 import useMatchMedia from '../../../shared/hooks/useMatchMedia';
 
@@ -11,9 +13,10 @@ import {
   LocationToPath,
 } from '../../../app/config/urls';
 
-const ContextualHelpHandler = () => {
+const ContextualHelp = () => {
   const history = useHistory();
-  const [articleId, setArticleId] = useState<string | null>(null);
+  const [articleId, setArticleId] = useState<string | undefined>(undefined);
+  const [displayButton, setDisplayButton] = useState(false);
   // Needs to match the height value in the contextual-help stylesheet
   const smallScreen = useMatchMedia('only screen and (max-height: 35em)');
 
@@ -33,6 +36,7 @@ const ContextualHelpHandler = () => {
             getLocationEntryPath(Location.HelpEntry, element.dataset.articleId)
           );
         } else {
+          setDisplayButton(false);
           setArticleId(element.dataset.articleId);
         }
       }
@@ -49,19 +53,37 @@ const ContextualHelpHandler = () => {
     (reason: 'outside' | 'button' | 'navigation' | 'escape') => void
   >((reason) => {
     if (reason !== 'outside') {
-      setArticleId(null);
+      setArticleId(undefined);
+      setDisplayButton(true);
     }
   }, []);
 
-  if (!shouldBeVisible) {
-    return null;
-  }
+  const handleButtonClick = useCallback<
+    MouseEventHandler<HTMLButtonElement>
+  >(() => {
+    setDisplayButton(false);
+  }, []);
+
+  useEffect(() => {
+    frame().then(() => {
+      // To trigger the animation, we switch the classname after first render
+      setDisplayButton(true);
+    });
+  }, []);
 
   // TODO: return button and panel
   // Probably shouldn't rely on articleId to display panel
-  return articleId ? (
-    <ContextualHelpContainer articleId={articleId} onClose={handleClose} />
-  ) : null;
+  return (
+    <>
+      {!displayButton && shouldBeVisible && (
+        <ContextualHelpContainer articleId={articleId} onClose={handleClose} />
+      )}
+      <SideButtons
+        displayHelp={shouldBeVisible && displayButton && !smallScreen}
+        onClick={handleButtonClick}
+      />
+    </>
+  );
 };
 
-export default ContextualHelpHandler;
+export default ContextualHelp;

--- a/src/help/components/contextual/ContextualHelpContainer.tsx
+++ b/src/help/components/contextual/ContextualHelpContainer.tsx
@@ -12,20 +12,33 @@ import { HelpEntryResponse } from '../../adapters/helpConverter';
 import styles from './styles/contextual-help.module.scss';
 
 type Props = {
-  articleId: string;
+  articleId?: string;
   onClose: (reason: 'outside' | 'button' | 'navigation' | 'escape') => void;
 };
 
 const ContextualHelpContainer = ({ articleId, onClose }: Props) => {
   const { data, loading, error, status, progress } =
-    useDataApi<HelpEntryResponse>(helpUrl.accession(articleId));
+    useDataApi<HelpEntryResponse>(
+      articleId ? helpUrl.accession(articleId) : null
+    );
 
-  if (loading && !data) {
-    return <Loader progress={progress} />;
-  }
+  let content = <Loader progress={progress} />;
 
-  if (error || !data) {
-    return <ErrorHandler status={status} />;
+  if (!loading) {
+    if (error || !data) {
+      content = <ErrorHandler status={status} />;
+    } else {
+      content = (
+        <>
+          <h2 className="medium">{data.title}</h2>
+          <HelpEntryContent
+            data={data}
+            handleClick={() => console.log('click!')}
+            upperHeadingLevel="h3"
+          />
+        </>
+      );
+    }
   }
 
   return (
@@ -37,14 +50,7 @@ const ContextualHelpContainer = ({ articleId, onClose }: Props) => {
       size="small"
       position="right"
     >
-      <>
-        <h2 className="medium">{data.title}</h2>
-        <HelpEntryContent
-          data={data}
-          handleClick={() => console.log('click!')}
-          upperHeadingLevel="h3"
-        />
-      </>
+      {content}
     </SlidingPanel>
   );
 };

--- a/src/help/components/contextual/ContextualHelpContainer.tsx
+++ b/src/help/components/contextual/ContextualHelpContainer.tsx
@@ -1,58 +1,86 @@
+import { lazy, Suspense } from 'react';
 import { Loader, SlidingPanel } from 'franklin-sites';
+import {
+  generatePath,
+  MemoryRouter,
+  Route,
+  RouteChildrenProps,
+  Switch,
+  useLocation,
+} from 'react-router-dom';
 
-import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
-import { HelpEntryContent } from '../entry/Entry';
-
-import useDataApi from '../../../shared/hooks/useDataApi';
-
-import { help as helpUrl } from '../../../shared/config/apiUrls';
-
-import { HelpEntryResponse } from '../../adapters/helpConverter';
+import { LocationToPath, Location } from '../../../app/config/urls';
 
 import styles from './styles/contextual-help.module.scss';
+
+// Help
+const HelpEntryPage = lazy(
+  () => import(/* webpackChunkName: "help-entry" */ '../entry/Entry')
+);
+const HelpResults = lazy(
+  () => import(/* webpackChunkName: "help-results" */ '../results/Results')
+);
+const ResourceNotFoundPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "resource-not-found" */ '../../../shared/components/error-pages/ResourceNotFoundPage'
+    )
+);
 
 type Props = {
   articleId?: string;
   onClose: (reason: 'outside' | 'button' | 'navigation' | 'escape') => void;
 };
 
-const ContextualHelpContainer = ({ articleId, onClose }: Props) => {
-  const { data, loading, error, status, progress } =
-    useDataApi<HelpEntryResponse>(
-      articleId ? helpUrl.accession(articleId) : null
-    );
-
-  let content = <Loader progress={progress} />;
-
-  if (!loading) {
-    if (error || !data) {
-      content = <ErrorHandler status={status} />;
-    } else {
-      content = (
-        <>
-          <h2 className="medium">{data.title}</h2>
-          <HelpEntryContent
-            data={data}
-            handleClick={() => console.log('click!')}
-            upperHeadingLevel="h3"
-          />
-        </>
-      );
-    }
-  }
-
+const HistoryDebug = () => {
+  const { pathname, search } = useLocation();
   return (
-    <SlidingPanel
-      title="Help"
-      onClose={onClose}
-      withCloseButton
-      className={styles['contextual-help-panel']}
-      size="small"
-      position="right"
-    >
-      {content}
-    </SlidingPanel>
+    <pre>
+      {pathname}
+      {search}
+    </pre>
   );
 };
+
+const ContextualHelpContainer = ({ articleId, onClose }: Props) => (
+  <SlidingPanel
+    title="Help"
+    onClose={onClose}
+    withCloseButton
+    className={styles['contextual-help-panel']}
+    size="small"
+    position="right"
+  >
+    <Suspense fallback={<Loader />}>
+      <MemoryRouter
+        initialEntries={[
+          articleId
+            ? generatePath(LocationToPath[Location.HelpEntry], {
+                accession: articleId,
+              })
+            : {
+                pathname: LocationToPath[Location.HelpResults],
+                search: 'query=*',
+              },
+        ]}
+      >
+        <HistoryDebug />
+        <Switch>
+          {/* Will get content from page later, for now, star search */}
+          <Route path={LocationToPath[Location.HelpEntry]}>
+            {(props: RouteChildrenProps<{ accession: string }>) => (
+              <HelpEntryPage inPanel {...props} />
+            )}
+          </Route>
+          <Route path={LocationToPath[Location.HelpResults]}>
+            {(props) => <HelpResults inPanel {...props} />}
+          </Route>
+          {/* Catch-all handler -> Redirect or not found use ResourceNotFoundPage */}
+          <Route path="*" component={ResourceNotFoundPage} />
+        </Switch>
+      </MemoryRouter>
+    </Suspense>
+  </SlidingPanel>
+);
 
 export default ContextualHelpContainer;

--- a/src/help/components/contextual/SideButtons.tsx
+++ b/src/help/components/contextual/SideButtons.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState, MouseEventHandler } from 'react';
+import { Link } from 'react-router-dom';
 import cn from 'classnames';
 import { sleep } from 'timing-functions';
+
+import { LocationToPath, Location } from '../../../app/config/urls';
 
 import styles from './styles/side-buttons.module.scss';
 
 type Props = {
   displayHelp: boolean;
-  onClick: MouseEventHandler<HTMLButtonElement>;
+  onClick: MouseEventHandler<HTMLAnchorElement>;
 };
 
 const SideButtons = ({ displayHelp, onClick }: Props) => {
@@ -23,7 +26,7 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
   });
 
   return (
-    <>
+    <span className={styles.container}>
       <a
         className={cn(styles['side-button'], styles.feedback, {
           [styles.visible]: displayFeedback,
@@ -35,17 +38,17 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
       >
         Feedback
       </a>
-      {/* Different style than franklin, so avoid using it to not fight it */}
-      <button type="button" onClick={onClick} tabIndex={-1}>
-        <p
-          className={cn(styles['side-button'], styles.help, {
-            [styles.visible]: displayHelp,
-          })}
-        >
-          Help
-        </p>
-      </button>
-    </>
+      <Link
+        to={LocationToPath[Location.HelpResults]}
+        onClick={onClick}
+        tabIndex={-1}
+        className={cn(styles['side-button'], styles.help, {
+          [styles.visible]: displayHelp,
+        })}
+      >
+        Help
+      </Link>
+    </span>
   );
 };
 

--- a/src/help/components/contextual/SideButtons.tsx
+++ b/src/help/components/contextual/SideButtons.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState, MouseEventHandler } from 'react';
+import cn from 'classnames';
+import { sleep } from 'timing-functions';
+
+import styles from './styles/side-buttons.module.scss';
+
+type Props = {
+  displayHelp: boolean;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+};
+
+const SideButtons = ({ displayHelp, onClick }: Props) => {
+  const [displayFeedback, setDisplayFeedback] = useState(false);
+
+  useEffect(() => {
+    sleep(3000).then(() => {
+      // If there's already Hotjar's feedback, don't do anything
+      if (document.querySelector('._hj_feedback_container')) {
+        return;
+      }
+      setDisplayFeedback(true);
+    });
+  });
+
+  return (
+    <>
+      <a
+        className={cn(styles['side-button'], styles.feedback, {
+          [styles.visible]: displayFeedback,
+        })}
+        target="_blank"
+        href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
+        rel="noopener noreferrer"
+        tabIndex={-1}
+      >
+        Feedback
+      </a>
+      {/* Different style than franklin, so avoid using it to not fight it */}
+      <button type="button" onClick={onClick} tabIndex={-1}>
+        <p
+          className={cn(styles['side-button'], styles.help, {
+            [styles.visible]: displayHelp,
+          })}
+        >
+          Help
+        </p>
+      </button>
+    </>
+  );
+};
+
+export default SideButtons;

--- a/src/help/components/contextual/styles/side-buttons.module.scss
+++ b/src/help/components/contextual/styles/side-buttons.module.scss
@@ -1,0 +1,46 @@
+@import 'franklin-sites/src/styles/colours';
+
+.side-button {
+  font-size: 0.8rem;
+  font-weight: bold;
+  line-height: 1rem;
+  padding: 1.5ch;
+  color: #fff;
+  background-color: #126a9f;
+  position: fixed;
+  right: 0;
+  border-radius: 0.5ch 0 0 0.5ch;
+  writing-mode: vertical-rl;
+  z-index: 99;
+  opacity: 0;
+  transform: translateX(100%) rotate(180deg);
+  transition-duration: 0.25s;
+  transition-timing-function: ease-out;
+  transition-property: transform, opacity;
+  border-radius: 0 3px 3px 0;
+  cursor: pointer;
+
+  &.visible {
+    transform: translateX(2px) rotate(180deg);
+    opacity: 1;
+
+    &:hover {
+      color: #fff;
+      transform: translateX(0) rotate(180deg);
+      box-shadow: 0 0 35px 2px rgb(0 0 0 / 24%);
+    }
+  }
+
+  &.feedback {
+    bottom: calc(50% - 5ch);
+  }
+
+  &.help {
+    bottom: calc(25% - 2ch);
+
+    &,
+    &:hover {
+      background-color: $colour-help-green;
+    }
+  }
+}

--- a/src/help/components/contextual/styles/side-buttons.module.scss
+++ b/src/help/components/contextual/styles/side-buttons.module.scss
@@ -1,5 +1,9 @@
 @import 'franklin-sites/src/styles/colours';
 
+.container {
+  position: absolute;
+}
+
 .side-button {
   font-size: 0.8rem;
   font-weight: bold;

--- a/src/help/components/entry/__tests__/Entry.spec.tsx
+++ b/src/help/components/entry/__tests__/Entry.spec.tsx
@@ -1,10 +1,13 @@
 import { screen } from '@testing-library/react';
+import { Route } from 'react-router-dom';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
 import Entry from '../Entry';
+
+import { LocationToPath, Location } from '../../../../app/config/urls';
 
 import mockData from '../../__mocks__/helpEntryModelData';
 
@@ -14,9 +17,12 @@ mock.onGet(/api\/help\/canonical_and_isoforms/).reply(200, mockData);
 
 describe('Help entry tests', () => {
   it('should render the Entry component', async () => {
-    const { asFragment } = customRender(<Entry />, {
-      route: '/help/canonical_and_isoforms',
-    });
+    const { asFragment } = customRender(
+      <Route path={LocationToPath[Location.HelpEntry]} component={Entry} />,
+      {
+        route: '/help/canonical_and_isoforms',
+      }
+    );
     await screen.findByText(mockData.title);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/help/components/results/Results.tsx
+++ b/src/help/components/results/Results.tsx
@@ -34,7 +34,15 @@ const dataRenderer = (article: HelpAPIModel) => (
 
 const getIdKey = (article: HelpAPIModel) => article.id;
 
-const Results = ({ history, location }: RouteChildrenProps) => {
+type Props = {
+  inPanel?: boolean;
+};
+
+const Results = ({
+  history,
+  location,
+  inPanel,
+}: RouteChildrenProps & Props) => {
   const [searchValue, setSearchValue] = useState<string>(() => {
     const { query } = qs.parse(location.search);
     const searchValue = Array.isArray(query) ? query.join(' ') : query;
@@ -109,6 +117,10 @@ const Results = ({ history, location }: RouteChildrenProps) => {
         dataRenderer={dataRenderer}
       />
     );
+  }
+
+  if (inPanel) {
+    return <>{main}</>;
   }
 
   return (


### PR DESCRIPTION
## Purpose
Add contextual help side button and start adding some content in it

## Approach
- Move all side buttons (help + feedback) in their own component
- Use router for contextual internal routing logic and reuse components

## Testing
Updated test for existing component
Manual testing for now (behaviour will likely change in the future, so no point at this point)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
