### PR TITLE
handle ID Mapping and Peptide Search in API Request tab

### DIFF
--- a/src/tools/components/APIRequest.tsx
+++ b/src/tools/components/APIRequest.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { Loader, CodeBlock, ExternalLink } from 'franklin-sites';
+import cn from 'classnames';
 
 import ErrorHandler from '../../shared/components/error-pages/ErrorHandler';
 
@@ -112,7 +113,7 @@ const APIRequest: FC<APIRequestProps> = ({ inputParamsData, jobType }) => {
     ('peps' in inputParamsData ? inputParamsData : inputParamsData.data);
 
   return (
-    <section className={styles.container}>
+    <section className={cn(styles.container, styles['api-request'])}>
       <p>
         Using{' '}
         <a

--- a/src/tools/components/APIRequest.tsx
+++ b/src/tools/components/APIRequest.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Loader, CodeBlock } from 'franklin-sites';
+import { Loader, CodeBlock, ExternalLink } from 'franklin-sites';
 
 import ErrorHandler from '../../shared/components/error-pages/ErrorHandler';
 
@@ -9,10 +9,14 @@ import toolsURLs from '../config/urls';
 
 import { PublicServerParameters } from '../types/toolsServerParameters';
 import { JobTypes } from '../types/toolsJobTypes';
+import { FormParameters as PeptideSearchFormParameters } from '../peptide-search/types/peptideSearchFormParameters';
+
+import styles from './styles/extra-tabs.module.css';
 
 // exclude data that is just there as information and cannot be set
 const exclude = new Map<JobTypes, string[]>([
   [JobTypes.ALIGN, ['program', 'version']],
+  [JobTypes.ID_MAPPING, ['redirectURL']],
 ]);
 
 const documentation = new Map<JobTypes, string>([
@@ -24,37 +28,91 @@ const documentation = new Map<JobTypes, string>([
     JobTypes.BLAST,
     'https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?pageId=94147939#NCBIBLAST+HelpandDocumentation-RESTAPI',
   ],
+  [
+    JobTypes.ID_MAPPING,
+    `${API_PREFIX}/docs/?urls.primaryName=idmapping#/job/submitJob`,
+  ],
+  [
+    JobTypes.PEPTIDE_SEARCH,
+    'https://research.bioinformatics.udel.edu/peptidematchws/',
+  ],
 ]);
 
 function inputToCurl<T extends JobTypes>(
-  input: Partial<PublicServerParameters[T]>,
-  jobType: T
+  jobType: T,
+  input?:
+    | Partial<PublicServerParameters[T]>
+    | PeptideSearchFormParameters
+    | null
 ) {
   const excluded = exclude.get(jobType) || [];
-  let command = "curl -F 'email=<enter your email here>' \\\n";
-  for (const [key, value] of Object.entries(input)) {
-    if (!excluded.includes(key)) {
-      command += `     -F '${key}=${value}' \\\n`;
+  const inputEntries = Object.entries(input || {}).filter(
+    ([key, value]) => !excluded.includes(key) && value !== undefined
+  );
+  if (jobType === JobTypes.ALIGN || jobType === JobTypes.BLAST) {
+    inputEntries.unshift(['email', '<enter_your_email_here>']);
+  }
+  if (jobType === JobTypes.PEPTIDE_SEARCH && !input) {
+    inputEntries.push(['peps', '<enter_your_peptide_or_peptides_here>']);
+  }
+  let command = 'curl';
+
+  let first = true;
+  for (const [key, value] of inputEntries) {
+    if (jobType === JobTypes.PEPTIDE_SEARCH) {
+      // Peptide Search doesn't support form data, needs to be in URL encoded
+      // append key/value to the URL string
+      if (key === 'peps' && value === '<enter_your_peptide_or_peptides_here>') {
+        command += `${first ? ' --data "' : '&'}${key}=${value}`;
+      } else {
+        command += `${first ? ' --data "' : '&'}${key}=${encodeURIComponent(
+          value
+        )}`;
+      }
+    } else {
+      // Add indentation if needed, and key/value
+      command += `${first ? '' : '    '} --form '${key}=${value}' \\\n`;
     }
+    first = false;
+  }
+
+  if (jobType === JobTypes.PEPTIDE_SEARCH) {
+    // Peptide Search doesn't support form data, needs to be in URL encoded
+    command += '" \\\n     --verbose \\\n';
   }
   command += `     ${toolsURLs(jobType).runUrl}`;
   return command;
 }
 
 type APIRequestProps = {
-  inputParamsData: Partial<UseDataAPIState<PublicServerParameters[JobTypes]>>;
+  // No public endpoint to expose this for peptide search, so for now replace
+  // with a "possible" job object in the case it's the same user that created it
+  inputParamsData?:
+    | Partial<UseDataAPIState<PublicServerParameters[JobTypes]>>
+    | PeptideSearchFormParameters
+    | null;
   jobType: JobTypes;
 };
 
 const APIRequest: FC<APIRequestProps> = ({ inputParamsData, jobType }) => {
-  const { loading, data, error, status } = inputParamsData;
-
-  if (error || !data) {
-    return <ErrorHandler status={status} />;
+  if (
+    inputParamsData &&
+    // This is for TS to typeguard, after that we're sure it's not a local job
+    !('peps' in inputParamsData) &&
+    // We now have a data payload for sure, check for errors normally
+    (inputParamsData.error || !inputParamsData.data)
+  ) {
+    return <ErrorHandler status={inputParamsData.status} />;
   }
 
+  const documentationURL = documentation.get(jobType);
+
+  const data =
+    inputParamsData &&
+    ('peps' in inputParamsData ? inputParamsData : inputParamsData.data);
+
   return (
-    <section>
+    <section className={styles.container}>
       <p>
         Using{' '}
         <a
@@ -67,12 +125,22 @@ const APIRequest: FC<APIRequestProps> = ({ inputParamsData, jobType }) => {
         , you could run a new job on the command line with the same input as
         this job by running:
       </p>
-      {loading ? (
+      {inputParamsData &&
+      'loading' in inputParamsData &&
+      inputParamsData.loading ? (
         <Loader />
       ) : (
-        <CodeBlock lightMode>{inputToCurl(data, jobType)}</CodeBlock>
+        <CodeBlock lightMode>{inputToCurl(jobType, data)}</CodeBlock>
       )}
-      {'sequence' in data && data.sequence.includes("'") && (
+      {jobType === JobTypes.PEPTIDE_SEARCH && (
+        <p>
+          <small>
+            The URL with your job result will be listed in the{' '}
+            <code>Location</code> response header
+          </small>
+        </p>
+      )}
+      {data && 'sequence' in data && data.sequence.includes("'") && (
         <p>
           <small>
             You might need to escape the sequence as it contains special
@@ -80,16 +148,14 @@ const APIRequest: FC<APIRequestProps> = ({ inputParamsData, jobType }) => {
           </small>
         </p>
       )}
-      <p>
-        You can refer to the documentation for these values on the{' '}
-        <a
-          target="_blank"
-          rel="noreferrer noopener"
-          href={documentation.get(jobType)}
-        >
-          API documentation page
-        </a>
-      </p>
+      {documentationURL && (
+        <p>
+          You can refer to the documentation for these values on the{' '}
+          <ExternalLink url={documentationURL}>
+            API documentation page
+          </ExternalLink>
+        </p>
+      )}
     </section>
   );
 };

--- a/src/tools/components/APIRequest.tsx
+++ b/src/tools/components/APIRequest.tsx
@@ -151,10 +151,9 @@ const APIRequest: FC<APIRequestProps> = ({ inputParamsData, jobType }) => {
       )}
       {documentationURL && (
         <p>
-          You can refer to the documentation for these values on the{' '}
-          <ExternalLink url={documentationURL}>
-            API documentation page
-          </ExternalLink>
+          Refer to the{' '}
+          <ExternalLink url={documentationURL}>API documentation</ExternalLink>{' '}
+          for information about parameters and instructions to retrieve the results.
         </p>
       )}
     </section>

--- a/src/tools/components/InputParameters.tsx
+++ b/src/tools/components/InputParameters.tsx
@@ -7,17 +7,17 @@ import { UseDataAPIState } from '../../shared/hooks/useDataApi';
 
 import { PublicServerParameters } from '../types/toolsServerParameters';
 import { JobTypes } from '../types/toolsJobTypes';
-import { FinishedJob } from '../types/toolsJob';
+import { FormParameters as PeptideSearchFormParameters } from '../peptide-search/types/peptideSearchFormParameters';
 
-import styles from './styles/input-parameters.module.css';
+import styles from './styles/extra-tabs.module.css';
 
 type InputParametersProps = {
   id: string;
   // No public endpoint to expose this for peptide search, so for now replace
   // with a "possible" job object in the case it's the same user that created it
-  inputParamsData:
+  inputParamsData?:
     | Partial<UseDataAPIState<PublicServerParameters[JobTypes]>>
-    | FinishedJob<JobTypes.PEPTIDE_SEARCH>
+    | PeptideSearchFormParameters
     | null;
   jobType: JobTypes;
 };
@@ -32,7 +32,7 @@ const InputParameters = ({
   if (
     inputParamsData &&
     // This is for TS to typeguard, after that we're sure it's not a local job
-    !('type' in inputParamsData) &&
+    !('peps' in inputParamsData) &&
     // We now have a data payload for sure, check for errors normally
     (inputParamsData.error || !inputParamsData.data)
   ) {
@@ -56,9 +56,7 @@ const InputParameters = ({
   }
 
   const inputParameters =
-    'parameters' in inputParamsData
-      ? inputParamsData.parameters
-      : inputParamsData.data;
+    'peps' in inputParamsData ? inputParamsData : inputParamsData.data;
 
   return (
     <>

--- a/src/tools/components/styles/extra-tabs.module.css
+++ b/src/tools/components/styles/extra-tabs.module.css
@@ -2,3 +2,7 @@
   line-break: anywhere;
   white-space: break-spaces;
 }
+
+.api-request pre {
+  margin-block-end: 1em;
+}

--- a/src/tools/components/styles/extra-tabs.module.css
+++ b/src/tools/components/styles/extra-tabs.module.css
@@ -1,0 +1,4 @@
+.container pre {
+  line-break: anywhere;
+  white-space: break-spaces;
+}

--- a/src/tools/components/styles/input-parameters.module.css
+++ b/src/tools/components/styles/input-parameters.module.css
@@ -1,3 +1,0 @@
-.container :global(.decorated-list-item__content) {
-  overflow: scroll;
-}

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -57,12 +57,12 @@ const InputParameters = lazy(
     )
 );
 // input-parameters
-// const APIRequest = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
-//     )
-// );
+const APIRequest = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
+    )
+);
 
 enum TabLocation {
   Overview = 'overview',
@@ -237,7 +237,7 @@ const IDMappingResult = () => {
         >
           <HTMLHead title={[title, 'API Request']} />
           <Suspense fallback={<Loader />}>
-            {/* <APIRequest jobType={jobType} inputParamsData={inputParamsData} /> */}
+            <APIRequest jobType={jobType} inputParamsData={detailsDataObject} />
           </Suspense>
         </Tab>
       </Tabs>

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -53,13 +53,13 @@ const InputParameters = lazy(
       /* webpackChunkName: "input-parameters" */ '../../../components/InputParameters'
     )
 );
-// // input-parameters
-// const APIRequest = lazy(
-//   () =>
-//     import(
-//       /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
-//     )
-// );
+// input-parameters
+const APIRequest = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "api-request" */ '../../../components/APIRequest'
+    )
+);
 
 enum TabLocation {
   Overview = 'overview',
@@ -270,7 +270,7 @@ const PeptideSearchResult = ({
           <Suspense fallback={<Loader />}>
             <InputParameters
               id={match.params.id}
-              inputParamsData={jobSubmission.current}
+              inputParamsData={jobSubmission.current?.parameters}
               jobType={jobType}
             />
           </Suspense>
@@ -285,7 +285,10 @@ const PeptideSearchResult = ({
         >
           <HTMLHead title={[title, 'API Request']} />
           <Suspense fallback={<Loader />}>
-            {/* <APIRequest jobType={jobType} inputParamsData={inputParamsData} /> */}
+            <APIRequest
+              jobType={jobType}
+              inputParamsData={jobSubmission.current?.parameters}
+            />
           </Suspense>
         </Tab>
       </Tabs>


### PR DESCRIPTION
## Purpose
Add content to the API Request tab

## Approach
Similar approach as the one taken for the Input Parameters tabs changes (pass local job parameters, if any).
Display a fallback snippet if no local job information
Also, fixed issue with long content in CodeBlock component

## Testing
Manual checks

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
