### PR TITLE
add tabs logic to all tools results

### DIFF
--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -254,6 +254,7 @@ export const jobTypeToPath = (type: JobTypes, job?: Job) => {
           )?.to.toLowerCase() as Database
         ),
         id: (job as FinishedJob<JobTypes.ID_MAPPING>).remoteID,
+        subPage: 'overview',
       });
     case JobTypes.PEPTIDE_SEARCH:
       if (!job) {
@@ -261,6 +262,7 @@ export const jobTypeToPath = (type: JobTypes, job?: Job) => {
       }
       return generatePath(LocationToPath[Location.PeptideSearchResult], {
         id: (job as FinishedJob<JobTypes.PEPTIDE_SEARCH>).remoteID,
+        subPage: 'overview',
       });
     default:
     //

--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -123,7 +123,7 @@ export const LocationToPath: Record<Location, string> = {
   [Location.PeptideSearch]: '/peptide-search',
   [Location.IDMappingResult]: `/id-mapping/:namespace(${IDMappingNamespaces.join(
     '|'
-  )})?/:id`,
+  )})?/:id/:subPage?`,
   [Location.IDMapping]: '/id-mapping',
   // Help
   [Location.HelpEntry]: '/help/:accession',

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -138,7 +138,7 @@ const AlignResult = () => {
   // get data from the align endpoint
   const { loading, data, error, status, progress } = useDataApi<AlignResults>(
     match?.params.id &&
-      urls.resultUrl(match.params.id || '', { format: 'aln-clustal_num' })
+      urls.resultUrl(match.params.id, { format: 'aln-clustal_num' })
   );
 
   const inputParamsData = useParamsData(match?.params.id || '');

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -1,11 +1,5 @@
 import { useMemo, useEffect, useState, lazy, Suspense } from 'react';
-import {
-  Link,
-  useRouteMatch,
-  useHistory,
-  useLocation,
-  generatePath,
-} from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Loader, PageIntro, Tabs, Tab } from 'franklin-sites';
 import cn from 'classnames';
 
@@ -36,7 +30,6 @@ import {
   blastNamespaces,
   changePathnameOnly,
   Location,
-  LocationToPath,
 } from '../../../../app/config/urls';
 import toolsURLs from '../../../config/urls';
 import { getAccessionsURL } from '../../../../shared/config/apiUrls';

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -53,6 +53,7 @@ import { UniRefLiteAPIModel } from '../../../../uniref/adapters/uniRefConverter'
 import { UniParcAPIModel } from '../../../../uniparc/adapters/uniParcConverter';
 
 import helper from '../../../../shared/styles/helper.module.scss';
+import { useMatchWithRedirect } from '../../../utils/hooks';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
@@ -184,29 +185,17 @@ export const enrich = (
 };
 
 const BlastResult = () => {
-  const history = useHistory();
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const match = useRouteMatch<Params>(LocationToPath[Location.BlastResult])!;
   const location = useLocation();
+  const match = useMatchWithRedirect<Params>(
+    Location.BlastResult,
+    TabLocation.Overview
+  );
 
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
   const [hspDetailPanel, setHspDetailPanel] =
     useState<HSPDetailPanelProps | null>();
 
   const [{ query }] = getParamsFromURL(location.search);
-
-  // if URL doesn't finish with "overview" redirect to /overview by default
-  useEffect(() => {
-    if (match && !match.params.subPage) {
-      history.replace({
-        ...history.location,
-        pathname: generatePath(LocationToPath[Location.AlignResult], {
-          ...match.params,
-          subPage: TabLocation.Overview,
-        }),
-      });
-    }
-  }, [match, history]);
 
   // get data from the blast endpoint
   const {
@@ -289,7 +278,7 @@ const BlastResult = () => {
     [data]
   );
 
-  useMarkJobAsSeen(data, match.params.id);
+  useMarkJobAsSeen(data, match?.params.id);
 
   const inputParamsData = useParamsData(match?.params.id || '');
 

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -311,33 +311,25 @@ const BlastResult = () => {
     return <ErrorHandler status={blastStatus} />;
   }
 
-  // sidebar option 1
-  const facetsSidebar = (
-    <ErrorBoundary>
-      <BlastResultSidebar
-        accessions={accessionsFilteredByLocalFacets}
-        allHits={blastData.hits}
-        namespace={namespace}
-      />
-    </ErrorBoundary>
-  );
-
-  // sidebar option 2
-  const emptySidebar = (
-    <div className="sidebar-layout__sidebar-content--empty" />
-  );
-
   let sidebar: JSX.Element;
   // Deciding what should be displayed on the sidebar
   switch (match.params.subPage) {
     case TabLocation.TextOutput:
     case TabLocation.InputParameters:
     case TabLocation.APIRequest:
-      sidebar = emptySidebar;
+      sidebar = <div className="sidebar-layout__sidebar-content--empty" />;
       break;
 
     default:
-      sidebar = facetsSidebar;
+      sidebar = (
+        <ErrorBoundary>
+          <BlastResultSidebar
+            accessions={accessionsFilteredByLocalFacets}
+            allHits={blastData.hits}
+            namespace={namespace}
+          />
+        </ErrorBoundary>
+      );
       break;
   }
 

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -53,7 +53,6 @@ import { UniRefLiteAPIModel } from '../../../../uniref/adapters/uniRefConverter'
 import { UniParcAPIModel } from '../../../../uniparc/adapters/uniParcConverter';
 
 import helper from '../../../../shared/styles/helper.module.scss';
-import sticky from '../../../../shared/styles/sticky.module.scss';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
@@ -350,7 +349,6 @@ const BlastResult = () => {
     <SideBarLayout
       title={<PageIntro title={title} resultsCount={hitsFiltered.length} />}
       sidebar={sidebar}
-      className={sticky['sticky-tabs-container']}
     >
       <HTMLHead title={title} />
       <Tabs

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -1,19 +1,18 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect, lazy, Suspense } from 'react';
+import { Loader, PageIntro, Tab, Tabs } from 'franklin-sites';
 import {
-  ExpandableList,
-  HeroContainer,
-  Loader,
-  PageIntro,
-} from 'franklin-sites';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+  generatePath,
+  Link,
+  useHistory,
+  useLocation,
+  useRouteMatch,
+} from 'react-router-dom';
 
 import HTMLHead from '../../../../shared/components/HTMLHead';
 import SideBarLayout from '../../../../shared/components/layouts/SideBarLayout';
-import ResultsData from '../../../../shared/components/results/ResultsData';
-import ResultsButtons from '../../../../shared/components/results/ResultsButtons';
+import ErrorBoundary from '../../../../shared/components/error-component/ErrorBoundary';
 import ResultsFacets from '../../../../shared/components/results/ResultsFacets';
 
-import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import useDataApi from '../../../../shared/hooks/useDataApi';
 import usePagination from '../../../../shared/hooks/usePagination';
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
@@ -23,11 +22,11 @@ import useDatabaseInfoMaps from '../../../../shared/hooks/useDatabaseInfoMaps';
 import toolsURLs from '../../../config/urls';
 import idMappingConverter from '../../adapters/idMappingConverter';
 import { getParamsFromURL } from '../../../../uniprotkb/utils/resultsUtils';
-import { getIdKeyFor } from '../../../../shared/utils/getIdKeyForNamespace';
 import { defaultFacets } from '../../../../shared/config/apiUrls';
 
 import { JobTypes } from '../../../types/toolsJobTypes';
 import {
+  changePathnameOnly,
   IDMappingNamespaces,
   Location,
   LocationToPath,
@@ -47,18 +46,64 @@ const jobType = JobTypes.ID_MAPPING;
 const urls = toolsURLs(jobType);
 const title = `${namespaceAndToolsLabels[jobType]} results`;
 
-const IDMappingResult = () => {
-  const match = useRouteMatch<{
-    id: string;
-    namespace?: typeof IDMappingNamespaces[number];
-  }>(LocationToPath[Location.IDMappingResult]);
-  const location = useLocation();
-  const databaseInfoMaps = useDatabaseInfoMaps();
-  const { search: queryParamFromUrl } = location;
-  const [{ selectedFacets, query }] = getParamsFromURL(queryParamFromUrl);
+// overview
+const IDMappingResultTable = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "id-mapping-result-page" */ './IDMappingResultTable'
+    )
+);
+// input-parameters
+// const InputParameters = lazy(
+//   () =>
+//     import(
+//       /* webpackChunkName: "input-parameters" */ '../../../components/InputParameters'
+//     )
+// );
+// input-parameters
+// const APIRequest = lazy(
+//   () =>
+//     import(
+//       /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
+//     )
+// );
 
-  const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
-    useItemSelect();
+enum TabLocation {
+  Overview = 'overview',
+  InputParameters = 'input-parameters',
+  APIRequest = 'api-request',
+}
+
+type Params = {
+  id: string;
+  namespace?: typeof IDMappingNamespaces[number];
+  subPage?: TabLocation;
+};
+
+const IDMappingResult = () => {
+  const history = useHistory();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const match = useRouteMatch<Params>(
+    LocationToPath[Location.IDMappingResult]
+  )!;
+  const location = useLocation();
+
+  const databaseInfoMaps = useDatabaseInfoMaps();
+
+  const [{ selectedFacets, query }] = getParamsFromURL(location.search);
+
+  // if URL doesn't finish with "overview" redirect to /overview by default
+  useEffect(() => {
+    if (match && !match.params.subPage) {
+      history.replace({
+        ...history.location,
+        pathname: generatePath(LocationToPath[Location.IDMappingResult], {
+          ...match.params,
+          subPage: TabLocation.Overview,
+        }),
+      });
+    }
+  }, [match, history]);
 
   const detailApiUrl =
     urls.detailsUrl && urls.detailsUrl(match?.params.id || '');
@@ -81,7 +126,7 @@ const IDMappingResult = () => {
 
   const {
     initialLoading: resultsDataInitialLoading,
-    failedIds,
+    progress,
     total,
   } = resultsDataObject;
 
@@ -108,6 +153,7 @@ const IDMappingResult = () => {
   const facets = defaultFacets.get(namespaceOverride);
   const facetsUrl =
     detailsData?.redirectURL &&
+    facets &&
     urls.resultUrl(detailsData.redirectURL, {
       facets,
       size: 0,
@@ -126,13 +172,32 @@ const IDMappingResult = () => {
     resultsDataInitialLoading &&
     !facetHasStaleData
   ) {
-    return <Loader />;
+    return <Loader progress={progress} />;
   }
 
-  const getIdKey = getIdKeyFor(namespaceOverride);
+  let sidebar: JSX.Element;
+  // Deciding what should be displayed on the sidebar
+  switch (match.params.subPage) {
+    case TabLocation.InputParameters:
+    case TabLocation.APIRequest:
+      sidebar = <div className="sidebar-layout__sidebar-content--empty" />;
+      break;
+
+    default:
+      sidebar = (
+        <ErrorBoundary>
+          <ResultsFacets dataApiObject={facetsData} />
+        </ErrorBoundary>
+      );
+      break;
+  }
+
+  const basePath = `/id-mapping/${
+    namespaceOverride === Namespace.idmapping ? '' : `${namespaceOverride}/`
+  }${match.params.id}/`;
 
   return (
-    <SideBarLayout sidebar={<ResultsFacets dataApiObject={facetsData} />}>
+    <SideBarLayout sidebar={sidebar}>
       <HTMLHead
         title={[
           title,
@@ -151,34 +216,57 @@ const IDMappingResult = () => {
         }
         resultsCount={total}
       />
-      <ResultsButtons
-        total={total || 0}
-        loadedTotal={resultsDataObject.allResults.length}
-        selectedEntries={selectedEntries}
-        accessions={resultsDataObject.allResults.map(getIdKey)}
-        namespaceOverride={namespaceOverride}
-        disableCardToggle
-        base={detailsData?.redirectURL}
-        notCustomisable={namespaceOverride === Namespace.idmapping}
-      />
-
-      {failedIds && (
-        <HeroContainer>
-          <strong>{failedIds.length}</strong> id
-          {failedIds.length === 1 ? ' is' : 's were'} not mapped:
-          <ExpandableList descriptionString="ids" numberCollapsedItems={0}>
-            {failedIds}
-          </ExpandableList>
-        </HeroContainer>
-      )}
-      <ResultsData
-        resultsDataObject={resultsDataObject}
-        setSelectedItemFromEvent={setSelectedItemFromEvent}
-        setSelectedEntries={setSelectedEntries}
-        namespaceOverride={namespaceOverride}
-        displayIdMappingColumns
-        disableCardToggle
-      />
+      <Tabs active={match.params.subPage}>
+        <Tab
+          id={TabLocation.Overview}
+          title={
+            <Link to={changePathnameOnly(basePath + TabLocation.Overview)}>
+              Overview
+            </Link>
+          }
+          cache
+        >
+          <Suspense fallback={<Loader />}>
+            <IDMappingResultTable
+              namespaceOverride={namespaceOverride}
+              resultsDataObject={resultsDataObject}
+              detailsData={detailsData}
+            />
+          </Suspense>
+        </Tab>
+        <Tab
+          id={TabLocation.InputParameters}
+          title={
+            <Link
+              to={changePathnameOnly(basePath + TabLocation.InputParameters)}
+            >
+              Input Parameters
+            </Link>
+          }
+        >
+          <HTMLHead title={[title, 'Input Parameters']} />
+          <Suspense fallback={<Loader />}>
+            {/* <InputParameters
+              id={match.params.id}
+              inputParamsData={inputParamsData}
+              jobType={jobType}
+            /> */}
+          </Suspense>
+        </Tab>
+        <Tab
+          id={TabLocation.APIRequest}
+          title={
+            <Link to={changePathnameOnly(basePath + TabLocation.APIRequest)}>
+              API Request
+            </Link>
+          }
+        >
+          <HTMLHead title={[title, 'API Request']} />
+          <Suspense fallback={<Loader />}>
+            {/* <APIRequest jobType={jobType} inputParamsData={inputParamsData} /> */}
+          </Suspense>
+        </Tab>
+      </Tabs>
     </SideBarLayout>
   );
 };

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -197,7 +197,22 @@ const IDMappingResult = () => {
   }${match.params.id}/`;
 
   return (
-    <SideBarLayout sidebar={sidebar}>
+    <SideBarLayout
+      title={
+        <PageIntro
+          title={namespaceAndToolsLabels[Namespace.idmapping]}
+          titlePostscript={
+            total && (
+              <small>
+                for {detailsData?.from} → {detailsData?.to}
+              </small>
+            )
+          }
+          resultsCount={total}
+        />
+      }
+      sidebar={sidebar}
+    >
       <HTMLHead
         title={[
           title,
@@ -205,17 +220,7 @@ const IDMappingResult = () => {
             namespaceAndToolsLabels[namespaceOverride],
         ]}
       />
-      <PageIntro
-        title={namespaceAndToolsLabels[namespaceOverride]}
-        titlePostscript={
-          total && (
-            <small>
-              for {detailsData?.from} → {detailsData?.to}
-            </small>
-          )
-        }
-        resultsCount={total}
-      />
+
       <Tabs active={match.params.subPage}>
         <Tab
           id={TabLocation.Overview}

--- a/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
@@ -1,0 +1,65 @@
+import { ExpandableList, HeroContainer } from 'franklin-sites';
+
+import ResultsData from '../../../../shared/components/results/ResultsData';
+import ResultsButtons from '../../../../shared/components/results/ResultsButtons';
+
+import useItemSelect from '../../../../shared/hooks/useItemSelect';
+
+import { getIdKeyFor } from '../../../../shared/utils/getIdKeyForNamespace';
+
+import { Namespace } from '../../../../shared/types/namespaces';
+import { PaginatedResults } from '../../../../shared/hooks/usePagination';
+import { MappingDetails } from '../../types/idMappingSearchResults';
+
+type IDMappingResultTable = {
+  namespaceOverride: Namespace;
+  resultsDataObject: PaginatedResults;
+  detailsData?: MappingDetails;
+};
+
+const IDMappingResultTable = ({
+  namespaceOverride,
+  resultsDataObject,
+  detailsData,
+}: IDMappingResultTable) => {
+  const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
+    useItemSelect();
+
+  const getIdKey = getIdKeyFor(namespaceOverride);
+
+  return (
+    <>
+      <ResultsButtons
+        total={resultsDataObject.total || 0}
+        loadedTotal={resultsDataObject.allResults.length}
+        selectedEntries={selectedEntries}
+        accessions={resultsDataObject.allResults.map(getIdKey)}
+        namespaceOverride={namespaceOverride}
+        disableCardToggle
+        base={detailsData?.redirectURL}
+        notCustomisable={namespaceOverride === Namespace.idmapping}
+      />
+
+      {resultsDataObject.failedIds && (
+        <HeroContainer>
+          <strong>{resultsDataObject.failedIds.length}</strong> id
+          {resultsDataObject.failedIds.length === 1 ? ' is' : 's were'} not
+          mapped:
+          <ExpandableList descriptionString="ids" numberCollapsedItems={0}>
+            {resultsDataObject.failedIds}
+          </ExpandableList>
+        </HeroContainer>
+      )}
+      <ResultsData
+        resultsDataObject={resultsDataObject}
+        setSelectedItemFromEvent={setSelectedItemFromEvent}
+        setSelectedEntries={setSelectedEntries}
+        namespaceOverride={namespaceOverride}
+        displayIdMappingColumns
+        disableCardToggle
+      />
+    </>
+  );
+};
+
+export default IDMappingResultTable;

--- a/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
@@ -11,7 +11,7 @@ import { Namespace } from '../../../../shared/types/namespaces';
 import { PaginatedResults } from '../../../../shared/hooks/usePagination';
 import { MappingDetails } from '../../types/idMappingSearchResults';
 
-type IDMappingResultTable = {
+type IDMappingResultTableProps = {
   namespaceOverride: Namespace;
   resultsDataObject: PaginatedResults;
   detailsData?: MappingDetails;
@@ -21,7 +21,7 @@ const IDMappingResultTable = ({
   namespaceOverride,
   resultsDataObject,
   detailsData,
-}: IDMappingResultTable) => {
+}: IDMappingResultTableProps) => {
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
 
@@ -39,7 +39,6 @@ const IDMappingResultTable = ({
         base={detailsData?.redirectURL}
         notCustomisable={namespaceOverride === Namespace.idmapping}
       />
-
       {resultsDataObject.failedIds && (
         <HeroContainer>
           <strong>{resultsDataObject.failedIds.length}</strong> id

--- a/src/tools/id-mapping/components/results/__tests__/IDMappingResult.spec.tsx
+++ b/src/tools/id-mapping/components/results/__tests__/IDMappingResult.spec.tsx
@@ -26,7 +26,7 @@ mock
 describe('IDMappingResult tests', () => {
   it('should render simple from/to mapping', async () => {
     customRender(<IDMappingResult />, {
-      route: '/id-mapping/id1',
+      route: '/id-mapping/id1/overview',
       initialLocalStorage: {
         'view-mode': 'table' as ViewMode, // This should eventually be removed
       },
@@ -36,7 +36,7 @@ describe('IDMappingResult tests', () => {
 
   it('should render mapping to UniProtKB and apply filter', async () => {
     const { history } = customRender(<IDMappingResult />, {
-      route: '/id-mapping/id2',
+      route: '/id-mapping/uniprotkb/id2/overview',
       initialLocalStorage: {
         'view-mode': 'table' as ViewMode, // This should eventually be removed
       },

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -1,50 +1,98 @@
-import { useMemo, useRef } from 'react';
-import { useRouteMatch } from 'react-router-dom';
-import { Loader } from 'franklin-sites';
+import { useMemo, useEffect, useRef, lazy, Suspense } from 'react';
+import {
+  generatePath,
+  Link,
+  useHistory,
+  useRouteMatch,
+} from 'react-router-dom';
+import { Loader, PageIntro, Tab, Tabs } from 'franklin-sites';
 import { partialRight } from 'lodash-es';
 
 import useDataApi from '../../../../shared/hooks/useDataApi';
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 import useNSQuery from '../../../../shared/hooks/useNSQuery';
-import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import usePagination from '../../../../shared/hooks/usePagination';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
 import { useToolsState } from '../../../../shared/contexts/Tools';
 
 import HTMLHead from '../../../../shared/components/HTMLHead';
-import ResultsData from '../../../../shared/components/results/ResultsData';
+import ErrorBoundary from '../../../../shared/components/error-component/ErrorBoundary';
 import ResultsFacets from '../../../../shared/components/results/ResultsFacets';
-import ResultsDataHeader from '../../../../shared/components/results/ResultsDataHeader';
 import SideBarLayout from '../../../../shared/components/layouts/SideBarLayout';
 import NoResultsPage from '../../../../shared/components/error-pages/NoResultsPage';
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
 
 import toolsURLs from '../../../config/urls';
-import { namespaceAndToolsLabels } from '../../../../shared/types/namespaces';
-import { LocationToPath, Location } from '../../../../app/config/urls';
+import {
+  Namespace,
+  namespaceAndToolsLabels,
+} from '../../../../shared/types/namespaces';
+import {
+  LocationToPath,
+  Location,
+  changePathnameOnly,
+} from '../../../../app/config/urls';
 import peptideSearchConverter from '../../adapters/peptideSearchConverter';
 
 import Response from '../../../../uniprotkb/types/responseTypes';
 import { PeptideSearchResults } from '../../types/peptideSearchResults';
 import { JobTypes } from '../../../types/toolsJobTypes';
 import { Status } from '../../../types/toolsStatuses';
-import { FinishedJob, Job } from '../../../types/toolsJob';
+import { FinishedJob } from '../../../types/toolsJob';
+import { ToolsState } from '../../../state/toolsInitialState';
+
+import helper from '../../../../shared/styles/helper.module.scss';
 
 const jobType = JobTypes.PEPTIDE_SEARCH;
 const urls = toolsURLs(jobType);
 const title = `${namespaceAndToolsLabels[jobType]} results`;
 
+// overview
+const PeptideSearchResultTable = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "peptide-search-result-page" */ './PeptideSearchResultTable'
+    )
+);
+// // input-parameters
+// const InputParameters = lazy(
+//   () =>
+//     import(
+//       /* webpackChunkName: "input-parameters" */ '../../../components/InputParameters'
+//     )
+// );
+// // input-parameters
+// const APIRequest = lazy(
+//   () =>
+//     import(
+//       /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
+//     )
+// );
+
+enum TabLocation {
+  Overview = 'overview',
+  InputParameters = 'input-parameters',
+  APIRequest = 'api-request',
+}
+
+type Params = {
+  id: string;
+  subPage?: TabLocation;
+};
+
 const PeptideSearchResult = ({
   toolsState,
 }: {
-  toolsState: { [key: string]: Job };
+  toolsState: NonNullable<ToolsState>;
 }) => {
-  const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
-    useItemSelect();
-  const jobSubmission = useRef<FinishedJob<JobTypes.PEPTIDE_SEARCH>>();
-
-  const match = useRouteMatch<{ id: string }>(
+  const history = useHistory();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const match = useRouteMatch<Params>(
     LocationToPath[Location.PeptideSearchResult]
+  )!;
+
+  const jobSubmission = useRef<FinishedJob<JobTypes.PEPTIDE_SEARCH> | null>(
+    null
   );
   const jobID = match?.params.id || '';
   const {
@@ -53,6 +101,19 @@ const PeptideSearchResult = ({
     error: jobResultError,
     status: jobResultStatus,
   } = useDataApi<PeptideSearchResults>(urls.resultUrl(jobID, {}));
+
+  // if URL doesn't finish with "overview" redirect to /overview by default
+  useEffect(() => {
+    if (match && !match.params.subPage) {
+      history.replace({
+        ...history.location,
+        pathname: generatePath(LocationToPath[Location.PeptideSearchResult], {
+          ...match.params,
+          subPage: TabLocation.Overview,
+        }),
+      });
+    }
+  }, [match, history]);
 
   // Get the job mission from local tools state. Save this in a reference as
   // the job may change with useMarkJobAsSeen but we don't want to have to
@@ -65,7 +126,7 @@ const PeptideSearchResult = ({
     );
     jobSubmission.current = found
       ? (found as FinishedJob<JobTypes.PEPTIDE_SEARCH>)
-      : undefined;
+      : null;
   }
 
   const accessions = useMemo(
@@ -157,22 +218,98 @@ const PeptideSearchResult = ({
   ) {
     return <Loader progress={resultsDataProgress} />;
   }
+
+  let sidebar: JSX.Element;
+  // Deciding what should be displayed on the sidebar
+  switch (match.params.subPage) {
+    case TabLocation.TextOutput:
+    case TabLocation.InputParameters:
+    case TabLocation.APIRequest:
+      sidebar = <div className="sidebar-layout__sidebar-content--empty" />;
+      break;
+
+    default:
+      sidebar = (
+        <ErrorBoundary>
+          <ResultsFacets dataApiObject={facetApiObject} />
+        </ErrorBoundary>
+      );
+      break;
+  }
+
+  const basePath = `/peptide-search/${match.params.id}/`;
+
   return (
-    <SideBarLayout sidebar={<ResultsFacets dataApiObject={facetApiObject} />}>
+    <SideBarLayout
+      title={
+        <PageIntro
+          title={namespaceAndToolsLabels[JobTypes.PEPTIDE_SEARCH]}
+          titlePostscript={
+            total && (
+              <small>in {namespaceAndToolsLabels[Namespace.uniprotkb]}</small>
+            )
+          }
+          resultsCount={total}
+        />
+      }
+      sidebar={sidebar}
+    >
       <HTMLHead title={title} />
-      <ResultsDataHeader
-        total={total}
-        loadedTotal={sortedResultsDataObject.allResults.length}
-        selectedEntries={selectedEntries}
-        accessions={accessions}
-      />
-      <ResultsData
-        resultsDataObject={sortedResultsDataObject}
-        setSelectedItemFromEvent={setSelectedItemFromEvent}
-        setSelectedEntries={setSelectedEntries}
-        // TODO: change logic when peptide search API is able to return submitted jobSubmission information
-        displayPeptideSearchMatchColumns={Boolean(jobSubmission.current)}
-      />
+      <Tabs
+        active={match.params.subPage}
+        className={jobResultLoading ? helper.stale : undefined}
+      >
+        <Tab
+          id={TabLocation.Overview}
+          title={
+            <Link to={changePathnameOnly(basePath + TabLocation.Overview)}>
+              Overview
+            </Link>
+          }
+          cache
+        >
+          <Suspense fallback={<Loader />}>
+            <PeptideSearchResultTable
+              total={total}
+              sortedResultsDataObject={sortedResultsDataObject}
+              accessions={accessions}
+              jobSubmission={jobSubmission}
+            />
+          </Suspense>
+        </Tab>
+        <Tab
+          id={TabLocation.InputParameters}
+          title={
+            <Link
+              to={changePathnameOnly(basePath + TabLocation.InputParameters)}
+            >
+              Input Parameters
+            </Link>
+          }
+        >
+          <HTMLHead title={[title, 'Input Parameters']} />
+          <Suspense fallback={<Loader />}>
+            {/* <InputParameters
+              id={match.params.id}
+              inputParamsData={inputParamsData}
+              jobType={jobType}
+            /> */}
+          </Suspense>
+        </Tab>
+        <Tab
+          id={TabLocation.APIRequest}
+          title={
+            <Link to={changePathnameOnly(basePath + TabLocation.APIRequest)}>
+              API Request
+            </Link>
+          }
+        >
+          <HTMLHead title={[title, 'API Request']} />
+          <Suspense fallback={<Loader />}>
+            {/* <APIRequest jobType={jobType} inputParamsData={inputParamsData} /> */}
+          </Suspense>
+        </Tab>
+      </Tabs>
     </SideBarLayout>
   );
 };

--- a/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
@@ -1,0 +1,54 @@
+import { MutableRefObject } from 'react';
+import ResultsButtons from '../../../../shared/components/results/ResultsButtons';
+import ResultsData from '../../../../shared/components/results/ResultsData';
+
+import useItemSelect from '../../../../shared/hooks/useItemSelect';
+
+import { APIModel } from '../../../../shared/types/apiModel';
+import { FinishedJob } from '../../../types/toolsJob';
+import { JobTypes } from '../../../types/toolsJobTypes';
+
+type PeptideSearchResultTableProps = {
+  total?: number;
+  sortedResultsDataObject: {
+    allResults: APIModel[];
+    initialLoading: boolean;
+    progress?: number | undefined;
+    hasMoreData: boolean;
+    handleLoadMoreRows: () => void;
+    total?: number | undefined;
+    failedIds?: string[] | undefined;
+  };
+  accessions?: string[];
+  jobSubmission: MutableRefObject<FinishedJob<JobTypes.PEPTIDE_SEARCH> | null>;
+};
+
+const PeptideSearchResultTable = ({
+  total,
+  sortedResultsDataObject,
+  accessions,
+  jobSubmission,
+}: PeptideSearchResultTableProps) => {
+  const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
+    useItemSelect();
+
+  return (
+    <>
+      <ResultsButtons
+        total={total || 0}
+        loadedTotal={sortedResultsDataObject.allResults.length}
+        selectedEntries={selectedEntries}
+        accessions={accessions}
+      />
+      <ResultsData
+        resultsDataObject={sortedResultsDataObject}
+        setSelectedItemFromEvent={setSelectedItemFromEvent}
+        setSelectedEntries={setSelectedEntries}
+        // TODO: change logic when peptide search API is able to return submitted jobSubmission information
+        displayPeptideSearchMatchColumns={Boolean(jobSubmission.current)}
+      />
+    </>
+  );
+};
+
+export default PeptideSearchResultTable;

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -13,363 +13,425 @@ exports[`PeptideSearchResult should render with the correct number of results in
     >
       <section
         class="sidebar-layout__title"
-      />
-      <div
-        class="page-intro"
       >
-        <h1
-          class=""
-        >
-          Peptide search
-          <small>
-             2 results 
-          </small>
-        </h1>
-      </div>
-      <div
-        class="button-group results-buttons"
-      >
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to run a BLAST job"
-          type="button"
-        >
-          BLAST
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least 2 entries to run an Align job"
-          type="button"
-        >
-          Align
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to map"
-          type="button"
-        >
-          Map IDs
-        </button>
-        <button
-          class="button tertiary"
-          type="button"
-        >
-          <test-file-stub />
-          Download
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to add to the basket"
-          type="button"
-        >
-          <test-file-stub />
-          Add
-        </button>
-        <span
-          role="radiogroup"
-        >
-          View:
-          <label>
-            Table 
-            <input
-              checked=""
-              name="view"
-              type="radio"
-            />
-          </label>
-          <label>
-            Card 
-            <input
-              name="view"
-              type="radio"
-            />
-          </label>
-        </span>
-        <button
-          class="button tertiary"
-          type="button"
-        >
-          <test-file-stub />
-          Customize columns
-        </button>
-      </div>
-      <div
-        class="results-data"
-      >
-        <table
-          class="data-table"
-        >
-          <thead>
-            <tr>
-              <th
-                class="data-table__header-cell--checkbox"
-              >
-                <div
-                  class="checkbox-cell"
-                >
-                  <input
-                    id="1"
-                    type="checkbox"
-                  />
-                  <label
-                    aria-label="Selection control for all visible items"
-                    for="1"
-                  />
-                </div>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span>
-                    Entry
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              />
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="entry_name"
-                  >
-                    Entry Name
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="protein_names"
-                  >
-                    Protein Names
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="gene_name"
-                  >
-                    Gene Names
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="organism-name"
-                  >
-                    Organism
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span>
-                    Length
-                  </span>
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td
-                class="checkbox-cell"
-              >
-                <input
-                  data-id="P35575"
-                  id="3"
-                  type="checkbox"
-                />
-                <label
-                  aria-label="P35575"
-                  for="3"
-                  title="click to select, shift+click for multiple selection"
-                />
-              </td>
-              <td>
-                <span
-                  class="no-wrap accession-view"
-                >
-                  <a
-                    class="accession"
-                    href="/uniprotkb/P35575"
-                  >
-                    P35575
-                  </a>
-                </span>
-              </td>
-              <td>
-                <span
-                  class="entry-title__status icon--reviewed"
-                  title="This marks a reviewed UniProtKB entry"
-                >
-                  <test-file-stub />
-                </span>
-              </td>
-              <td>
-                <span>
-                  G6PC1_HUMAN
-                </span>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  Glucose-6-phosphatase catalytic subunit 1
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  G6PC1
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <a
-                  href="/taxonomy/9606"
-                  title="Homo sapiens (Human), taxon ID 9606"
-                >
-                  Homo sapiens (Human)
-                </a>
-              </td>
-              <td>
-                357 AA
-              </td>
-            </tr>
-            <tr>
-              <td
-                class="checkbox-cell"
-              >
-                <input
-                  data-id="O43826"
-                  id="4"
-                  type="checkbox"
-                />
-                <label
-                  aria-label="O43826"
-                  for="4"
-                  title="click to select, shift+click for multiple selection"
-                />
-              </td>
-              <td>
-                <span
-                  class="no-wrap accession-view"
-                >
-                  <a
-                    class="accession"
-                    href="/uniprotkb/O43826"
-                  >
-                    O43826
-                  </a>
-                </span>
-              </td>
-              <td>
-                <span
-                  class="entry-title__status icon--reviewed"
-                  title="This marks a reviewed UniProtKB entry"
-                >
-                  <test-file-stub />
-                </span>
-              </td>
-              <td>
-                <span>
-                  G6PT1_HUMAN
-                </span>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  Glucose-6-phosphate exchanger SLC37A4
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  SLC37A4
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <a
-                  href="/taxonomy/9606"
-                  title="Homo sapiens (Human), taxon ID 9606"
-                >
-                  Homo sapiens (Human)
-                </a>
-              </td>
-              <td>
-                429 AA
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <div
-          class="data-loader__loading"
-        />
+          class="page-intro"
+        >
+          <h1
+            class=""
+          >
+            Peptide search
+            <small>
+               2 results 
+            </small>
+            <small>
+              in UniProtKB
+            </small>
+          </h1>
+        </div>
+      </section>
+      <div
+        class="tabs"
+      >
+        <div
+          class="tabs__header"
+          role="tablist"
+        >
+          <div
+            aria-controls="1"
+            class="tabs__header__item tabs__header__item--active"
+            data-target="overview"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/overview"
+            >
+              Overview
+            </a>
+          </div>
+          <div
+            aria-controls="1"
+            class="tabs__header__item"
+            data-target="input-parameters"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/input-parameters"
+            >
+              Input Parameters
+            </a>
+          </div>
+          <div
+            aria-controls="1"
+            class="tabs__header__item"
+            data-target="api-request"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/api-request"
+            >
+              API Request
+            </a>
+          </div>
+        </div>
+        <div
+          data-testid="tab-content"
+          id="1"
+          role="tabpanel"
+        >
+          <div
+            style="display: block;"
+          >
+            <div
+              class="button-group results-buttons"
+            >
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to run a BLAST job"
+                type="button"
+              >
+                BLAST
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least 2 entries to run an Align job"
+                type="button"
+              >
+                Align
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to map"
+                type="button"
+              >
+                Map IDs
+              </button>
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                <test-file-stub />
+                Download
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to add to the basket"
+                type="button"
+              >
+                <test-file-stub />
+                Add
+              </button>
+              <span
+                role="radiogroup"
+              >
+                View:
+                <label>
+                  Table 
+                  <input
+                    checked=""
+                    name="view"
+                    type="radio"
+                  />
+                </label>
+                <label>
+                  Card 
+                  <input
+                    name="view"
+                    type="radio"
+                  />
+                </label>
+              </span>
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                <test-file-stub />
+                Customize columns
+              </button>
+            </div>
+            <div
+              class="results-data"
+            >
+              <table
+                class="data-table"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      class="data-table__header-cell--checkbox"
+                    >
+                      <div
+                        class="checkbox-cell"
+                      >
+                        <input
+                          id="3"
+                          type="checkbox"
+                        />
+                        <label
+                          aria-label="Selection control for all visible items"
+                          for="3"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span>
+                          Entry
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    />
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="entry_name"
+                        >
+                          Entry Name
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="protein_names"
+                        >
+                          Protein Names
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="gene_name"
+                        >
+                          Gene Names
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="organism-name"
+                        >
+                          Organism
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span>
+                          Length
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      class="checkbox-cell"
+                    >
+                      <input
+                        data-id="P35575"
+                        id="6"
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="P35575"
+                        for="6"
+                        title="click to select, shift+click for multiple selection"
+                      />
+                    </td>
+                    <td>
+                      <span
+                        class="no-wrap accession-view"
+                      >
+                        <a
+                          class="accession"
+                          href="/uniprotkb/P35575"
+                        >
+                          P35575
+                        </a>
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        class="entry-title__status icon--reviewed"
+                        title="This marks a reviewed UniProtKB entry"
+                      >
+                        <test-file-stub />
+                      </span>
+                    </td>
+                    <td>
+                      <span>
+                        G6PC1_HUMAN
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        Glucose-6-phosphatase catalytic subunit 1
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        G6PC1
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <a
+                        href="/taxonomy/9606"
+                        title="Homo sapiens (Human), taxon ID 9606"
+                      >
+                        Homo sapiens (Human)
+                      </a>
+                    </td>
+                    <td>
+                      357 AA
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      class="checkbox-cell"
+                    >
+                      <input
+                        data-id="O43826"
+                        id="7"
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="O43826"
+                        for="7"
+                        title="click to select, shift+click for multiple selection"
+                      />
+                    </td>
+                    <td>
+                      <span
+                        class="no-wrap accession-view"
+                      >
+                        <a
+                          class="accession"
+                          href="/uniprotkb/O43826"
+                        >
+                          O43826
+                        </a>
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        class="entry-title__status icon--reviewed"
+                        title="This marks a reviewed UniProtKB entry"
+                      >
+                        <test-file-stub />
+                      </span>
+                    </td>
+                    <td>
+                      <span>
+                        G6PT1_HUMAN
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        Glucose-6-phosphate exchanger SLC37A4
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        SLC37A4
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <a
+                        href="/taxonomy/9606"
+                        title="Homo sapiens (Human), taxon ID 9606"
+                      >
+                        Homo sapiens (Human)
+                      </a>
+                    </td>
+                    <td>
+                      429 AA
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="data-loader__loading"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   </div>
@@ -389,408 +451,470 @@ exports[`PeptideSearchResult should render with the correct number of results in
     >
       <section
         class="sidebar-layout__title"
-      />
-      <div
-        class="page-intro"
       >
-        <h1
-          class=""
-        >
-          Peptide search
-          <small>
-             2 results 
-          </small>
-        </h1>
-      </div>
-      <div
-        class="button-group results-buttons"
-      >
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to run a BLAST job"
-          type="button"
-        >
-          BLAST
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least 2 entries to run an Align job"
-          type="button"
-        >
-          Align
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to map"
-          type="button"
-        >
-          Map IDs
-        </button>
-        <button
-          class="button tertiary"
-          type="button"
-        >
-          <test-file-stub />
-          Download
-        </button>
-        <button
-          class="button tertiary disabled"
-          disabled=""
-          title="Select at least one entry to add to the basket"
-          type="button"
-        >
-          <test-file-stub />
-          Add
-        </button>
-        <span
-          role="radiogroup"
-        >
-          View:
-          <label>
-            Table 
-            <input
-              checked=""
-              name="view"
-              type="radio"
-            />
-          </label>
-          <label>
-            Card 
-            <input
-              name="view"
-              type="radio"
-            />
-          </label>
-        </span>
-        <button
-          class="button tertiary"
-          type="button"
-        >
-          <test-file-stub />
-          Customize columns
-        </button>
-      </div>
-      <div
-        class="results-data"
-      >
-        <table
-          class="data-table"
-        >
-          <thead>
-            <tr>
-              <th
-                class="data-table__header-cell--checkbox"
-              >
-                <div
-                  class="checkbox-cell"
-                >
-                  <input
-                    id="1"
-                    type="checkbox"
-                  />
-                  <label
-                    aria-label="Selection control for all visible items"
-                    for="1"
-                  />
-                </div>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span>
-                    Entry
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span>
-                    Match
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              />
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="entry_name"
-                  >
-                    Entry Name
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="protein_names"
-                  >
-                    Protein Names
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="gene_name"
-                  >
-                    Gene Names
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span
-                    data-article-id="organism-name"
-                  >
-                    Organism
-                  </span>
-                </span>
-              </th>
-              <th
-                class=""
-              >
-                <span
-                  aria-expanded="false"
-                >
-                  <span>
-                    Length
-                  </span>
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td
-                class="checkbox-cell"
-              >
-                <input
-                  data-id="P35575"
-                  id="3"
-                  type="checkbox"
-                />
-                <label
-                  aria-label="P35575"
-                  for="3"
-                  title="click to select, shift+click for multiple selection"
-                />
-              </td>
-              <td>
-                <span
-                  class="no-wrap accession-view"
-                >
-                  <a
-                    class="accession"
-                    href="/uniprotkb/P35575"
-                  >
-                    P35575
-                  </a>
-                </span>
-              </td>
-              <td>
-                <ul
-                  class="no-bullet no-wrap"
-                >
-                  <li>
-                    Positions 13-59: IQSTHYLQVN
-                    <button
-                      aria-expanded="false"
-                      class="button tertiary ellipsis-reveal"
-                      title="Show more"
-                      type="button"
-                    >
-                      [...]
-                    </button>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <span
-                  class="entry-title__status icon--reviewed"
-                  title="This marks a reviewed UniProtKB entry"
-                >
-                  <test-file-stub />
-                </span>
-              </td>
-              <td>
-                <span>
-                  G6PC1_HUMAN
-                </span>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  Glucose-6-phosphatase catalytic subunit 1
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  G6PC1
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <a
-                  href="/taxonomy/9606"
-                  title="Homo sapiens (Human), taxon ID 9606"
-                >
-                  Homo sapiens (Human)
-                </a>
-              </td>
-              <td>
-                357 AA
-              </td>
-            </tr>
-            <tr>
-              <td
-                class="checkbox-cell"
-              >
-                <input
-                  data-id="O43826"
-                  id="4"
-                  type="checkbox"
-                />
-                <label
-                  aria-label="O43826"
-                  for="4"
-                  title="click to select, shift+click for multiple selection"
-                />
-              </td>
-              <td>
-                <span
-                  class="no-wrap accession-view"
-                >
-                  <a
-                    class="accession"
-                    href="/uniprotkb/O43826"
-                  >
-                    O43826
-                  </a>
-                </span>
-              </td>
-              <td>
-                <ul
-                  class="no-bullet no-wrap"
-                >
-                  <li>
-                    Positions 2-33: AAQGYGYYRT
-                    <button
-                      aria-expanded="false"
-                      class="button tertiary ellipsis-reveal"
-                      title="Show more"
-                      type="button"
-                    >
-                      [...]
-                    </button>
-                  </li>
-                </ul>
-              </td>
-              <td>
-                <span
-                  class="entry-title__status icon--reviewed"
-                  title="This marks a reviewed UniProtKB entry"
-                >
-                  <test-file-stub />
-                </span>
-              </td>
-              <td>
-                <span>
-                  G6PT1_HUMAN
-                </span>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  Glucose-6-phosphate exchanger SLC37A4
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <span
-                  style="font-weight: bolder;"
-                >
-                  SLC37A4
-                </span>
-                <button
-                  aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
-                >
-                  [...]
-                </button>
-              </td>
-              <td>
-                <a
-                  href="/taxonomy/9606"
-                  title="Homo sapiens (Human), taxon ID 9606"
-                >
-                  Homo sapiens (Human)
-                </a>
-              </td>
-              <td>
-                429 AA
-              </td>
-            </tr>
-          </tbody>
-        </table>
         <div
-          class="data-loader__loading"
-        />
+          class="page-intro"
+        >
+          <h1
+            class=""
+          >
+            Peptide search
+            <small>
+               2 results 
+            </small>
+            <small>
+              in UniProtKB
+            </small>
+          </h1>
+        </div>
+      </section>
+      <div
+        class="tabs"
+      >
+        <div
+          class="tabs__header"
+          role="tablist"
+        >
+          <div
+            aria-controls="2"
+            class="tabs__header__item tabs__header__item--active"
+            data-target="overview"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/overview"
+            >
+              Overview
+            </a>
+          </div>
+          <div
+            aria-controls="2"
+            class="tabs__header__item"
+            data-target="input-parameters"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/input-parameters"
+            >
+              Input Parameters
+            </a>
+          </div>
+          <div
+            aria-controls="2"
+            class="tabs__header__item"
+            data-target="api-request"
+            data-testid="tab-title"
+            role="tab"
+          >
+            <a
+              href="/peptide-search/remote-id/api-request"
+            >
+              API Request
+            </a>
+          </div>
+        </div>
+        <div
+          data-testid="tab-content"
+          id="2"
+          role="tabpanel"
+        >
+          <div
+            style="display: block;"
+          >
+            <div
+              class="button-group results-buttons"
+            >
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to run a BLAST job"
+                type="button"
+              >
+                BLAST
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least 2 entries to run an Align job"
+                type="button"
+              >
+                Align
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to map"
+                type="button"
+              >
+                Map IDs
+              </button>
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                <test-file-stub />
+                Download
+              </button>
+              <button
+                class="button tertiary disabled"
+                disabled=""
+                title="Select at least one entry to add to the basket"
+                type="button"
+              >
+                <test-file-stub />
+                Add
+              </button>
+              <span
+                role="radiogroup"
+              >
+                View:
+                <label>
+                  Table 
+                  <input
+                    checked=""
+                    name="view"
+                    type="radio"
+                  />
+                </label>
+                <label>
+                  Card 
+                  <input
+                    name="view"
+                    type="radio"
+                  />
+                </label>
+              </span>
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                <test-file-stub />
+                Customize columns
+              </button>
+            </div>
+            <div
+              class="results-data"
+            >
+              <table
+                class="data-table"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      class="data-table__header-cell--checkbox"
+                    >
+                      <div
+                        class="checkbox-cell"
+                      >
+                        <input
+                          id="4"
+                          type="checkbox"
+                        />
+                        <label
+                          aria-label="Selection control for all visible items"
+                          for="4"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span>
+                          Entry
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span>
+                          Match
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    />
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="entry_name"
+                        >
+                          Entry Name
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="protein_names"
+                        >
+                          Protein Names
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="gene_name"
+                        >
+                          Gene Names
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span
+                          data-article-id="organism-name"
+                        >
+                          Organism
+                        </span>
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        aria-expanded="false"
+                      >
+                        <span>
+                          Length
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      class="checkbox-cell"
+                    >
+                      <input
+                        data-id="P35575"
+                        id="7"
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="P35575"
+                        for="7"
+                        title="click to select, shift+click for multiple selection"
+                      />
+                    </td>
+                    <td>
+                      <span
+                        class="no-wrap accession-view"
+                      >
+                        <a
+                          class="accession"
+                          href="/uniprotkb/P35575"
+                        >
+                          P35575
+                        </a>
+                      </span>
+                    </td>
+                    <td>
+                      <ul
+                        class="no-bullet no-wrap"
+                      >
+                        <li>
+                          Positions 13-59: IQSTHYLQVN
+                          <button
+                            aria-expanded="false"
+                            class="button tertiary ellipsis-reveal"
+                            title="Show more"
+                            type="button"
+                          >
+                            [...]
+                          </button>
+                        </li>
+                      </ul>
+                    </td>
+                    <td>
+                      <span
+                        class="entry-title__status icon--reviewed"
+                        title="This marks a reviewed UniProtKB entry"
+                      >
+                        <test-file-stub />
+                      </span>
+                    </td>
+                    <td>
+                      <span>
+                        G6PC1_HUMAN
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        Glucose-6-phosphatase catalytic subunit 1
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        G6PC1
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <a
+                        href="/taxonomy/9606"
+                        title="Homo sapiens (Human), taxon ID 9606"
+                      >
+                        Homo sapiens (Human)
+                      </a>
+                    </td>
+                    <td>
+                      357 AA
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      class="checkbox-cell"
+                    >
+                      <input
+                        data-id="O43826"
+                        id="8"
+                        type="checkbox"
+                      />
+                      <label
+                        aria-label="O43826"
+                        for="8"
+                        title="click to select, shift+click for multiple selection"
+                      />
+                    </td>
+                    <td>
+                      <span
+                        class="no-wrap accession-view"
+                      >
+                        <a
+                          class="accession"
+                          href="/uniprotkb/O43826"
+                        >
+                          O43826
+                        </a>
+                      </span>
+                    </td>
+                    <td>
+                      <ul
+                        class="no-bullet no-wrap"
+                      >
+                        <li>
+                          Positions 2-33: AAQGYGYYRT
+                          <button
+                            aria-expanded="false"
+                            class="button tertiary ellipsis-reveal"
+                            title="Show more"
+                            type="button"
+                          >
+                            [...]
+                          </button>
+                        </li>
+                      </ul>
+                    </td>
+                    <td>
+                      <span
+                        class="entry-title__status icon--reviewed"
+                        title="This marks a reviewed UniProtKB entry"
+                      >
+                        <test-file-stub />
+                      </span>
+                    </td>
+                    <td>
+                      <span>
+                        G6PT1_HUMAN
+                      </span>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        Glucose-6-phosphate exchanger SLC37A4
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <span
+                        style="font-weight: bolder;"
+                      >
+                        SLC37A4
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        class="button tertiary ellipsis-reveal"
+                        title="Show more"
+                        type="button"
+                      >
+                        [...]
+                      </button>
+                    </td>
+                    <td>
+                      <a
+                        href="/taxonomy/9606"
+                        title="Homo sapiens (Human), taxon ID 9606"
+                      >
+                        Homo sapiens (Human)
+                      </a>
+                    </td>
+                    <td>
+                      429 AA
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="data-loader__loading"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   </div>

--- a/src/tools/utils/hooks.ts
+++ b/src/tools/utils/hooks.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useHistory, generatePath, useRouteMatch } from 'react-router-dom';
+
+import { LocationToPath, Location } from '../../app/config/urls';
+
+export const useMatchWithRedirect = <T extends { subPage?: string }>(
+  location: Location,
+  defaultSubPage: string
+) => {
+  const history = useHistory();
+  const match = useRouteMatch<T>(LocationToPath[location]);
+
+  // if URL doesn't finish with a subpage redirect to a default
+  useEffect(() => {
+    if (match && !match.params.subPage) {
+      history.replace({
+        ...history.location,
+        pathname: generatePath(LocationToPath[location], {
+          ...match.params,
+          subPage: defaultSubPage,
+        }),
+      });
+    }
+  }, [match, history, location, defaultSubPage]);
+
+  return match;
+};


### PR DESCRIPTION
## Purpose
Add tab logic for all tools results.

## Approach
Add tab logic for all tools results, including correct routing, and a bit of refactor in order to have as much as possible parallel logic in all files (to help future refactors) + isolate custom hook to redirect to "overview" when no subpage is specified.
Doesn't include the actual content of the added tabs.

## Testing
Manual test + update snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
