### PR TITLE
2022 05 did you mean url params

### DIFF
--- a/src/shared/__test-helpers__/customRenderHook.tsx
+++ b/src/shared/__test-helpers__/customRenderHook.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+
+function getCustomRenderHook<TProps, TResult>(
+  hook: (props: TProps) => TResult
+) {
+  return function customRenderHook(path?: string, state?: unknown) {
+    const history = createMemoryHistory();
+    if (path) {
+      history.push(path, state);
+    }
+    return renderHook(hook, {
+      wrapper: ({ children }) => <Router history={history}>{children}</Router>,
+    });
+  };
+}
+
+export default getCustomRenderHook;

--- a/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
+++ b/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
@@ -79,12 +79,13 @@ describe('useInitialFormParameters: Align', () => {
 describe('useInitialFormParameters: Peptide Search', () => {
   it('should return defaultAlignFormValues and peps, lEQi, spOnly from url parameters', () => {
     const peps = 'ABCDEF';
-
+    const lEQi = 'on';
+    const spOnly = 'off';
     const { result } = customRenderHook(
       defaultPeptideSearchFormValues,
       queryString.stringifyUrl({
         url: LocationToPath[Location.PeptideSearch],
-        query: { peps, lEQi: 'on', spOnly: 'off' },
+        query: { peps, lEQi, spOnly },
       })
     );
     expect(result.current.initialFormValues).toEqual({
@@ -97,13 +98,13 @@ describe('useInitialFormParameters: Peptide Search', () => {
         ...defaultPeptideSearchFormValues[
           'Search UniProt Reviewed (Swiss-Prot) only'
         ],
-        selected: 'off',
+        selected: spOnly,
       },
       'Treat isoleucine and leucine as equivalent': {
         ...defaultPeptideSearchFormValues[
           'Treat isoleucine and leucine as equivalent'
         ],
-        selected: 'on',
+        selected: lEQi,
       },
     });
   });

--- a/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
+++ b/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
@@ -15,7 +15,7 @@ import defaultPeptideSearchFormValues from '../../peptide-search/config/PeptideS
 import accessionsData from '../../../uniprotkb/components/entry/__tests__/__mocks__/accessionsData.json';
 
 function customRenderHook<Fields extends string>(
-  defaultAlignFormValues: Readonly<FormValues<Fields>>,
+  defaultFormValues: Readonly<FormValues<Fields>>,
   path?: string,
   state?: unknown
 ) {
@@ -23,7 +23,7 @@ function customRenderHook<Fields extends string>(
   if (path) {
     history.push(path, state);
   }
-  return renderHook(() => useInitialFormParameters(defaultAlignFormValues), {
+  return renderHook(() => useInitialFormParameters(defaultFormValues), {
     wrapper: ({ children }) => <Router history={history}>{children}</Router>,
   });
 }

--- a/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
+++ b/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
@@ -77,13 +77,14 @@ describe('useInitialFormParameters: Align', () => {
 });
 
 describe('useInitialFormParameters: Peptide Search', () => {
-  it('should return defaultAlignFormValues and peps from url parameters', () => {
+  it('should return defaultAlignFormValues and peps, lEQi, spOnly from url parameters', () => {
     const peps = 'ABCDEF';
+
     const { result } = customRenderHook(
       defaultPeptideSearchFormValues,
       queryString.stringifyUrl({
         url: LocationToPath[Location.PeptideSearch],
-        query: { peps },
+        query: { peps, lEQi: 'on', spOnly: 'off' },
       })
     );
     expect(result.current.initialFormValues).toEqual({
@@ -91,6 +92,18 @@ describe('useInitialFormParameters: Peptide Search', () => {
       'Peptide sequences': {
         ...defaultPeptideSearchFormValues['Peptide sequences'],
         selected: peps,
+      },
+      'Search UniProt Reviewed (Swiss-Prot) only': {
+        ...defaultPeptideSearchFormValues[
+          'Search UniProt Reviewed (Swiss-Prot) only'
+        ],
+        selected: 'off',
+      },
+      'Treat isoleucine and leucine as equivalent': {
+        ...defaultPeptideSearchFormValues[
+          'Treat isoleucine and leucine as equivalent'
+        ],
+        selected: 'on',
       },
     });
   });

--- a/src/tools/hooks/useInitialFormParameters.ts
+++ b/src/tools/hooks/useInitialFormParameters.ts
@@ -5,6 +5,7 @@ import { sequenceProcessor } from 'franklin-sites';
 import useDataApi from '../../shared/hooks/useDataApi';
 import { useMessagesDispatch } from '../../shared/contexts/Messages';
 
+import { addMessage } from '../../messages/state/messagesActions';
 import { parseIdsFromSearchParams } from '../utils/urls';
 import { getAccessionsURL } from '../../shared/config/apiUrls';
 import entryToFASTAWithHeaders from '../../shared/utils/entryToFASTAWithHeaders';
@@ -13,7 +14,6 @@ import { Location, LocationToPath } from '../../app/config/urls';
 
 import { SelectedTaxon } from '../types/toolsFormData';
 import { UniProtkbAPIModel } from '../../uniprotkb/adapters/uniProtkbConverter';
-import { addMessage } from '../../messages/state/messagesActions';
 import {
   MessageFormat,
   MessageLevel,
@@ -60,7 +60,6 @@ function useInitialFormParameters<
   );
 
   const idsMaybeWithRange = useMemo(() => {
-    // This only happens on first mount as we reset the history.location.search in a useEffect hook
     if (!alignmentLocations.has(history.location.pathname)) {
       return null;
     }

--- a/src/tools/hooks/useInitialFormParameters.ts
+++ b/src/tools/hooks/useInitialFormParameters.ts
@@ -95,14 +95,14 @@ function useInitialFormParameters<
   }, [accessionsData, dispatchMessages, parametersFromSearch]);
 
   // Discard 'search' part of url to avoid url state issues.
-  // useEffect(() => {
-  //   if (history.location?.search) {
-  //     // eslint-disable-next-line uniprot-website/use-config-location
-  //     history.replace({
-  //       pathname: history.location.pathname,
-  //     });
-  //   }
-  // }, [history]);
+  useEffect(() => {
+    if (history.location?.search) {
+      // eslint-disable-next-line uniprot-website/use-config-location
+      history.replace({
+        pathname: history.location.pathname,
+      });
+    }
+  }, [history]);
 
   const initialFormValues = useMemo(() => {
     if (accessionsLoading) {

--- a/src/tools/hooks/useInitialFormParameters.ts
+++ b/src/tools/hooks/useInitialFormParameters.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
-import { cloneDeep } from 'lodash-es';
 
 import { sequenceProcessor } from 'franklin-sites';
 import useDataApi from '../../shared/hooks/useDataApi';
@@ -56,42 +55,43 @@ function useInitialFormParameters<
   }>(url);
 
   // Discard 'search' part of url to avoid url state issues.
-  useEffect(() => {
-    if (history.location?.search) {
-      // eslint-disable-next-line uniprot-website/use-config-location
-      history.replace({
-        pathname: history.location.pathname,
-      });
-    }
-  }, [history]);
+  // useEffect(() => {
+  //   if (history.location?.search) {
+  //     // eslint-disable-next-line uniprot-website/use-config-location
+  //     history.replace({
+  //       pathname: history.location.pathname,
+  //     });
+  //   }
+  // }, [history]);
 
   const initialFormValues = useMemo(() => {
     if (accessionsLoading) {
       return null;
     }
 
-    // NOTE: we should use a similar logic to pre-fill fields based on querystring
     const parametersFromHistoryState = (
       history.location?.state as CustomLocationState<FormParameters>
     )?.parameters;
 
-    // Might want to use structuredClone eventually, but it's really new and we
-    // need to make sure that it's polyfilled by core-js first.
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-    const formValues: FormValues<Fields> = cloneDeep(defaultFormValues);
-    // Parameters from state
-    if (parametersFromHistoryState) {
+    const parametersFromSearch = new URLSearchParams(history.location?.search);
+    // This will eventually be filled in
+    const formValues: Partial<FormValues<Fields>> = {};
+    if (parametersFromHistoryState || parametersFromSearch) {
       const defaultValuesEntries = Object.entries<FormValue>(defaultFormValues);
-      // for every field of the form, get its value from the history state if
-      // present, otherwise leave as the default value
       for (const [key, field] of defaultValuesEntries) {
         const fieldName = field.fieldName as keyof FormParameters;
-        if (fieldName in parametersFromHistoryState) {
-          formValues[key as Fields] = Object.freeze({
-            ...field,
-            selected: parametersFromHistoryState[fieldName],
-          } as FormValue);
-        }
+        formValues[key as Fields] = Object.freeze({
+          ...field,
+          selected:
+            // url params
+            (parametersFromSearch &&
+              parametersFromSearch.get(fieldName.toString())) ||
+            // history state
+            (parametersFromHistoryState &&
+              parametersFromHistoryState[fieldName]) ||
+            // default
+            field.selected,
+        } as FormValue);
       }
     }
 
@@ -132,10 +132,11 @@ function useInitialFormParameters<
       });
     }
 
-    return Object.freeze(formValues);
+    return Object.freeze(formValues as FormValues<Fields>);
   }, [
     accessionsLoading,
     history.location?.state,
+    history.location?.search,
     defaultFormValues,
     accessionsData?.results,
     idsMaybeWithRange,

--- a/src/tools/hooks/useInitialFormParameters.tsx
+++ b/src/tools/hooks/useInitialFormParameters.tsx
@@ -81,19 +81,34 @@ function useInitialFormParameters<
     if (
       parametersFromHistorySearch.has('sequence') &&
       parametersFromHistorySearch.has('ids') &&
+      idsMaybeWithRange?.length &&
       accessionsData
     ) {
       dispatchMessages(
         addMessage({
-          content:
-            'Found both "ids" and "sequence" in URL parameters. Sequence data will be loaded from "ids".',
+          content: (
+            <>
+              Found both <code>ids</code> and <code>sequence</code> in URL
+              parameters. Sequence data will be loaded from <code>ids</code>:{' '}
+              {`${idsMaybeWithRange
+                .slice(0, 3)
+                .map(({ id }) => id)
+                .join(', ')}${idsMaybeWithRange.length > 3 ? ', …' : ''}`}
+              .
+            </>
+          ),
           format: MessageFormat.POP_UP,
           level: MessageLevel.INFO,
-          displayTime: 5_000,
+          displayTime: 15_000,
         })
       );
     }
-  }, [accessionsData, dispatchMessages, parametersFromHistorySearch]);
+  }, [
+    accessionsData,
+    dispatchMessages,
+    idsMaybeWithRange,
+    parametersFromHistorySearch,
+  ]);
 
   // Discard 'search' part of url to avoid url state issues.
   useEffect(() => {


### PR DESCRIPTION
## Purpose
Generic approach to load any form field data from the URL (similar way as we do currently with accession). Works with Peptide Search's server params with the exception of taxonomy. Created [jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-27685) for validation more generally.

## Approach

- Iterate through all default values and look first for url params, then state values, and finally use default if neither of these are there
- Alignment forms:
  - Check if the user is at an alignment location before fetching accessions
  - Dispatch message if user provides both ids and sequence in 

## Testing
Added more unit tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
