### PR TITLE
Entry section anchors

### DIFF
--- a/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
@@ -142,13 +142,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P11413#ptm-processing"
+              href="/uniprotkb/P11413#ptm_processing"
             >
               11 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11413#disease-and-drugs"
+              href="/uniprotkb/P11413#disease_and_drugs"
             >
               71 reviewed variants
             </a>
@@ -172,7 +172,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11413#disease-and-drugs"
+              href="/uniprotkb/P11413#disease_and_drugs"
             >
               1 disease
             </a>
@@ -330,13 +330,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P36871#ptm-processing"
+              href="/uniprotkb/P36871#ptm_processing"
             >
               22 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P36871#disease-and-drugs"
+              href="/uniprotkb/P36871#disease_and_drugs"
             >
               18 reviewed variants
             </a>
@@ -360,7 +360,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P36871#disease-and-drugs"
+              href="/uniprotkb/P36871#disease_and_drugs"
             >
               1 disease
             </a>
@@ -651,13 +651,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P13866#ptm-processing"
+              href="/uniprotkb/P13866#ptm_processing"
             >
               1 PTM
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P13866#disease-and-drugs"
+              href="/uniprotkb/P13866#disease_and_drugs"
             >
               7 reviewed variants
             </a>
@@ -675,7 +675,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P13866#disease-and-drugs"
+              href="/uniprotkb/P13866#disease_and_drugs"
             >
               1 disease
             </a>
@@ -970,13 +970,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/O95479#ptm-processing"
+              href="/uniprotkb/O95479#ptm_processing"
             >
               2 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/O95479#disease-and-drugs"
+              href="/uniprotkb/O95479#disease_and_drugs"
             >
               10 reviewed variants
             </a>
@@ -994,7 +994,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/O95479#disease-and-drugs"
+              href="/uniprotkb/O95479#disease_and_drugs"
             >
               1 disease
             </a>
@@ -1146,7 +1146,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P31639#disease-and-drugs"
+              href="/uniprotkb/P31639#disease_and_drugs"
             >
               1 reviewed variant
             </a>
@@ -1158,7 +1158,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P31639#disease-and-drugs"
+              href="/uniprotkb/P31639#disease_and_drugs"
             >
               1 disease
             </a>
@@ -1326,13 +1326,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P11166#ptm-processing"
+              href="/uniprotkb/P11166#ptm_processing"
             >
               5 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11166#disease-and-drugs"
+              href="/uniprotkb/P11166#disease_and_drugs"
             >
               53 reviewed variants
             </a>
@@ -1344,7 +1344,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11166#disease-and-drugs"
+              href="/uniprotkb/P11166#disease_and_drugs"
             >
               5 diseases
             </a>
@@ -1492,13 +1492,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q16851#ptm-processing"
+              href="/uniprotkb/Q16851#ptm_processing"
             >
               8 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q16851#disease-and-drugs"
+              href="/uniprotkb/Q16851#disease_and_drugs"
             >
               2 reviewed variants
             </a>
@@ -1522,7 +1522,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q16851#disease-and-drugs"
+              href="/uniprotkb/Q16851#disease_and_drugs"
             >
               1 disease
             </a>
@@ -1665,13 +1665,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q96G03#ptm-processing"
+              href="/uniprotkb/Q96G03#ptm_processing"
             >
               2 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q96G03#disease-and-drugs"
+              href="/uniprotkb/Q96G03#disease_and_drugs"
             >
               2 reviewed variants
             </a>
@@ -1821,7 +1821,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q9NY64#disease-and-drugs"
+              href="/uniprotkb/Q9NY64#disease_and_drugs"
             >
               1 reviewed variant
             </a>
@@ -2255,7 +2255,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P38263#ptm-processing"
+              href="/uniprotkb/P38263#ptm_processing"
             >
               1 PTM
             </a>
@@ -2398,13 +2398,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P11168#ptm-processing"
+              href="/uniprotkb/P11168#ptm_processing"
             >
               1 PTM
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11168#disease-and-drugs"
+              href="/uniprotkb/P11168#disease_and_drugs"
             >
               9 reviewed variants
             </a>
@@ -2416,7 +2416,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11168#disease-and-drugs"
+              href="/uniprotkb/P11168#disease_and_drugs"
             >
               1 disease
             </a>
@@ -2563,7 +2563,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q8TDB8#disease-and-drugs"
+              href="/uniprotkb/Q8TDB8#disease_and_drugs"
             >
               1 reviewed variant
             </a>
@@ -2701,13 +2701,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q9UGQ3#ptm-processing"
+              href="/uniprotkb/Q9UGQ3#ptm_processing"
             >
               1 PTM
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q9UGQ3#disease-and-drugs"
+              href="/uniprotkb/Q9UGQ3#disease_and_drugs"
             >
               1 reviewed variant
             </a>
