### PR TITLE
2022 04 tools adv search tool results searchspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "core-js": "3.20.2",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.185",
+    "franklin-sites": "0.0.187",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "7.0.0",

--- a/src/app/components/home-page/HomePage.tsx
+++ b/src/app/components/home-page/HomePage.tsx
@@ -127,9 +127,9 @@ const HomePageHeader = memo(() => {
     >
       <div className="uniprot-grid uniprot-grid--centered">
         <SearchContainer
-          namespace={selectedNamespace}
-          onNamespaceChange={useCallback((namespace) => {
-            setSelectedNamespace(namespace);
+          searchspace={selectedNamespace}
+          onSearchspaceChange={useCallback((namespace) => {
+            setSelectedNamespace(namespace as SearchableNamespace);
             const textInput: HTMLInputElement | null = document.querySelector(
               'form.main-search input[type="text"]'
             );

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -32,6 +32,7 @@ import apiUrls from '../../shared/config/apiUrls';
 import {
   searchableNamespaceLabels,
   SearchableNamespace,
+  Searchspace,
 } from '../../shared/types/namespaces';
 import {
   LocationToPath,
@@ -60,7 +61,7 @@ type Props = {
   /**
    * The namespace to initialise the dropdown with
    */
-  initialNamespace: SearchableNamespace;
+  initialSearchspace: Searchspace;
 };
 interface Style extends CSSProperties {
   // TODO: define and extend the supported custom properties in franklin
@@ -68,18 +69,18 @@ interface Style extends CSSProperties {
   '--main-button-color': string;
 }
 
-const QueryBuilder = ({ onCancel, fieldToAdd, initialNamespace }: Props) => {
+const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
   const history = useHistory();
   const location = useLocation();
   const dispatch = useMessagesDispatch();
-
+  console.log(initialSearchspace);
   const [clauses, setClauses] = useState<Clause[]>([]);
 
   const { jobId, jobResultsNamespace, jobResultsLocation } = useJobFromUrl();
 
-  const [namespace, setNamespace] = useState(initialNamespace);
-  const [searchSpace, setSearchSpace] = useState<SearchableNamespace | 'job'>(
-    jobId ? 'job' : initialNamespace
+  const [namespace, setNamespace] = useState(initialSearchspace);
+  const [searchspace, setSearchspace] = useState<SearchableNamespace | 'job'>(
+    jobId ? 'job' : initialSearchspace
   );
   const style = useMemo<Style>(
     () => ({
@@ -95,7 +96,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialNamespace }: Props) => {
 
   useEffect(() => {
     setClauses([]);
-  }, [searchSpace]);
+  }, [searchspace]);
 
   useEffect(() => {
     if (!(searchTermsData && namespace) || loading) {
@@ -183,11 +184,11 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialNamespace }: Props) => {
     ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) => {
       if (value === 'job' && jobResultsNamespace) {
         setNamespace(jobResultsNamespace);
-        setSearchSpace('job');
+        setSearchspace('job');
         return;
       }
       setNamespace(value as SearchableNamespace);
-      setSearchSpace(value as SearchableNamespace);
+      setSearchspace(value as SearchableNamespace);
     },
     [jobResultsNamespace]
   );
@@ -242,7 +243,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialNamespace }: Props) => {
     event.preventDefault();
     const queryString = stringify(clauses) || '*';
     const pathname =
-      searchSpace === 'job' && jobId && jobResultsLocation
+      searchspace === 'job' && jobId && jobResultsLocation
         ? generatePath(LocationToPath[jobResultsLocation], {
             id: jobId,
             namespace: jobResultsNamespace,
@@ -269,7 +270,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialNamespace }: Props) => {
           <select
             id="namespace-select"
             onChange={onSearchSpaceChange}
-            value={searchSpace}
+            value={searchspace}
           >
             {searchSpaceOptions.map(({ value, label }) => (
               <option value={value} key={label}>

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -33,6 +33,7 @@ import {
   SearchableNamespace,
   searchableNamespaceLabels,
   Searchspace,
+  searchspaceLabels,
   toolResults,
 } from '../../shared/types/namespaces';
 import {
@@ -82,17 +83,12 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
   const namespace =
     searchspace === toolResults ? jobResultsNamespace : searchspace;
 
-  const color =
-    searchspace === toolResults
-      ? '#7F3D98'
-      : (colors as Record<string, string>)[searchspace];
-
   const style = useMemo<Style>(
     () => ({
       // change color of all buttons within this element to match the namespace
-      '--main-button-color': color,
+      '--main-button-color': (colors as Record<string, string>)[searchspace],
     }),
-    [color]
+    [searchspace]
   );
 
   const { loading, data: searchTermsData } = useDataApi<SearchTermType[]>(
@@ -165,23 +161,18 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
 
   const searchSpaceOptions = useMemo(() => {
     const options = [];
+    // If the user is looking at a job result populate the "Searching in" with this
+    // as an option just before the corresponding namespace
+    if (jobResultsNamespace && jobResultsLocation && jobId) {
+      const jobResultsNamespaceLabel =
+        searchableNamespaceLabels[jobResultsNamespace];
+      const jobToolLabel = toolsResultsLocationToLabel[jobResultsLocation];
+      options.push({
+        label: `${searchspaceLabels[toolResults]}: ${jobToolLabel} / ${jobResultsNamespaceLabel} / ${jobId}`,
+        value: toolResults,
+      });
+    }
     for (const [ns, label] of Object.entries(searchableNamespaceLabels)) {
-      // If the user is looking at a job result populate the "Searching in" with this
-      // as an option just before the corresponding namespace
-      if (
-        ns === jobResultsNamespace &&
-        jobResultsNamespace &&
-        jobResultsLocation &&
-        jobId
-      ) {
-        const jobResultsNamespaceLabel =
-          searchableNamespaceLabels[jobResultsNamespace];
-        const jobToolLabel = toolsResultsLocationToLabel[jobResultsLocation];
-        options.push({
-          label: `${jobResultsNamespaceLabel} / ${jobToolLabel} / ${jobId}`,
-          value: toolResults,
-        });
-      }
       options.push({ label, value: ns });
     }
     return options;

--- a/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
+++ b/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
@@ -22,7 +22,7 @@ describe('QueryBuilder', () => {
     rendered = customRender(
       <QueryBuilder
         onCancel={onCancel}
-        initialNamespace={Namespace.uniprotkb}
+        initialSearchspace={Namespace.uniprotkb}
       />
     );
   });
@@ -34,7 +34,7 @@ describe('QueryBuilder', () => {
     rendered = customRender(
       <QueryBuilder
         onCancel={onCancel}
-        initialNamespace={Namespace.uniprotkb}
+        initialSearchspace={Namespace.uniprotkb}
       />
     );
 

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -11,12 +11,7 @@ import useJobFromUrl from '../../hooks/useJobFromUrl';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
-import {
-  Namespace,
-  SearchableNamespace,
-  Searchspace,
-  toolResults,
-} from '../../types/namespaces';
+import { Namespace, Searchspace, toolResults } from '../../types/namespaces';
 
 import Logo from '../../../images/uniprot-logo-beta.svg';
 
@@ -45,24 +40,24 @@ const headerItems = [
 
 const SearchContainerWithNamespace = () => {
   const { jobId } = useJobFromUrl();
-  const searchspace = jobId ? toolResults : useNS() || Namespace.uniprotkb;
+  // namespace are proper namespaces of uniprot eg uniprotkb, uniref
+  const namespace = useNS() || Namespace.uniprotkb;
+  // searchspace is more general to include Tool results
+  const searchspace = jobId ? toolResults : namespace;
 
   const [selectedSearchspace, setSelectedSearchspace] = useState(searchspace);
 
   useEffect(() => {
     if (searchspace) {
-      console.log(searchspace);
       setSelectedSearchspace(searchspace);
     }
   }, [searchspace]);
 
-  console.log(selectedSearchspace);
-
   return (
     <SearchContainer
-      searchspace={selectedSearchspace}
-      onSearchspaceChange={(namespace: Searchspace) => {
-        setSelectedSearchspace(namespace);
+      searchspace={selectedSearchspace as Searchspace}
+      onSearchspaceChange={(searchspace: Searchspace) => {
+        setSelectedSearchspace(searchspace);
       }}
     />
   );

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -7,10 +7,16 @@ import ReleaseInfo from './ReleaseInfo';
 import secondaryItems from './SecondaryItems';
 
 import useNS from '../../hooks/useNS';
+import useJobFromUrl from '../../hooks/useJobFromUrl';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
-import { Namespace, SearchableNamespace } from '../../types/namespaces';
+import {
+  Namespace,
+  SearchableNamespace,
+  Searchspace,
+  toolResults,
+} from '../../types/namespaces';
 
 import Logo from '../../../images/uniprot-logo-beta.svg';
 
@@ -38,22 +44,26 @@ const headerItems = [
 ];
 
 const SearchContainerWithNamespace = () => {
-  const namespace = useNS() || Namespace.uniprotkb;
+  const { jobId } = useJobFromUrl();
+  const searchspace = jobId ? toolResults : useNS() || Namespace.uniprotkb;
 
-  const [selectedNamespace, setSelectedNamespace] = useState(namespace);
+  const [selectedSearchspace, setSelectedSearchspace] = useState(searchspace);
 
   useEffect(() => {
-    if (namespace) {
-      setSelectedNamespace(namespace);
+    if (searchspace) {
+      console.log(searchspace);
+      setSelectedSearchspace(searchspace);
     }
-  }, [namespace]);
+  }, [searchspace]);
+
+  console.log(selectedSearchspace);
 
   return (
     <SearchContainer
-      namespace={selectedNamespace as SearchableNamespace}
-      onNamespaceChange={(namespace: Namespace) =>
-        setSelectedNamespace(namespace)
-      }
+      searchspace={selectedSearchspace}
+      onSearchspaceChange={(namespace: Searchspace) => {
+        setSelectedSearchspace(namespace);
+      }}
     />
   );
 };

--- a/src/shared/components/results/TaxonomyFacet.tsx
+++ b/src/shared/components/results/TaxonomyFacet.tsx
@@ -89,7 +89,7 @@ const TaxonomyFacet: FC<{ namespace: SearchableNamespace }> = ({
               <QueryBuilder
                 onCancel={handleClose}
                 fieldToAdd="taxonomy_name"
-                initialNamespace={namespace}
+                initialSearchspace={namespace}
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -28,6 +28,8 @@ import {
   Namespace,
   searchableNamespaceLabels,
   SearchableNamespace,
+  Searchspace,
+  toolResults,
 } from '../../types/namespaces';
 
 import './styles/search-container.scss';
@@ -86,15 +88,15 @@ const examples: Record<SearchableNamespace, string[]> = {
 
 type Props = {
   isOnHomePage?: boolean;
-  namespace: SearchableNamespace;
-  onNamespaceChange: (namespace: SearchableNamespace) => void;
+  searchspace: Searchspace;
+  onSearchspaceChange: (searchspace: Searchspace) => void;
 };
 
 const jobRE = /job:[^ ]+( AND )?/i;
 
 const SearchContainer: FC<
   Props & Exclude<HTMLAttributes<HTMLDivElement>, 'role'>
-> = ({ isOnHomePage, namespace, onNamespaceChange, ...props }) => {
+> = ({ isOnHomePage, searchspace, onSearchspaceChange, ...props }) => {
   const history = useHistory();
   const location = useLocation();
   const [displayQueryBuilder, setDisplayQueryBuilder] = useState(false);
@@ -117,13 +119,17 @@ const SearchContainer: FC<
     // push a new location to the history containing the modified search term
     history.push({
       // If there was a job ID in the search bar, keep the same URL (job result)
-      pathname: jobId ? location.pathname : SearchResultsLocations[namespace],
+      pathname:
+        searchspace === toolResults
+          ? location.pathname
+          : SearchResultsLocations[searchspace],
       search: stringifiedSearch,
     });
   };
 
-  const setNamespace = (namespace: string) => {
-    onNamespaceChange(namespace as SearchableNamespace);
+  const setSearchspace = (searchspace: string) => {
+    console.log(searchspace);
+    onSearchspaceChange(searchspace as Searchspace);
   };
 
   const loadExample = (example: string) => {
@@ -184,16 +190,27 @@ const SearchContainer: FC<
     setSearchTerm(queryTokens.join(' AND '));
   }, [history, location.search, jobId, jobResultsLocation]);
 
+  // const [searchSpace, searchSpaces] = useMemo(
+  //   () =>
+  //     jobId
+  //       ? [
+  //           'Tool results',
+  //           { 'Tool results': 'Tool results', ...searchableNamespaceLabels },
+  //         ]
+  //       : [searchspace, searchableNamespaceLabels],
+  //   [jobId]
+  // );
+
   return (
     <>
       <section role="search" {...props}>
         <MainSearch
-          namespaces={searchableNamespaceLabels}
+          namespaces={searchSpaces}
           searchTerm={searchTerm}
           onTextChange={setSearchTerm}
           onSubmit={handleSubmit}
-          onNamespaceChange={setNamespace}
-          selectedNamespace={namespace}
+          onNamespaceChange={setSearchspace}
+          selectedNamespace={searchspace}
           secondaryButtons={secondaryButtons}
           autoFocus={isOnHomePage}
         />
@@ -242,7 +259,7 @@ const SearchContainer: FC<
             <ErrorBoundary>
               <QueryBuilder
                 onCancel={handleClose}
-                initialNamespace={namespace}
+                initialNamespace={searchspace}
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -190,22 +190,19 @@ const SearchContainer: FC<
     setSearchTerm(queryTokens.join(' AND '));
   }, [history, location.search, jobId, jobResultsLocation]);
 
-  // const [searchSpace, searchSpaces] = useMemo(
-  //   () =>
-  //     jobId
-  //       ? [
-  //           'Tool results',
-  //           { 'Tool results': 'Tool results', ...searchableNamespaceLabels },
-  //         ]
-  //       : [searchspace, searchableNamespaceLabels],
-  //   [jobId]
-  // );
+  const searchspaces = useMemo(
+    () =>
+      jobId
+        ? { toolResults, ...searchableNamespaceLabels }
+        : searchableNamespaceLabels,
+    [jobId]
+  );
 
   return (
     <>
       <section role="search" {...props}>
         <MainSearch
-          namespaces={searchSpaces}
+          namespaces={searchspaces}
           searchTerm={searchTerm}
           onTextChange={setSearchTerm}
           onSubmit={handleSubmit}

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -30,6 +30,7 @@ import {
   SearchableNamespace,
   Searchspace,
   toolResults,
+  searchspaceLabels,
 } from '../../types/namespaces';
 
 import './styles/search-container.scss';
@@ -122,13 +123,12 @@ const SearchContainer: FC<
       pathname:
         searchspace === toolResults
           ? location.pathname
-          : SearchResultsLocations[searchspace],
+          : SearchResultsLocations[searchspace as SearchableNamespace],
       search: stringifiedSearch,
     });
   };
 
   const setSearchspace = (searchspace: string) => {
-    console.log(searchspace);
     onSearchspaceChange(searchspace as Searchspace);
   };
 
@@ -190,13 +190,7 @@ const SearchContainer: FC<
     setSearchTerm(queryTokens.join(' AND '));
   }, [history, location.search, jobId, jobResultsLocation]);
 
-  const searchspaces = useMemo(
-    () =>
-      jobId
-        ? { toolResults, ...searchableNamespaceLabels }
-        : searchableNamespaceLabels,
-    [jobId]
-  );
+  const searchspaces = jobId ? searchspaceLabels : searchableNamespaceLabels;
 
   return (
     <>
@@ -214,20 +208,22 @@ const SearchContainer: FC<
         {isOnHomePage && (
           <div className="search-container-footer">
             <div>
-              {examples[namespace] && (
+              {examples[searchspace as SearchableNamespace] && (
                 <>
                   Examples:{' '}
-                  {examples[namespace]?.map((example, index) => (
-                    <Fragment key={example}>
-                      {index === 0 ? null : ', '}
-                      <Button
-                        variant="tertiary"
-                        onClick={() => loadExample(example)}
-                      >
-                        {example}
-                      </Button>
-                    </Fragment>
-                  ))}
+                  {examples[searchspace as SearchableNamespace]?.map(
+                    (example, index) => (
+                      <Fragment key={example}>
+                        {index === 0 ? null : ', '}
+                        <Button
+                          variant="tertiary"
+                          onClick={() => loadExample(example)}
+                        >
+                          {example}
+                        </Button>
+                      </Fragment>
+                    )
+                  )}
                 </>
               )}
             </div>
@@ -256,7 +252,7 @@ const SearchContainer: FC<
             <ErrorBoundary>
               <QueryBuilder
                 onCancel={handleClose}
-                initialNamespace={searchspace}
+                initialSearchspace={searchspace}
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -93,8 +93,6 @@ type Props = {
   onSearchspaceChange: (searchspace: Searchspace) => void;
 };
 
-const jobRE = /job:[^ ]+( AND )?/i;
-
 const SearchContainer: FC<
   Props & Exclude<HTMLAttributes<HTMLDivElement>, 'role'>
 > = ({ isOnHomePage, searchspace, onSearchspaceChange, ...props }) => {
@@ -113,7 +111,7 @@ const SearchContainer: FC<
 
     // restringify the resulting search
     const stringifiedSearch = queryString.stringify(
-      { query: searchTerm.replace(jobRE, '') || '*' },
+      { query: searchTerm || '*' },
       { encode: true }
     );
 
@@ -168,10 +166,6 @@ const SearchContainer: FC<
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.
   useEffect(() => {
-    const queryTokens = [];
-    if (jobId) {
-      queryTokens.push(`job:${jobId}`);
-    }
     const { query } = queryString.parse(location.search, { decode: true });
     // Using history here because history won't change, while location will
     if (
@@ -179,16 +173,12 @@ const SearchContainer: FC<
     ) {
       return;
     }
-    // Don't add any query that may be in URL for Align results
-    if (jobResultsLocation !== Location.AlignResult) {
-      if (Array.isArray(query)) {
-        queryTokens.push(query[0]);
-      } else if (query) {
-        queryTokens.push(query);
-      }
+    if (Array.isArray(query)) {
+      setSearchTerm(query[0]);
+      return;
     }
-    setSearchTerm(queryTokens.join(' AND '));
-  }, [history, location.search, jobId, jobResultsLocation]);
+    setSearchTerm(query || '');
+  }, [history, location.search]);
 
   const searchspaces = jobId ? searchspaceLabels : searchableNamespaceLabels;
 

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -41,26 +41,19 @@ describe('Search component on results page', () => {
       { route }
     );
   };
-  it('should display the job id when on a tools results page', () => {
+  it('should not display the job id when on a tools results page', () => {
     renderWithRoute('/id-mapping/uniparc/job123');
-    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
-      'job:job123'
-    );
+    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue('');
   });
   it('should display the job id and query when on a tools results page', () => {
     renderWithRoute('/id-mapping/uniparc/job123?query=foo');
-    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
-      'job:job123 AND foo'
-    );
+    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue('foo');
     expect(
       screen.getByRole('button', { name: 'Advanced' })
     ).toBeInTheDocument();
   });
-  it('should only display the job id when on an align tool results page', () => {
-    renderWithRoute('/align/job123?query=foo');
-    expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue(
-      'job:job123'
-    );
+  it('should not display the advanced search when on an align tool results page', () => {
+    renderWithRoute('/align/job123');
     expect(
       screen.queryByRole('button', { name: 'Advanced' })
     ).not.toBeInTheDocument();

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -12,8 +12,8 @@ describe('Search component on home page', () => {
     rendered = customRender(
       <SearchContainer
         isOnHomePage
-        namespace={Namespace.uniprotkb}
-        onNamespaceChange={jest.fn()}
+        searchspace={Namespace.uniprotkb}
+        onSearchspaceChange={jest.fn()}
       />
     );
   });
@@ -35,8 +35,8 @@ describe('Search component on results page', () => {
     customRender(
       <SearchContainer
         isOnHomePage={false}
-        namespace={Namespace.uniprotkb}
-        onNamespaceChange={jest.fn()}
+        searchspace={Namespace.uniprotkb}
+        onSearchspaceChange={jest.fn()}
       />,
       { route }
     );

--- a/src/shared/components/search/__tests__/SearchContainer.spec.tsx
+++ b/src/shared/components/search/__tests__/SearchContainer.spec.tsx
@@ -45,7 +45,7 @@ describe('Search component on results page', () => {
     renderWithRoute('/id-mapping/uniparc/job123');
     expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue('');
   });
-  it('should display the job id and query when on a tools results page', () => {
+  it('should display the query when on a tools results page', () => {
     renderWithRoute('/id-mapping/uniparc/job123?query=foo');
     expect(screen.getByLabelText('Text query in uniprotkb')).toHaveValue('foo');
     expect(

--- a/src/shared/types/namespaces.ts
+++ b/src/shared/types/namespaces.ts
@@ -49,7 +49,12 @@ export const supportingDataAndAANamespaces = new Set<Namespace>([
 
 export type SearchableNamespace = Exclude<Namespace, Namespace.idmapping>;
 
-export const searchableNamespaceLabels: Record<SearchableNamespace, string> = {
+export const toolResults = 'Tool results' as const;
+export type ToolResults = typeof toolResults;
+
+export type Searchspace = SearchableNamespace | ToolResults;
+
+export const searchableNamespaceLabels: Record<Searchspace, string> = {
   // Main data
   [Namespace.uniprotkb]: 'UniProtKB',
   [Namespace.uniref]: 'UniRef',
@@ -65,6 +70,8 @@ export const searchableNamespaceLabels: Record<SearchableNamespace, string> = {
   // Annotations
   [Namespace.unirule]: 'UniRule',
   [Namespace.arba]: 'ARBA',
+  // Tool results
+  [toolResults]: 'Tool results',
 };
 
 export const namespaceAndToolsLabels: Record<Namespace | JobTypes, string> = {

--- a/src/shared/types/namespaces.ts
+++ b/src/shared/types/namespaces.ts
@@ -66,11 +66,11 @@ export const searchableNamespaceLabels: Record<SearchableNamespace, string> = {
   [Namespace.unirule]: 'UniRule',
   [Namespace.arba]: 'ARBA',
 };
-export const toolResults = 'Tool results' as const;
+export const toolResults = 'toolResults' as const;
 export type ToolResults = typeof toolResults;
 export type Searchspace = SearchableNamespace | ToolResults;
 export const searchspaceLabels = {
-  [toolResults]: toolResults,
+  [toolResults]: 'Tool results',
   ...searchableNamespaceLabels,
 };
 

--- a/src/shared/types/namespaces.ts
+++ b/src/shared/types/namespaces.ts
@@ -49,12 +49,7 @@ export const supportingDataAndAANamespaces = new Set<Namespace>([
 
 export type SearchableNamespace = Exclude<Namespace, Namespace.idmapping>;
 
-export const toolResults = 'Tool results' as const;
-export type ToolResults = typeof toolResults;
-
-export type Searchspace = SearchableNamespace | ToolResults;
-
-export const searchableNamespaceLabels: Record<Searchspace, string> = {
+export const searchableNamespaceLabels: Record<SearchableNamespace, string> = {
   // Main data
   [Namespace.uniprotkb]: 'UniProtKB',
   [Namespace.uniref]: 'UniRef',
@@ -70,8 +65,13 @@ export const searchableNamespaceLabels: Record<Searchspace, string> = {
   // Annotations
   [Namespace.unirule]: 'UniRule',
   [Namespace.arba]: 'ARBA',
-  // Tool results
-  [toolResults]: 'Tool results',
+};
+export const toolResults = 'Tool results' as const;
+export type ToolResults = typeof toolResults;
+export type Searchspace = SearchableNamespace | ToolResults;
+export const searchspaceLabels = {
+  [toolResults]: toolResults,
+  ...searchableNamespaceLabels,
 };
 
 export const namespaceAndToolsLabels: Record<Namespace | JobTypes, string> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,10 +6427,10 @@ foundation-sites@6.7.4:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.7.4.tgz#495ddb3b7014ae33df3bf7cc1f9fe74b2cfd572e"
   integrity sha512-2QPaZJ0Od0DyklhQyKC3zPbr8AAUXSkr1scZJrQTgj/KTLresuCgUBfi7ft32NlOWhuqVXisjOgTE8N5EPS3cg==
 
-franklin-sites@0.0.185:
-  version "0.0.185"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.185.tgz#7be8fa6e150da43766b1051d4c00bfb9f4f443f8"
-  integrity sha512-XySrdA11YMa/Niz3jefvsZGgVmLduyfro6sMvPoxb3+8GKSA5UAFzzG9Mq8zJYKh0+s7g5rE7TGSSFSyHPgmow==
+franklin-sites@0.0.187:
+  version "0.0.187"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.187.tgz#c0166a48e80c2ccf27adaf2edf532fd049dab50a"
+  integrity sha512-40GOxFpt4ioBjOrez0qjKhyxJhS1/Q3R68d7qscNshywXZGOavU6jhkO6mzJKXPkCNbWrHUx/3L26H8y08iX0Q==
   dependencies:
     "@tippyjs/react" "4.2.6"
     classnames "2.3.1"


### PR DESCRIPTION
## Purpose
Use a tool results search space for all jobs and use franklin's corresponding color.

## Approach

- Create `searchspace` which is all searchable namespaces and tool results. This is only visible when there is a job in the url.
- Remove `job:<jobId>` from search input when viewing tool results

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why