### PR TITLE
Use data api options

### DIFF
--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosPromise, AxiosRequestConfig, CancelToken } from 'axios';
-import { cloneDeep } from 'lodash-es';
 
 import { keysToLowerCase } from './utils';
 
@@ -22,7 +21,7 @@ export default function fetchData<T>(
   cancelToken: CancelToken | undefined = undefined,
   axiosOptions: AxiosRequestConfig = {}
 ): AxiosPromise<T> {
-  const options = cloneDeep(axiosOptions);
+  const options = { ...axiosOptions };
   if (!options.responseType) {
     options.responseType =
       typeof axiosOptions?.headers?.Accept === 'string' &&
@@ -34,7 +33,7 @@ export default function fetchData<T>(
     options.headers = {};
   }
   if (!options.headers.Accept) {
-    options.headers.Accept = 'application/json';
+    options.headers = { ...options.headers, Accept: 'application/json' };
   }
   return axios({
     url,

--- a/src/shared/utils/fetchData.ts
+++ b/src/shared/utils/fetchData.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosPromise, AxiosRequestConfig, CancelToken } from 'axios';
+import { cloneDeep } from 'lodash-es';
+
 import { keysToLowerCase } from './utils';
 
 axios.interceptors.response.use((response) => {
@@ -17,20 +19,27 @@ axios.interceptors.response.use((response) => {
 
 export default function fetchData<T>(
   url: string,
-  headers: Record<string, string> = {},
   cancelToken: CancelToken | undefined = undefined,
   axiosOptions: AxiosRequestConfig = {}
 ): AxiosPromise<T> {
+  const options = cloneDeep(axiosOptions);
+  if (!options.responseType) {
+    options.responseType =
+      typeof axiosOptions?.headers?.Accept === 'string' &&
+      !axiosOptions.headers.Accept.includes('json')
+        ? 'text'
+        : 'json';
+  }
+  if (!options?.headers) {
+    options.headers = {};
+  }
+  if (!options.headers.Accept) {
+    options.headers.Accept = 'application/json';
+  }
   return axios({
     url,
     method: 'GET',
-    responseType:
-      headers.Accept && !headers.Accept.includes('json') ? 'text' : 'json',
-    headers: {
-      Accept: 'application/json',
-      ...headers,
-    },
     cancelToken,
-    ...axiosOptions,
+    ...options,
   });
 }

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -91,7 +91,9 @@ const PeptideSearchResult = ({
     loading: jobResultLoading,
     error: jobResultError,
     status: jobResultStatus,
-  } = useDataApi<PeptideSearchResults>(urls.resultUrl(jobID, {}));
+  } = useDataApi<PeptideSearchResults>(urls.resultUrl(jobID, {}), {
+    headers: { accept: 'text/plain' },
+  });
 
   // Get the job mission from local tools state. Save this in a reference as
   // the job may change with useMarkJobAsSeen but we don't want to have to

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -151,12 +151,9 @@ const getCheckJobStatus =
         );
       } else if (job.type === JobTypes.ID_MAPPING && idMappingResultsUrl) {
         // only ID Mapping jobs
-        const response = await fetchData(
-          idMappingResultsUrl,
-          undefined,
-          undefined,
-          { method: 'HEAD' }
-        );
+        const response = await fetchData(idMappingResultsUrl, undefined, {
+          method: 'HEAD',
+        });
 
         // get a new reference to the job
         currentStateOfJob = stateRef.current[job.internalID];


### PR DESCRIPTION
## Purpose
There is an issue at:

https://beta.uniprot.org/peptide-search/PM20220323d25f892452724e5db0ac67d571484bc9

where we are asking for json from the peptide search endpoint but text is returned instead and so causes a json parsing error.

## Approach

- Request text in the header
- Remove redundant headers from `fetchData` args
- Use a ref for options in `useDataApi` to prevent the useEffect continually re-firing

## Testing
TODO: tests need fixing because of a lodash-es issue.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