@@ -2861,13 +2861,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q6PCE3#ptm-processing"
+              href="/uniprotkb/Q6PCE3#ptm_processing"
             >
               1 PTM
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q6PCE3#disease-and-drugs"
+              href="/uniprotkb/Q6PCE3#disease_and_drugs"
             >
               3 reviewed variants
             </a>
@@ -3010,7 +3010,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q9BUM1#disease-and-drugs"
+              href="/uniprotkb/Q9BUM1#disease_and_drugs"
             >
               22 reviewed variants
             </a>
@@ -3022,7 +3022,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/Q9BUM1#disease-and-drugs"
+              href="/uniprotkb/Q9BUM1#disease_and_drugs"
             >
               2 diseases
             </a>
@@ -3154,7 +3154,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q9BYW1#disease-and-drugs"
+              href="/uniprotkb/Q9BYW1#disease_and_drugs"
             >
               5 reviewed variants
             </a>
@@ -3292,13 +3292,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P11169#ptm-processing"
+              href="/uniprotkb/P11169#ptm_processing"
             >
               4 PTMs
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P11169#disease-and-drugs"
+              href="/uniprotkb/P11169#disease_and_drugs"
             >
               1 reviewed variant
             </a>
@@ -3447,13 +3447,13 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/O95528#disease-and-drugs"
+              href="/uniprotkb/O95528#disease_and_drugs"
             >
               13 reviewed variants
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/O95528#disease-and-drugs"
+              href="/uniprotkb/O95528#disease_and_drugs"
             >
               1 disease
             </a>
@@ -3595,7 +3595,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/P35575#disease-and-drugs"
+              href="/uniprotkb/P35575#disease_and_drugs"
             >
               56 reviewed variants
             </a>
