### PR TITLE
2022 03 share url consume v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "global": {
         "lines": 82.14,
         "statements": 81.92,
-        "functions": 82.12,
+        "functions": 82.06,
         "branches": 69.6
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "global": {
         "lines": 82.14,
         "statements": 81.92,
-        "functions": 82.06,
+        "functions": 82.08,
         "branches": 69.6
       }
     },

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -5,7 +5,6 @@ import { DropdownButton, Button, CopyIcon } from 'franklin-sites';
 import { createPath } from 'history';
 
 import useNS from '../../hooks/useNS';
-import useLocalStorage from '../../hooks/useLocalStorage';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 
@@ -14,8 +13,8 @@ import {
   MessageFormat,
   MessageLevel,
 } from '../../../messages/types/messagesTypes';
-import { Column, nsToDefaultColumns } from '../../config/columns';
-import { defaultViewMode, ViewMode } from '../results/ResultsData';
+import useColumnNames from '../../hooks/useColumnNames';
+import useViewMode from '../../hooks/useViewMode';
 
 const isCopySupported =
   'clipboard' in navigator && 'writeText' in navigator.clipboard;
@@ -30,22 +29,26 @@ const clickOnDropdown = (element: HTMLElement) => {
   )?.click();
 };
 
-const CopyLinkWebsite = () => {
+const CopyLinkWebsite = ({
+  namespaceOverride,
+  disableCardToggle = false,
+}: {
+  namespaceOverride: Namespace | undefined;
+  disableCardToggle: boolean;
+}) => {
   const dispatch = useDispatch();
-  const ns = useNS() || Namespace.uniprotkb;
-  const [userColumns] = useLocalStorage<Column[]>(
-    `table columns for ${ns}` as const,
-    nsToDefaultColumns(ns)
-  );
-  const [viewMode] = useLocalStorage<ViewMode>('view-mode', defaultViewMode);
-
+  const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
+  const [userColumns] = useColumnNames(namespaceOverride);
+  const [viewMode] = useViewMode(namespace, disableCardToggle);
   const location = useLocation();
 
   const searchParams = new URLSearchParams(location.search);
   if (viewMode === 'table') {
     searchParams.set('fields', userColumns.join(','));
   }
-  searchParams.set('view', `${viewMode}`);
+  if (!disableCardToggle) {
+    searchParams.set('view', `${viewMode}`);
+  }
   const url =
     document.location.origin +
     createPath({ ...location, search: searchParams.toString() });
@@ -91,8 +94,12 @@ const CopyLinkWebsite = () => {
 
 const ShareDropdown = ({
   setDisplayDownloadPanel,
+  namespaceOverride,
+  disableCardToggle = false,
 }: {
   setDisplayDownloadPanel: Dispatch<SetStateAction<boolean>>;
+  namespaceOverride?: Namespace | undefined;
+  disableCardToggle?: boolean;
 }) => {
   if (!isCopySupported) {
     return null;
@@ -103,7 +110,10 @@ const ShareDropdown = ({
       <div className="dropdown-menu__content">
         <ul>
           <li>
-            <CopyLinkWebsite />
+            <CopyLinkWebsite
+              namespaceOverride={namespaceOverride}
+              disableCardToggle={disableCardToggle}
+            />
           </li>
           <li>
             <Button

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -5,6 +5,8 @@ import { DropdownButton, Button, CopyIcon } from 'franklin-sites';
 import { createPath } from 'history';
 
 import useNS from '../../hooks/useNS';
+import useColumnNames from '../../hooks/useColumnNames';
+import useViewMode from '../../hooks/useViewMode';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 
@@ -13,8 +15,6 @@ import {
   MessageFormat,
   MessageLevel,
 } from '../../../messages/types/messagesTypes';
-import useColumnNames from '../../hooks/useColumnNames';
-import useViewMode from '../../hooks/useViewMode';
 
 const isCopySupported =
   'clipboard' in navigator && 'writeText' in navigator.clipboard;

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -45,6 +45,8 @@ const CopyLinkWebsite = ({
   const searchParams = new URLSearchParams(location.search);
   if (viewMode === 'table') {
     searchParams.set('fields', columnNames.join(','));
+  } else {
+    searchParams.delete('fields');
   }
   if (!disableCardToggle) {
     searchParams.set('view', `${viewMode}`);

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -38,13 +38,13 @@ const CopyLinkWebsite = ({
 }) => {
   const dispatch = useDispatch();
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [userColumns] = useColumnNames(namespaceOverride);
+  const { columnNames } = useColumnNames(namespaceOverride);
   const [viewMode] = useViewMode(namespace, disableCardToggle);
   const location = useLocation();
 
   const searchParams = new URLSearchParams(location.search);
   if (viewMode === 'table') {
-    searchParams.set('fields', userColumns.join(','));
+    searchParams.set('fields', columnNames.join(','));
   }
   if (!disableCardToggle) {
     searchParams.set('view', `${viewMode}`);

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -39,7 +39,7 @@ const CopyLinkWebsite = ({
   const dispatch = useDispatch();
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const { columnNames } = useColumnNames(namespaceOverride);
-  const [viewMode] = useViewMode(namespace, disableCardToggle);
+  const { viewMode } = useViewMode(namespace, disableCardToggle);
   const location = useLocation();
 
   const searchParams = new URLSearchParams(location.search);

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -74,12 +74,9 @@ const Download: FC<DownloadProps> = ({
     data: '',
   });
   const { search: queryParamFromUrl } = useLocation();
-  const {
-    query: queryFromUrl,
-    selectedFacets = [],
-    sortColumn,
-    sortDirection,
-  } = getParamsFromURL(queryParamFromUrl);
+  const [
+    { query: queryFromUrl, selectedFacets = [], sortColumn, sortDirection },
+  ] = getParamsFromURL(queryParamFromUrl);
 
   const [selectedIdField] = nsToPrimaryKeyColumns(namespace);
 

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -63,7 +63,7 @@ const Results = () => {
     total = +resultsDataTotal;
   }
 
-  const params = getParamsFromURL(search);
+  const [params] = getParamsFromURL(search);
 
   const helmet = ns && (
     <HTMLHead

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -89,17 +89,16 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const [urlParams, invalidParamValues] = getParamsFromURL(
+  const [urlParams, invalidParamValues, unknownParams] = getParamsFromURL(
     history.location.search,
     namespace
   );
-  if (invalidParamValues.length) {
-    dispatch(
-      addMessage({
-        id: 'invalid url params',
-        content: (
+  if (invalidParamValues.length || unknownParams.length) {
+    const content = (
+      <>
+        {invalidParamValues.length > 0 && (
           <>
-            Ignoring invalid URL parameter values:
+            Ignoring invalid URL values:
             <ul>
               {invalidParamValues.map(({ parameter, value }) => (
                 <li>
@@ -109,10 +108,28 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
               ))}
             </ul>
           </>
-        ),
+        )}
+        {unknownParams.length > 0 && (
+          <>
+            Ignoring invalid URL parameters:
+            <ul>
+              {unknownParams.map((unknownParam) => (
+                <li>
+                  <b>{unknownParam}</b>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </>
+    );
+    dispatch(
+      addMessage({
+        id: 'invalid url params',
+        content,
         format: MessageFormat.POP_UP,
         level: MessageLevel.WARNING,
-        displayTime: 5_000,
+        displayTime: 15_000,
       })
     );
   }

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
 } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import cn from 'classnames';
 import {
   DownloadIcon,
@@ -30,16 +31,21 @@ import ErrorBoundary from '../error-component/ErrorBoundary';
 import useLocalStorage from '../../hooks/useLocalStorage';
 import useNS from '../../hooks/useNS';
 
+import { addMessage } from '../../../messages/state/messagesActions';
 import lazy from '../../utils/lazy';
-
-import { Namespace, mainNamespaces } from '../../types/namespaces';
-import { defaultViewMode, ViewMode } from './ResultsData';
-
-import './styles/results-buttons.scss';
 import {
   getLocationObjForParams,
   getParamsFromURL,
 } from '../../../uniprotkb/utils/resultsUtils';
+
+import { Namespace, mainNamespaces } from '../../types/namespaces';
+import { defaultViewMode, ViewMode } from './ResultsData';
+import {
+  MessageFormat,
+  MessageLevel,
+} from '../../../messages/types/messagesTypes';
+
+import './styles/results-buttons.scss';
 
 const DownloadComponent = lazy(
   /* istanbul ignore next */
@@ -81,8 +87,26 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     defaultViewMode
   );
   const history = useHistory();
+  const dispatch = useDispatch();
 
-  const urlParams = getParamsFromURL(history.location.search, namespace);
+  const [urlParams, invalidParamValues] = getParamsFromURL(
+    history.location.search,
+    namespace
+  );
+  if (invalidParamValues.length) {
+    const invalid = invalidParamValues
+      .map(({ parameter, value }) => `${parameter}: ${value}`)
+      .join('\n');
+    dispatch(
+      addMessage({
+        id: 'invalid url params',
+        content: `Ignoring the following invalid parameter values:\n${invalid}`,
+        format: MessageFormat.POP_UP,
+        level: MessageLevel.WARNING,
+        displayTime: 5_000,
+      })
+    );
+  }
 
   // TODO: eventually remove it
   // This is just to convert for people currently using the website as they

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -78,7 +78,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode, setViewMode, invalidViewMode] = useViewMode(
+  const { viewMode, setViewMode, invalidUrlViewMode } = useViewMode(
     namespaceOverride,
     disableCardToggle
   );
@@ -87,9 +87,10 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const invalidParamValues = [invalidViewMode, invalidUrlColumnNames].filter(
-      Boolean
-    ) as InvalidParamValue[];
+    const invalidParamValues = [
+      invalidUrlViewMode,
+      invalidUrlColumnNames,
+    ].filter(Boolean) as InvalidParamValue[];
     const [, unknownParams] = getParamsFromURL(history.location.search);
     if (invalidParamValues.length || unknownParams.length) {
       const content = (
@@ -135,7 +136,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     dispatch,
     history.location.search,
     invalidUrlColumnNames,
-    invalidViewMode,
+    invalidUrlViewMode,
   ]);
 
   const isMain = mainNamespaces.has(namespace);

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -94,13 +94,22 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     namespace
   );
   if (invalidParamValues.length) {
-    const invalid = invalidParamValues
-      .map(({ parameter, value }) => `${parameter}: ${value}`)
-      .join('\n');
     dispatch(
       addMessage({
         id: 'invalid url params',
-        content: `Ignoring the following invalid parameter values:\n${invalid}`,
+        content: (
+          <>
+            Ignoring invalid URL parameter values:
+            <ul>
+              {invalidParamValues.map(({ parameter, value }) => (
+                <li>
+                  <b>{parameter}</b>
+                  {`: ${value}`}
+                </li>
+              ))}
+            </ul>
+          </>
+        ),
         format: MessageFormat.POP_UP,
         level: MessageLevel.WARNING,
         displayTime: 5_000,

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -147,16 +147,9 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     }
   }, [setViewMode, viewMode]);
 
-  useEffect(() => {
-    if (urlParams.viewMode) {
-      setViewMode(urlParams.viewMode);
-    }
-  }, [setViewMode, urlParams.viewMode]);
-
   const onViewModeToggle = useCallback(() => {
     if (urlParams.viewMode) {
       // Use the URL as the source of truth until a user creates a new query
-      // TODO: Leave the user's stored view preference alone
       urlParams.viewMode = toggleViewMode(urlParams.viewMode);
       // TODO: this changes the URL from encoded to decoded which is different to the faucet behavior
       history.replace(

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -82,12 +82,12 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
     namespaceOverride,
     disableCardToggle
   );
-  const [, , , invalidColumns] = useColumnNames(namespaceOverride);
+  const { invalidUrlColumnNames } = useColumnNames(namespaceOverride);
   const history = useHistory();
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const invalidParamValues = [invalidViewMode, invalidColumns].filter(
+    const invalidParamValues = [invalidViewMode, invalidUrlColumnNames].filter(
       Boolean
     ) as InvalidParamValue[];
     const [, unknownParams] = getParamsFromURL(history.location.search);
@@ -131,7 +131,12 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
         })
       );
     }
-  }, [dispatch, history.location.search, invalidColumns, invalidViewMode]);
+  }, [
+    dispatch,
+    history.location.search,
+    invalidUrlColumnNames,
+    invalidViewMode,
+  ]);
 
   const isMain = mainNamespaces.has(namespace);
 

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -1,4 +1,11 @@
-import { FC, useState, Suspense, Dispatch, SetStateAction } from 'react';
+import {
+  FC,
+  useState,
+  Suspense,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+} from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import cn from 'classnames';
@@ -79,50 +86,52 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const invalidParamValues = [invalidViewMode, invalidColumns].filter(
-    Boolean
-  ) as InvalidParamValue[];
-  const [, unknownParams] = getParamsFromURL(history.location.search);
-  if (invalidParamValues.length || unknownParams.length) {
-    const content = (
-      <>
-        {invalidParamValues.length > 0 && (
-          <>
-            Ignoring invalid URL values:
-            <ul>
-              {invalidParamValues.map(({ parameter, value }) => (
-                <li key={parameter}>
-                  <b>{parameter}</b>
-                  {`: ${value}`}
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-        {unknownParams.length > 0 && (
-          <>
-            Ignoring invalid URL parameters:
-            <ul>
-              {unknownParams.map((unknownParam) => (
-                <li key={unknownParam}>
-                  <b>{unknownParam}</b>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-      </>
-    );
-    dispatch(
-      addMessage({
-        id: 'invalid url params',
-        content,
-        format: MessageFormat.POP_UP,
-        level: MessageLevel.WARNING,
-        displayTime: 15_000,
-      })
-    );
-  }
+  useEffect(() => {
+    const invalidParamValues = [invalidViewMode, invalidColumns].filter(
+      Boolean
+    ) as InvalidParamValue[];
+    const [, unknownParams] = getParamsFromURL(history.location.search);
+    if (invalidParamValues.length || unknownParams.length) {
+      const content = (
+        <>
+          {invalidParamValues.length > 0 && (
+            <>
+              Ignoring invalid URL values:
+              <ul>
+                {invalidParamValues.map(({ parameter, value }) => (
+                  <li key={parameter}>
+                    <b>{parameter}</b>
+                    {`: ${value}`}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          {unknownParams.length > 0 && (
+            <>
+              Ignoring invalid URL parameters:
+              <ul>
+                {unknownParams.map((unknownParam) => (
+                  <li key={unknownParam}>
+                    <b>{unknownParam}</b>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </>
+      );
+      dispatch(
+        addMessage({
+          id: 'invalid url params',
+          content,
+          format: MessageFormat.POP_UP,
+          level: MessageLevel.WARNING,
+          displayTime: 15_000,
+        })
+      );
+    }
+  }, [dispatch, history.location.search, invalidColumns, invalidViewMode]);
 
   const isMain = mainNamespaces.has(namespace);
 

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -1,12 +1,4 @@
-import {
-  FC,
-  useState,
-  Suspense,
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useCallback,
-} from 'react';
+import { FC, useState, Suspense, Dispatch, SetStateAction } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import cn from 'classnames';
@@ -32,7 +24,10 @@ import useNS from '../../hooks/useNS';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 import lazy from '../../utils/lazy';
-import { getParamsFromURL } from '../../../uniprotkb/utils/resultsUtils';
+import {
+  getParamsFromURL,
+  InvalidParamValue,
+} from '../../../uniprotkb/utils/resultsUtils';
 
 import { Namespace, mainNamespaces } from '../../types/namespaces';
 import {
@@ -76,12 +71,17 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode, setViewMode, invalidViewMode] = useViewMode();
-  const [, , , invalidColumns] = useColumnNames();
+  const [viewMode, setViewMode, invalidViewMode] = useViewMode(
+    namespaceOverride,
+    disableCardToggle
+  );
+  const [, , , invalidColumns] = useColumnNames(namespaceOverride);
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const invalidParamValues = [invalidViewMode, invalidColumns].filter(Boolean);
+  const invalidParamValues = [invalidViewMode, invalidColumns].filter(
+    Boolean
+  ) as InvalidParamValue[];
   const [, unknownParams] = getParamsFromURL(history.location.search);
   if (invalidParamValues.length || unknownParams.length) {
     const content = (
@@ -91,7 +91,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             Ignoring invalid URL values:
             <ul>
               {invalidParamValues.map(({ parameter, value }) => (
-                <li>
+                <li key={parameter}>
                   <b>{parameter}</b>
                   {`: ${value}`}
                 </li>
@@ -104,7 +104,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             Ignoring invalid URL parameters:
             <ul>
               {unknownParams.map((unknownParam) => (
-                <li>
+                <li key={unknownParam}>
                   <b>{unknownParam}</b>
                 </li>
               ))}
@@ -210,7 +210,11 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
             <CustomiseButton namespace={namespace} />
           )}
         {!notCustomisable && (
-          <ShareDropdown setDisplayDownloadPanel={setDisplayDownloadPanel} />
+          <ShareDropdown
+            setDisplayDownloadPanel={setDisplayDownloadPanel}
+            namespaceOverride={namespaceOverride}
+            disableCardToggle={disableCardToggle}
+          />
         )}
         <ItemCount selected={selectedEntries.length} loaded={loadedTotal} />
       </div>

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -21,6 +21,8 @@ import ItemCount from '../ItemCount';
 import ErrorBoundary from '../error-component/ErrorBoundary';
 
 import useNS from '../../hooks/useNS';
+import useViewMode from '../../hooks/useViewMode';
+import useColumnNames from '../../hooks/useColumnNames';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 import lazy from '../../utils/lazy';
@@ -36,8 +38,6 @@ import {
 } from '../../../messages/types/messagesTypes';
 
 import './styles/results-buttons.scss';
-import useViewMode from '../../hooks/useViewMode';
-import useColumnNames from '../../hooks/useColumnNames';
 
 const DownloadComponent = lazy(
   /* istanbul ignore next */

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -48,7 +48,7 @@ const ResultsData = ({
   className,
 }: Props) => {
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode] = useViewMode(namespaceOverride, disableCardToggle);
+  const { viewMode } = useViewMode(namespaceOverride, disableCardToggle);
   const history = useHistory();
   const [{ query, direct }] = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -23,6 +23,7 @@ import { Basket } from '../../hooks/useBasket';
 
 import './styles/warning.scss';
 import './styles/results-data.scss';
+import useViewMode from '../../hooks/useViewMode';
 
 export type ViewMode = 'table' | 'card';
 export const defaultViewMode: ViewMode = 'card';
@@ -49,14 +50,9 @@ const ResultsData = ({
   className,
 }: Props) => {
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewModeFromStorage] = useLocalStorage<ViewMode>(
-    'view-mode',
-    defaultViewMode
-  );
+  const [viewMode] = useViewMode();
   const history = useHistory();
-  const [
-    { query, direct, viewMode: viewModeFromUrl, columns: columnsFromUrl },
-  ] = getParamsFromURL(useLocation().search, namespace);
+  const [{ query, direct }] = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,
@@ -71,15 +67,6 @@ const ResultsData = ({
     hasMoreData,
     progress,
   } = resultsDataObject;
-
-  let viewMode: ViewMode;
-  if (viewModeFromUrl) {
-    viewMode = viewModeFromUrl;
-  } else if (columnsFromUrl?.length) {
-    viewMode = 'table';
-  } else {
-    viewMode = viewModeFromStorage;
-  }
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {
@@ -117,7 +104,7 @@ const ResultsData = ({
         // ... or matches the UniProtKB ID ...
         ('uniProtkbId' in uniqueItem && uniqueItem.uniProtkbId === trimmedQuery)
       ) {
-        history.replace(getEntryPathForEntry(uniqueItem));
+        // history.replace(getEntryPathForEntry(uniqueItem));
       }
     }
   }, [

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -37,6 +37,7 @@ type Props = {
   displayIdMappingColumns?: boolean;
   basketSetter?: Dispatch<SetStateAction<Basket>>;
   className?: string;
+  disableCardToggle?: boolean;
 };
 
 const ResultsData = ({
@@ -47,10 +48,11 @@ const ResultsData = ({
   columnsOverride,
   displayIdMappingColumns,
   basketSetter,
+  disableCardToggle = false,
   className,
 }: Props) => {
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode] = useViewMode();
+  const [viewMode] = useViewMode(namespaceOverride, disableCardToggle);
   const history = useHistory();
   const [{ query, direct }] = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -54,11 +54,9 @@ const ResultsData = ({
     defaultViewMode
   );
   const history = useHistory();
-  const {
-    query,
-    direct,
-    viewMode: viewModeFromUrl,
-  } = getParamsFromURL(useLocation().search);
+  const [{ query, direct, viewMode: viewModeFromUrl }] = getParamsFromURL(
+    useLocation().search
+  );
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -8,6 +8,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import useNS from '../../hooks/useNS';
 import useColumns, { ColumnDescriptor } from '../../hooks/useColumns';
+import useViewMode from '../../hooks/useViewMode';
 
 import { getIdKeyFor } from '../../utils/getIdKeyForNamespace';
 import { getParamsFromURL } from '../../../uniprotkb/utils/resultsUtils';
@@ -22,10 +23,6 @@ import { Basket } from '../../hooks/useBasket';
 
 import './styles/warning.scss';
 import './styles/results-data.scss';
-import useViewMode from '../../hooks/useViewMode';
-
-export type ViewMode = 'table' | 'card';
-export const defaultViewMode: ViewMode = 'card';
 
 type Props = {
   resultsDataObject: PaginatedResults;

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -54,9 +54,9 @@ const ResultsData = ({
     defaultViewMode
   );
   const history = useHistory();
-  const [{ query, direct, viewMode: viewModeFromUrl }] = getParamsFromURL(
-    useLocation().search
-  );
+  const [
+    { query, direct, viewMode: viewModeFromUrl, columns: columnsFromUrl },
+  ] = getParamsFromURL(useLocation().search, namespace);
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,
@@ -72,7 +72,14 @@ const ResultsData = ({
     progress,
   } = resultsDataObject;
 
-  const viewMode = viewModeFromUrl || viewModeFromStorage;
+  let viewMode: ViewMode;
+  if (viewModeFromUrl) {
+    viewMode = viewModeFromUrl;
+  } else if (columnsFromUrl?.length) {
+    viewMode = 'table';
+  } else {
+    viewMode = viewModeFromStorage;
+  }
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -7,7 +7,6 @@ import {
 import { useHistory, useLocation } from 'react-router-dom';
 
 import useNS from '../../hooks/useNS';
-import useLocalStorage from '../../hooks/useLocalStorage';
 import useColumns, { ColumnDescriptor } from '../../hooks/useColumns';
 
 import { getIdKeyFor } from '../../utils/getIdKeyForNamespace';
@@ -106,7 +105,7 @@ const ResultsData = ({
         // ... or matches the UniProtKB ID ...
         ('uniProtkbId' in uniqueItem && uniqueItem.uniProtkbId === trimmedQuery)
       ) {
-        // history.replace(getEntryPathForEntry(uniqueItem));
+        history.replace(getEntryPathForEntry(uniqueItem));
       }
     }
   }, [

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -49,9 +49,16 @@ const ResultsData = ({
   className,
 }: Props) => {
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const [viewMode] = useLocalStorage<ViewMode>('view-mode', defaultViewMode);
+  const [viewModeFromStorage] = useLocalStorage<ViewMode>(
+    'view-mode',
+    defaultViewMode
+  );
   const history = useHistory();
-  const { query, direct } = getParamsFromURL(useLocation().search);
+  const {
+    query,
+    direct,
+    viewMode: viewModeFromUrl,
+  } = getParamsFromURL(useLocation().search);
   const [columns, updateColumnSort] = useColumns(
     namespaceOverride,
     displayIdMappingColumns,
@@ -66,6 +73,8 @@ const ResultsData = ({
     hasMoreData,
     progress,
   } = resultsDataObject;
+
+  const viewMode = viewModeFromUrl || viewModeFromStorage;
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {
@@ -142,7 +151,6 @@ const ResultsData = ({
   ) {
     return <Loader progress={progress} />;
   }
-
   return (
     <div className="results-data">
       {viewMode === 'card' && !displayIdMappingColumns ? (

--- a/src/shared/components/results/__tests__/Results.spec.tsx
+++ b/src/shared/components/results/__tests__/Results.spec.tsx
@@ -6,7 +6,7 @@ import customRender from '../../../__test-helpers__/customRender';
 
 import '../../../../uniprotkb/components/__mocks__/mockApi';
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
-import { ViewMode } from '../ResultsData';
+import { ViewMode } from '../../../hooks/useViewMode';
 
 describe('Results component', () => {
   // Testing the button, and testing the 2 views, this is probably enough

--- a/src/shared/components/results/__tests__/Results.spec.tsx
+++ b/src/shared/components/results/__tests__/Results.spec.tsx
@@ -70,7 +70,7 @@ describe('Results component', () => {
       },
     });
     const cards = await screen.findAllByText('Gene:');
-    expect(cards).toBeTruthy();
+    expect(cards).not.toHaveLength(0);
   });
 
   it('should show table view if URL has no view specified but has fields', async () => {

--- a/src/shared/components/results/__tests__/Results.spec.tsx
+++ b/src/shared/components/results/__tests__/Results.spec.tsx
@@ -60,4 +60,28 @@ describe('Results component', () => {
       );
     });
   });
+
+  it('should show card view if URL has view=card as well as fields', async () => {
+    customRender(<Results />, {
+      route: '/uniprotkb?query=blah&view=card&fields=accession,id',
+      initialLocalStorage: {
+        'view-mode': 'table' as ViewMode,
+        'table columns for uniprotkb': [UniProtKBColumn.accession],
+      },
+    });
+    const cards = await screen.findAllByText('Gene:');
+    expect(cards).toBeTruthy();
+  });
+
+  it('should show table view if URL has no view specified but has fields', async () => {
+    customRender(<Results />, {
+      route: '/uniprotkb?query=blah&fields=accession,id',
+      initialLocalStorage: {
+        'view-mode': 'card' as ViewMode,
+        'table columns for uniprotkb': [UniProtKBColumn.accession],
+      },
+    });
+    const table = await screen.findByText('Entry');
+    expect(table).toBeInTheDocument();
+  });
 });

--- a/src/shared/components/results/__tests__/ResultsData.spec.tsx
+++ b/src/shared/components/results/__tests__/ResultsData.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 
-import ResultsData, { ViewMode } from '../ResultsData';
+import ResultsData from '../ResultsData';
+import { ViewMode } from '../../../hooks/useViewMode';
 
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
 

--- a/src/shared/hooks/useColumnNames.ts
+++ b/src/shared/hooks/useColumnNames.ts
@@ -1,0 +1,53 @@
+import { partition } from 'lodash-es';
+import qs from 'query-string';
+import { Dispatch, SetStateAction } from 'react';
+import { useLocation } from 'react-router-dom';
+import { IDMappingColumn } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
+import { InvalidParamValues } from '../../uniprotkb/utils/resultsUtils';
+import { Column, nsToDefaultColumns } from '../config/columns';
+import { Namespace } from '../types/namespaces';
+import { ColumnConfigurations } from './useColumns';
+import useLocalStorage from './useLocalStorage';
+import useNS from './useNS';
+
+const useColumnNames = (
+  displayIdMappingColumns?: boolean
+): [
+  Column[],
+  Dispatch<SetStateAction<Column[]>>,
+  boolean,
+  InvalidParamValues | undefined
+] => {
+  const ns = useNS() || Namespace.uniprotkb;
+  const { fields: columnNamesFromUrl } = qs.parse(useLocation().search);
+  const [columnNamesFromStorage, setColumnNamesFromStorage] = useLocalStorage<
+    Column[]
+  >(`table columns for ${ns}` as const, nsToDefaultColumns(ns));
+
+  let columnNames: Column[] = columnNamesFromStorage;
+  let error: InvalidParamValues | undefined;
+  let fromUrl = false;
+
+  if (columnNamesFromUrl && ns && ns !== Namespace.idmapping) {
+    const columnsAsArray = Array.isArray(columnNamesFromUrl)
+      ? columnNamesFromUrl
+      : columnNamesFromUrl?.split(',');
+    const columnConfig = ColumnConfigurations[ns];
+    const columns = new Set(columnConfig?.keys());
+    const [validColumns, invalidColumns] = partition(columnsAsArray, (column) =>
+      columns.has(column)
+    );
+    if (invalidColumns?.length) {
+      error = { parameter: 'columns', value: invalidColumns };
+    }
+    columnNames = validColumns as Column[];
+    fromUrl = true;
+  }
+
+  if (displayIdMappingColumns && ns !== Namespace.idmapping) {
+    columnNames = [IDMappingColumn.from, ...columnNames];
+  }
+  return [columnNames, setColumnNamesFromStorage, fromUrl, error];
+};
+
+export default useColumnNames;

--- a/src/shared/hooks/useColumnNames.ts
+++ b/src/shared/hooks/useColumnNames.ts
@@ -16,20 +16,21 @@ import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 const useColumnNames = (
   namespaceOverride: Namespace | undefined,
   displayIdMappingColumns?: boolean
-): [
-  Column[],
-  Dispatch<SetStateAction<Column[]>>,
-  boolean,
-  InvalidParamValue | undefined
-] => {
+): {
+  columnNames: Column[];
+  setColumnNames: Dispatch<SetStateAction<Column[]>>;
+  fromUrl: boolean;
+  invalidUrlColumnNames: InvalidParamValue | undefined;
+} => {
   const ns = useNS(namespaceOverride) || Namespace.uniprotkb;
   const { fields: columnNamesFromUrl } = qs.parse(useLocation().search);
-  const [columnNamesFromStorage, setColumnNamesFromStorage] = useLocalStorage<
-    Column[]
-  >(`table columns for ${ns}` as const, nsToDefaultColumns(ns));
+  const [columnNamesFromStorage, setColumnNames] = useLocalStorage<Column[]>(
+    `table columns for ${ns}` as const,
+    nsToDefaultColumns(ns)
+  );
 
   let columnNames: Column[] = columnNamesFromStorage;
-  let error: InvalidParamValue | undefined;
+  let invalidUrlColumnNames: InvalidParamValue | undefined;
   let fromUrl = false;
 
   if (columnNamesFromUrl && ns && ns !== Namespace.idmapping) {
@@ -42,7 +43,7 @@ const useColumnNames = (
       columns.has(column)
     );
     if (invalidColumns?.length) {
-      error = { parameter: 'columns', value: invalidColumns };
+      invalidUrlColumnNames = { parameter: 'columns', value: invalidColumns };
     }
     columnNames = validColumns as Column[];
     fromUrl = true;
@@ -50,7 +51,7 @@ const useColumnNames = (
   if (displayIdMappingColumns && ns !== Namespace.idmapping) {
     columnNames = [IDMappingColumn.from, ...columnNames];
   }
-  return [columnNames, setColumnNamesFromStorage, fromUrl, error];
+  return { columnNames, setColumnNames, fromUrl, invalidUrlColumnNames };
 };
 
 export default useColumnNames;

--- a/src/shared/hooks/useColumnNames.ts
+++ b/src/shared/hooks/useColumnNames.ts
@@ -1,14 +1,17 @@
-import { partition } from 'lodash-es';
-import qs from 'query-string';
 import { Dispatch, SetStateAction } from 'react';
 import { useLocation } from 'react-router-dom';
-import { IDMappingColumn } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
-import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
-import { Column, nsToDefaultColumns } from '../config/columns';
-import { Namespace } from '../types/namespaces';
-import { ColumnConfigurations } from './useColumns';
+import { partition } from 'lodash-es';
+import qs from 'query-string';
+
 import useLocalStorage from './useLocalStorage';
 import useNS from './useNS';
+
+import { Column, nsToDefaultColumns } from '../config/columns';
+import { ColumnConfigurations } from './useColumns';
+
+import { Namespace } from '../types/namespaces';
+import { IDMappingColumn } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
+import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 
 const useColumnNames = (
   namespaceOverride: Namespace | undefined,

--- a/src/shared/hooks/useColumnNames.ts
+++ b/src/shared/hooks/useColumnNames.ts
@@ -3,7 +3,7 @@ import qs from 'query-string';
 import { Dispatch, SetStateAction } from 'react';
 import { useLocation } from 'react-router-dom';
 import { IDMappingColumn } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
-import { InvalidParamValues } from '../../uniprotkb/utils/resultsUtils';
+import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 import { Column, nsToDefaultColumns } from '../config/columns';
 import { Namespace } from '../types/namespaces';
 import { ColumnConfigurations } from './useColumns';
@@ -11,21 +11,22 @@ import useLocalStorage from './useLocalStorage';
 import useNS from './useNS';
 
 const useColumnNames = (
+  namespaceOverride: Namespace | undefined,
   displayIdMappingColumns?: boolean
 ): [
   Column[],
   Dispatch<SetStateAction<Column[]>>,
   boolean,
-  InvalidParamValues | undefined
+  InvalidParamValue | undefined
 ] => {
-  const ns = useNS() || Namespace.uniprotkb;
+  const ns = useNS(namespaceOverride) || Namespace.uniprotkb;
   const { fields: columnNamesFromUrl } = qs.parse(useLocation().search);
   const [columnNamesFromStorage, setColumnNamesFromStorage] = useLocalStorage<
     Column[]
   >(`table columns for ${ns}` as const, nsToDefaultColumns(ns));
 
   let columnNames: Column[] = columnNamesFromStorage;
-  let error: InvalidParamValues | undefined;
+  let error: InvalidParamValue | undefined;
   let fromUrl = false;
 
   if (columnNamesFromUrl && ns && ns !== Namespace.idmapping) {
@@ -43,7 +44,6 @@ const useColumnNames = (
     columnNames = validColumns as Column[];
     fromUrl = true;
   }
-
   if (displayIdMappingColumns && ns !== Namespace.idmapping) {
     columnNames = [IDMappingColumn.from, ...columnNames];
   }

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -198,14 +198,16 @@ const useColumns = (
   const databaseInfoMaps = useDatabaseInfoMaps();
 
   const { search: queryParamFromUrl } = location;
-  const {
-    query,
-    selectedFacets,
-    sortColumn,
-    sortDirection,
-    columns: columnsFromUrl,
-    viewMode: viewModeFromUrl,
-  } = getParamsFromURL(queryParamFromUrl, namespace);
+  const [
+    {
+      query,
+      selectedFacets,
+      sortColumn,
+      sortDirection,
+      columns: columnsFromUrl,
+      viewMode: viewModeFromUrl,
+    },
+  ] = getParamsFromURL(queryParamFromUrl, namespace);
 
   const { data: dataResultFields, loading } = useDataApi<ReceivedFieldData>(
     // For now, assume no configure endpoint for supporting data

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -10,7 +10,6 @@ import { BinIcon, Button } from 'franklin-sites';
 
 import useDataApi from './useDataApi';
 import useNS from './useNS';
-import useLocalStorage from './useLocalStorage';
 import useDatabaseInfoMaps from './useDatabaseInfoMaps';
 
 import apiUrls from '../config/apiUrls';
@@ -24,7 +23,7 @@ import {
 import * as logging from '../utils/logging';
 
 import { mainNamespaces, Namespace } from '../types/namespaces';
-import { Column, nsToDefaultColumns } from '../config/columns';
+import { Column } from '../config/columns';
 import {
   ReceivedFieldData,
   SortDirection,
@@ -64,10 +63,7 @@ import LocationsColumnConfiguration from '../../supporting-data/locations/config
 import UniRuleColumnConfiguration from '../../automatic-annotations/unirule/config/UniRuleColumnConfiguration';
 import ARBAColumnConfiguration from '../../automatic-annotations/arba/config/ARBAColumnConfiguration';
 
-import {
-  IDMappingColumn,
-  IdMappingColumnConfiguration,
-} from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
+import { IdMappingColumnConfiguration } from '../../tools/id-mapping/config/IdMappingColumnConfiguration';
 
 import { MappingAPIModel } from '../../tools/id-mapping/types/idMappingSearchResults';
 import { Basket } from './useBasket';
@@ -193,8 +189,11 @@ const useColumns = (
   const history = useHistory();
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const location = useLocation();
-  const [viewMode] = useViewMode();
-  const [columnNames] = useColumnNames(displayIdMappingColumns);
+  const [viewMode] = useViewMode(namespaceOverride);
+  const [columnNames] = useColumnNames(
+    namespaceOverride,
+    displayIdMappingColumns
+  );
   const databaseInfoMaps = useDatabaseInfoMaps();
 
   const { search: queryParamFromUrl } = location;

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -188,7 +188,7 @@ const useColumns = (
   const history = useHistory();
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const location = useLocation();
-  const [columnNames] = useColumnNames(
+  const { columnNames } = useColumnNames(
     namespaceOverride,
     displayIdMappingColumns
   );

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -11,6 +11,7 @@ import { BinIcon, Button } from 'franklin-sites';
 import useDataApi from './useDataApi';
 import useNS from './useNS';
 import useDatabaseInfoMaps from './useDatabaseInfoMaps';
+import useColumnNames from './useColumnNames';
 
 import apiUrls from '../config/apiUrls';
 import { SearchResultsLocations } from '../../app/config/urls';
@@ -68,7 +69,6 @@ import { IdMappingColumnConfiguration } from '../../tools/id-mapping/config/IdMa
 import { MappingAPIModel } from '../../tools/id-mapping/types/idMappingSearchResults';
 import { Basket } from './useBasket';
 import { DatabaseInfoMaps } from '../../uniprotkb/utils/database';
-import useColumnNames from './useColumnNames';
 
 export type ColumnDescriptor<Datum = APIModel> = {
   name: string;

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -68,7 +68,6 @@ import { IdMappingColumnConfiguration } from '../../tools/id-mapping/config/IdMa
 import { MappingAPIModel } from '../../tools/id-mapping/types/idMappingSearchResults';
 import { Basket } from './useBasket';
 import { DatabaseInfoMaps } from '../../uniprotkb/utils/database';
-import useViewMode from './useViewMode';
 import useColumnNames from './useColumnNames';
 
 export type ColumnDescriptor<Datum = APIModel> = {
@@ -189,7 +188,6 @@ const useColumns = (
   const history = useHistory();
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const location = useLocation();
-  const [viewMode] = useViewMode(namespaceOverride);
   const [columnNames] = useColumnNames(
     namespaceOverride,
     displayIdMappingColumns
@@ -297,20 +295,16 @@ const useColumns = (
           selectedFacets,
           sortColumn: newSortColumn,
           sortDirection: updatedSortDirection,
-          columns: columnNames,
-          viewMode,
         })
       );
     },
     [
-      columnNames,
       history,
       namespace,
       query,
       selectedFacets,
       sortDirection,
       sortableColumnToSortColumn,
-      viewMode,
     ]
   );
   return [columns, updateColumnSort];

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -287,7 +287,7 @@ const useColumns = (
           ? SortDirection.ascend
           : SortDirection.descend;
 
-      // TODO: this changes the URL from encoded to decoded which is different to the faucet behavior
+      // TODO: this changes the URL from encoded to decoded which is different to the facet behavior
       history.push(
         getLocationObjForParams({
           pathname: SearchResultsLocations[namespace],

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -31,8 +31,8 @@ const useNSQuery = ({
 }: Arg = {}) => {
   const namespace = useNS(overrideNS) || Namespace.uniprotkb;
   const location = useLocation();
-  const [viewMode] = useViewMode();
-  const [columnNames] = useColumnNames();
+  const [viewMode] = useViewMode(overrideNS);
+  const [columnNames] = useColumnNames(overrideNS);
 
   const { search: queryParamFromUrl } = location;
   const [{ query, selectedFacets, sortColumn, sortDirection }] =

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -31,7 +31,7 @@ const useNSQuery = ({
 }: Arg = {}) => {
   const namespace = useNS(overrideNS) || Namespace.uniprotkb;
   const location = useLocation();
-  const [viewMode] = useViewMode(overrideNS);
+  const { viewMode } = useViewMode(overrideNS);
   const { columnNames } = useColumnNames(overrideNS);
 
   const { search: queryParamFromUrl } = location;

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -32,7 +32,7 @@ const useNSQuery = ({
   const namespace = useNS(overrideNS) || Namespace.uniprotkb;
   const location = useLocation();
   const [viewMode] = useViewMode(overrideNS);
-  const [columnNames] = useColumnNames(overrideNS);
+  const { columnNames } = useColumnNames(overrideNS);
 
   const { search: queryParamFromUrl } = location;
   const [{ query, selectedFacets, sortColumn, sortDirection }] =

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import useLocalStorage from './useLocalStorage';
 import useNS from './useNS';
 
 import { getParamsFromURL } from '../../uniprotkb/utils/resultsUtils';
 import { getAccessionsURL, getAPIQueryUrl } from '../config/apiUrls';
 import fieldsForUniProtKBCards from '../../uniprotkb/config/UniProtKBCardConfiguration';
-import { Column, nsToDefaultColumns } from '../config/columns';
+import { Column } from '../config/columns';
 
-import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
 import { Namespace } from '../types/namespaces';
+import useViewMode from './useViewMode';
+import useColumnNames from './useColumnNames';
 
 type Arg = {
   size?: number;
@@ -31,31 +31,16 @@ const useNSQuery = ({
 }: Arg = {}) => {
   const namespace = useNS(overrideNS) || Namespace.uniprotkb;
   const location = useLocation();
-  const [viewModeFromStorage] = useLocalStorage<ViewMode>(
-    'view-mode',
-    defaultViewMode
-  );
-  const [columnsFromStorage] = useLocalStorage<Column[]>(
-    `table columns for ${namespace}` as const,
-    nsToDefaultColumns(namespace)
-  );
+  const [viewMode] = useViewMode();
+  const [columnNames] = useColumnNames();
 
   const { search: queryParamFromUrl } = location;
-  const [
-    {
-      query,
-      selectedFacets,
-      sortColumn,
-      sortDirection,
-      viewMode: viewModeFromUrl,
-      columns: columnsFromUrl,
-    },
-  ] = getParamsFromURL(queryParamFromUrl, namespace);
+  const [{ query, selectedFacets, sortColumn, sortDirection }] =
+    getParamsFromURL(queryParamFromUrl);
 
-  const viewMode = viewModeFromUrl || viewModeFromStorage;
+  let queryColumns: Column[] | undefined = columnNames;
 
-  let queryColumns: Column[] | undefined = columnsFromUrl || columnsFromStorage;
-
+  // TODO: put this into useColumnNames
   if (viewMode === 'card') {
     // TODO: Do similar things for the rest of namespaces
     if (namespace === Namespace.uniprotkb) {

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import useNS from './useNS';
+import useViewMode from './useViewMode';
+import useColumnNames from './useColumnNames';
 
 import { getParamsFromURL } from '../../uniprotkb/utils/resultsUtils';
 import { getAccessionsURL, getAPIQueryUrl } from '../config/apiUrls';
@@ -9,8 +11,6 @@ import fieldsForUniProtKBCards from '../../uniprotkb/config/UniProtKBCardConfigu
 import { Column } from '../config/columns';
 
 import { Namespace } from '../types/namespaces';
-import useViewMode from './useViewMode';
-import useColumnNames from './useColumnNames';
 
 type Arg = {
   size?: number;

--- a/src/shared/hooks/useNSQuery.ts
+++ b/src/shared/hooks/useNSQuery.ts
@@ -41,14 +41,16 @@ const useNSQuery = ({
   );
 
   const { search: queryParamFromUrl } = location;
-  const {
-    query,
-    selectedFacets,
-    sortColumn,
-    sortDirection,
-    viewMode: viewModeFromUrl,
-    columns: columnsFromUrl,
-  } = getParamsFromURL(queryParamFromUrl, namespace);
+  const [
+    {
+      query,
+      selectedFacets,
+      sortColumn,
+      sortDirection,
+      viewMode: viewModeFromUrl,
+      columns: columnsFromUrl,
+    },
+  ] = getParamsFromURL(queryParamFromUrl, namespace);
 
   const viewMode = viewModeFromUrl || viewModeFromStorage;
 

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -1,11 +1,9 @@
 import qs from 'query-string';
 import { useCallback } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import {
-  getLocationObjForParams,
-  InvalidParamValue,
-} from '../../uniprotkb/utils/resultsUtils';
+import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
+import { Namespace } from '../types/namespaces';
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
 
@@ -24,23 +22,25 @@ const normalize = (viewMode: ViewMode) => {
   return viewMode;
 };
 
-const useViewMode = (): [
-  ViewMode,
-  (vm: ViewMode) => void,
-  InvalidParamValue | undefined
-] => {
-  const [, , columnNamesAreFromUrl] = useColumnNames();
+const useViewMode = (
+  namespaceOverride: Namespace | undefined,
+  disableCardToggle = false
+): [ViewMode, (vm: ViewMode) => void, InvalidParamValue | undefined] => {
+  const [, , columnNamesAreFromUrl] = useColumnNames(namespaceOverride);
   const [viewModeFromStorage, setViewModeFromStorage] =
     useLocalStorage<ViewMode>('view-mode', defaultViewMode);
   const history = useHistory();
   const locationSearch = useLocation().search;
+
   let viewMode: ViewMode = normalize(viewModeFromStorage);
   let error: InvalidParamValue | undefined;
   let fromUrl = false;
 
   const { view: viewModeFromUrl, ...urlParams } = qs.parse(locationSearch);
 
-  if (viewModeFromUrl) {
+  if (disableCardToggle) {
+    viewMode = 'table';
+  } else if (viewModeFromUrl) {
     if (
       typeof viewModeFromUrl === 'string' &&
       viewModes.has(viewModeFromUrl as ViewMode)

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -28,7 +28,11 @@ const normalize = (viewMode: ViewMode) => {
 const useViewMode = (
   namespaceOverride: Namespace | undefined,
   disableCardToggle = false
-): [ViewMode, (vm: ViewMode) => void, InvalidParamValue | undefined] => {
+): {
+  viewMode: ViewMode;
+  setViewMode: (vm: ViewMode) => void;
+  invalidUrlViewMode: InvalidParamValue | undefined;
+} => {
   const { fromUrl: columnNamesAreFromUrl } = useColumnNames(namespaceOverride);
   const [viewModeFromStorage, setViewModeFromStorage] =
     useLocalStorage<ViewMode>('view-mode', defaultViewMode);
@@ -36,7 +40,7 @@ const useViewMode = (
   const locationSearch = useLocation().search;
 
   let viewMode: ViewMode = normalize(viewModeFromStorage);
-  let error: InvalidParamValue | undefined;
+  let invalidUrlViewMode: InvalidParamValue | undefined;
   let fromUrl = false;
 
   const { view: viewModeFromUrl, ...urlParams } = qs.parse(locationSearch);
@@ -51,7 +55,7 @@ const useViewMode = (
       viewMode = viewModeFromUrl as ViewMode;
       fromUrl = true;
     } else {
-      error = { parameter: 'view', value: viewModeFromUrl };
+      invalidUrlViewMode = { parameter: 'view', value: viewModeFromUrl };
     }
   } else if (columnNamesAreFromUrl) {
     viewMode = 'table';
@@ -74,7 +78,7 @@ const useViewMode = (
     [fromUrl, history, setViewModeFromStorage, urlParams]
   );
 
-  return [viewMode, setViewMode, error];
+  return { viewMode, setViewMode, invalidUrlViewMode };
 };
 
 export default useViewMode;

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -57,16 +57,11 @@ const useViewMode = (): [
   const setViewMode = useCallback(
     (vm: ViewMode) => {
       if (fromUrl) {
-        console.log({
-          pathname: history.location.pathname,
-          state: qs.stringify({ ...urlParams, view: vm }),
-        });
-        // TODO: this changes the URL from encoded to decoded which is different to the faucet behavior
         history.push(
           // eslint-disable-next-line uniprot-website/use-config-location
           {
             pathname: history.location.pathname,
-            state: qs.stringify({ ...urlParams, view: vm }),
+            search: qs.stringify({ ...urlParams, view: vm }),
           }
         );
       } else {

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -1,26 +1,44 @@
 import qs from 'query-string';
-import { Dispatch, SetStateAction } from 'react';
-import { useLocation } from 'react-router-dom';
-import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
+import { useCallback } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import {
+  getLocationObjForParams,
+  InvalidParamValue,
+} from '../../uniprotkb/utils/resultsUtils';
 import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
 
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 
+// TODO: eventually remove it
+// This is just to convert for people currently using the website as they
+// might have a viewMode of 0 or 1 because of the previous way it was stored
+const normalize = (viewMode: ViewMode) => {
+  if (viewMode !== 'card' && viewMode !== 'table') {
+    if (viewMode === 0) {
+      return 'table';
+    }
+    return 'card';
+  }
+  return viewMode;
+};
+
 const useViewMode = (): [
   ViewMode,
-  Dispatch<SetStateAction<ViewMode>>,
+  (vm: ViewMode) => void,
   InvalidParamValue | undefined
 ] => {
   const [, , columnNamesAreFromUrl] = useColumnNames();
   const [viewModeFromStorage, setViewModeFromStorage] =
     useLocalStorage<ViewMode>('view-mode', defaultViewMode);
-
-  let viewMode: ViewMode = viewModeFromStorage;
+  const history = useHistory();
+  const locationSearch = useLocation().search;
+  let viewMode: ViewMode = normalize(viewModeFromStorage);
   let error: InvalidParamValue | undefined;
+  let fromUrl = false;
 
-  const { view: viewModeFromUrl } = qs.parse(useLocation().search);
+  const { view: viewModeFromUrl, ...urlParams } = qs.parse(locationSearch);
 
   if (viewModeFromUrl) {
     if (
@@ -28,6 +46,7 @@ const useViewMode = (): [
       viewModes.has(viewModeFromUrl as ViewMode)
     ) {
       viewMode = viewModeFromUrl as ViewMode;
+      fromUrl = true;
     } else {
       error = { parameter: 'view', value: viewModeFromUrl };
     }
@@ -35,7 +54,29 @@ const useViewMode = (): [
     viewMode = 'table';
   }
 
-  return [viewMode, setViewModeFromStorage, error];
+  const setViewMode = useCallback(
+    (vm: ViewMode) => {
+      if (fromUrl) {
+        console.log({
+          pathname: history.location.pathname,
+          state: qs.stringify({ ...urlParams, view: vm }),
+        });
+        // TODO: this changes the URL from encoded to decoded which is different to the faucet behavior
+        history.push(
+          // eslint-disable-next-line uniprot-website/use-config-location
+          {
+            pathname: history.location.pathname,
+            state: qs.stringify({ ...urlParams, view: vm }),
+          }
+        );
+      } else {
+        setViewModeFromStorage(vm);
+      }
+    },
+    [fromUrl, history, setViewModeFromStorage, urlParams]
+  );
+
+  return [viewMode, setViewMode, error];
 };
 
 export default useViewMode;

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -5,11 +5,12 @@ import qs from 'query-string';
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
 
-import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
 import { Namespace } from '../types/namespaces';
 import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
+export type ViewMode = 'table' | 'card';
+export const defaultViewMode: ViewMode = 'card';
 
 // TODO: eventually remove it
 // This is just to convert for people currently using the website as they

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -1,11 +1,13 @@
-import qs from 'query-string';
 import { useCallback } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
-import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
-import { Namespace } from '../types/namespaces';
+import qs from 'query-string';
+
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
+
+import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
+import { Namespace } from '../types/namespaces';
+import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
 
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -29,7 +29,7 @@ const useViewMode = (
   namespaceOverride: Namespace | undefined,
   disableCardToggle = false
 ): [ViewMode, (vm: ViewMode) => void, InvalidParamValue | undefined] => {
-  const [, , columnNamesAreFromUrl] = useColumnNames(namespaceOverride);
+  const { fromUrl: columnNamesAreFromUrl } = useColumnNames(namespaceOverride);
   const [viewModeFromStorage, setViewModeFromStorage] =
     useLocalStorage<ViewMode>('view-mode', defaultViewMode);
   const history = useHistory();

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -1,0 +1,41 @@
+import qs from 'query-string';
+import { Dispatch, SetStateAction } from 'react';
+import { useLocation } from 'react-router-dom';
+import { InvalidParamValue } from '../../uniprotkb/utils/resultsUtils';
+import { defaultViewMode, ViewMode } from '../components/results/ResultsData';
+import useColumnNames from './useColumnNames';
+import useLocalStorage from './useLocalStorage';
+
+const viewModes: Set<ViewMode> = new Set(['card', 'table']);
+
+const useViewMode = (): [
+  ViewMode,
+  Dispatch<SetStateAction<ViewMode>>,
+  InvalidParamValue | undefined
+] => {
+  const [, , columnNamesAreFromUrl] = useColumnNames();
+  const [viewModeFromStorage, setViewModeFromStorage] =
+    useLocalStorage<ViewMode>('view-mode', defaultViewMode);
+
+  let viewMode: ViewMode = viewModeFromStorage;
+  let error: InvalidParamValue | undefined;
+
+  const { view: viewModeFromUrl } = qs.parse(useLocation().search);
+
+  if (viewModeFromUrl) {
+    if (
+      typeof viewModeFromUrl === 'string' &&
+      viewModes.has(viewModeFromUrl as ViewMode)
+    ) {
+      viewMode = viewModeFromUrl as ViewMode;
+    } else {
+      error = { parameter: 'view', value: viewModeFromUrl };
+    }
+  } else if (columnNamesAreFromUrl) {
+    viewMode = 'table';
+  }
+
+  return [viewMode, setViewModeFromStorage, error];
+};
+
+export default useViewMode;

--- a/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
+++ b/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
@@ -56,12 +56,12 @@ DatabaseColumnConfiguration.set(DatabaseColumn.category, {
     category && (
       <Link
         to={({ search }) => {
-          const parsed = getParamsFromURL(search);
+          const [params] = getParamsFromURL(search);
           return getLocationObjForParams({
             pathname: LocationToPath[Location.DatabaseResults],
-            ...parsed,
+            ...params,
             selectedFacets: [
-              ...parsed.selectedFacets.filter(
+              ...params.selectedFacets.filter(
                 ({ name }) => name !== 'category_exact'
               ),
               { name: 'category_exact', value: category },

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -23,10 +23,7 @@ import useDataApi, {
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
 
-import {
-  getParamsFromURL,
-  URLResultParams,
-} from '../../../../uniprotkb/utils/resultsUtils';
+import { getParamsFromURL } from '../../../../uniprotkb/utils/resultsUtils';
 import {
   filterBlastDataForResults,
   filterBlastByFacets,
@@ -216,7 +213,7 @@ const BlastResult = () => {
   );
 
   // extract facets and other info from URL querystring
-  const urlParams: URLResultParams = useMemo(
+  const [urlParams] = useMemo(
     () => getParamsFromURL(location.search),
     [location.search]
   );

--- a/src/tools/blast/components/results/BlastResultLocalFacets.tsx
+++ b/src/tools/blast/components/results/BlastResultLocalFacets.tsx
@@ -119,7 +119,7 @@ const BlastResultLocalFacets: FC<{
 }> = ({ allHits, namespace }) => {
   const { search: queryParamFromUrl } = useLocation();
 
-  const { selectedFacets } = getParamsFromURL(queryParamFromUrl);
+  const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
 
   // get data from accessions endpoint with facets applied
   const { data, isStale, loading } = useDataApiWithStale<Response['data']>(

--- a/src/tools/blast/components/results/BlastResultSidebar.tsx
+++ b/src/tools/blast/components/results/BlastResultSidebar.tsx
@@ -37,7 +37,7 @@ type BlastResultSidebarProps = {
 const BlastResultSidebar = memo<BlastResultSidebarProps>(
   ({ accessions, allHits, namespace }) => {
     const { search } = useLocation();
-    const { selectedFacets } = getParamsFromURL(search);
+    const [{ selectedFacets }] = getParamsFromURL(search);
     const dataApiObject = useDataApiWithStale<Response['data']>(
       // For UniRef, the only avalailable facet is the identity value, which
       // doesn't make sense in BLAST's context where all have the same value

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -44,6 +44,7 @@ const urls = toolsURLs(jobType);
 const title = `${namespaceAndToolsLabels[jobType]} results`;
 
 const IDMappingResult = () => {
+  console.log('IDMappingResult');
   const match = useRouteMatch<{ id: string }>(
     LocationToPath[Location.IDMappingResult]
   );
@@ -171,6 +172,7 @@ const IDMappingResult = () => {
         setSelectedEntries={setSelectedEntries}
         namespaceOverride={namespaceOverride}
         displayIdMappingColumns
+        disableCardToggle
       />
     </SideBarLayout>
   );

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -44,7 +44,6 @@ const urls = toolsURLs(jobType);
 const title = `${namespaceAndToolsLabels[jobType]} results`;
 
 const IDMappingResult = () => {
-  console.log('IDMappingResult');
   const match = useRouteMatch<{ id: string }>(
     LocationToPath[Location.IDMappingResult]
   );

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -50,7 +50,7 @@ const IDMappingResult = () => {
   const location = useLocation();
   const databaseInfoMaps = useDatabaseInfoMaps();
   const { search: queryParamFromUrl } = location;
-  const { selectedFacets } = getParamsFromURL(queryParamFromUrl);
+  const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
 
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();

--- a/src/tools/id-mapping/components/results/__tests__/IDMappingResult.spec.tsx
+++ b/src/tools/id-mapping/components/results/__tests__/IDMappingResult.spec.tsx
@@ -10,7 +10,7 @@ import SimpleMappingDetails from '../__mocks__/SimpleMappingDetails';
 import UniProtkbMapping from '../__mocks__/UniProtkbMapping';
 import UniProtkbMappingDetails from '../__mocks__/UniProtkbMappingDetails';
 
-import { ViewMode } from '../../../../../shared/components/results/ResultsData';
+import { ViewMode } from '../../../../../shared/hooks/useViewMode';
 
 const mock = new MockAdapter(axios);
 mock

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -75,7 +75,7 @@ const Entry: FC = () => {
 
   const baseURL = apiUrls.entry(match?.params.accession, Namespace.uniparc);
   const xRefsURL = useMemo(() => {
-    const { selectedFacets } = getParamsFromURL(search);
+    const [{ selectedFacets }] = getParamsFromURL(search);
     if (!selectedFacets.length) {
       return baseURL;
     }

--- a/src/uniprotkb/components/entry/EntryPublications.tsx
+++ b/src/uniprotkb/components/entry/EntryPublications.tsx
@@ -195,7 +195,7 @@ const hasReference = (
 
 const EntryPublications: FC<{ accession: string }> = ({ accession }) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
   const initialUrl = getUniProtPublicationsQueryUrl({
     accession,
     selectedFacets,

--- a/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
+++ b/src/uniprotkb/components/entry/EntryPublicationsFacets.tsx
@@ -17,7 +17,7 @@ import helper from '../../../shared/styles/helper.module.scss';
 const EntryPublicationsFacets: FC<{ accession: string }> = ({ accession }) => {
   const { search } = useLocation();
 
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
   const url = getUniProtPublicationsQueryUrl({
     accession,
     facets: ['types', 'categories', 'is_large_scale'],

--- a/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
+++ b/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getParamsFromURL,
   getSortableColumnToSortColumn,
   sortInteractionData,
 } from '../resultsUtils';
@@ -8,6 +9,7 @@ import { ReceivedFieldData } from '../../types/resultsTypes';
 import resultFields from '../../__mocks__/resultFields';
 import { Interactant } from '../../adapters/interactionConverter';
 import { InteractionType } from '../../types/commentTypes';
+import { Namespace } from '../../../shared/types/namespaces';
 
 describe('getSortableColumnToSortColumn', () => {
   it('should return columns with the sortField property', () => {
@@ -40,6 +42,49 @@ describe('getSortableColumnToSortColumn', () => {
       { intActId: 'C' },
       { intActId: 'A', geneName: 'AA' },
       { intActId: 'A', geneName: 'AB' },
+    ]);
+  });
+});
+
+describe('getParamsFromURL', () => {
+  it('should get parameters from URL', () => {
+    expect(
+      getParamsFromURL(
+        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id&view=table',
+        Namespace.uniprotkb
+      )
+    ).toEqual([
+      {
+        query: '*',
+        selectedFacets: [],
+        sortColumn: 'id',
+        sortDirection: 'ascend',
+        direct: false,
+        columns: ['accession', 'reviewed', 'id'],
+        viewMode: 'table',
+      },
+      [],
+      [],
+    ]);
+  });
+  it('should get parameters, invalid values, unknown params from URL', () => {
+    expect(
+      getParamsFromURL(
+        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id,foo&view=table&bar=baz',
+        Namespace.uniprotkb
+      )
+    ).toEqual([
+      {
+        query: '*',
+        selectedFacets: [],
+        sortColumn: 'id',
+        sortDirection: 'ascend',
+        direct: false,
+        columns: ['accession', 'reviewed', 'id'],
+        viewMode: 'table',
+      },
+      [{ parameter: 'columns', value: ['foo'] }],
+      ['bar'],
     ]);
   });
 });

--- a/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
+++ b/src/uniprotkb/utils/__tests__/resultsUtils.spec.ts
@@ -1,5 +1,4 @@
 import {
-  getParamsFromURL,
   getSortableColumnToSortColumn,
   sortInteractionData,
 } from '../resultsUtils';
@@ -9,7 +8,6 @@ import { ReceivedFieldData } from '../../types/resultsTypes';
 import resultFields from '../../__mocks__/resultFields';
 import { Interactant } from '../../adapters/interactionConverter';
 import { InteractionType } from '../../types/commentTypes';
-import { Namespace } from '../../../shared/types/namespaces';
 
 describe('getSortableColumnToSortColumn', () => {
   it('should return columns with the sortField property', () => {
@@ -42,49 +40,6 @@ describe('getSortableColumnToSortColumn', () => {
       { intActId: 'C' },
       { intActId: 'A', geneName: 'AA' },
       { intActId: 'A', geneName: 'AB' },
-    ]);
-  });
-});
-
-describe('getParamsFromURL', () => {
-  it('should get parameters from URL', () => {
-    expect(
-      getParamsFromURL(
-        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id&view=table',
-        Namespace.uniprotkb
-      )
-    ).toEqual([
-      {
-        query: '*',
-        selectedFacets: [],
-        sortColumn: 'id',
-        sortDirection: 'ascend',
-        direct: false,
-        columns: ['accession', 'reviewed', 'id'],
-        viewMode: 'table',
-      },
-      [],
-      [],
-    ]);
-  });
-  it('should get parameters, invalid values, unknown params from URL', () => {
-    expect(
-      getParamsFromURL(
-        '?query=*&sort=id&dir=ascend&fields=accession,reviewed,id,foo&view=table&bar=baz',
-        Namespace.uniprotkb
-      )
-    ).toEqual([
-      {
-        query: '*',
-        selectedFacets: [],
-        sortColumn: 'id',
-        sortDirection: 'ascend',
-        direct: false,
-        columns: ['accession', 'reviewed', 'id'],
-        viewMode: 'table',
-      },
-      [{ parameter: 'columns', value: ['foo'] }],
-      ['bar'],
     ]);
   });
 });

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -35,10 +35,10 @@ export type URLResultParams = {
   viewMode?: ViewMode;
 };
 
-type InvalidParamValues = {
+export type InvalidParamValue = {
   parameter: string;
   value: string | string[];
-}[];
+};
 
 type UnknownParams = string[];
 
@@ -47,7 +47,7 @@ const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 export const getParamsFromURL = (
   url: string,
   namespace?: Namespace
-): [URLResultParams, InvalidParamValues, UnknownParams] => {
+): [URLResultParams, InvalidParamValue[], UnknownParams] => {
   const invalidValues = [];
   const {
     query,

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -72,7 +72,7 @@ export const getParamsFromURL = (
     const columnConfig = ColumnConfigurations[namespace];
     const columns = new Set(columnConfig?.keys());
     const [validColumns, invalidColumns] = partition(columnsAsArray, (column) =>
-      columns.has(column) ? 'validColumns' : 'invalidColumns'
+      columns.has(column)
     );
     if (invalidColumns?.length) {
       invalidValues.push({ parameter: 'columns', value: invalidColumns });

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -58,7 +58,7 @@ export const getParamsFromURL = (
     direct,
     fields,
     view,
-    ...restParameters
+    ...restParams
   } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
@@ -99,9 +99,9 @@ export const getParamsFromURL = (
     }
   }
 
-  const unknownParameters = Object.keys(restParameters);
+  const unknownParams = Object.keys(restParams);
 
-  return [params, invalidValues, unknownParameters];
+  return [params, invalidValues, unknownParams];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -78,7 +78,7 @@ export const getParamsFromURL = (
     direct: direct !== undefined,
   };
 
-  if (fields && namespace) {
+  if (fields && namespace && namespace !== Namespace.idmapping) {
     const columnsAsArray = Array.isArray(fields) ? fields : fields?.split(',');
     const columnConfig = ColumnConfigurations[namespace];
     const columns = new Set(columnConfig?.keys());

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -40,15 +40,26 @@ type InvalidParamValues = {
   value: string | string[];
 }[];
 
+type UnknownParams = string[];
+
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 
 export const getParamsFromURL = (
   url: string,
   namespace?: Namespace
-): [URLResultParams, InvalidParamValues] => {
+): [URLResultParams, InvalidParamValues, UnknownParams] => {
   const invalidValues = [];
-  const { query, facets, sort, dir, activeFacet, direct, fields, view } =
-    qs.parse(url);
+  const {
+    query,
+    facets,
+    sort,
+    dir,
+    activeFacet,
+    direct,
+    fields,
+    view,
+    ...restParameters
+  } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {
@@ -88,7 +99,9 @@ export const getParamsFromURL = (
     }
   }
 
-  return [params, invalidValues];
+  const unknownParameters = Object.keys(restParameters);
+
+  return [params, invalidValues, unknownParameters];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -1,7 +1,4 @@
 import qs from 'query-string';
-import { partition } from 'lodash-es';
-
-import { ColumnConfigurations } from '../../shared/hooks/useColumns';
 
 import { Column } from '../../shared/config/columns';
 import { SortableColumn } from '../types/columnTypes';
@@ -13,7 +10,6 @@ import {
 import { Interactant } from '../adapters/interactionConverter';
 import { InteractionType } from '../types/commentTypes';
 import { ViewMode } from '../../shared/components/results/ResultsData';
-import { Namespace } from '../../shared/types/namespaces';
 
 const facetsAsArray = (facetString: string): SelectedFacet[] =>
   facetString.split(',').map((stringItem) => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -35,12 +35,18 @@ export type URLResultParams = {
   viewMode?: ViewMode;
 };
 
+type InvalidParamValues = {
+  parameter: string;
+  value: string | string[];
+}[];
+
 const viewModes: Set<ViewMode> = new Set(['card', 'table']);
 
 export const getParamsFromURL = (
   url: string,
   namespace?: Namespace
-): URLResultParams => {
+): [URLResultParams, InvalidParamValues] => {
+  const invalidValues = [];
   const { query, facets, sort, dir, activeFacet, direct, fields, view } =
     qs.parse(url);
 
@@ -69,20 +75,20 @@ export const getParamsFromURL = (
       columns.has(column) ? 'validColumns' : 'invalidColumns'
     );
     if (invalidColumns?.length) {
-      // TODO: warn
+      invalidValues.push({ parameter: 'columns', value: invalidColumns });
     }
     params.columns = validColumns as Column[];
   }
 
-  if (view && typeof view === 'string') {
-    if (viewModes.has(view as ViewMode)) {
+  if (view) {
+    if (typeof view === 'string' && viewModes.has(view as ViewMode)) {
       params.viewMode = view as ViewMode;
     } else {
-      // TODO: warn
+      invalidValues.push({ parameter: 'view', value: view });
     }
   }
 
-  return params;
+  return [params, invalidValues];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -48,8 +48,8 @@ export const getParamsFromURL = (
     dir,
     activeFacet,
     direct,
-    fields, // These are handled in useColumnNames
-    view, // These are handled in useViewMode
+    fields, // Handled in useColumnNames
+    view, // Handled in useViewMode
     ...restParams
   } = qs.parse(url);
 

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -42,24 +42,11 @@ export type InvalidParamValue = {
 
 type UnknownParams = string[];
 
-const viewModes: Set<ViewMode> = new Set(['card', 'table']);
-
 export const getParamsFromURL = (
-  url: string,
-  namespace?: Namespace
-): [URLResultParams, InvalidParamValue[], UnknownParams] => {
-  const invalidValues = [];
-  const {
-    query,
-    facets,
-    sort,
-    dir,
-    activeFacet,
-    direct,
-    fields,
-    view,
-    ...restParams
-  } = qs.parse(url);
+  url: string
+): [URLResultParams, UnknownParams] => {
+  const { query, facets, sort, dir, activeFacet, direct, ...restParams } =
+    qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {
@@ -78,30 +65,9 @@ export const getParamsFromURL = (
     direct: direct !== undefined,
   };
 
-  if (fields && namespace && namespace !== Namespace.idmapping) {
-    const columnsAsArray = Array.isArray(fields) ? fields : fields?.split(',');
-    const columnConfig = ColumnConfigurations[namespace];
-    const columns = new Set(columnConfig?.keys());
-    const [validColumns, invalidColumns] = partition(columnsAsArray, (column) =>
-      columns.has(column)
-    );
-    if (invalidColumns?.length) {
-      invalidValues.push({ parameter: 'columns', value: invalidColumns });
-    }
-    params.columns = validColumns as Column[];
-  }
-
-  if (view) {
-    if (typeof view === 'string' && viewModes.has(view as ViewMode)) {
-      params.viewMode = view as ViewMode;
-    } else {
-      invalidValues.push({ parameter: 'view', value: view });
-    }
-  }
-
   const unknownParams = Object.keys(restParams);
 
-  return [params, invalidValues, unknownParams];
+  return [params, unknownParams];
 };
 
 export const facetsAsString = (facets?: SelectedFacet[]): string => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -9,7 +9,7 @@ import {
 } from '../types/resultsTypes';
 import { Interactant } from '../adapters/interactionConverter';
 import { InteractionType } from '../types/commentTypes';
-import { ViewMode } from '../../shared/components/results/ResultsData';
+import { ViewMode } from '../../shared/hooks/useViewMode';
 
 const facetsAsArray = (facetString: string): SelectedFacet[] =>
   facetString.split(',').map((stringItem) => {

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -41,8 +41,17 @@ type UnknownParams = string[];
 export const getParamsFromURL = (
   url: string
 ): [URLResultParams, UnknownParams] => {
-  const { query, facets, sort, dir, activeFacet, direct, ...restParams } =
-    qs.parse(url);
+  const {
+    query,
+    facets,
+    sort,
+    dir,
+    activeFacet,
+    direct,
+    fields, // These are handled in useColumnNames
+    view, // These are handled in useViewMode
+    ...restParams
+  } = qs.parse(url);
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {

--- a/src/uniref/components/entry/MembersFacets.tsx
+++ b/src/uniref/components/entry/MembersFacets.tsx
@@ -16,7 +16,7 @@ import helper from '../../../shared/styles/helper.module.scss';
 
 const MembersFacet = memo<{ accession: string }>(({ accession }) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
 
   const selectedFacetsStrings = selectedFacets.map(
     (facet) => `${facet.name}:${facet.value}`

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -261,7 +261,7 @@ export const MembersSection = ({
   representativeMember,
 }: Props) => {
   const { search } = useLocation();
-  const { selectedFacets } = getParamsFromURL(search);
+  const [{ selectedFacets }] = getParamsFromURL(search);
 
   const initialUrl = apiUrls.members(id, {
     selectedFacets: selectedFacets.map(


### PR DESCRIPTION
## Purpose
Consume view and fields parameters from the url.

## Approach
- Create two new hooks: `useViewMode` and `useColumnNames` which holds most of the logic to determine which of localStorage or the url should be used.
- If invalid param/value send a message to user
- Keep view and fields in URL when switching viewMode and sorting columns

## Testing
- Updated tests

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
