### PR TITLE
2022 03 share url close on url copy

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -70,7 +70,6 @@ const Download: FC<DownloadProps> = ({
   const [downloadAll, setDownloadAll] = useState(!selectedEntries.length);
   const [fileFormat, setFileFormat] = useState(fileFormats[0]);
   const [compressed, setCompressed] = useState(true);
-
   const [extraContent, setExtraContent] = useState<null | ExtraContent>(null);
 
   const [
@@ -140,10 +139,18 @@ const Download: FC<DownloadProps> = ({
     setCompressed(e.target.value === 'true');
 
   const extraContentRef = useRef<HTMLElement>(null);
-  const displayExtraContent = useCallback((content: ExtraContent) => {
-    setExtraContent(content);
+
+  const scrollExtraIntoView = useCallback(() => {
     extraContentRef.current?.scrollIntoView();
   }, []);
+
+  const displayExtraContent = useCallback(
+    (content: ExtraContent) => {
+      setExtraContent(content);
+      scrollExtraIntoView();
+    },
+    [scrollExtraIntoView]
+  );
 
   return (
     <>
@@ -253,12 +260,17 @@ const Download: FC<DownloadProps> = ({
       </section>
       <section ref={extraContentRef}>
         {extraContent === 'url' && (
-          <DownloadAPIURL apiURL={downloadUrl} onCopy={onClose} />
+          <DownloadAPIURL
+            apiURL={downloadUrl}
+            onCopy={onClose}
+            onMount={scrollExtraIntoView}
+          />
         )}
         {extraContent === 'preview' && (
           <DownloadPreview
             previewUrl={previewUrl}
             previewFileFormat={previewFileFormat}
+            onMount={scrollExtraIntoView}
           />
         )}
       </section>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -252,7 +252,9 @@ const Download: FC<DownloadProps> = ({
         </a>
       </section>
       <section ref={extraContentRef}>
-        {extraContent === 'url' && <DownloadAPIURL apiURL={downloadUrl} />}
+        {extraContent === 'url' && (
+          <DownloadAPIURL apiURL={downloadUrl} onCopy={onClose} />
+        )}
         {extraContent === 'preview' && (
           <DownloadPreview
             previewUrl={previewUrl}

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -8,7 +8,13 @@ import {
 
 import styles from './styles/download-api-url.module.scss';
 
-const DownloadAPIURL = ({ apiURL }: { apiURL: string }) => {
+const DownloadAPIURL = ({
+  apiURL,
+  onCopy,
+}: {
+  apiURL: string;
+  onCopy: () => void;
+}) => {
   const dispatch = useDispatch();
   const handleCopyURL = useCallback(async () => {
     try {
@@ -19,7 +25,9 @@ const DownloadAPIURL = ({ apiURL }: { apiURL: string }) => {
       // Issue with Clipboard API too, bail with error message
       dispatch(copyFailureMessage());
     }
-  }, [apiURL, dispatch]);
+
+    onCopy();
+  }, [apiURL, dispatch, onCopy]);
 
   return (
     <div className={styles['api-url']}>

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -1,5 +1,5 @@
 import { Button, CodeBlock, CopyIcon } from 'franklin-sites';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   copyFailureMessage,
@@ -11,10 +11,16 @@ import styles from './styles/download-api-url.module.scss';
 const DownloadAPIURL = ({
   apiURL,
   onCopy,
+  onMount,
 }: {
   apiURL: string;
   onCopy: () => void;
+  onMount: () => void;
 }) => {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+
   const dispatch = useDispatch();
   const handleCopyURL = useCallback(async () => {
     try {
@@ -25,7 +31,6 @@ const DownloadAPIURL = ({
       // Issue with Clipboard API too, bail with error message
       dispatch(copyFailureMessage());
     }
-
     onCopy();
   }, [apiURL, dispatch, onCopy]);
 

--- a/src/shared/components/download/DownloadPreview.tsx
+++ b/src/shared/components/download/DownloadPreview.tsx
@@ -1,5 +1,5 @@
 import { CodeBlock, Loader } from 'franklin-sites';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { JsonObject } from 'type-fest';
 
 import useDataApi from '../../hooks/useDataApi';
@@ -13,10 +13,16 @@ import styles from './styles/download-preview.module.scss';
 const DownloadPreview = ({
   previewUrl,
   previewFileFormat,
+  onMount,
 }: {
   previewUrl: string;
   previewFileFormat: FileFormat;
+  onMount: () => void;
 }) => {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+
   const options = useMemo(() => {
     const headers: Record<string, string> = {};
     const accept = fileFormatToContentType[previewFileFormat];

--- a/src/shared/components/download/__tests__/DownloadAPIURL.spec.tsx
+++ b/src/shared/components/download/__tests__/DownloadAPIURL.spec.tsx
@@ -16,8 +16,14 @@ const store: Store = {
 const apiURL = 'https://foo.org';
 
 describe('DownloadAPIURL', () => {
-  it('should dispatch an unsuccessful copy message when the navigator.clipboard is not available', async () => {
-    customRender(<DownloadAPIURL apiURL={apiURL} />, { store });
+  const onCopy = jest.fn();
+
+  beforeEach(() => {
+    onCopy.mockReset();
+  });
+
+  it('should dispatch an unsuccessful copy message when the navigator.clipboard is not available and call onCopy', async () => {
+    customRender(<DownloadAPIURL apiURL={apiURL} onCopy={onCopy} />, { store });
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     await waitFor(() =>
@@ -31,15 +37,16 @@ describe('DownloadAPIURL', () => {
         type: 'ADD_MESSAGE',
       })
     );
+    expect(onCopy).toHaveBeenCalledTimes(1);
   });
-  it('should copy a message with navigator.clipboard and dispatch a successful copy message', async () => {
+  it('should copy a message with navigator.clipboard and dispatch a successful copy message and call onCopy', async () => {
     const mockWriteText = jest.fn();
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: mockWriteText,
       },
     });
-    customRender(<DownloadAPIURL apiURL={apiURL} />, { store });
+    customRender(<DownloadAPIURL apiURL={apiURL} onCopy={onCopy} />, { store });
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     expect(mockWriteText).toHaveBeenCalledWith(apiURL);
@@ -54,5 +61,6 @@ describe('DownloadAPIURL', () => {
         type: 'ADD_MESSAGE',
       })
     );
+    expect(onCopy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/components/download/__tests__/DownloadAPIURL.spec.tsx
+++ b/src/shared/components/download/__tests__/DownloadAPIURL.spec.tsx
@@ -17,13 +17,17 @@ const apiURL = 'https://foo.org';
 
 describe('DownloadAPIURL', () => {
   const onCopy = jest.fn();
+  const onMount = jest.fn();
 
   beforeEach(() => {
     onCopy.mockReset();
   });
 
   it('should dispatch an unsuccessful copy message when the navigator.clipboard is not available and call onCopy', async () => {
-    customRender(<DownloadAPIURL apiURL={apiURL} onCopy={onCopy} />, { store });
+    customRender(
+      <DownloadAPIURL apiURL={apiURL} onCopy={onCopy} onMount={onMount} />,
+      { store }
+    );
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     await waitFor(() =>
@@ -46,7 +50,10 @@ describe('DownloadAPIURL', () => {
         writeText: mockWriteText,
       },
     });
-    customRender(<DownloadAPIURL apiURL={apiURL} onCopy={onCopy} />, { store });
+    customRender(
+      <DownloadAPIURL apiURL={apiURL} onCopy={onCopy} onMount={onMount} />,
+      { store }
+    );
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     expect(mockWriteText).toHaveBeenCalledWith(apiURL);


### PR DESCRIPTION
## Purpose
Close the download panel when user clicks on api url copy

## Approach
- Use a callback
- Also noticed that the extra content doesn't always scroll into view in the case that the component has mounted yet so passed an `onMount` which is called within a `useEffect`.

## Testing
Test the callback

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
