### PR TITLE
2022 04 tools adv search search bar2

### DIFF
--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -1,4 +1,4 @@
-import { generatePath } from 'react-router-dom';
+import { generatePath, matchPath } from 'react-router-dom';
 import { partial } from 'lodash-es';
 import { LocationDescriptorObject } from 'history';
 
@@ -288,3 +288,11 @@ export const changePathnameOnly =
     ...location,
     pathname,
   });
+
+export const getToolResultsLocation = (pathname: string) =>
+  [
+    Location.AlignResult,
+    Location.BlastResult,
+    Location.IDMappingResult,
+    Location.PeptideSearchResult,
+  ].find((location) => matchPath(pathname, { path: LocationToPath[location] }));

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -168,32 +168,34 @@ const SearchContainer: FC<
     setSearchTerm(example);
   };
 
-  const secondaryButtons = [];
-  if (toolResultsPage !== Location.AlignResult) {
-    secondaryButtons.push({
-      label:
-        // TODO:
-        // <span
-        //   onPointerOver={QueryBuilder.preload}
-        //   onFocus={QueryBuilder.preload}
-        // >
-        //   Advanced
-        // </span>
-        'Advanced',
+  const secondaryButtons = useMemo(() => {
+    const buttons = [];
+    if (toolResultsPage !== Location.AlignResult) {
+      buttons.push({
+        label:
+          // TODO:
+          // <span
+          //   onPointerOver={QueryBuilder.preload}
+          //   onFocus={QueryBuilder.preload}
+          // >
+          //   Advanced
+          // </span>
+          'Advanced',
+        action: () => {
+          setDisplayQueryBuilder((value) => !value);
+        },
+      });
+    }
+    buttons.push({
+      label: 'List',
       action: () => {
-        setDisplayQueryBuilder((value) => !value);
+        history.push({
+          pathname: LocationToPath[Location.IDMapping],
+        });
       },
     });
-  }
-
-  secondaryButtons.push({
-    label: 'List',
-    action: () => {
-      history.push({
-        pathname: LocationToPath[Location.IDMapping],
-      });
-    },
-  });
+    return buttons;
+  }, [history, toolResultsPage]);
 
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -168,8 +168,9 @@ const SearchContainer: FC<
     setSearchTerm(example);
   };
 
-  const secondaryButtons = [
-    {
+  const secondaryButtons = [];
+  if (toolResultsPage !== Location.AlignResult) {
+    secondaryButtons.push({
       label:
         // TODO:
         // <span
@@ -182,16 +183,17 @@ const SearchContainer: FC<
       action: () => {
         setDisplayQueryBuilder((value) => !value);
       },
+    });
+  }
+
+  secondaryButtons.push({
+    label: 'List',
+    action: () => {
+      history.push({
+        pathname: LocationToPath[Location.IDMapping],
+      });
     },
-    {
-      label: 'List',
-      action: () => {
-        history.push({
-          pathname: LocationToPath[Location.IDMapping],
-        });
-      },
-    },
-  ];
+  });
 
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -195,13 +195,16 @@ const SearchContainer: FC<
     ) {
       return;
     }
-    if (Array.isArray(query)) {
-      queryTokens.push(query[0]);
-    } else if (query) {
-      queryTokens.push(query);
+    // Don't add any query that may be in URL for Align results
+    if (toolResultsPage !== Location.AlignResult) {
+      if (Array.isArray(query)) {
+        queryTokens.push(query[0]);
+      } else if (query) {
+        queryTokens.push(query);
+      }
     }
     setSearchTerm(queryTokens.join(' AND '));
-  }, [history, location.search, jobId]);
+  }, [history, location.search, jobId, toolResultsPage]);
 
   return (
     <>

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -99,7 +99,8 @@ const SearchContainer: FC<
   const history = useHistory();
   const location = useLocation();
   const [displayQueryBuilder, setDisplayQueryBuilder] = useState(false);
-
+  // local state to hold the search value without modifying URL
+  const [searchTerm, setSearchTerm] = useState<string>('');
   const handleClose = useCallback(() => setDisplayQueryBuilder(false), []);
 
   const toolResultsPage = useMemo(
@@ -123,9 +124,6 @@ const SearchContainer: FC<
       : []
   );
   const jobId = match?.params.id;
-
-  // local state to hold the search value without modifying URL
-  const [searchTerm, setSearchTerm] = useState<string>('');
 
   const handleSubmit = (event: SyntheticEvent) => {
     // prevent normal browser submission

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -125,23 +125,7 @@ const SearchContainer: FC<
   const jobId = match?.params.id;
 
   // local state to hold the search value without modifying URL
-  const [searchTerm, setSearchTerm] = useState<string>(
-    // initialise with whatever is already in the URL
-    () => {
-      const { query } = queryString.parse(history.location.search, {
-        decode: true,
-      });
-      if (
-        history.location.pathname.includes(LocationToPath[Location.HelpResults])
-      ) {
-        return '';
-      }
-      if (Array.isArray(query)) {
-        return query[0];
-      }
-      return query || '';
-    }
-  );
+  const [searchTerm, setSearchTerm] = useState<string>('');
 
   const handleSubmit = (event: SyntheticEvent) => {
     // prevent normal browser submission

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -9,12 +9,7 @@ import {
   SyntheticEvent,
   useMemo,
 } from 'react';
-import {
-  matchPath,
-  useHistory,
-  useLocation,
-  useRouteMatch,
-} from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import queryString from 'query-string';
 import { MainSearch, Button, SlidingPanel } from 'franklin-sites';
 
@@ -23,6 +18,7 @@ import ErrorBoundary from '../error-component/ErrorBoundary';
 import lazy from '../../utils/lazy';
 
 import {
+  getToolResultsLocation,
   Location,
   LocationToPath,
   SearchResultsLocations,
@@ -103,24 +99,16 @@ const SearchContainer: FC<
   const [searchTerm, setSearchTerm] = useState<string>('');
   const handleClose = useCallback(() => setDisplayQueryBuilder(false), []);
 
-  const toolResultsPage = useMemo(
-    () =>
-      [
-        Location.AlignResult,
-        Location.BlastResult,
-        Location.IDMappingResult,
-        Location.PeptideSearchResult,
-      ].find((location) =>
-        matchPath(history.location.pathname, { path: LocationToPath[location] })
-      ),
+  const toolResultsLocation = useMemo(
+    () => getToolResultsLocation(history.location.pathname),
     [history.location.pathname]
   );
 
   const match = useRouteMatch<{
     id: string;
   }>(
-    toolResultsPage && toolResultsPage in LocationToPath
-      ? LocationToPath[toolResultsPage]
+    toolResultsLocation && toolResultsLocation in LocationToPath
+      ? LocationToPath[toolResultsLocation]
       : []
   );
   const jobId = match?.params.id;
@@ -152,7 +140,7 @@ const SearchContainer: FC<
 
   const secondaryButtons = useMemo(() => {
     const buttons = [];
-    if (toolResultsPage !== Location.AlignResult) {
+    if (toolResultsLocation !== Location.AlignResult) {
       buttons.push({
         label:
           // TODO:
@@ -177,7 +165,7 @@ const SearchContainer: FC<
       },
     });
     return buttons;
-  }, [history, toolResultsPage]);
+  }, [history, toolResultsLocation]);
 
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.
@@ -194,7 +182,7 @@ const SearchContainer: FC<
       return;
     }
     // Don't add any query that may be in URL for Align results
-    if (toolResultsPage !== Location.AlignResult) {
+    if (toolResultsLocation !== Location.AlignResult) {
       if (Array.isArray(query)) {
         queryTokens.push(query[0]);
       } else if (query) {
@@ -202,7 +190,7 @@ const SearchContainer: FC<
       }
     }
     setSearchTerm(queryTokens.join(' AND '));
-  }, [history, location.search, jobId, toolResultsPage]);
+  }, [history, location.search, jobId, toolResultsLocation]);
 
   return (
     <>

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -6,7 +6,7 @@ import SearchContainer from '../SearchContainer';
 
 import { Namespace } from '../../../types/namespaces';
 
-describe('Search shallow components on home page', () => {
+describe('Search component on home page', () => {
   let rendered: ReturnType<typeof customRender>;
   beforeEach(() => {
     rendered = customRender(
@@ -30,8 +30,8 @@ describe('Search shallow components on home page', () => {
   });
 });
 
-describe('Search shallow components on results page', () => {
-  const getSearchQueryWithRoute = (route: string) => {
+describe('Search component on results page', () => {
+  const renderWithRoute = (route: string) => {
     customRender(
       <SearchContainer
         isOnHomePage={false}
@@ -40,16 +40,29 @@ describe('Search shallow components on results page', () => {
       />,
       { route }
     );
-    return screen.getByLabelText('Text query in uniprotkb');
   };
   it('should display the job id when on a tools results page', () => {
-    const input = getSearchQueryWithRoute('/id-mapping/uniparc/job123');
-    expect(input).toHaveValue('job:job123');
+    renderWithRoute('/id-mapping/uniparc/job123');
+    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
+      'job:job123'
+    );
   });
   it('should display the job id and query when on a tools results page', () => {
-    const input = getSearchQueryWithRoute(
-      '/id-mapping/uniparc/job123?query=foo'
+    renderWithRoute('/id-mapping/uniparc/job123?query=foo');
+    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
+      'job:job123 AND foo'
     );
-    expect(input).toHaveValue('job:job123 AND foo');
+    expect(
+      screen.getByRole('button', { name: 'Advanced' })
+    ).toBeInTheDocument();
+  });
+  it('should only display the job id when on an align tool results page', () => {
+    renderWithRoute('/align/job123?query=foo');
+    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
+      'job:job123'
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Advanced' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 
 import customRender from '../../../__test-helpers__/customRender';
 
@@ -6,9 +6,8 @@ import SearchContainer from '../SearchContainer';
 
 import { Namespace } from '../../../types/namespaces';
 
-let rendered: ReturnType<typeof customRender>;
-
-describe('Search shallow components', () => {
+describe('Search shallow components on home page', () => {
+  let rendered: ReturnType<typeof customRender>;
   beforeEach(() => {
     rendered = customRender(
       <SearchContainer
@@ -28,5 +27,29 @@ describe('Search shallow components', () => {
     expect(screen.queryByDisplayValue('Insulin')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Insulin' }));
     expect(screen.getByDisplayValue('Insulin')).toBeInTheDocument();
+  });
+});
+
+describe('Search shallow components on results page', () => {
+  const getSearchQueryWithRoute = (route: string) => {
+    customRender(
+      <SearchContainer
+        isOnHomePage={false}
+        namespace={Namespace.uniprotkb}
+        onNamespaceChange={jest.fn()}
+      />,
+      { route }
+    );
+    return screen.getByLabelText('Text query in uniprotkb');
+  };
+  it('should display the job id when on a tools results page', () => {
+    const input = getSearchQueryWithRoute('/id-mapping/uniparc/job123');
+    expect(input).toHaveValue('job:job123');
+  });
+  it('should display the job id and query when on a tools results page', () => {
+    const input = getSearchQueryWithRoute(
+      '/id-mapping/uniparc/job123?query=foo'
+    );
+    expect(input).toHaveValue('job:job123 AND foo');
   });
 });

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 
 import customRender from '../../../__test-helpers__/customRender';
 

--- a/src/shared/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
+++ b/src/shared/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search shallow components on home page should render 1`] = `
+exports[`Search component on home page should render 1`] = `
 <DocumentFragment>
   <section
     role="search"

--- a/src/shared/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
+++ b/src/shared/components/search/__tests__/__snapshots__/SearchContainer.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Search shallow components should render 1`] = `
+exports[`Search shallow components on home page should render 1`] = `
 <DocumentFragment>
   <section
     role="search"

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -52,7 +52,6 @@ const IDMappingResult = () => {
     id: string;
     namespace?: typeof IDMappingNamespaces[number];
   }>(LocationToPath[Location.IDMappingResult]);
-  console.log(match?.params.namespace);
   const location = useLocation();
   const databaseInfoMaps = useDatabaseInfoMaps();
   const { search: queryParamFromUrl } = location;


### PR DESCRIPTION
## Purpose

- Add job ID to search bar on tools results for URL location (namespace + job-id)
- Remove/disable advanced search for Align results page

## Approach
Determine if the user is on a tool results page and if so extract the job id and place this in the main search input.

## Testing
Updated unit tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
