### PR TITLE
2022 04 tools adv search id mapping search

### DIFF
--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -89,6 +89,8 @@ type Props = {
   onNamespaceChange: (namespace: SearchableNamespace) => void;
 };
 
+const jobRE = /job:[^ ]+( AND )?/i;
+
 const SearchContainer: FC<
   Props & Exclude<HTMLAttributes<HTMLDivElement>, 'role'>
 > = ({ isOnHomePage, namespace, onNamespaceChange, ...props }) => {
@@ -100,8 +102,8 @@ const SearchContainer: FC<
   const handleClose = useCallback(() => setDisplayQueryBuilder(false), []);
 
   const toolResultsLocation = useMemo(
-    () => getToolResultsLocation(history.location.pathname),
-    [history.location.pathname]
+    () => getToolResultsLocation(location.pathname),
+    [location.pathname]
   );
 
   const match = useRouteMatch<{
@@ -119,13 +121,16 @@ const SearchContainer: FC<
 
     // restringify the resulting search
     const stringifiedSearch = queryString.stringify(
-      { query: searchTerm || '*' },
+      { query: searchTerm.replace(jobRE, '') || '*' },
       { encode: true }
     );
 
     // push a new location to the history containing the modified search term
     history.push({
-      pathname: SearchResultsLocations[namespace],
+      // If there was a job ID in the search bar, keep the same URL (job result)
+      pathname: jobRE.test(searchTerm)
+        ? location.pathname
+        : SearchResultsLocations[namespace],
       search: stringifiedSearch,
     });
   };

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -103,6 +103,7 @@ const SearchContainer: FC<
   const handleClose = useCallback(() => setDisplayQueryBuilder(false), []);
 
   const { jobId, jobResultsLocation } = useJobFromUrl();
+
   const handleSubmit = (event: SyntheticEvent) => {
     // prevent normal browser submission
     event.preventDefault();
@@ -116,9 +117,7 @@ const SearchContainer: FC<
     // push a new location to the history containing the modified search term
     history.push({
       // If there was a job ID in the search bar, keep the same URL (job result)
-      pathname: jobRE.test(searchTerm)
-        ? location.pathname
-        : SearchResultsLocations[namespace],
+      pathname: jobId ? location.pathname : SearchResultsLocations[namespace],
       search: stringifiedSearch,
     });
   };

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -225,7 +225,7 @@ export const getAPIQueryUrl = ({
   }
   return `${apiUrls.search(namespace)}?${queryString.stringify({
     size,
-    query: `${[`(${query})` || '*', createFacetsQueryString(selectedFacets)]
+    query: `${[`(${query})`, createFacetsQueryString(selectedFacets)]
       .filter(Boolean)
       .join(' AND ')}`,
     fields: columns?.join(',') || undefined,

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -248,6 +248,7 @@ type GetOptions = {
   sortDirection?: SortDirection;
   facets?: Facets[] | null;
   size?: number;
+  query?: string;
 };
 
 export const getAccessionsURL = (
@@ -260,6 +261,7 @@ export const getAccessionsURL = (
     sortDirection = SortDirection.ascend,
     facets,
     size,
+    query,
   }: GetOptions = {}
 ) => {
   if (!(accessions && accessions.length)) {
@@ -279,6 +281,7 @@ export const getAccessionsURL = (
       size,
       // sort to improve possible cache hit
       [key]: Array.from(accessions).sort().join(','),
+      query: query || undefined,
       facetFilter:
         createFacetsQueryString(
           selectedFacets.filter(excludeLocalBlastFacets)

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -194,6 +194,8 @@ const BlastResult = () => {
   const [hspDetailPanel, setHspDetailPanel] =
     useState<HSPDetailPanelProps | null>();
 
+  const [{ query }] = getParamsFromURL(location.search);
+
   // if URL doesn't finish with "overview" redirect to /overview by default
   useEffect(() => {
     if (match && !match.params.subPage) {
@@ -259,8 +261,14 @@ const BlastResult = () => {
           namespace,
           selectedFacets: urlParams.selectedFacets,
           facets: [],
+          query,
         }),
-      [accessionsFilteredByLocalFacets, namespace, urlParams.selectedFacets]
+      [
+        accessionsFilteredByLocalFacets,
+        namespace,
+        query,
+        urlParams.selectedFacets,
+      ]
     )
   );
 

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -57,6 +57,7 @@ type Return<T extends JobTypes> = Readonly<{
       facets?: string[];
       size?: number;
       selectedFacets?: SelectedFacet[];
+      query?: string;
     }
   ) => string;
   detailsUrl?: (jobId: string) => string;
@@ -78,11 +79,20 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
         statusUrl: (jobId) =>
           // The cachebust extra query is just here to avoid using cached value
           `${baseURL}/status/${jobId}?cachebust=${new Date().getTime()}`,
-        resultUrl: (redirectUrl, { facets, size, selectedFacets = [] }) =>
+        resultUrl: (
+          redirectUrl,
+          { facets, size, selectedFacets = [], query }
+        ) =>
           `${redirectUrl}?${queryString.stringify({
             size,
             facets: facets?.join(','),
-            query: createFacetsQueryString(selectedFacets),
+            // Similar approach to the one in apiUrls.ts file
+            query: `${[
+              `(${query || '*'})`,
+              createFacetsQueryString(selectedFacets),
+            ]
+              .filter(Boolean)
+              .join(' AND ')}`,
           })}`,
         detailsUrl: (jobId) => `${baseURL}/details/${jobId}`,
       });

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -55,7 +55,7 @@ const IDMappingResult = () => {
   const location = useLocation();
   const databaseInfoMaps = useDatabaseInfoMaps();
   const { search: queryParamFromUrl } = location;
-  const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
+  const [{ selectedFacets, query }] = getParamsFromURL(queryParamFromUrl);
 
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
@@ -70,7 +70,7 @@ const IDMappingResult = () => {
   // Query for results data from the idmapping endpoint
   const initialApiUrl =
     detailsData?.redirectURL &&
-    urls.resultUrl(detailsData.redirectURL, { selectedFacets });
+    urls.resultUrl(detailsData.redirectURL, { selectedFacets, query });
 
   const converter = useMemo(() => idMappingConverter(toDBInfo), [toDBInfo]);
 
@@ -112,6 +112,7 @@ const IDMappingResult = () => {
       facets,
       size: 0,
       selectedFacets,
+      query,
     });
   const facetsData = useDataApiWithStale<Response['data']>(facetsUrl);
 


### PR DESCRIPTION
## Purpose
Add filtering according to the URL for ID Mapping, Peptide Search, and BLAST results.
Make the search bar work when submitting a search from there

## Approach
ID Mapping => pass query (without the job) to the ID mapping results endpoint
Peptide Search & BLAST => pass query (without the job) to the accessions endpoint (unable to check much because it's not supported yet + endpoint glitching, I'm assuming because of the ongoing update)

## Testing
Just a bit of manual testing for now

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
