### PR TITLE
No stream warnings

### DIFF
--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -29,6 +29,7 @@ import {
   getLocationEntryPathFor,
   Location,
 } from '../../../app/config/urls';
+import { warn } from '../../utils/logging';
 
 import { fileFormatEntryDownload as uniProtKBFFED } from '../../../uniprotkb/config/download';
 import { fileFormatEntryDownload as uniRefFFED } from '../../../uniref/config/download';
@@ -126,6 +127,7 @@ const EntryDownload = ({ nResults }: Props) => {
 
   const downloadOnClick = useCallback(() => {
     if (namespace === Namespace.uniparc) {
+      warn('tried downloading a UniParc XRef list > 500');
       messagesDispatch(
         addMessage({
           id: 'uniparc-stream-warning',
@@ -165,6 +167,7 @@ const EntryDownload = ({ nResults }: Props) => {
         })
       );
     } else if (namespace === Namespace.uniref) {
+      warn('tried downloading a UniRef member tsv > 500');
       messagesDispatch(
         addMessage({
           id: 'uniref-stream-warning',

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -1,10 +1,34 @@
-import { useRouteMatch } from 'react-router-dom';
-import { DropdownButton, DownloadIcon } from 'franklin-sites';
+/* eslint-disable uniprot-website/use-config-location */
 
+// TODO: remove all of the uniref and uniparc contingency code as soon as streaming is provided:
+//  - https://www.ebi.ac.uk/panda/jira/browse/TRM-27649
+//  - https://www.ebi.ac.uk/panda/jira/browse/TRM-27650
+// It maybe easier to just checkout this file at 820fdb305a092 rather than going through the file.
+// Just make to sure to see if any other commits have been made on top of it since.
+
+import { useCallback } from 'react';
+import { Link, useRouteMatch } from 'react-router-dom';
+import {
+  DropdownButton,
+  DownloadIcon,
+  Button,
+  LongNumber,
+} from 'franklin-sites';
+
+// eslint-disable-next-line import/no-relative-packages
+import colors from '../../../../node_modules/franklin-sites/src/styles/colours.json';
+
+import { useMessagesDispatch } from '../../contexts/Messages';
+
+import { addMessage } from '../../../messages/state/messagesActions';
 import apiUrls from '../../config/apiUrls';
 import uniparcApiUrls from '../../../uniparc/config/apiUrls';
 import unirefApiUrls from '../../../uniref/config/apiUrls';
-import { allEntryPages } from '../../../app/config/urls';
+import {
+  allEntryPages,
+  getLocationEntryPathFor,
+  Location,
+} from '../../../app/config/urls';
 
 import { fileFormatEntryDownload as uniProtKBFFED } from '../../../uniprotkb/config/download';
 import { fileFormatEntryDownload as uniRefFFED } from '../../../uniref/config/download';
@@ -21,6 +45,10 @@ import { fileFormatEntryDownload as arbaFFED } from '../../../automatic-annotati
 
 import { Namespace } from '../../types/namespaces';
 import { FileFormat } from '../../types/resultsDownload';
+import {
+  MessageFormat,
+  MessageLevel,
+} from '../../../messages/types/messagesTypes';
 
 const formatMap = new Map<Namespace, FileFormat[]>([
   [Namespace.uniprotkb, uniProtKBFFED],
@@ -37,43 +65,148 @@ const formatMap = new Map<Namespace, FileFormat[]>([
   [Namespace.arba, arbaFFED],
 ]);
 
+const maxPaginationDownload = 500;
+const isUniparcTsv = (namespace: Namespace, fileFormat: FileFormat) =>
+  namespace === Namespace.uniparc && fileFormat === FileFormat.tsv;
+const isUniRefList = (namespace: Namespace, fileFormat: FileFormat) =>
+  namespace === Namespace.uniref && fileFormat === FileFormat.list;
+
 const getEntryDownloadUrl = (
   accession: string,
   fileFormat: FileFormat,
   namespace: Namespace
 ) => {
-  if (namespace === Namespace.uniparc) {
-    if (fileFormat === FileFormat.tsv) {
-      return uniparcApiUrls.databases(accession, {
-        format: fileFormat,
-        // TODO: remove when this endpoint has streaming https://www.ebi.ac.uk/panda/jira/browse/TRM-27649
-        // If this isn't ready by full release then remove this download choice altogether to avoid users
-        // having truncated results
-        size: 500,
-      });
-    }
+  if (isUniparcTsv(namespace, fileFormat)) {
+    return uniparcApiUrls.databases(accession, {
+      format: fileFormat as FileFormat.tsv,
+      // TODO: remove when this endpoint has streaming https://www.ebi.ac.uk/panda/jira/browse/TRM-27649
+      size: 500,
+    });
   }
-  if (namespace === Namespace.uniref) {
-    if (fileFormat === FileFormat.list) {
-      return unirefApiUrls.members(accession, {
-        format: fileFormat,
-        // TODO: remove when this endpoint has streaming https://www.ebi.ac.uk/panda/jira/browse/TRM-27650
-        // If this isn't ready by full release then remove this download choice altogether to avoid users
-        // having truncated results
-        size: 500,
-      });
-    }
+  if (isUniRefList(namespace, fileFormat)) {
+    return unirefApiUrls.members(accession, {
+      format: fileFormat as FileFormat.list,
+      // TODO: remove when this endpoint has streaming https://www.ebi.ac.uk/panda/jira/browse/TRM-27650
+      size: 500,
+    });
   }
   return apiUrls.entryDownload(accession, fileFormat, namespace);
 };
 
-const EntryDownload = () => {
+type DownloadAnchorProps = {
+  accession: string;
+  fileFormat: FileFormat;
+  namespace: Namespace;
+};
+
+const DownloadAnchor = ({
+  accession,
+  fileFormat,
+  namespace,
+}: DownloadAnchorProps) => (
+  <a
+    target="_blank"
+    href={getEntryDownloadUrl(accession, fileFormat, namespace)}
+    rel="noreferrer"
+  >
+    {fileFormat}
+  </a>
+);
+
+type Props = {
+  nResults?: number;
+};
+const EntryDownload = ({ nResults }: Props) => {
   const match =
     useRouteMatch<{ namespace: Namespace; accession: string }>(allEntryPages);
   const { namespace, accession } = match?.params || {};
+  const messagesDispatch = useMessagesDispatch();
 
   const fileFormatEntryDownload = namespace && formatMap.get(namespace);
 
+  const downloadOnClick = useCallback(() => {
+    if (namespace === Namespace.uniparc) {
+      messagesDispatch(
+        addMessage({
+          id: 'uniparc-stream-warning',
+          content: (
+            <>
+              There is a current limitation where UniParc cross reference TSV
+              downloads are limited to 500 entries. Until this is fixed there
+              are several options:
+              <ul>
+                <li>
+                  Download the{' '}
+                  <DownloadAnchor
+                    accession={accession as string}
+                    fileFormat={FileFormat.json}
+                    namespace={namespace}
+                  />{' '}
+                  file format instead which includes all{' '}
+                  <LongNumber>{nResults as number}</LongNumber> of the cross
+                  references in the <pre>uniParcCrossReferences</pre> attribute
+                </li>
+                <li>
+                  Continue to download the{' '}
+                  <DownloadAnchor
+                    accession={accession as string}
+                    fileFormat={FileFormat.tsv}
+                    namespace={namespace}
+                  />{' '}
+                  file format which only has only 500 entries (meaning{' '}
+                  <LongNumber>{(nResults as number) - 500}</LongNumber> cross
+                  references will not be downloaded)
+                </li>
+              </ul>
+            </>
+          ),
+          format: MessageFormat.POP_UP,
+          level: MessageLevel.WARNING,
+        })
+      );
+    } else if (namespace === Namespace.uniref) {
+      messagesDispatch(
+        addMessage({
+          id: 'uniref-stream-warning',
+          content: (
+            <>
+              There is a current limitation where UniRef member list downloads
+              are limited to 500 entries. Until this is fixed there are several
+              options:
+              <ul>
+                <li>
+                  View the{' '}
+                  <Link
+                    to={getLocationEntryPathFor(Location.HelpEntry)(
+                      'pagination'
+                    )}
+                  >
+                    pagination documenation
+                  </Link>{' '}
+                  to download all <LongNumber>{nResults as number}</LongNumber>{' '}
+                  members programmatically
+                </li>
+                <li>
+                  Continue to download the{' '}
+                  <DownloadAnchor
+                    accession={accession as string}
+                    fileFormat={FileFormat.list}
+                    namespace={namespace}
+                  />{' '}
+                  file format which only has only 500 entries (meaning{' '}
+                  <LongNumber>{(nResults as number) - 500}</LongNumber> cross
+                  references will not be downloaded)
+                </li>
+              </ul>
+            </>
+          ),
+          format: MessageFormat.POP_UP,
+          level: MessageLevel.WARNING,
+        })
+      );
+    }
+  }, [accession, messagesDispatch, nResults, namespace]);
+  //
   if (!(namespace && accession && fileFormatEntryDownload)) {
     return null;
   }
@@ -92,13 +225,24 @@ const EntryDownload = () => {
         <ul>
           {fileFormatEntryDownload.map((fileFormat) => (
             <li key={fileFormat}>
-              <a
-                target="_blank"
-                href={getEntryDownloadUrl(accession, fileFormat, namespace)}
-                rel="noreferrer"
-              >
-                {fileFormat}
-              </a>
+              {nResults &&
+              nResults > maxPaginationDownload &&
+              (isUniRefList(namespace, fileFormat) ||
+                isUniparcTsv(namespace, fileFormat)) ? (
+                <Button
+                  variant="tertiary"
+                  onClick={downloadOnClick}
+                  style={{ color: colors.sapphireBlue }}
+                >
+                  {fileFormat}
+                </Button>
+              ) : (
+                <DownloadAnchor
+                  accession={accession}
+                  fileFormat={fileFormat}
+                  namespace={namespace}
+                />
+              )}
             </li>
           ))}
         </ul>

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -133,8 +133,8 @@ const EntryDownload = ({ nResults }: Props) => {
           id: 'uniparc-stream-warning',
           content: (
             <>
-              There is a current limitation where UniParc cross reference TSV
-              downloads are limited to 500 entries. Until this is fixed there
+              There is a current limitation where UniParc cross-reference TSV
+              downloads are limited to 500 entries. Until this is fixed, there
               are several options:
               <ul>
                 <li>
@@ -145,8 +145,9 @@ const EntryDownload = ({ nResults }: Props) => {
                     namespace={namespace}
                   />{' '}
                   file format instead which includes all{' '}
-                  <LongNumber>{nResults as number}</LongNumber> of the cross
-                  references in the <pre>uniParcCrossReferences</pre> attribute
+                  <LongNumber>{nResults as number}</LongNumber> of the
+                  cross-references in the <pre>uniParcCrossReferences</pre>{' '}
+                  attribute
                 </li>
                 <li>
                   Continue to download the{' '}
@@ -155,9 +156,9 @@ const EntryDownload = ({ nResults }: Props) => {
                     fileFormat={FileFormat.tsv}
                     namespace={namespace}
                   />{' '}
-                  file format which only has only 500 entries (meaning{' '}
-                  <LongNumber>{(nResults as number) - 500}</LongNumber> cross
-                  references will not be downloaded)
+                  file format which has only 500 entries (meaning{' '}
+                  <LongNumber>{(nResults as number) - 500}</LongNumber>{' '}
+                  cross-references will not be downloaded)
                 </li>
               </ul>
             </>
@@ -174,7 +175,7 @@ const EntryDownload = ({ nResults }: Props) => {
           content: (
             <>
               There is a current limitation where UniRef member list downloads
-              are limited to 500 entries. Until this is fixed there are several
+              are limited to 500 entries. Until this is fixed, there are several
               options:
               <ul>
                 <li>
@@ -196,9 +197,9 @@ const EntryDownload = ({ nResults }: Props) => {
                     fileFormat={FileFormat.list}
                     namespace={namespace}
                   />{' '}
-                  file format which only has only 500 entries (meaning{' '}
-                  <LongNumber>{(nResults as number) - 500}</LongNumber> cross
-                  references will not be downloaded)
+                  file format which has only 500 entries (meaning{' '}
+                  <LongNumber>{(nResults as number) - 500}</LongNumber> members
+                  will not be downloaded)
                 </li>
               </ul>
             </>

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -181,7 +181,7 @@ const EntryDownload = ({ nResults }: Props) => {
                       'pagination'
                     )}
                   >
-                    pagination documenation
+                    pagination documentation
                   </Link>{' '}
                   to download all <LongNumber>{nResults as number}</LongNumber>{' '}
                   members programmatically

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -154,7 +154,12 @@ const Entry = () => {
         >
           <div className="button-group">
             <BlastButton selectedEntries={[match.params.accession]} />
-            <EntryDownload />
+            {
+              // TODO: evenutally remove nResults prop (see note in EntryDownload)
+            }
+            <EntryDownload
+              nResults={xrefsDataObject.data?.uniParcCrossReferences?.length}
+            />
             <AddToBasketButton selectedEntries={match.params.accession} />
           </div>
           <EntryMain

--- a/src/uniref/components/entry/Entry.tsx
+++ b/src/uniref/components/entry/Entry.tsx
@@ -95,7 +95,10 @@ const Entry = () => {
           <Overview transformedData={transformedData} />
           <div className="button-group">
             <BlastButton selectedEntries={[accession]} />
-            <EntryDownload />
+            {
+              // TODO: evenutally remove nResults prop (see note in EntryDownload)
+            }
+            <EntryDownload nResults={transformedData.memberCount} />
             <AddToBasketButton selectedEntries={accession} />
           </div>
         </ErrorBoundary>


### PR DESCRIPTION
## Purpose
Temporarily warn users when downloading uniref members or uniparc xrefs.

Jiras

- https://www.ebi.ac.uk/panda/jira/browse/TRM-27679
- https://www.ebi.ac.uk/panda/jira/browse/TRM-27680

## Approach
Dispatch messages with choices

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
