### PR TITLE
Add sorting to ID mapping results.

### DIFF
--- a/src/shared/components/results/__tests__/Results.spec.tsx
+++ b/src/shared/components/results/__tests__/Results.spec.tsx
@@ -42,21 +42,21 @@ describe('Results component', () => {
     fireEvent.click(columnHeader);
     await waitFor(() => {
       expect(history.location.search).toBe(
-        '?query=blah&sort=accession&dir=ascend'
+        '?dir=ascend&query=blah&sort=accession'
       );
     });
     columnHeader = await screen.findByText('Entry');
     fireEvent.click(columnHeader);
     await waitFor(() => {
       expect(history.location.search).toBe(
-        '?query=blah&sort=accession&dir=descend'
+        '?dir=descend&query=blah&sort=accession'
       );
     });
     columnHeader = await screen.findByText('Entry');
     await waitFor(() => {
       fireEvent.click(columnHeader);
       expect(history.location.search).toBe(
-        '?query=blah&sort=accession&dir=ascend'
+        '?dir=ascend&query=blah&sort=accession'
       );
     });
   });

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -418,16 +418,19 @@ export const getDownloadUrl = ({
           .join(' AND ');
   }
 
-  if (fileFormatsWithColumns.has(fileFormat)) {
-    if (sortColumn) {
-      parameters.sort = `${sortColumn} ${getApiSortDirection(
-        SortDirection[sortDirection]
-      )}`;
-    }
-    // Can't customise columns on UniSave
-    if (columns && namespace !== Namespace.unisave) {
-      parameters.fields = columns.join(',');
-    }
+  if (sortColumn) {
+    parameters.sort = `${sortColumn} ${getApiSortDirection(
+      SortDirection[sortDirection]
+    )}`;
+  }
+
+  // Can't customise columns on UniSave
+  if (
+    fileFormatsWithColumns.has(fileFormat) &&
+    columns &&
+    namespace !== Namespace.unisave
+  ) {
+    parameters.fields = columns.join(',');
   }
 
   if (fileFormat === FileFormat.fastaCanonicalIsoform) {

--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -14,7 +14,6 @@ import useDatabaseInfoMaps from './useDatabaseInfoMaps';
 import useColumnNames from './useColumnNames';
 
 import apiUrls from '../config/apiUrls';
-import { SearchResultsLocations } from '../../app/config/urls';
 import { getIdKeyFor } from '../utils/getIdKeyForNamespace';
 import {
   getParamsFromURL,
@@ -294,8 +293,9 @@ const useColumns = (
 
       // TODO: this changes the URL from encoded to decoded which is different to the facet behavior
       history.push(
+        // eslint-disable-next-line uniprot-website/use-config-location
         getLocationObjForParams({
-          pathname: SearchResultsLocations[namespace],
+          pathname: history.location.pathname,
           query,
           selectedFacets,
           sortColumn: newSortColumn,

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -6,8 +6,13 @@ import {
   apiPrefix,
 } from '../../shared/config/apiUrls';
 import joinUrl from '../../shared/config/testingApiUrls'; // TODO: revert import to: import joinUrl from 'url-join'
-import { SelectedFacet } from '../../uniprotkb/types/resultsTypes';
+import {
+  getApiSortDirection,
+  SelectedFacet,
+  SortDirection,
+} from '../../uniprotkb/types/resultsTypes';
 import { JobTypes } from '../types/toolsJobTypes';
+import { Column } from '../../shared/config/columns';
 
 type CommonResultFormats =
   | 'out' // raw output of the tool
@@ -58,6 +63,8 @@ type Return<T extends JobTypes> = Readonly<{
       size?: number;
       selectedFacets?: SelectedFacet[];
       query?: string;
+      sortColumn?: Column;
+      sortDirection?: SortDirection;
     }
   ) => string;
   detailsUrl?: (jobId: string) => string;
@@ -81,7 +88,14 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
           `${baseURL}/status/${jobId}?cachebust=${new Date().getTime()}`,
         resultUrl: (
           redirectUrl,
-          { facets, size, selectedFacets = [], query }
+          {
+            facets,
+            size,
+            selectedFacets = [],
+            query,
+            sortColumn,
+            sortDirection,
+          }
         ) =>
           `${redirectUrl}?${queryString.stringify({
             size,
@@ -93,6 +107,10 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
             ]
               .filter(Boolean)
               .join(' AND ')}`,
+            sort:
+              sortColumn && sortDirection
+                ? `${sortColumn} ${getApiSortDirection(sortDirection)}`
+                : undefined,
           })}`,
         detailsUrl: (jobId) => `${baseURL}/details/${jobId}`,
       });

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -91,7 +91,8 @@ const IDMappingResult = () => {
     progress: detailsProgress,
   } = idMappingDetails || {};
 
-  const [{ selectedFacets, query }] = getParamsFromURL(location.search);
+  const [{ selectedFacets, query, sortColumn, sortDirection }] =
+    getParamsFromURL(location.search);
 
   const toDBInfo =
     detailsData && databaseInfoMaps?.databaseToDatabaseInfo[detailsData.to];
@@ -99,7 +100,12 @@ const IDMappingResult = () => {
   // Query for results data from the idmapping endpoint
   const initialApiUrl =
     detailsData?.redirectURL &&
-    urls.resultUrl(detailsData.redirectURL, { selectedFacets, query });
+    urls.resultUrl(detailsData.redirectURL, {
+      selectedFacets,
+      query,
+      sortColumn,
+      sortDirection,
+    });
 
   const converter = useMemo(() => idMappingConverter(toDBInfo), [toDBInfo]);
 

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -1,3 +1,4 @@
+import qs from 'query-string';
 import { parseQueryString } from '../../shared/utils/url';
 
 import { Column } from '../../shared/config/columns';
@@ -74,16 +75,10 @@ export const getParamsFromURL = (
   return [params, unknownParams];
 };
 
-export const facetsAsString = (facets?: SelectedFacet[]): string => {
-  if (!facets?.length) {
-    return '';
-  }
-  return facets.reduce(
-    (accumulator, facet, i) =>
-      `${accumulator}${i > 0 ? ',' : ''}${facet.name}:${facet.value}`,
-    'facets='
-  );
-};
+export const facetsAsString = (facets?: SelectedFacet[]): string | undefined =>
+  facets?.length
+    ? facets.map(({ name, value }) => `${name}:${value}`).join(',')
+    : undefined;
 
 type GetLocationObjForParams = {
   pathname?: string;
@@ -107,16 +102,18 @@ export const getLocationObjForParams = ({
   viewMode,
 }: GetLocationObjForParams = {}) => ({
   pathname,
-  search: [
-    `${[query && `query=${query}`, facetsAsString(selectedFacets)]
-      .filter(Boolean)
-      .join('&')}`,
-    `${sortColumn ? `&sort=${sortColumn}` : ''}`,
-    `${sortDirection ? `&dir=${sortDirection}` : ''}`,
-    `${activeFacet ? `&activeFacet=${activeFacet}` : ''}`,
-    `${columns ? `&fields=${columns}` : ''}`,
-    `${viewMode ? `&view=${viewMode}` : ''}`,
-  ].join(''),
+  search: qs.stringify(
+    {
+      query: query || undefined,
+      facets: facetsAsString(selectedFacets),
+      sort: sortColumn,
+      dir: sortDirection,
+      activeFacet,
+      fields: columns,
+      view: viewMode,
+    },
+    { encode: false }
+  ),
 });
 
 export const getSortableColumnToSortColumn = (


### PR DESCRIPTION
## Purpose
Get column sorting in ID mapping results working
https://www.ebi.ac.uk/panda/jira/browse/TRM-27602

(Peptide search sorting doesn't work because the accessions endpoint doesn't currently support this but I'm about to write a jira for this)

## Approach

- When updating column sort use `history.location.pathname` rather than the corresponding `SearchResultsLocations[namespace]`
- Add `sort` param to ID mapping results API request

## Testing
Manual

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
