### PR TITLE
Add UniParc version-less suggestion (if not already there).

### DIFF
--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -135,10 +135,10 @@ const DidYouMean = ({ suggestions }: DidYouMeanProps) => {
     const match = query?.match(reIdWithVersion);
     const id = match?.groups?.id;
     if (id) {
-      const upidAlreadySuggested = suggestionsSortedByHits.some(
+      const idAlreadySuggested = suggestionsSortedByHits.some(
         (s) => s.query.replace(reCleanUp, '$1') === id
       );
-      if (!upidAlreadySuggested) {
+      if (!idAlreadySuggested) {
         suggestionsSortedByHits.unshift({ query: id, hits: 1 });
       }
     }

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -151,7 +151,7 @@ const DidYouMean = ({ suggestions }: DidYouMeanProps) => {
       <QuerySuggestionListItem
         suggestions={suggestionsSortedByHits}
         namespace={currentNamespace as SearchableNamespace}
-        key={currentNamespace}
+        key={`${currentNamespace}-${query}`}
       />
     );
   }

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -30,7 +30,10 @@ import styles from './styles/did-you-mean.module.scss';
 // example input: '( abc )' -> capturing group: 'abc'
 // not matching '( id:abc )' or '( abc OR def )'
 const reCleanUp = /^\( ([^: ]+) \)$/;
-const reUniparcIdWithVersion = /(?<upid>UPI[\w]{10})\.\d+/;
+
+// Matches any generic ID that might exist within UniParc
+// eg: P05067.1, P05066.1-1, xref-id.1
+const reIdWithVersion = /(?<id>\S+)\.\d+/;
 
 type QuerySuggestionListItemProps = {
   suggestions: Suggestion[];
@@ -129,14 +132,14 @@ const DidYouMean = ({ suggestions }: DidYouMeanProps) => {
   const suggestionsSortedByHits = orderBy(suggestions, 'hits', 'desc');
 
   if (currentNamespace === Namespace.uniparc) {
-    const match = query?.match(reUniparcIdWithVersion);
-    const upid = match?.groups?.upid;
-    if (upid) {
+    const match = query?.match(reIdWithVersion);
+    const id = match?.groups?.id;
+    if (id) {
       const upidAlreadySuggested = suggestionsSortedByHits.some(
-        (s) => s.query.replace(reCleanUp, '$1') === upid
+        (s) => s.query.replace(reCleanUp, '$1') === id
       );
       if (!upidAlreadySuggested) {
-        suggestionsSortedByHits.unshift({ query: upid, hits: 1 });
+        suggestionsSortedByHits.unshift({ query: id, hits: 1 });
       }
     }
   }


### PR DESCRIPTION
## Purpose
Show version-less uniparc suggestion if user searched with a version.

## Approach
- Use a regex to make sure it's an upid with version
- Only add suggestion if not returned in results already
- Make key more specific as duplicate key warning still being observed. To reproduce (on commit before [0c26595](https://github.com/ebi-uniprot/uniprot-website/pull/593/commits/0c265955ebaf2a7c8ef44a854f9347bee1278bb4)):
  1. http://localhost:8080/uniparc?query=p05067.3
  2. (click on the uniprotkb suggestion)
  3. http://localhost:8080/uniprotkb?query=p05067.3

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
