### PR TITLE
2022 04 download id mapping

### DIFF
--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -5,16 +5,16 @@ import customRender from '../../../__test-helpers__/customRender';
 
 import Download, { getPreviewFileFormat } from '../Download';
 
+import { IDMappingDetailsContext } from '../../../contexts/IDMappingDetails';
+
 import { FileFormat } from '../../../types/resultsDownload';
 import { Namespace } from '../../../types/namespaces';
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
 
 import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
-
-import '../../../../uniprotkb/components/__mocks__/mockApi';
-import { IDMappingDetailsContext } from '../../../contexts/IDMappingDetails';
 import SimpleMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/SimpleMappingDetails';
 import UniProtkbMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/UniProtkbMappingDetails';
+import '../../../../uniprotkb/components/__mocks__/mockApi';
 
 const initialColumns = [
   UniProtKBColumn.accession,

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -376,10 +376,14 @@ export const getDownloadUrl = ({
   }
 
   let endpoint = apiUrls.download(namespace);
-  if (accessions) {
+  if (base) {
+    if (base.startsWith(apiPrefix)) {
+      endpoint = base;
+    } else {
+      endpoint = joinUrl(apiPrefix, base);
+    }
+  } else if (accessions) {
     endpoint = joinUrl(apiPrefix, `/${namespace}/${accessionKey}`);
-  } else if (base) {
-    endpoint = joinUrl(apiPrefix, base);
   } else if (size) {
     endpoint = apiUrls.search(namespace);
   }

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -332,10 +332,10 @@ type Parameters = {
   facetFilter?: string;
 };
 
-type GetDownloadUrlProps = {
+export type DownloadUrlOptions = {
   base?: string;
   query?: string;
-  columns: string[];
+  columns?: string[];
   selectedFacets: SelectedFacet[];
   sortColumn?: SortableColumn;
   sortDirection?: SortDirection;
@@ -363,7 +363,7 @@ export const getDownloadUrl = ({
   selectedIdField,
   namespace,
   accessions,
-}: GetDownloadUrlProps) => {
+}: DownloadUrlOptions) => {
   // If the consumer of this fn has passed specified a size we have to use the search endpoint
   // otherwise use download/stream which is much quicker but doesn't allow specification of size
 

--- a/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
@@ -8,7 +8,6 @@ import { IDMappingFromContext } from './FromColumn';
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 
 import { rawDBToNamespace } from '../../utils';
-import { getIdKeyFor } from '../../../../shared/utils/getIdKeyForNamespace';
 
 import { Namespace } from '../../../../shared/types/namespaces';
 import { PaginatedResults } from '../../../../shared/hooks/usePagination';
@@ -28,15 +27,12 @@ const IDMappingResultTable = ({
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
 
-  const getIdKey = getIdKeyFor(namespaceOverride);
-
   return (
     <>
       <ResultsButtons
         total={resultsDataObject.total || 0}
         loadedTotal={resultsDataObject.allResults.length}
         selectedEntries={selectedEntries}
-        accessions={resultsDataObject.allResults.map(getIdKey)}
         namespaceOverride={namespaceOverride}
         disableCardToggle
         base={detailsData?.redirectURL}


### PR DESCRIPTION
## Purpose
Use ID mapping results endpoint for downloads

## Approach

- In `getDownloadUrl` if `base` is present use this for the endpoint
- Don't pass accessions to `ResultsButtons` in `IDMappingResultTable`

## Testing
Add unit tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
