### PR TITLE
generalise the use of useMatchWithRedirect

### DIFF
--- a/src/shared/hooks/useMatchWithRedirect.ts
+++ b/src/shared/hooks/useMatchWithRedirect.ts
@@ -3,16 +3,22 @@ import { useHistory, generatePath, useRouteMatch } from 'react-router-dom';
 
 import { LocationToPath, Location } from '../../app/config/urls';
 
-export const useMatchWithRedirect = <T extends { subPage?: string }>(
+const useMatchWithRedirect = <T extends { subPage?: string }>(
   location: Location,
-  defaultSubPage: string
+  defaultSubPage: string,
+  possibleSubPages: Record<string, string>
 ) => {
   const history = useHistory();
   const match = useRouteMatch<T>(LocationToPath[location]);
 
-  // if URL doesn't finish with a subpage redirect to a default
   useEffect(() => {
-    if (match && !match.params.subPage) {
+    if (
+      match &&
+      // if URL doesn't finish with a subpage redirect to the default
+      (!match.params.subPage ||
+        // if URL doesn't finish with an a valid subpage redirect to the default
+        !Object.values(possibleSubPages).includes(match.params.subPage))
+    ) {
       history.replace({
         ...history.location,
         pathname: generatePath(LocationToPath[location], {
@@ -21,7 +27,9 @@ export const useMatchWithRedirect = <T extends { subPage?: string }>(
         }),
       });
     }
-  }, [match, history, location, defaultSubPage]);
+  }, [match, history, location, defaultSubPage, possibleSubPages]);
 
   return match;
 };
+
+export default useMatchWithRedirect;

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -118,11 +118,7 @@ type Params = {
 };
 
 const AlignResult = () => {
-  const match = useMatchWithRedirect<Params>(
-    Location.AlignResult,
-    TabLocation.Overview,
-    TabLocation
-  );
+  const match = useMatchWithRedirect<Params>(Location.AlignResult, TabLocation);
 
   const [selectedEntries, , setSelectedEntries] = useItemSelect();
   const handleEntrySelection = useCallback(

--- a/src/tools/align/components/results/AlignResult.tsx
+++ b/src/tools/align/components/results/AlignResult.tsx
@@ -14,7 +14,7 @@ import useDataApi, {
 import useSequenceInfo from '../../utils/useSequenceInfo';
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
-import { useMatchWithRedirect } from '../../../utils/hooks';
+import useMatchWithRedirect from '../../../../shared/hooks/useMatchWithRedirect';
 
 import inputParamsXMLToObject from '../../adapters/inputParamsXMLToObject';
 
@@ -120,7 +120,8 @@ type Params = {
 const AlignResult = () => {
   const match = useMatchWithRedirect<Params>(
     Location.AlignResult,
-    TabLocation.Overview
+    TabLocation.Overview,
+    TabLocation
   );
 
   const [selectedEntries, , setSelectedEntries] = useItemSelect();

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -16,6 +16,7 @@ import useDataApi, {
 } from '../../../../shared/hooks/useDataApi';
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
+import useMatchWithRedirect from '../../../../shared/hooks/useMatchWithRedirect';
 
 import { getParamsFromURL } from '../../../../uniprotkb/utils/resultsUtils';
 import {
@@ -46,7 +47,6 @@ import { UniRefLiteAPIModel } from '../../../../uniref/adapters/uniRefConverter'
 import { UniParcAPIModel } from '../../../../uniparc/adapters/uniParcConverter';
 
 import helper from '../../../../shared/styles/helper.module.scss';
-import { useMatchWithRedirect } from '../../../utils/hooks';
 
 const jobType = JobTypes.BLAST;
 const urls = toolsURLs(jobType);
@@ -181,7 +181,8 @@ const BlastResult = () => {
   const location = useLocation();
   const match = useMatchWithRedirect<Params>(
     Location.BlastResult,
-    TabLocation.Overview
+    TabLocation.Overview,
+    TabLocation
   );
 
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -179,11 +179,7 @@ export const enrich = (
 
 const BlastResult = () => {
   const location = useLocation();
-  const match = useMatchWithRedirect<Params>(
-    Location.BlastResult,
-    TabLocation.Overview,
-    TabLocation
-  );
+  const match = useMatchWithRedirect<Params>(Location.BlastResult, TabLocation);
 
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
   const [hspDetailPanel, setHspDetailPanel] =

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -12,7 +12,7 @@ import usePagination from '../../../../shared/hooks/usePagination';
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
 import useDatabaseInfoMaps from '../../../../shared/hooks/useDatabaseInfoMaps';
-import { useMatchWithRedirect } from '../../../utils/hooks';
+import useMatchWithRedirect from '../../../../shared/hooks/useMatchWithRedirect';
 import useIDMappingDetails from '../../../../shared/hooks/useIDMappingDetails';
 
 import { rawDBToNamespace } from '../../utils';
@@ -79,7 +79,8 @@ const IDMappingResult = () => {
   const location = useLocation();
   const match = useMatchWithRedirect<Params>(
     Location.IDMappingResult,
-    TabLocation.Overview
+    TabLocation.Overview,
+    TabLocation
   );
 
   const databaseInfoMaps = useDatabaseInfoMaps();

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -79,7 +79,6 @@ const IDMappingResult = () => {
   const location = useLocation();
   const match = useMatchWithRedirect<Params>(
     Location.IDMappingResult,
-    TabLocation.Overview,
     TabLocation
   );
 

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -79,7 +79,6 @@ const PeptideSearchResult = ({
 }) => {
   const match = useMatchWithRedirect<Params>(
     Location.PeptideSearchResult,
-    TabLocation.Overview,
     TabLocation
   );
 

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -9,7 +9,7 @@ import useNSQuery from '../../../../shared/hooks/useNSQuery';
 import usePagination from '../../../../shared/hooks/usePagination';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
 import { useToolsState } from '../../../../shared/contexts/Tools';
-import { useMatchWithRedirect } from '../../../utils/hooks';
+import useMatchWithRedirect from '../../../../shared/hooks/useMatchWithRedirect';
 
 import HTMLHead from '../../../../shared/components/HTMLHead';
 import ErrorBoundary from '../../../../shared/components/error-component/ErrorBoundary';
@@ -79,7 +79,8 @@ const PeptideSearchResult = ({
 }) => {
   const match = useMatchWithRedirect<Params>(
     Location.PeptideSearchResult,
-    TabLocation.Overview
+    TabLocation.Overview,
+    TabLocation
   );
 
   const jobSubmission = useRef<FinishedJob<JobTypes.PEPTIDE_SEARCH> | null>(

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -1,5 +1,5 @@
-import { FC, useEffect, useMemo } from 'react';
-import { useRouteMatch, useLocation, Link, useHistory } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useLocation, Link } from 'react-router-dom';
 import { stringify } from 'query-string';
 import { Loader, Tabs, Tab } from 'franklin-sites';
 
@@ -19,6 +19,7 @@ import ErrorBoundary from '../../../shared/components/error-component/ErrorBound
 
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 import useLocalStorage from '../../../shared/hooks/useLocalStorage';
+import useMatchWithRedirect from '../../../shared/hooks/useMatchWithRedirect';
 
 import { getParamsFromURL } from '../../../uniprotkb/utils/resultsUtils';
 import apiUrls from '../../../shared/config/apiUrls';
@@ -26,11 +27,7 @@ import {
   defaultColumns,
   UniParcXRefsColumn,
 } from '../../config/UniParcXRefsColumnConfiguration';
-import {
-  LocationToPath,
-  Location,
-  getEntryPath,
-} from '../../../app/config/urls';
+import { Location, getEntryPath } from '../../../app/config/urls';
 
 import uniParcConverter, {
   UniParcAPIModel,
@@ -47,31 +44,17 @@ export enum TabLocation {
   FeatureViewer = 'feature-viewer',
 }
 
-const Entry: FC = () => {
-  const match = useRouteMatch<{ accession: string; subPage?: TabLocation }>(
-    LocationToPath[Location.UniParcEntry]
-  );
-  const history = useHistory();
+const Entry = () => {
+  const match = useMatchWithRedirect<{
+    accession: string;
+    subPage?: TabLocation;
+  }>(Location.UniParcEntry, TabLocation.Entry, TabLocation);
   const { search } = useLocation();
 
   const [columns] = useLocalStorage(
     `table columns for ${Namespace.uniparc} entry page` as const,
     defaultColumns
   );
-
-  // if URL doesn't finish with "entry" redirect to /entry by default
-  useEffect(() => {
-    if (match && !match.params.subPage) {
-      history.replace({
-        ...history.location,
-        pathname: getEntryPath(
-          Namespace.uniparc,
-          match.params.accession,
-          TabLocation.Entry
-        ),
-      });
-    }
-  }, [match, history]);
 
   const baseURL = apiUrls.entry(match?.params.accession, Namespace.uniparc);
   const xRefsURL = useMemo(() => {

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -48,7 +48,7 @@ const Entry = () => {
   const match = useMatchWithRedirect<{
     accession: string;
     subPage?: TabLocation;
-  }>(Location.UniParcEntry, TabLocation.Entry, TabLocation);
+  }>(Location.UniParcEntry, TabLocation);
   const { search } = useLocation();
 
   const [columns] = useLocalStorage(

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, Suspense } from 'react';
-import { Link, useRouteMatch, useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { InPageNav, Loader, Tabs, Tab } from 'franklin-sites';
 import cn from 'classnames';
 import qs from 'query-string';
@@ -35,6 +35,7 @@ import UniProtKBEntryConfig from '../../config/UniProtEntryConfig';
 import useDataApi from '../../../shared/hooks/useDataApi';
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 import { useMessagesDispatch } from '../../../shared/contexts/Messages';
+import useMatchWithRedirect from '../../../shared/hooks/useMatchWithRedirect';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 
@@ -103,23 +104,10 @@ const EntryHistory = lazy(
 const Entry = () => {
   const dispatch = useMessagesDispatch();
   const history = useHistory();
-  const match = useRouteMatch<{ accession: string; subPage?: TabLocation }>(
-    LocationToPath[Location.UniProtKBEntry]
-  );
-
-  // if URL doesn't finish with "entry" redirect to /entry by default
-  useEffect(() => {
-    if (match && !match.params.subPage) {
-      history.replace({
-        ...history.location,
-        pathname: getEntryPath(
-          Namespace.uniprotkb,
-          match.params.accession,
-          TabLocation.Entry
-        ),
-      });
-    }
-  }, [match, history]);
+  const match = useMatchWithRedirect<{
+    accession: string;
+    subPage?: TabLocation;
+  }>(Location.UniProtKBEntry, TabLocation.Entry, TabLocation);
 
   const { loading, data, status, error, redirectedTo, progress } =
     useDataApi<UniProtkbAPIModel>(

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -75,6 +75,8 @@ export enum TabLocation {
   History = 'history',
 }
 
+const legacyToNewSubPages = { protvista: TabLocation.FeatureViewer };
+
 const FeatureViewer = lazy(
   () =>
     import(
@@ -107,7 +109,12 @@ const Entry = () => {
   const match = useMatchWithRedirect<{
     accession: string;
     subPage?: TabLocation;
-  }>(Location.UniProtKBEntry, TabLocation.Entry, TabLocation);
+  }>(
+    Location.UniProtKBEntry,
+    TabLocation,
+    TabLocation.Entry,
+    legacyToNewSubPages
+  );
 
   const { loading, data, status, error, redirectedTo, progress } =
     useDataApi<UniProtkbAPIModel>(


### PR DESCRIPTION
## Purpose
generalise the use of useMatchWithRedirect to entry pages too, and redirect any non-valid tab value to a default subPage instead of crashing

## Approach
Change the hook to cover more use cases, use it in more places

## Testing
Go edit the "subpage" section of the URL for any tool or UniProtKB or UniParc entry pages to either remove it completely or invent something invalid.

This is really an edge-case for if a user edits the URL to at least point to something useful AND in the case of UniProtKB entry in the case where the user followed a now invalid URL (like https://www.uniprot.org/uniprot/P05067/protvista)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
