### PR TITLE
2022 02 links to supporting data

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -832,7 +832,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          ENZYME
+                          <a
+                            href="/database?query=(name:ENZYME)&direct"
+                          >
+                            ENZYME
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -2171,6 +2175,10 @@ exports[`Entry basic should render main 1`] = `
                             <div
                               id="id1term"
                             >
+                              <test-file-stub
+                                classname="sub-cell-viz__in-view-pin"
+                                height="1em"
+                              />
                               <strong>
                                 location value
                               </strong>
@@ -2827,7 +2835,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          ModBase
+                          <a
+                            href="/database?query=(name:ModBase)&direct"
+                          >
+                            ModBase
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -2860,7 +2872,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          SWISS-MODEL-Workspace
+                          <a
+                            href="/database?query=(name:SWISS-MODEL-Workspace)&direct"
+                          >
+                            SWISS-MODEL-Workspace
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -2925,7 +2941,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          Domain
+                          <a
+                            href="/keywords?query=(name:Domain)&direct"
+                          >
+                            Domain
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -2980,7 +3000,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          MobiDB
+                          <a
+                            href="/database?query=(name:MobiDB)&direct"
+                          >
+                            MobiDB
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -3013,7 +3037,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          ProtoNet
+                          <a
+                            href="/database?query=(name:ProtoNet)&direct"
+                          >
+                            ProtoNet
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"
@@ -3370,7 +3398,11 @@ exports[`Entry basic should render main 1`] = `
                         <div
                           class="decorated-list-item__title tiny"
                         >
-                          Ensembl
+                          <a
+                            href="/database?query=(name:Ensembl)&direct"
+                          >
+                            Ensembl
+                          </a>
                         </div>
                         <div
                           class="decorated-list-item__content"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryExternalLinks.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryExternalLinks.spec.tsx.snap