@@ -3619,7 +3619,7 @@ exports[`ResultsData component should render the card view with the correct numb
             </a>
             <a
               class="card-action"
-              href="/uniprotkb/P35575#disease-and-drugs"
+              href="/uniprotkb/P35575#disease_and_drugs"
             >
               1 disease
             </a>
@@ -3751,7 +3751,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q6PXP3#disease-and-drugs"
+              href="/uniprotkb/Q6PXP3#disease_and_drugs"
             >
               2 reviewed variants
             </a>
@@ -3898,7 +3898,7 @@ exports[`ResultsData component should render the card view with the correct numb
           >
             <a
               class="card-action"
-              href="/uniprotkb/Q16739#ptm-processing"
+              href="/uniprotkb/Q16739#ptm_processing"
             >
               1 PTM
             </a>

--- a/src/uniparc/types/entrySection.ts
+++ b/src/uniparc/types/entrySection.ts
@@ -1,6 +1,6 @@
 export enum EntrySection {
   Sequence = 'sequence',
-  XRefs = 'cross-references',
+  XRefs = 'cross_references',
 }
 
 export type EntrySectionNameAndId = {

--- a/src/uniprotkb/adapters/generatePageTitle.ts
+++ b/src/uniprotkb/adapters/generatePageTitle.ts
@@ -1,26 +1,28 @@
 import { UniProtkbUIModel } from './uniProtkbConverter';
 
+import EntrySection from '../types/entrySection';
+
 export default (data: UniProtkbUIModel) => {
   const geneName =
-    data['names-and-taxonomy'].geneNamesData?.[0].geneName?.value;
+    data[EntrySection.NamesAndTaxonomy].geneNamesData?.[0].geneName?.value;
   const proteinName =
-    data['names-and-taxonomy'].proteinNamesData?.recommendedName?.fullName
-      .value ||
-    data['names-and-taxonomy'].proteinNamesData?.submissionNames?.[0].fullName
-      .value;
+    data[EntrySection.NamesAndTaxonomy].proteinNamesData?.recommendedName
+      ?.fullName.value ||
+    data[EntrySection.NamesAndTaxonomy].proteinNamesData?.submissionNames?.[0]
+      .fullName.value;
   let organismName: string | number | undefined;
   {
     const organismScientificName =
-      data['names-and-taxonomy'].organismData?.scientificName;
+      data[EntrySection.NamesAndTaxonomy].organismData?.scientificName;
     const organismCommonName =
-      data['names-and-taxonomy'].organismData?.commonName;
+      data[EntrySection.NamesAndTaxonomy].organismData?.commonName;
     if (organismScientificName && organismCommonName) {
       organismName = `${organismScientificName} (${organismCommonName})`;
     } else {
       organismName =
         organismScientificName ||
         organismCommonName ||
-        data['names-and-taxonomy'].organismData?.taxonId;
+        data[EntrySection.NamesAndTaxonomy].organismData?.taxonId;
     }
   }
   return `${[geneName, proteinName, organismName].filter(Boolean).join(' - ')}`;

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -154,7 +154,7 @@ const Entry = () => {
             break;
           case EntrySection.SubCellularLocation:
             disabled = !subcellularLocationSectionHasContent(
-              transformedData['subcellular-location']
+              transformedData[EntrySection.SubCellularLocation]
             );
             break;
           default:

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#names-and-taxonomy"
+            href="/uniprotkb/P21802/entry#names_and_taxonomy"
           >
             Names & Taxonomy
           </a>
@@ -39,7 +39,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#subcellular-location"
+            href="/uniprotkb/P21802/entry#subcellular_location"
           >
             Subcellular Location
           </a>
@@ -49,7 +49,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#disease-and-drugs"
+            href="/uniprotkb/P21802/entry#disease_and_drugs"
           >
             Disease & Drugs
           </a>
@@ -59,7 +59,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#ptm-processing"
+            href="/uniprotkb/P21802/entry#ptm_processing"
           >
             PTM/Processing
           </a>
@@ -99,7 +99,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#family-and-domains"
+            href="/uniprotkb/P21802/entry#family_and_domains"
           >
             Family & Domains
           </a>
@@ -119,7 +119,7 @@ exports[`Entry basic should render main 1`] = `
         >
           <a
             class=""
-            href="/uniprotkb/P21802/entry#similar-proteins"
+            href="/uniprotkb/P21802/entry#similar_proteins"
           >
             Similar Proteins
           </a>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -553,7 +553,7 @@ exports[`Entry view should render 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="names-and-taxonomy"
+    id="names_and_taxonomy"
   >
     <div
       class="card__container"
@@ -1917,7 +1917,7 @@ exports[`Entry view should render 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="subcellular-location"
+    id="subcellular_location"
   >
     <div
       class="card__container"
@@ -2119,7 +2119,7 @@ exports[`Entry view should render 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="disease-and-drugs"
+    id="disease_and_drugs"
   >
     <div
       class="card__container"
@@ -2358,7 +2358,7 @@ exports[`Entry view should render 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="ptm-processing"
+    id="ptm_processing"
   >
     <div
       class="card__container"
@@ -2764,7 +2764,7 @@ exports[`Entry view should render 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="family-and-domains"
+    id="family_and_domains"
   >
     <div
       class="card__container"
@@ -4675,7 +4675,7 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="names-and-taxonomy"
+    id="names_and_taxonomy"
   >
     <div
       class="card__container"
@@ -5390,7 +5390,7 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="ptm-processing"
+    id="ptm_processing"
   >
     <div
       class="card__container"
@@ -5751,7 +5751,7 @@ exports[`Entry view should render for non-human entry 1`] = `
   <section
     class="card"
     data-entry-section="true"
-    id="family-and-domains"
+    id="family_and_domains"
   >
     <div
       class="card__container"

--- a/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
+++ b/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBCard.spec.tsx.snap
@@ -116,7 +116,7 @@ exports[`UniProtKBCard component should render 1`] = `
       </a>
       <a
         class="card-action"
-        href="/uniprotkb/P21802#disease-and-drugs"
+        href="/uniprotkb/P21802#disease_and_drugs"
       >
         1 disease
       </a>

--- a/src/uniprotkb/types/entrySection.ts
+++ b/src/uniprotkb/types/entrySection.ts
@@ -1,17 +1,17 @@
 export enum EntrySection {
   Function = 'function',
-  FamilyAndDomains = 'family-and-domains',
+  FamilyAndDomains = 'family_and_domains',
   Expression = 'expression',
   Interaction = 'interaction',
-  NamesAndTaxonomy = 'names-and-taxonomy',
-  DiseaseAndDrugs = 'disease-and-drugs',
+  NamesAndTaxonomy = 'names_and_taxonomy',
+  DiseaseAndDrugs = 'disease_and_drugs',
   Phenotypes = 'phenotypes',
-  ProteinProcessing = 'ptm-processing',
+  ProteinProcessing = 'ptm_processing',
   Sequence = 'sequence',
   Structure = 'structure',
-  SubCellularLocation = 'subcellular-location',
-  ExternalLinks = 'external-links',
-  SimilarProteins = 'similar-proteins',
+  SubCellularLocation = 'subcellular_location',
+  ExternalLinks = 'external_links',
+  SimilarProteins = 'similar_proteins',
 }
 
 export type EntrySectionWithFeatures =


### PR DESCRIPTION
## Purpose
Use `_` convention for anchor links for consistency with pre-5/22 website. [Jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-27782)

## Approach
- Updated all `EntrySection` enums so that the anchors now use `_` convention
- Used the enums in a few places where we just used text

## Testing
Updated snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
