### PR TITLE
2022 04 tools adv search bar

### DIFF
--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -149,10 +149,14 @@ export const SearchResultsLocations: Record<SearchableNamespace, string> = {
   [Namespace.arba]: LocationToPath[Location.ARBAResults],
 };
 
-// "/:namespace(uniprotkb|uniparc|........)"
-export const allSearchResultLocations = `/:namespace(${Object.keys(
-  searchableNamespaceLabels
-).join('|')})`;
+export const toolsWithNamespaces = [Location.Blast, Location.IDMapping].map(
+  (location) => LocationToPath[location].slice(1)
+);
+
+// "/(blast|id-mapping)?/:namespace(uniprotkb|uniparc|........)"
+export const allSearchResultLocations = `/:tool(${toolsWithNamespaces.join(
+  '|'
+)})?/:namespace(${Object.keys(searchableNamespaceLabels).join('|')})`;
 
 // "/:namespace(uniprotkb|uniparc|........)/:accession"
 export const allEntryPages = `/:namespace(${Object.keys(

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -149,12 +149,30 @@ export const SearchResultsLocations: Record<SearchableNamespace, string> = {
   [Namespace.arba]: LocationToPath[Location.ARBAResults],
 };
 
-export const toolsWithNamespaces = [Location.Blast, Location.IDMapping].map(
-  (location) => LocationToPath[location].slice(1)
-);
+const getPathWithoutLeadingSlash = (location: Location) =>
+  LocationToPath[location].replace('/', '');
 
-// "/(blast|id-mapping)?/:namespace(uniprotkb|uniparc|........)"
-export const allSearchResultLocations = `/:tool(${toolsWithNamespaces.join(
+export const pathNameToolsWithNamespaces = [
+  Location.Blast,
+  Location.IDMapping,
+  Location.PeptideSearch,
+].map(getPathWithoutLeadingSlash);
+
+export const pathNameTools = [
+  Location.Align,
+  Location.Blast,
+  Location.IDMapping,
+  Location.PeptideSearch,
+].map(getPathWithoutLeadingSlash);
+
+export const pathNameToolNamespaces = [
+  Location.UniProtKBResults,
+  Location.UniRefResults,
+  Location.UniParcResults,
+].map(getPathWithoutLeadingSlash);
+
+// "/(blast|id-mapping|peptide-search)?/:namespace(uniprotkb|uniparc|........)"
+export const allSearchResultLocations = `/:tool(${pathNameToolsWithNamespaces.join(
   '|'
 )})?/:namespace(${Object.keys(searchableNamespaceLabels).join('|')})`;
 

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -15,6 +15,7 @@ import { MainSearch, Button, SlidingPanel } from 'franklin-sites';
 import ErrorBoundary from '../error-component/ErrorBoundary';
 
 import lazy from '../../utils/lazy';
+import { getJobIdFromPathname } from '../../utils/url';
 
 import {
   Location,
@@ -168,6 +169,11 @@ const SearchContainer: FC<
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.
   useEffect(() => {
+    const jobId = getJobIdFromPathname(history.location.pathname);
+    const queryTokens = [];
+    if (jobId) {
+      queryTokens.push(`job:${jobId}`);
+    }
     const { query } = queryString.parse(location.search, { decode: true });
     // Using history here because history won't change, while location will
     if (
@@ -176,11 +182,12 @@ const SearchContainer: FC<
       return;
     }
     if (Array.isArray(query)) {
-      setSearchTerm(query[0]);
-      return;
+      queryTokens.push(query[0]);
+    } else if (query && query !== '*' && !jobId) {
+      queryTokens.push(query);
     }
-    setSearchTerm(query || '');
-  }, [history, location.search]);
+    setSearchTerm(queryTokens.join(' AND '));
+  }, [history.location.pathname, location.search]);
 
   return (
     <>

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -8,3 +8,14 @@ export const getLocationForPathname = (pathname: string) => {
   );
   return found?.[0];
 };
+
+const reJobId =
+  /^\/(?<tool>align|blast|id-mapping|peptide-search)(\/(uniprotkb|uniref|uniparc))?\/(?<jobID>[^/]+)/;
+
+export const getJobIdFromPathname = (pathname: string) => {
+  const m = pathname.match(reJobId);
+  if (m && m.groups?.tool && m.groups?.jobID) {
+    return m.groups.jobID;
+  }
+  return null;
+};

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -1,6 +1,10 @@
 import { matchPath } from 'react-router-dom';
 
-import { LocationToPath } from '../../app/config/urls';
+import {
+  LocationToPath,
+  pathNameToolNamespaces,
+  pathNameTools,
+} from '../../app/config/urls';
 
 export const getLocationForPathname = (pathname: string) => {
   const found = Object.entries(LocationToPath).find(([, path]) =>
@@ -9,13 +13,10 @@ export const getLocationForPathname = (pathname: string) => {
   return found?.[0];
 };
 
-const reJobId =
-  /^\/(?<tool>align|blast|id-mapping|peptide-search)(\/(uniprotkb|uniref|uniparc))?\/(?<jobID>[^/]+)/;
-
-export const getJobIdFromPathname = (pathname: string) => {
-  const m = pathname.match(reJobId);
-  if (m && m.groups?.tool && m.groups?.jobID) {
-    return m.groups.jobID;
-  }
-  return null;
-};
+const toolsPattern = pathNameTools.join('|');
+const namespacesPattern = pathNameToolNamespaces.join('|');
+const reJobId = RegExp(
+  `^/(${toolsPattern})(/(${namespacesPattern}))?/(?<jobID>[^/]+)`
+);
+export const getJobIdFromPathname = (pathname: string) =>
+  pathname.match(reJobId)?.groups?.jobID;

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -52,7 +52,6 @@ const IDMappingResult = () => {
     id: string;
     namespace?: typeof IDMappingNamespaces[number];
   }>(LocationToPath[Location.IDMappingResult]);
-  console.log(match?.params.namespace);
   const location = useLocation();
   const databaseInfoMaps = useDatabaseInfoMaps();
   const { search: queryParamFromUrl } = location;


### PR DESCRIPTION
## Purpose
Add job ID to search bar on tools results for URL location (namespace + job-id)

## Approach
- Modify `allSearchResultLocations` to include tools in path
- Create `getJobIdFromPathname` to get job id from pathname

## Testing
todo

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