@@ -54,7 +54,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ENZYME
+                <a
+                  href="/database?query=(name:ENZYME)&direct"
+                >
+                  ENZYME
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -94,7 +98,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                MobiDB
+                <a
+                  href="/database?query=(name:MobiDB)&direct"
+                >
+                  MobiDB
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -127,7 +135,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ProtoNet
+                <a
+                  href="/database?query=(name:ProtoNet)&direct"
+                >
+                  ProtoNet
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -167,7 +179,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Ensembl
+                <a
+                  href="/database?query=(name:Ensembl)&direct"
+                >
+                  Ensembl
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -226,7 +242,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ModBase
+                <a
+                  href="/database?query=(name:ModBase)&direct"
+                >
+                  ModBase
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -259,7 +279,11 @@ exports[`Entry - External Links view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                SWISS-MODEL-Workspace
+                <a
+                  href="/database?query=(name:SWISS-MODEL-Workspace)&direct"
+                >
+                  SWISS-MODEL-Workspace
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -516,7 +516,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ENZYME
+                <a
+                  href="/database?query=(name:ENZYME)&direct"
+                >
+                  ENZYME
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2420,7 +2424,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ModBase
+                <a
+                  href="/database?query=(name:ModBase)&direct"
+                >
+                  ModBase
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2453,7 +2461,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                SWISS-MODEL-Workspace
+                <a
+                  href="/database?query=(name:SWISS-MODEL-Workspace)&direct"
+                >
+                  SWISS-MODEL-Workspace
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2518,7 +2530,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Domain
+                <a
+                  href="/keywords?query=(name:Domain)&direct"
+                >
+                  Domain
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2573,7 +2589,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                MobiDB
+                <a
+                  href="/database?query=(name:MobiDB)&direct"
+                >
+                  MobiDB
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2606,7 +2626,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ProtoNet
+                <a
+                  href="/database?query=(name:ProtoNet)&direct"
+                >
+                  ProtoNet
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -2963,7 +2987,11 @@ exports[`Entry view should render 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Ensembl
+                <a
+                  href="/database?query=(name:Ensembl)&direct"
+                >
+                  Ensembl
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -4290,7 +4318,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Molecular function
+                <a
+                  href="/keywords?query=(name:Molecular function)&direct"
+                >
+                  Molecular function
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -4323,7 +4355,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Ligand
+                <a
+                  href="/keywords?query=(name:Ligand)&direct"
+                >
+                  Ligand
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -4356,7 +4392,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ENZYME
+                <a
+                  href="/database?query=(name:ENZYME)&direct"
+                >
+                  ENZYME
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5346,7 +5386,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                SMR
+                <a
+                  href="/database?query=(name:SMR)&direct"
+                >
+                  SMR
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5379,7 +5423,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ModBase
+                <a
+                  href="/database?query=(name:ModBase)&direct"
+                >
+                  ModBase
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5412,7 +5460,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                PDBe-KB
+                <a
+                  href="/database?query=(name:PDBe-KB)&direct"
+                >
+                  PDBe-KB
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5849,7 +5901,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Domain
+                <a
+                  href="/keywords?query=(name:Domain)&direct"
+                >
+                  Domain
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5882,7 +5938,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Gene3D
+                <a
+                  href="/database?query=(name:Gene3D)&direct"
+                >
+                  Gene3D
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -5931,7 +5991,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                InterPro
+                <a
+                  href="/database?query=(name:InterPro)&direct"
+                >
+                  InterPro
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6033,7 +6097,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                PROSITE
+                <a
+                  href="/database?query=(name:PROSITE)&direct"
+                >
+                  PROSITE
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6081,7 +6149,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Pfam
+                <a
+                  href="/database?query=(name:Pfam)&direct"
+                >
+                  Pfam
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6144,7 +6216,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                SMART
+                <a
+                  href="/database?query=(name:SMART)&direct"
+                >
+                  SMART
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6192,7 +6268,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                SUPFAM
+                <a
+                  href="/database?query=(name:SUPFAM)&direct"
+                >
+                  SUPFAM
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6271,7 +6351,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                MobiDB
+                <a
+                  href="/database?query=(name:MobiDB)&direct"
+                >
+                  MobiDB
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6304,7 +6388,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                ProtoNet
+                <a
+                  href="/database?query=(name:ProtoNet)&direct"
+                >
+                  ProtoNet
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6929,7 +7017,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                Technical term
+                <a
+                  href="/keywords?query=(name:Technical term)&direct"
+                >
+                  Technical term
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -6962,7 +7054,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                RefSeq
+                <a
+                  href="/database?query=(name:RefSeq)&direct"
+                >
+                  RefSeq
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"
@@ -7003,7 +7099,11 @@ exports[`Entry view should render for non-human entry 1`] = `
               <div
                 class="decorated-list-item__title tiny"
               >
-                GeneID
+                <a
+                  href="/database?query=(name:GeneID)&direct"
+                >
+                  GeneID
+                </a>
               </div>
               <div
                 class="decorated-list-item__content"

--- a/src/uniprotkb/components/protein-data-views/KeywordView.tsx
+++ b/src/uniprotkb/components/protein-data-views/KeywordView.tsx
@@ -4,7 +4,11 @@ import { Link } from 'react-router-dom';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
-import { getEntryPath } from '../../../app/config/urls';
+import {
+  getEntryPath,
+  LocationToPath,
+  Location,
+} from '../../../app/config/urls';
 
 import { Namespace } from '../../../shared/types/namespaces';
 import { Keyword, KeywordUIModel } from '../../utils/KeywordsUtil';
@@ -53,23 +57,27 @@ export const KeywordList = ({ keywords, idOnly, inline }: KeywordListProps) => {
   );
 };
 
-const KeywordView = ({ keywords }: { keywords: KeywordUIModel[] }) => {
-  if (!keywords?.length) {
-    return null;
-  }
-  const infoData = keywords.map((keywordCategory) => ({
-    title: keywordCategory.category,
+const KeywordView = ({ keywords }: { keywords?: KeywordUIModel[] }) => {
+  const infoData = keywords?.map((keywordCategory) => ({
+    title: (
+      <Link
+        to={{
+          pathname: LocationToPath[Location.KeywordsResults],
+          search: `query=(name:${keywordCategory.category})&direct`,
+        }}
+      >
+        {keywordCategory.category}
+      </Link>
+    ),
     content: <KeywordList keywords={keywordCategory.keywords} />,
   }));
-  if (!infoData.length) {
-    return null;
-  }
-  return (
+
+  return infoData?.length ? (
     <>
       <h3 data-article-id="keywords">Keywords</h3>
       <InfoList infoData={infoData} />
     </>
-  );
+  ) : null;
 };
 
 export default KeywordView;

--- a/src/uniprotkb/components/protein-data-views/SubcellularLocationGOView.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubcellularLocationGOView.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { ExternalLink } from 'franklin-sites';
+import { ExternalLink, LocationPinIcon } from 'franklin-sites';
 
 import externalUrls from '../../../shared/config/externalUrls';
 
@@ -31,6 +31,10 @@ const SubcellularLocationGOView: FC<{
             // with @swissprot/swissbiopics-visualizer
             className={getSwissBioPicLocationId(id)}
           >
+            <LocationPinIcon
+              className="sub-cell-viz__in-view-pin"
+              height="1em"
+            />
             <ExternalLink url={externalUrls.QuickGO(id)}>
               {properties.GoTerm}
             </ExternalLink>

--- a/src/uniprotkb/components/protein-data-views/SubcellularLocationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubcellularLocationView.tsx
@@ -1,9 +1,13 @@
+import { Link } from 'react-router-dom';
 import { LocationPinIcon } from 'franklin-sites';
 
 import { TextView } from './FreeTextView';
+import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
+
+import { getEntryPath } from '../../../app/config/urls';
 
 import { SubcellularLocationComment } from '../../types/commentTypes';
-import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
+import { Namespace } from '../../../shared/types/namespaces';
 
 import './styles/sub-cell-viz.scss';
 
@@ -34,7 +38,17 @@ const SubcellularLocationView = ({ comments }: Props) => {
                       className="sub-cell-viz__in-view-pin"
                       height="1em"
                     />
-                    <strong>{location.value}</strong>{' '}
+                    <strong>
+                      {location.id ? (
+                        <Link
+                          to={getEntryPath(Namespace.locations, location.id)}
+                        >
+                          {location.value}
+                        </Link>
+                      ) : (
+                        location.value
+                      )}
+                    </strong>{' '}
                     {location.evidences && (
                       <UniProtKBEvidenceTag evidences={location.evidences} />
                     )}

--- a/src/uniprotkb/components/protein-data-views/SubcellularLocationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubcellularLocationView.tsx
@@ -1,15 +1,17 @@
-import { FC } from 'react';
+import { LocationPinIcon } from 'franklin-sites';
 
 import { TextView } from './FreeTextView';
 
 import { SubcellularLocationComment } from '../../types/commentTypes';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
+import './styles/sub-cell-viz.scss';
+
 const getSwissBioPicLocationId = (id: string) => `${id.replace('-', '')}term`;
 
-const SubcellularLocationView: FC<{
-  comments?: SubcellularLocationComment[];
-}> = ({ comments }) => {
+type Props = { comments?: SubcellularLocationComment[] };
+
+const SubcellularLocationView = ({ comments }: Props) => {
   if (!comments?.length) {
     return null;
   }
@@ -28,6 +30,10 @@ const SubcellularLocationView: FC<{
                     id={location.id && getSwissBioPicLocationId(location.id)}
                     key={`${location.value}${topology?.value}`}
                   >
+                    <LocationPinIcon
+                      className="sub-cell-viz__in-view-pin"
+                      height="1em"
+                    />
                     <strong>{location.value}</strong>{' '}
                     {location.evidences && (
                       <UniProtKBEvidenceTag evidences={location.evidences} />

--- a/src/uniprotkb/components/protein-data-views/SubcellularLocationWithVizView.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubcellularLocationWithVizView.tsx
@@ -1,5 +1,5 @@
 import { FC, Suspense, lazy, ReactNode, ReactElement } from 'react';
-import { Tabs, Tab } from 'franklin-sites';
+import { Tabs, Tab, HeroContainer } from 'franklin-sites';
 
 import SubcellularLocationView from './SubcellularLocationView';
 import SubcellularLocationGOView from './SubcellularLocationGOView';
@@ -56,7 +56,7 @@ export const getSubcellularLocationId = (id: string) =>
 export const getGoId = (id: string) => id.match(/GO:(\d+)/)?.[1];
 
 const getNoAnnotationMessage = (name: string) => (
-  <>{`No specific ${name} annotations available regarding subcellular location.`}</>
+  <HeroContainer>{`No specific ${name} annotations available regarding subcellular location.`}</HeroContainer>
 );
 
 const SubcellularLocationWithVizView: FC<

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -354,7 +354,7 @@ const XRefsGroupedByCategory = ({
         <Link
           to={{
             pathname: LocationToPath[Location.DatabaseResults],
-            search: `query=(name:${databaseInfo.name})&direct`,
+            search: `query=(name:${databaseInfo.displayName})&direct`,
           }}
         >
           {databaseInfo.displayName}

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -1,6 +1,8 @@
 import { Fragment } from 'react';
 import { isEqual, sortBy, uniqWith } from 'lodash-es';
 import { InfoList, ExternalLink, ExpandableList } from 'franklin-sites';
+import { Link } from 'react-router-dom';
+import { InfoListItem } from 'franklin-sites/dist/types/components/info-list';
 
 import { pluralise } from '../../../shared/utils/utils';
 import * as logging from '../../../shared/utils/logging';
@@ -18,9 +20,9 @@ import {
   XrefsGoupedByDatabase,
   partitionStructureDatabases,
 } from '../../utils/xrefUtils';
-
 import externalUrls from '../../../shared/config/externalUrls';
 
+import { LocationToPath, Location } from '../../../app/config/urls';
 import { Xref } from '../../../shared/types/apiModel';
 import { PropertyKey } from '../../types/modelTypes';
 import {
@@ -79,11 +81,7 @@ export const getPropertyLinkAttributes = (
     return null;
   }
   const attribute = getDatabaseInfoAttribute(attributes, property);
-  const { properties } = xref;
-  if (!properties) {
-    return null;
-  }
-  const id = properties[property];
+  const id = xref.properties?.[property];
   if (!id || !attribute || !attribute.uriLink) {
     return null;
   }
@@ -346,30 +344,32 @@ const XRefsGroupedByCategory = ({
     return null;
   }
   const { databaseToDatabaseInfo } = databaseInfoMaps;
-  const infoData = sortBy(databases, ({ database }) => [
+  const infoData: InfoListItem[] = sortBy(databases, ({ database }) => [
     databaseToDatabaseInfo?.[database].implicit,
     database,
-  ]).map(
-    (
-      database
-    ): {
-      title: string;
-      content: JSX.Element;
-    } => {
-      const databaseInfo = databaseToDatabaseInfo[database.database];
-      return {
-        title: databaseInfo.displayName,
-        content: (
-          <DatabaseList
-            xrefsGoupedByDatabase={database}
-            primaryAccession={primaryAccession}
-            crc64={crc64}
-            databaseToDatabaseInfo={databaseToDatabaseInfo}
-          />
-        ),
-      };
-    }
-  );
+  ]).map((database) => {
+    const databaseInfo = databaseToDatabaseInfo[database.database];
+    return {
+      title: (
+        <Link
+          to={{
+            pathname: LocationToPath[Location.DatabaseResults],
+            search: `query=(name:${databaseInfo.name})&direct`,
+          }}
+        >
+          {databaseInfo.displayName}
+        </Link>
+      ),
+      content: (
+        <DatabaseList
+          xrefsGoupedByDatabase={database}
+          primaryAccession={primaryAccession}
+          crc64={crc64}
+          databaseToDatabaseInfo={databaseToDatabaseInfo}
+        />
+      ),
+    };
+  });
   return <InfoList infoData={infoData} columns />;
 };
 

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/KeywordView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/KeywordView.spec.tsx.snap
@@ -17,7 +17,11 @@ exports[`Keyword should render Keywords for section 1`] = `
         <div
           class="decorated-list-item__title tiny"
         >
-          Cellular component
+          <a
+            href="/keywords?query=(name:Cellular component)&direct"
+          >
+            Cellular component
+          </a>
         </div>
         <div
           class="decorated-list-item__content"

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/SubcellularLocationGOView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/SubcellularLocationGOView.spec.tsx.snap
@@ -8,6 +8,10 @@ exports[`SubcellularLocationGOView should render 1`] = `
     <li
       class="GO5576"
     >
+      <test-file-stub
+        classname="sub-cell-viz__in-view-pin"
+        height="1em"
+      />
       <a
         class="external-link"
         href="//www.ebi.ac.uk/QuickGO/term/GO:0005576"
@@ -24,6 +28,10 @@ exports[`SubcellularLocationGOView should render 1`] = `
     <li
       class="GO5615"
     >
+      <test-file-stub
+        classname="sub-cell-viz__in-view-pin"
+        height="1em"
+      />
       <a
         class="external-link"
         href="//www.ebi.ac.uk/QuickGO/term/GO:0005615"

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
@@ -15,7 +15,11 @@ exports[`XRefView should render section 1`] = `
         <div
           class="decorated-list-item__title tiny"
         >
-          EMBL
+          <a
+            href="/database?query=(name:EMBL)&direct"
+          >
+            EMBL
+          </a>
         </div>
         <div
           class="decorated-list-item__content"

--- a/src/uniprotkb/components/protein-data-views/styles/sub-cell-viz.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/sub-cell-viz.scss
@@ -1,20 +1,26 @@
 @import 'franklin-sites/src/styles/colours';
 
+.sub-cell-viz__in-view-pin {
+  display: none;
+}
+
 .inpicture {
   cursor: default;
 
-  &:before {
-    content: '🔎';
-    margin-right: 0.5em;
+  & .sub-cell-viz__in-view-pin {
+    display: initial;
+    margin-inline: 0.1ch 0.5ch;
   }
 
   &.lookedAt,
   &:hover {
     background-color: $colour-sea-blue;
     color: white;
+
     article {
       color: black;
     }
+
     & > a {
       color: white;
     }

--- a/src/uniprotkb/components/protein-data-views/styles/sub-cell-viz.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/sub-cell-viz.scss
@@ -17,11 +17,11 @@
     background-color: $colour-sea-blue;
     color: white;
 
-    article {
+    & article {
       color: black;
     }
 
-    & > a {
+    & a {
       color: white;
     }
   }

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -749,6 +749,10 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_subcell
     <div
       id="id1term"
     >
+      <test-file-stub
+        classname="sub-cell-viz__in-view-pin"
+        height="1em"
+      />
       <strong>
         location value
       </strong>


### PR DESCRIPTION
## Purpose
Add links to supporting data pages (instead of current website's contextual help) -> from sprint board
Also, https://www.ebi.ac.uk/panda/jira/browse/TRM-26988 & https://www.ebi.ac.uk/panda/jira/browse/TRM-26761

## Approach
On UniProtKB pages, replace where we refer to databases, subcellular locations, and keywords, with links.
Also, tackled the 2 above jiras as part of this because I touched the subcell location part.
For subcell location, link to ID.
For Databases and remaining Keywords (categories), we don't have IDs in the data so link to a search and redirect if we can (if only 1 result). That's the best I could do with the data we had at this moment.

## Testing
Updated snapshots + manual checks

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
