### PR TITLE
Axios fail on parse error

### DIFF
--- a/src/shared/hooks/__tests__/useDataApi.spec.tsx
+++ b/src/shared/hooks/__tests__/useDataApi.spec.tsx
@@ -22,13 +22,13 @@ afterAll(() => {
 });
 
 describe('useDataApi hook', () => {
-  test('no URL', async () => {
+  it('should handle no URL', async () => {
     const { result } = renderHook(() => useDataApi());
 
     expect(result.current).toEqual({ loading: false });
   });
 
-  test('no error', async () => {
+  it('should return no error', async () => {
     mock.onGet(url).reply(200, 'some data');
     const { result, waitForNextUpdate } = renderHook(() => useDataApi(url));
 
@@ -45,7 +45,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('no network', async () => {
+  it('should return no network error', async () => {
     mock.onGet(url).networkError();
     const { result, waitForNextUpdate } = renderHook(() => useDataApi(url));
 
@@ -60,7 +60,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('timeout', async () => {
+  it('should return timeout error', async () => {
     mock.onGet(url).timeout();
     const { result, waitForNextUpdate } = renderHook(() => useDataApi(url));
 
@@ -75,7 +75,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('400', async () => {
+  it('should return 400', async () => {
     const message = '??? does not exist';
     mock.onGet(url).reply(400, { messages: [message] });
     const mockDispatch = jest.fn();
@@ -110,7 +110,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('404', async () => {
+  it('should return 404', async () => {
     mock.onGet(url).reply(404);
     const { result, waitForNextUpdate } = renderHook(() => useDataApi(url));
 
@@ -126,7 +126,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('cancellation', async () => {
+  it('should handle cancellation', async () => {
     mock.onGet(url).reply(200, 'some data');
     const { result, unmount } = renderHook(() => useDataApi(url));
 
@@ -137,7 +137,7 @@ describe('useDataApi hook', () => {
     // error when we cancel before getting data
   });
 
-  test('change of URL', async () => {
+  it('should handle change of URL', async () => {
     mock.onGet(url).reply(200, 'some data');
     mock.onGet(url2).reply(200, 'some other data');
     const { result, waitForNextUpdate, rerender } = renderHook(
@@ -172,7 +172,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('change of URL without waiting', async () => {
+  it('should handle change of URL without waiting', async () => {
     mock.onGet(url).reply(200, 'some data');
     mock.onGet(url2).reply(200, 'some other data');
     const { result, waitForNextUpdate, rerender } = renderHook(
@@ -197,7 +197,7 @@ describe('useDataApi hook', () => {
     });
   });
 
-  test('detect redirect', async () => {
+  it('should detect redirect', async () => {
     mock.onGet(url).reply(200, 'some data');
     mock.onGet(url2).reply(() => axios.get(url));
 
@@ -218,7 +218,7 @@ describe('useDataApi hook', () => {
 });
 
 describe('useDataApiWithStale hook', () => {
-  test('change of URL', async () => {
+  it('should change URL', async () => {
     mock.onGet(url).reply(200, 'some data');
     mock.onGet(url2).reply(200, 'some other data');
     const { result, waitForNextUpdate, rerender } = renderHook(
@@ -255,6 +255,23 @@ describe('useDataApiWithStale hook', () => {
       url: url2,
       data: 'some other data',
       status: 200,
+    });
+  });
+
+  it('should return SyntaxError with invalid json from a 200 response', async () => {
+    mock
+      .onGet(url)
+      .reply(200, '{"key" : "value",,', { 'Content-Type': 'application/json' });
+    const { result, waitForNextUpdate } = renderHook(() => useDataApi(url));
+
+    expect(result.current).toEqual({ loading: true, url });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      error: new SyntaxError('Unexpected token , in JSON at position 17'),
+      loading: false,
+      url,
     });
   });
 });

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   isSameEntry,
   deepFindAllByKey,
   addBlastLinksToFreeText,
+  keysToLowerCase,
 } from '../utils';
 
 describe('Model Utils', () => {
@@ -200,5 +201,14 @@ describe('deepFindAllByKey', () => {
       const result = addBlastLinksToFreeText(['SOME TEXT'], 'UP_ACCESSION');
       expect(result).toMatchSnapshot();
     });
+  });
+});
+
+describe('keysToLowerCase', () => {
+  it('should convert lowercase all keys', () => {
+    expect(keysToLowerCase({ Foo: 1, BAR: 2 })).toEqual({ foo: 1, bar: 2 });
+  });
+  it('should return empty object with nothing provided', () => {
+    expect(keysToLowerCase(undefined)).toEqual({});
   });
 });

--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -9,11 +9,16 @@ export default function fetchData<T>(
   return axios({
     url,
     method: 'GET',
+    responseType:
+      headers.Accept && !headers.Accept.includes('json') ? 'text' : 'json',
     headers: {
       Accept: 'application/json',
       ...headers,
     },
     cancelToken,
+    transitional: {
+      silentJSONParsing: false,
+    },
     ...axiosOptions,
   });
 }

--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -1,4 +1,19 @@
 import axios, { AxiosPromise, AxiosRequestConfig, CancelToken } from 'axios';
+import { keysToLowerCase } from './utils';
+
+axios.interceptors.response.use((response) => {
+  if (
+    response.data &&
+    response.status >= 200 &&
+    response.status < 300 &&
+    typeof response.data === 'string' &&
+    // Need to lowercase headers as axios doesn't do this before the interceptor.
+    keysToLowerCase(response?.headers)['content-type']?.includes('json')
+  ) {
+    response.data = JSON.parse(response.data);
+  }
+  return response;
+});
 
 export default function fetchData<T>(
   url: string,
@@ -16,9 +31,9 @@ export default function fetchData<T>(
       ...headers,
     },
     cancelToken,
-    transitional: {
-      silentJSONParsing: false,
-    },
+    // transitional: {
+    //   silentJSONParsing: false,
+    // },
     ...axiosOptions,
   });
 }

--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -31,6 +31,7 @@ export default function fetchData<T>(
       ...headers,
     },
     cancelToken,
+    // NOTE: this was used initially but it would try to parse everything as JSON
     // transitional: {
     //   silentJSONParsing: false,
     // },

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -138,3 +138,11 @@ export const addBlastLinksToFreeText = (
       })
       .filter((item) => item);
   });
+
+export function keysToLowerCase<T>(o: { [k: string]: T } = {}): {
+  [key: string]: T;
+} {
+  return Object.fromEntries(
+    Object.entries(o).map(([k, v]) => [k.toLowerCase(), v])
+  );
+}


### PR DESCRIPTION
## Purpose
Axios was not reporting a parsing error for invalid json responses.

## Approach
Use axios.interceptors to handle parsing of JSON.

## Testing
Unit test

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
