### PR TITLE
2022 02 contextual help panel landing

### DIFF
--- a/src/help/components/contextual/Landing.tsx
+++ b/src/help/components/contextual/Landing.tsx
@@ -1,7 +1,98 @@
+import { useEffect, useState, useMemo } from 'react';
+import { throttle } from 'lodash-es';
+
+const headerHeight = 70; // 70px, also defined in _settings.scss -> keep in sync
+
+type InPageArticles = Map<string, boolean>;
+
+const getAllArticles = () => {
+  console.time('getting articles');
+  const inPageArticles: InPageArticles = new Map();
+
+  const screenHeight =
+    window.innerHeight || document.documentElement.clientHeight;
+  const screenWidth = window.innerWidth || document.documentElement.clientWidth;
+
+  for (const element of document.querySelectorAll<HTMLElement>(
+    '[data-article-id]'
+  )) {
+    const { articleId } = element.dataset;
+    /* istanbul ignore if */
+    if (!articleId) {
+      // eslint-disable-next-line no-continue
+      continue; // shouldn't happen
+    }
+    // If this article was already in the page, and visible
+    if (inPageArticles.get(articleId)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    const isVisible =
+      rect.top >= headerHeight &&
+      rect.left >= headerHeight &&
+      rect.bottom <= screenHeight &&
+      rect.right <= screenWidth;
+    inPageArticles.set(articleId, isVisible);
+    // NOTE: maybe optimisation if breaking the loop as soon as an element is
+    // not visible after the previous one was visible. Assumption of elements in
+    // order in HTML, and corresponding order in the page
+  }
+
+  console.timeEnd('getting articles');
+  return inPageArticles;
+};
+
 const Landing = () => {
-  // TODO: get all articles in page, and load their title in the panel
-  console.log('landing');
-  return <>Landing page</>;
+  const [inPageArticles, setInPageArticles] = useState<InPageArticles>(
+    new Map()
+  );
+
+  const updateContent = useMemo(
+    () =>
+      throttle(() => {
+        setInPageArticles(getAllArticles());
+      }, 500),
+    []
+  );
+
+  useEffect(() => {
+    updateContent();
+
+    const mutationObserver = new MutationObserver(() => {
+      updateContent();
+    });
+
+    const reactRoot = document.getElementById('root');
+    if (reactRoot) {
+      mutationObserver.observe(reactRoot, { childList: true, subtree: true });
+    }
+
+    window.addEventListener('scroll', updateContent, { passive: true });
+    window.addEventListener('resize', updateContent, { passive: true });
+
+    return () => {
+      mutationObserver.disconnect();
+
+      window.removeEventListener('scroll', updateContent);
+      window.removeEventListener('resize', updateContent);
+
+      updateContent.cancel();
+    };
+  }, [updateContent]);
+
+  return (
+    <section>
+      <h2 className="small">Start here</h2>
+      <ul className="no-bullet">
+        {Array.from(inPageArticles).map(([id, isVisible]) => (
+          <li key={id}>
+            {id} {isVisible ? '👀' : '🙈'}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
 };
 
 export default Landing;

--- a/src/help/components/contextual/NavigationBar.tsx
+++ b/src/help/components/contextual/NavigationBar.tsx
@@ -38,7 +38,15 @@ const NavigationBar = ({ localHistory }: { localHistory: MemoryHistory }) => {
       >
         ←
       </Button>{' '}
-      <Link to={LocationToPath[Location.HelpResults]}>
+      <Link
+        to={LocationToPath[Location.HelpResults]}
+        onClick={(event) => {
+          if (!event.metaKey && !event.ctrlKey) {
+            event.preventDefault();
+            localHistory.push(LocationToPath[Location.HelpResults]);
+          }
+        }}
+      >
         <h1 className="medium">Help</h1>
       </Link>{' '}
       <Button

--- a/src/help/components/contextual/styles/landing.module.css
+++ b/src/help/components/contextual/styles/landing.module.css
@@ -1,0 +1,9 @@
+.container li {
+  /* indentation in order to structure visually as we're not using bullets */
+  padding-inline-start: 1ch;
+}
+
+.in-view {
+  /* TODO: have nicer way to present visibility (vertical bar like in entry?) */
+  text-decoration: underline;
+}

--- a/src/help/components/contextual/styles/search-bar.module.scss
+++ b/src/help/components/contextual/styles/search-bar.module.scss
@@ -10,4 +10,8 @@
   & :global(.search-input__suffix) {
     color: $colour-help-green;
   }
+
+  & input {
+    margin: 0;
+  }
 }

--- a/src/help/components/contextual/styles/search-bar.module.scss
+++ b/src/help/components/contextual/styles/search-bar.module.scss
@@ -3,6 +3,7 @@
 
 .container {
   margin: -$global-margin;
+  margin-block-end: 0;
   position: sticky;
   top: -$global-margin;
   z-index: 1;

--- a/src/help/components/contextual/styles/shortcuts.module.scss
+++ b/src/help/components/contextual/styles/shortcuts.module.scss
@@ -8,7 +8,7 @@ $shadow-padding: 0.125rem;
 .container {
   background: lighten($colour-help-green, 50%);
   margin: -$global-margin;
-  margin-block-end: 0;
+  margin-block: 0;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   font-size: 90%;

--- a/src/shared/styles/_settings.scss
+++ b/src/shared/styles/_settings.scss
@@ -2,4 +2,5 @@ $gutter-size: 1rem;
 
 $action-buttons-height: 2.5rem;
 
+/*  also defined in help/components/contextual/Landing.tsx -> keep in sync */
 $header-height: 70px;


### PR DESCRIPTION
## Purpose
Landing page for the contextual help (part of https://www.ebi.ac.uk/panda/jira/browse/TRM-27303)

## Approach
Add content to the landing page:
 - If no help content in the page, default to a list of links (similar to the full page Help Centre)
 - If help content in the page, retrieve it and display links
   - Retrieve title for each article (limitation of the API, probably need an "accessions" endpoint for the help endpoints too)
   - Visual difference for those that are in the user's view (probably need to iterate on that later)
   - Scroll in the middle of the panel the help article corresponding to the first one in the user's view

## Testing
Manual test

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
