### PR TITLE
2022 03 share url consume

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "global": {
         "lines": 82.14,
         "statements": 81.92,
-        "functions": 82.12,
+        "functions": 82.06,
         "branches": 69.6
       }
     },

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -74,12 +74,9 @@ const Download: FC<DownloadProps> = ({
     data: '',
   });
   const { search: queryParamFromUrl } = useLocation();
-  const {
-    query: queryFromUrl,
-    selectedFacets = [],
-    sortColumn,
-    sortDirection,
-  } = getParamsFromURL(queryParamFromUrl);
+  const [
+    { query: queryFromUrl, selectedFacets = [], sortColumn, sortDirection },
+  ] = getParamsFromURL(queryParamFromUrl);
 
   const [selectedIdField] = nsToPrimaryKeyColumns(namespace);
 

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -63,7 +63,7 @@ const Results = () => {
     total = +resultsDataTotal;
   }
 
-  const params = getParamsFromURL(search);
+  const [params] = getParamsFromURL(search);
 
   const helmet = ns && (
     <HTMLHead

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -89,17 +89,16 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const [urlParams, invalidParamValues] = getParamsFromURL(
+  const [urlParams, invalidParamValues, unknownParams] = getParamsFromURL(
     history.location.search,
     namespace
   );
-  if (invalidParamValues.length) {
-    dispatch(
-      addMessage({
-        id: 'invalid url params',
-        content: (
+  if (invalidParamValues.length || unknownParams.length) {
+    const content = (
+      <>
+        {invalidParamValues.length > 0 && (
           <>
-            Ignoring invalid URL parameter values:
+            Ignoring invalid URL values:
             <ul>
               {invalidParamValues.map(({ parameter, value }) => (
                 <li>
@@ -109,10 +108,28 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
               ))}
             </ul>
           </>
-        ),
+        )}
+        {unknownParams.length > 0 && (
+          <>
+            Ignoring invalid URL parameters:
+            <ul>
+              {unknownParams.map((unknownParam) => (
+                <li>
+                  <b>{unknownParam}</b>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </>
+    );
+    dispatch(
+      addMessage({
+        id: 'invalid url params',
+        content,
         format: MessageFormat.POP_UP,
         level: MessageLevel.WARNING,
-        displayTime: 5_000,
+        displayTime: 15_000,
       })
     );
   }

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
 } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import cn from 'classnames';
 import {
   DownloadIcon,
@@ -30,16 +31,21 @@ import ErrorBoundary from '../error-component/ErrorBoundary';
 import useLocalStorage from '../../hooks/useLocalStorage';
 import useNS from '../../hooks/useNS';
 
+import { addMessage } from '../../../messages/state/messagesActions';
 import lazy from '../../utils/lazy';
-
-import { Namespace, mainNamespaces } from '../../types/namespaces';
-import { defaultViewMode, ViewMode } from './ResultsData';
-
-import './styles/results-buttons.scss';
 import {
   getLocationObjForParams,
   getParamsFromURL,
 } from '../../../uniprotkb/utils/resultsUtils';
+
+import { Namespace, mainNamespaces } from '../../types/namespaces';
+import { defaultViewMode, ViewMode } from './ResultsData';
+import {
+  MessageFormat,
+  MessageLevel,
+} from '../../../messages/types/messagesTypes';
+
+import './styles/results-buttons.scss';
 
 const DownloadComponent = lazy(
   /* istanbul ignore next */
@@ -81,8 +87,26 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     defaultViewMode
   );
   const history = useHistory();
+  const dispatch = useDispatch();
 
-  const urlParams = getParamsFromURL(history.location.search, namespace);
+  const [urlParams, invalidParamValues] = getParamsFromURL(
+    history.location.search,
+    namespace
+  );
+  if (invalidParamValues.length) {
+    const invalid = invalidParamValues
+      .map(({ parameter, value }) => `${parameter}: ${value}`)
+      .join('\n');
+    dispatch(
+      addMessage({
+        id: 'invalid url params',
+        content: `Ignoring the following invalid parameter values:\n${invalid}`,
+        format: MessageFormat.POP_UP,
+        level: MessageLevel.WARNING,
+        displayTime: 5_000,
+      })
+    );
+  }
 
   // TODO: eventually remove it
   // This is just to convert for people currently using the website as they

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -94,13 +94,22 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     namespace
   );
   if (invalidParamValues.length) {
-    const invalid = invalidParamValues
-      .map(({ parameter, value }) => `${parameter}: ${value}`)
-      .join('\n');
     dispatch(
       addMessage({
         id: 'invalid url params',
-        content: `Ignoring the following invalid parameter values:\n${invalid}`,
+        content: (
+          <>
+            Ignoring invalid URL parameter values:
+            <ul>
+              {invalidParamValues.map(({ parameter, value }) => (
+                <li>
+                  <b>{parameter}</b>
+                  {`: ${value}`}
+                </li>
+              ))}
+            </ul>
+          </>
+        ),
         format: MessageFormat.POP_UP,
         level: MessageLevel.WARNING,
         displayTime: 5_000,

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -147,16 +147,9 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     }
   }, [setViewMode, viewMode]);
 
-  useEffect(() => {
-    if (urlParams.viewMode) {
-      setViewMode(urlParams.viewMode);
-    }
-  }, [setViewMode, urlParams.viewMode]);
-
   const onViewModeToggle = useCallback(() => {
     if (urlParams.viewMode) {
       // Use the URL as the source of truth until a user creates a new query
-      // TODO: Leave the user's stored view preference alone
       urlParams.viewMode = toggleViewMode(urlParams.viewMode);
       // TODO: this changes the URL from encoded to decoded which is different to the faucet behavior
       history.replace(

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -54,11 +54,9 @@ const ResultsData = ({
     defaultViewMode
   );
   const history = useHistory();
-  const {
-    query,
-    direct,
-    viewMode: viewModeFromUrl,
-  } = getParamsFromURL(useLocation().search);
+  const [{ query, direct, viewMode: viewModeFromUrl }] = getParamsFromURL(
+    useLocation().search
+  );
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -54,9 +54,9 @@ const ResultsData = ({
     defaultViewMode
   );
   const history = useHistory();
-  const [{ query, direct, viewMode: viewModeFromUrl }] = getParamsFromURL(
-    useLocation().search
-  );
+  const [
+    { query, direct, viewMode: viewModeFromUrl, columns: columnsFromUrl },
+  ] = getParamsFromURL(useLocation().search, namespace);
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,
@@ -72,7 +72,14 @@ const ResultsData = ({
     progress,
   } = resultsDataObject;
 
-  const viewMode = viewModeFromUrl || viewModeFromStorage;
+  let viewMode: ViewMode;
+  if (viewModeFromUrl) {
+    viewMode = viewModeFromUrl;
+  } else if (columnsFromUrl?.length) {
+    viewMode = 'table';
+  } else {
+    viewMode = viewModeFromStorage;
+  }
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -49,9 +49,16 @@ const ResultsData = ({
   className,
 }: Props) => {
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode] = useLocalStorage<ViewMode>('view-mode', defaultViewMode);
+  const [viewModeFromStorage] = useLocalStorage<ViewMode>(
+    'view-mode',
+    defaultViewMode
+  );
   const history = useHistory();
-  const { query, direct } = getParamsFromURL(useLocation().search);
+  const {
+    query,
+    direct,
+    viewMode: viewModeFromUrl,
+  } = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,
@@ -66,6 +73,8 @@ const ResultsData = ({
     hasMoreData,
     progress,
   } = resultsDataObject;
+
+  const viewMode = viewModeFromUrl || viewModeFromStorage;
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {
@@ -142,7 +151,6 @@ const ResultsData = ({
   ) {
     return <Loader progress={progress} />;
   }
-
   return (
     <div className="results-data">
       {viewMode === 'card' && !displayIdMappingColumns ? (

--- a/src/shared/components/results/__tests__/Results.spec.tsx
+++ b/src/shared/components/results/__tests__/Results.spec.tsx
@@ -60,4 +60,28 @@ describe('Results component', () => {
       );
     });
   });
+
+  it('should show card view if URL has view=card as well as fields', async () => {
+    customRender(<Results />, {
+      route: '/uniprotkb?query=blah&view=card&fields=accession,id',
+      initialLocalStorage: {
+        'view-mode': 'table' as ViewMode,
+        'table columns for uniprotkb': [UniProtKBColumn.accession],
+      },
+    });
+    const cards = await screen.findAllByText('Gene:');
+    expect(cards).toBeTruthy();
+  });
+
+  it('should show table view if URL has no view specified but has fields', async () => {
+    customRender(<Results />, {
+      route: '/uniprotkb?query=blah&fields=accession,id',
+      initialLocalStorage: {
+        'view-mode': 'card' as ViewMode,
+        'table columns for uniprotkb': [UniProtKBColumn.accession],
+      },
+    });
+    const table = await screen.findByText('Entry');
+    expect(table).toBeInTheDocument();
+  });
 });

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -198,14 +198,16 @@ const useColumns = (
   const databaseInfoMaps = useDatabaseInfoMaps();
 
   const { search: queryParamFromUrl } = location;
-  const {
-    query,
-    selectedFacets,
-    sortColumn,
-    sortDirection,
-    columns: columnsFromUrl,
-    viewMode: viewModeFromUrl,
-  } = getParamsFromURL(queryParamFromUrl, namespace);
+  const [
+    {
+      query,
+      selectedFacets,
+      sortColumn,
+      sortDirection,
+      columns: columnsFromUrl,
+      viewMode: viewModeFromUrl,
+    },
+  ] = getParamsFromURL(queryParamFromUrl, namespace);
 
   const { data: dataResultFields, loading } = useDataApi<ReceivedFieldData>(
     // For now, assume no configure endpoint for supporting data

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -41,14 +41,16 @@ const useNSQuery = ({
   );
 
   const { search: queryParamFromUrl } = location;
-  const {
-    query,
-    selectedFacets,
-    sortColumn,
-    sortDirection,
-    viewMode: viewModeFromUrl,
-    columns: columnsFromUrl,
-  } = getParamsFromURL(queryParamFromUrl, namespace);
+  const [
+    {
+      query,
+      selectedFacets,
+      sortColumn,
+      sortDirection,
+      viewMode: viewModeFromUrl,
+      columns: columnsFromUrl,
+    },
+  ] = getParamsFromURL(queryParamFromUrl, namespace);
 
   const viewMode = viewModeFromUrl || viewModeFromStorage;
 

--- a/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
+++ b/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
@@ -56,12 +56,12 @@ DatabaseColumnConfiguration.set(DatabaseColumn.category, {
     category && (
       <Link
         to={({ search }) => {
-          const parsed = getParamsFromURL(search);
+          const [params] = getParamsFromURL(search);
           return getLocationObjForParams({
             pathname: LocationToPath[Location.DatabaseResults],
-            ...parsed,
+            ...params,
             selectedFacets: [
-              ...parsed.selectedFacets.filter(
+              ...params.selectedFacets.filter(
                 ({ name }) => name !== 'category_exact'
               ),
               { name: 'category_exact', value: category },

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -23,10 +23,7 @@ import useDataApi, {
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
 
-import {
-  getParamsFromURL,
-  URLResultParams,
-} from '../../../../uniprotkb/utils/resultsUtils';
+import { getParamsFromURL } from '../../../../uniprotkb/utils/resultsUtils';
 import {
   filterBlastDataForResults,
   filterBlastByFacets,
@@ -216,7 +213,7 @@ const BlastResult = () => {
   );
 
   // extract facets and other info from URL querystring
-  const urlParams: URLResultParams = useMemo(
+  const [urlParams] = useMemo(
     () => getParamsFromURL(location.search),
     [location.search]
   );

--- a/src/tools/blast/components/results/BlastResultLocalFacets.tsx
+++ b/src/tools/blast/components/results/BlastResultLocalFacets.tsx
@@ -119,7 +119,7 @@ const BlastResultLocalFacets: FC<{
 }> = ({ allHits, namespace }) => {
   const { search: queryParamFromUrl } = useLocation();
 
-  const { selectedFacets } = getParamsFromURL(queryParamFromUrl);
+  const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
 
   // get data from accessions endpoint with facets applied
   const { data, isStale, loading } = useDataApiWithStale<Response['data']>(

--- a/src/tools/blast/components/results/BlastResultSidebar.tsx
+++ b/src/tools/blast/components/results/BlastResultSidebar.tsx
@@ -37,7 +37,7 @@ type BlastResultSidebarProps = {
 const BlastResultSidebar = memo<BlastResultSidebarProps>(
   ({ accessions, allHits, namespace }) => {
     const { search } = useLocation();
-    const { selectedFacets } = getParamsFromURL(search);
+    const [{ selectedFacets }] = getParamsFromURL(search);
     const dataApiObject = useDataApiWithStale<Response['data']>(
       // For UniRef, the only avalailable facet is the identity value, which
       // doesn't make sense in BLAST's context where all have the same value

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -50,7 +50,7 @@ const IDMappingResult = () => {
   const location = useLocation();
   const databaseInfoMaps = useDatabaseInfoMaps();
   const { search: queryParamFromUrl } = location;
-  const { selectedFacets } = getParamsFromURL(queryParamFromUrl);
+  const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
 
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -75,7 +75,7 @@ const Entry: FC = () => {
 
   const baseURL = apiUrls.entry(match?.params.accession, Namespace.uniparc);
   const xRefsURL = useMemo(() => {
-    const { selectedFacets } = getParamsFromURL(search);
+    const [{ selectedFacets }] = getParamsFromURL(search);
     if (!selectedFacets.length) {
       return baseURL;
     }

--- a/src/uniprotkb/components/entry/EntryPublications.tsx
+++ b/src/uniprotkb/components/entry/EntryPublications.tsx
@@ -195,7 +195,7 @@ const hasReference = (
 
 const EntryPublications: FC<{ accession: string }> = ({ accession }) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
   const initialUrl = getUniProtPublicationsQueryUrl({
     accession,
     selectedFacets,

--- a/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
+++ b/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
@@ -17,7 +17,7 @@ import helper from '../../../shared/styles/helper.module.scss';
 const EntryPublicationsFacets: FC<{ accession: string }> = ({ accession }) => {
   const { search } = useLocation();
 
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
   const url = getUniProtPublicationsQueryUrl({
     accession,
     facets: ['types', 'categories', 'is_large_scale'],

--- a/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
+++ b/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getParamsFromURL,
   getSortableColumnToSortColumn,
   sortInteractionData,
 } from '../resultsUtils';
@@ -8,6 +9,7 @@ import { ReceivedFieldData } from '../../types/resultsTypes';
 import resultFields from '../../__mocks__/resultFields';
 import { Interactant } from '../../adapters/interactionConverter';
 import { InteractionType } from '../../types/commentTypes';
+import { Namespace } from '../../../shared/types/namespaces';
 
 describe('getSortableColumnToSortColumn', () => {
   it('should return columns with the sortField property', () => {
@@ -40,6 +42,49 @@ describe('getSortableColumnToSortColumn', () => {
       { intActId: 'C' },
       { intActId: 'A', geneName: 'AA' },
       { intActId: 'A', geneName: 'AB' },
+    ]);
+  });
+});
+
+describe('getParamsFromURL', () => {
+  it('should get parameters from URL', () => {
+    expect(
+      getParamsFromURL(
+        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id&view=table',
+        Namespace.uniprotkb
+      )
+    ).toEqual([
+      {
+        query: '*',
+        selectedFacets: [],
+        sortColumn: 'id',
+        sortDirection: 'ascend',
+        direct: false,
+        columns: ['accession', 'reviewed', 'id'],
+        viewMode: 'table',
+      },
+      [],
+      [],
+    ]);
+  });
+  it('should get parameters, invalid values, unknown params from URL', () => {
+    expect(
+      getParamsFromURL(
+        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id,foo&view=table&bar=baz',
+        Namespace.uniprotkb
+      )
+    ).toEqual([
+      {
+        query: '*',
+        selectedFacets: [],
+        sortColumn: 'id',
+        sortDirection: 'ascend',
+        direct: false,
+        columns: ['accession', 'reviewed', 'id'],
+        viewMode: 'table',
+      },
+      [{ parameter: 'columns', value: ['foo'] }],
+      ['bar'],
     ]);
   });
 });

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -72,7 +72,7 @@ export const getParamsFromURL = (
     const columnConfig = ColumnConfigurations[namespace];
     const columns = new Set(columnConfig?.keys());
     const [validColumns, invalidColumns] = partition(columnsAsArray, (column) =>
-      columns.has(column) ? 'validColumns' : 'invalidColumns'
+      columns.has(column)
     );
     if (invalidColumns?.length) {
       invalidValues.push({ parameter: 'columns', value: invalidColumns });

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -58,7 +58,7 @@ export const getParamsFromURL = (
     direct,
     fields,
     view,
-    ...restParameters
+    ...restParams
   } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
@@ -99,9 +99,9 @@ export const getParamsFromURL = (
     }
   }
 
-  const unknownParameters = Object.keys(restParameters);
+  const unknownParams = Object.keys(restParams);
 
-  return [params, invalidValues, unknownParameters];
+  return [params, invalidValues, unknownParams];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -78,7 +78,7 @@ export const getParamsFromURL = (
     direct: direct !== undefined,
   };
 
-  if (fields && namespace) {
+  if (fields && namespace && namespace !== Namespace.idmapping) {
     const columnsAsArray = Array.isArray(fields) ? fields : fields?.split(',');
     const columnConfig = ColumnConfigurations[namespace];
     const columns = new Set(columnConfig?.keys());

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -40,15 +40,26 @@ type InvalidParamValues = {
   value: string | string[];
 }[];
 
+type UnknownParams = string[];
+
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 
 export const getParamsFromURL = (
   url: string,
   namespace?: Namespace
-): [URLResultParams, InvalidParamValues] => {
+): [URLResultParams, InvalidParamValues, UnknownParams] => {
   const invalidValues = [];
-  const { query, facets, sort, dir, activeFacet, direct, fields, view } =
-    qs.parse(url);
+  const {
+    query,
+    facets,
+    sort,
+    dir,
+    activeFacet,
+    direct,
+    fields,
+    view,
+    ...restParameters
+  } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {
@@ -88,7 +99,9 @@ export const getParamsFromURL = (
     }
   }
 
-  return [params, invalidValues];
+  const unknownParameters = Object.keys(restParameters);
+
+  return [params, invalidValues, unknownParameters];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -35,12 +35,18 @@ export type URLResultParams = {
   viewMode?: ViewMode;
 };
 
+type InvalidParamValues = {
+  parameter: string;
+  value: string | string[];
+}[];
+
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 
 export const getParamsFromURL = (
   url: string,
   namespace?: Namespace
-): URLResultParams => {
+): [URLResultParams, InvalidParamValues] => {
+  const invalidValues = [];
   const { query, facets, sort, dir, activeFacet, direct, fields, view } =
     qs.parse(url);
 
@@ -69,20 +75,20 @@ export const getParamsFromURL = (
       columns.has(column) ? 'validColumns' : 'invalidColumns'
     );
     if (invalidColumns?.length) {
-      // TODO: warn
+      invalidValues.push({ parameter: 'columns', value: invalidColumns });
     }
     params.columns = validColumns as Column[];
   }
 
-  if (view && typeof view === 'string') {
-    if (viewModes.has(view as ViewMode)) {
+  if (view) {
+    if (typeof view === 'string' && viewModes.has(view as ViewMode)) {
       params.viewMode = view as ViewMode;
     } else {
-      // TODO: warn
+      invalidValues.push({ parameter: 'view', value: view });
     }
   }
 
-  return params;
+  return [params, invalidValues];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniref/components/entry/MembersFacets.tsx
+++ b/src/uniref/components/entry/MembersFacets.tsx
@@ -16,7 +16,7 @@ import helper from '../../../shared/styles/helper.module.scss';
 
 const MembersFacet = memo<{ accession: string }>(({ accession }) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
 
   const selectedFacetsStrings = selectedFacets.map(
     (facet) => `${facet.name}:${facet.value}`

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -261,7 +261,7 @@ export const MembersSection = ({
   representativeMember,
 }: Props) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
 
   const initialUrl = apiUrls.members(id, {
     selectedFacets: selectedFacets.map(


### PR DESCRIPTION
## Purpose
Consume view and fields parameters from the url.

## Approach
- Update `getParamsFromURL` to
  - Extract view and fields
  - Accept an optional namespace argument and use this to determine if valid columns names have been passed
  - Return any invalid params/values
- Use output of `getParamsFromURL` to determine which view and fields to use through result fetching
- If invalid param/value send a message to user
- Keep view and fields in URL when switching viewMode and sorting columns

## Testing
- Updated tests

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
