### PR TITLE
fix issue in mutagenesis display of sequence change

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -2663,7 +2663,7 @@ exports[`Entry basic should render main 1`] = `
                               <strong>
                                 Sequence: 
                               </strong>
-                              APSQDFM
+                              original value → alternative value
                             </td>
                           </tr>
                         </tbody>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2248,7 +2248,7 @@ exports[`Entry view should render 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    APSQDFM
+                    original value → alternative value
                   </td>
                 </tr>
               </tbody>
@@ -4886,7 +4886,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    E
+                    E → A or L
                   </td>
                 </tr>
                 <tr
@@ -4940,7 +4940,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    C
+                    C → A or S
                   </td>
                 </tr>
                 <tr
@@ -4994,7 +4994,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    D
+                    D → N
                   </td>
                 </tr>
                 <tr
@@ -5048,7 +5048,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    H
+                    H → A or F
                   </td>
                 </tr>
                 <tr
@@ -5102,7 +5102,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     <strong>
                       Sequence: 
                     </strong>
-                    Y
+                    Y → F
                   </td>
                 </tr>
               </tbody>

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -54,8 +54,8 @@ export const UniProtEvidenceTagContent = ({
       {Object.entries(groupedEvidencesWithoutPubs).map(
         ([key, mappedEvidences], index) => (
           <Fragment key={key || index}>
-            {mappedEvidences.map(({ id }: Evidence) => (
-              <div key={id}>
+            {mappedEvidences.map(({ id }: Evidence, index) => (
+              <div key={id || index}>
                 <EvidenceLink source={key} value={id} />
               </div>
             ))}

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1211,6 +1211,18 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
           </a>
         </td>
       </tr>
+      <tr
+        data-end="8"
+        data-group-for="id value CHAIN"
+        data-start="2"
+      >
+        <td>
+          <strong>
+            Sequence: 
+          </strong>
+          original value → alternative value
+        </td>
+      </tr>
     </tbody>
   </table>
 </DocumentFragment>


### PR DESCRIPTION
## Purpose
Fix display issue in mutagenesis display of changed sequence https://www.ebi.ac.uk/panda/jira/browse/TRM-27423

## Approach
Display the alternative sequence (matches display of the current website)

## Testing
Updated snapshot + manual checks

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

To check:
Check the phenotypes or pathology & biotech section of an entry, features table showing mutagenesis, open the row to display the sequence. Main cases:
`sequence → sequence`: most entries
`sequence → sequence or sequence`: P0DTR4
`Missing`: first mutagenesis row in P0DTC2
