### PR TITLE
2022 04 tools adv search titles & peptide search form fix

### DIFF
--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -57,7 +57,7 @@ import sticky from '../../../../shared/styles/sticky.module.scss';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
-const title = `${namespaceAndToolsLabels[jobType]}`;
+const title = namespaceAndToolsLabels[jobType];
 
 // overview
 const BlastResultTable = lazy(

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -57,7 +57,7 @@ import sticky from '../../../../shared/styles/sticky.module.scss';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
-const title = `${namespaceAndToolsLabels[jobType]} results`;
+const title = `${namespaceAndToolsLabels[jobType]}`;
 
 // overview
 const BlastResultTable = lazy(
@@ -356,7 +356,15 @@ const BlastResult = () => {
 
   return (
     <SideBarLayout
-      title={<PageIntro title={title} resultsCount={hitsFiltered.length} />}
+      title={
+        <PageIntro
+          title={title}
+          titlePostscript={
+            <small>found in {namespaceAndToolsLabels[namespace]}</small>
+          }
+          resultsCount={hitsFiltered.length}
+        />
+      }
       sidebar={sidebar}
       className={sticky['sticky-tabs-container']}
     >

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -141,11 +141,11 @@ const IDMappingResult = () => {
         ]}
       />
       <PageIntro
-        title={namespaceAndToolsLabels[namespaceOverride]}
+        title={namespaceAndToolsLabels[Namespace.idmapping]}
         titlePostscript={
           total && (
             <small>
-              for {detailsData?.from} → {detailsData?.to}
+              found for {detailsData?.from} → {detailsData?.to}
             </small>
           )
         }

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -13,6 +13,7 @@ import { useHistory } from 'react-router-dom';
 import { Chip, PageIntro, SpinnerIcon } from 'franklin-sites';
 import { sleep } from 'timing-functions';
 import cn from 'classnames';
+import { truncate } from 'lodash-es';
 
 import HTMLHead from '../../../shared/components/HTMLHead';
 import AutocompleteWrapper from '../../../query-builder/components/AutocompleteWrapper';
@@ -240,7 +241,7 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
       return;
     }
     if (parsedSequences.length > 0) {
-      const potentialJobName = `${firstParsedSequence}${
+      const potentialJobName = `${truncate(firstParsedSequence)}${
         parsedSequences.length > 1 ? ` +${parsedSequences.length - 1}` : ''
       }`;
       setJobName((jobName) => {

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -20,7 +20,10 @@ import NoResultsPage from '../../../../shared/components/error-pages/NoResultsPa
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
 
 import toolsURLs from '../../../config/urls';
-import { namespaceAndToolsLabels } from '../../../../shared/types/namespaces';
+import {
+  Namespace,
+  namespaceAndToolsLabels,
+} from '../../../../shared/types/namespaces';
 import { LocationToPath, Location } from '../../../../app/config/urls';
 import peptideSearchConverter from '../../adapters/peptideSearchConverter';
 
@@ -162,6 +165,9 @@ const PeptideSearchResult = ({
       <HTMLHead title={title} />
       <ResultsDataHeader
         total={total}
+        titlePostscript={
+          <small>found in {namespaceAndToolsLabels[Namespace.uniprotkb]}</small>
+        }
         loadedTotal={sortedResultsDataObject.allResults.length}
         selectedEntries={selectedEntries}
         accessions={accessions}

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -24,6 +24,9 @@ exports[`PeptideSearchResult should render with the correct number of results in
           <small>
              2 results 
           </small>
+          <small>
+            found in UniProtKB
+          </small>
         </h1>
       </div>
       <div
@@ -399,6 +402,9 @@ exports[`PeptideSearchResult should render with the correct number of results in
           Peptide search
           <small>
              2 results 
+          </small>
+          <small>
+            found in UniProtKB
           </small>
         </h1>
       </div>


### PR DESCRIPTION
## Purpose
1. Standardise tool results titles
2. Fix peptide search form from growing

## Approach
1. Update title wording
2. Truncate long peptide sequences with ellipsis (defaults to 30) 

## Testing
Update snapshots

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
