### PR TITLE
add taxonomy navigation through search page

### DIFF
--- a/src/supporting-data/taxonomy/components/entry/ChildNavigation.tsx
+++ b/src/supporting-data/taxonomy/components/entry/ChildNavigation.tsx
@@ -1,0 +1,73 @@
+import { Link } from 'react-router-dom';
+import { Button } from 'franklin-sites';
+
+import { pluralise } from '../../../../shared/utils/utils';
+import {
+  getEntryPath,
+  LocationToPath,
+  Location,
+} from '../../../../app/config/urls';
+
+import { TaxonomyAPIModel } from '../../adapters/taxonomyConverter';
+import { Namespace } from '../../../../shared/types/namespaces';
+
+import styles from './styles/child-navigation.module.css';
+
+// Match the "ExpandableList" default count
+export const CHILDREN_TO_DISPLAY = 5;
+
+const ChildNavigation = ({
+  taxonId,
+  childTaxons,
+  total,
+}: {
+  taxonId: number;
+  childTaxons: TaxonomyAPIModel[];
+  total: number;
+}) => {
+  const remainingChildren = total - CHILDREN_TO_DISPLAY;
+  return (
+    <ul className="no-bullet">
+      {childTaxons.map((child) => (
+        <li key={child.taxonId}>
+          <Link to={getEntryPath(Namespace.taxonomy, child.taxonId)}>
+            {child.commonName || child.scientificName || child.taxonId}
+          </Link>
+        </li>
+      ))}
+      <li>
+        <Button
+          to={{
+            pathname: LocationToPath[Location.TaxonomyResults],
+            search: `query=parent:${taxonId}`,
+          }}
+          element={Link}
+          variant="tertiary"
+          className={styles['no-margin']}
+        >
+          {remainingChildren > 0
+            ? `${remainingChildren} more direct ${pluralise(
+                'child',
+                remainingChildren,
+                'children'
+              )}`
+            : 'Browse all direct children'}
+        </Button>
+      </li>
+      <li>
+        <Button
+          to={{
+            pathname: LocationToPath[Location.TaxonomyResults],
+            search: `query=ancestor:${taxonId}`,
+          }}
+          element={Link}
+          variant="tertiary"
+        >
+          Browse all descendants
+        </Button>
+      </li>
+    </ul>
+  );
+};
+
+export default ChildNavigation;

--- a/src/supporting-data/taxonomy/components/entry/ChildNavigation.tsx
+++ b/src/supporting-data/taxonomy/components/entry/ChildNavigation.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
-import { Button } from 'franklin-sites';
+import { Button, LongNumber } from 'franklin-sites';
 
-import { pluralise } from '../../../../shared/utils/utils';
 import {
   getEntryPath,
   LocationToPath,
@@ -13,9 +12,6 @@ import { Namespace } from '../../../../shared/types/namespaces';
 
 import styles from './styles/child-navigation.module.css';
 
-// Match the "ExpandableList" default count
-export const CHILDREN_TO_DISPLAY = 5;
-
 const ChildNavigation = ({
   taxonId,
   childTaxons,
@@ -24,50 +20,41 @@ const ChildNavigation = ({
   taxonId: number;
   childTaxons: TaxonomyAPIModel[];
   total: number;
-}) => {
-  const remainingChildren = total - CHILDREN_TO_DISPLAY;
-  return (
-    <ul className="no-bullet">
-      {childTaxons.map((child) => (
-        <li key={child.taxonId}>
-          <Link to={getEntryPath(Namespace.taxonomy, child.taxonId)}>
-            {child.commonName || child.scientificName || child.taxonId}
-          </Link>
-        </li>
-      ))}
-      <li>
-        <Button
-          to={{
-            pathname: LocationToPath[Location.TaxonomyResults],
-            search: `query=parent:${taxonId}`,
-          }}
-          element={Link}
-          variant="tertiary"
-          className={styles['no-margin']}
-        >
-          {remainingChildren > 0
-            ? `${remainingChildren} more direct ${pluralise(
-                'child',
-                remainingChildren,
-                'children'
-              )}`
-            : 'Browse all direct children'}
-        </Button>
+}) => (
+  <ul className="no-bullet">
+    {childTaxons.map((child) => (
+      <li key={child.taxonId}>
+        <Link to={getEntryPath(Namespace.taxonomy, child.taxonId)}>
+          {child.commonName || child.scientificName || child.taxonId}
+        </Link>
       </li>
-      <li>
-        <Button
-          to={{
-            pathname: LocationToPath[Location.TaxonomyResults],
-            search: `query=ancestor:${taxonId}`,
-          }}
-          element={Link}
-          variant="tertiary"
-        >
-          Browse all descendants
-        </Button>
-      </li>
-    </ul>
-  );
-};
+    ))}
+    <li>
+      <Button
+        to={{
+          pathname: LocationToPath[Location.TaxonomyResults],
+          search: `query=parent:${taxonId}`,
+        }}
+        element={Link}
+        variant="tertiary"
+        className={styles['no-margin']}
+      >
+        Browse all direct children (<LongNumber>{total}</LongNumber>)
+      </Button>
+    </li>
+    <li>
+      <Button
+        to={{
+          pathname: LocationToPath[Location.TaxonomyResults],
+          search: `query=ancestor:${taxonId}`,
+        }}
+        element={Link}
+        variant="tertiary"
+      >
+        Browse all descendants
+      </Button>
+    </li>
+  </ul>
+);
 
 export default ChildNavigation;

--- a/src/supporting-data/taxonomy/components/entry/Entry.tsx
+++ b/src/supporting-data/taxonomy/components/entry/Entry.tsx
@@ -7,7 +7,7 @@ import SingleColumnLayout from '../../../../shared/components/layouts/SingleColu
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
 import EntryDownload from '../../../../shared/components/entry/EntryDownload';
 import { MapToDropdown } from '../../../../shared/components/MapTo';
-import ChildNavigation, { CHILDREN_TO_DISPLAY } from './ChildNavigation';
+import ChildNavigation from './ChildNavigation';
 
 import useDataApi from '../../../../shared/hooks/useDataApi';
 
@@ -54,7 +54,7 @@ const TaxonomyEntry = (props: RouteChildrenProps<{ accession: string }>) => {
       query: `parent:${accession}`,
       columns: [TaxonomyColumn.scientificName, TaxonomyColumn.commonName],
       facets: null,
-      size: CHILDREN_TO_DISPLAY,
+      size: 5, // Match the "ExpandableList" default count
     })
   );
 

--- a/src/supporting-data/taxonomy/components/entry/Entry.tsx
+++ b/src/supporting-data/taxonomy/components/entry/Entry.tsx
@@ -27,15 +27,18 @@ import { SearchResults } from '../../../../shared/types/results';
 
 import entryPageStyles from '../../../shared/styles/entry-page.module.scss';
 
-const columns = [
+const firstColumns = [
   TaxonomyColumn.mnemonic,
   TaxonomyColumn.id,
   TaxonomyColumn.scientificName,
-  TaxonomyColumn.commonName,
-  TaxonomyColumn.otherNames,
-  TaxonomyColumn.synonyms,
-  TaxonomyColumn.rank,
   TaxonomyColumn.parent,
+];
+
+const lastColumns = [
+  TaxonomyColumn.commonName,
+  TaxonomyColumn.synonyms,
+  TaxonomyColumn.otherNames,
+  TaxonomyColumn.rank,
   TaxonomyColumn.lineage,
   TaxonomyColumn.hosts,
   TaxonomyColumn.strains,
@@ -81,7 +84,16 @@ const TaxonomyEntry = (props: RouteChildrenProps<{ accession: string }>) => {
     'referenceProteomeCount',
   ]);
 
+  const infoDataRenderer = (column: TaxonomyColumn) => {
+    const renderer = TaxonomyColumnConfiguration.get(column);
+    return {
+      title: renderer?.label,
+      content: renderer?.render(data),
+    };
+  };
+
   const infoData = [
+    ...firstColumns.map(infoDataRenderer),
     {
       title: 'Children',
       content: childrenData.data.results.length ? (
@@ -92,13 +104,7 @@ const TaxonomyEntry = (props: RouteChildrenProps<{ accession: string }>) => {
         />
       ) : null,
     },
-    ...columns.map((column) => {
-      const renderer = TaxonomyColumnConfiguration.get(column);
-      return {
-        title: renderer?.label,
-        content: renderer?.render(data),
-      };
-    }),
+    ...lastColumns.map(infoDataRenderer),
   ];
 
   return (

--- a/src/supporting-data/taxonomy/components/entry/__tests__/ChildNavigation.spec.tsx
+++ b/src/supporting-data/taxonomy/components/entry/__tests__/ChildNavigation.spec.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+
+import customRender from '../../../../../shared/__test-helpers__/customRender';
+
+import ChildNavigation from '../ChildNavigation';
+
+import taxonomyData from '../../../__mocks__/taxonomyModelData';
+
+describe('ChildNavigation', () => {
+  it('should render, one', () => {
+    const { asFragment } = customRender(
+      <ChildNavigation
+        taxonId={9606}
+        childTaxons={[taxonomyData[0]]}
+        total={1}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+  });
+
+  it('should render, many', () => {
+    const { asFragment } = customRender(
+      <ChildNavigation
+        taxonId={9606}
+        childTaxons={Array.from({ length: 5 }, (_, i) => ({
+          ...taxonomyData[i % 2],
+          taxonId: i,
+        }))}
+        total={5}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getAllByRole('link')).toHaveLength(7);
+  });
+
+  it('should render, lots', () => {
+    const { asFragment } = customRender(
+      <ChildNavigation
+        taxonId={9606}
+        childTaxons={Array.from({ length: 5 }, (_, i) => ({
+          ...taxonomyData[i % 2],
+          taxonId: i,
+        }))}
+        total={10}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getAllByRole('link')).toHaveLength(7);
+  });
+});

--- a/src/supporting-data/taxonomy/components/entry/__tests__/ChildNavigation.spec.tsx
+++ b/src/supporting-data/taxonomy/components/entry/__tests__/ChildNavigation.spec.tsx
@@ -19,21 +19,6 @@ describe('ChildNavigation', () => {
     expect(screen.getAllByRole('link')).toHaveLength(3);
   });
 
-  it('should render, many', () => {
-    const { asFragment } = customRender(
-      <ChildNavigation
-        taxonId={9606}
-        childTaxons={Array.from({ length: 5 }, (_, i) => ({
-          ...taxonomyData[i % 2],
-          taxonId: i,
-        }))}
-        total={5}
-      />
-    );
-    expect(asFragment()).toMatchSnapshot();
-    expect(screen.getAllByRole('link')).toHaveLength(7);
-  });
-
   it('should render, lots', () => {
     const { asFragment } = customRender(
       <ChildNavigation

--- a/src/supporting-data/taxonomy/components/entry/__tests__/__snapshots__/ChildNavigation.spec.tsx.snap
+++ b/src/supporting-data/taxonomy/components/entry/__tests__/__snapshots__/ChildNavigation.spec.tsx.snap
@@ -45,67 +45,7 @@ exports[`ChildNavigation should render, lots 1`] = `
         class="button tertiary no-margin"
         href="/taxonomy?query=parent:9606"
       >
-        5 more direct children
-      </a>
-    </li>
-    <li>
-      <a
-        class="button tertiary"
-        href="/taxonomy?query=ancestor:9606"
-      >
-        Browse all descendants
-      </a>
-    </li>
-  </ul>
-</DocumentFragment>
-`;
-
-exports[`ChildNavigation should render, many 1`] = `
-<DocumentFragment>
-  <ul
-    class="no-bullet"
-  >
-    <li>
-      <a
-        href="/taxonomy/0"
-      >
-        Primate lentivirus group
-      </a>
-    </li>
-    <li>
-      <a
-        href="/taxonomy/1"
-      >
-        Primate calicivirus
-      </a>
-    </li>
-    <li>
-      <a
-        href="/taxonomy/2"
-      >
-        Primate lentivirus group
-      </a>
-    </li>
-    <li>
-      <a
-        href="/taxonomy/3"
-      >
-        Primate calicivirus
-      </a>
-    </li>
-    <li>
-      <a
-        href="/taxonomy/4"
-      >
-        Primate lentivirus group
-      </a>
-    </li>
-    <li>
-      <a
-        class="button tertiary no-margin"
-        href="/taxonomy?query=parent:9606"
-      >
-        Browse all direct children
+        Browse all direct children (10)
       </a>
     </li>
     <li>
@@ -137,7 +77,7 @@ exports[`ChildNavigation should render, one 1`] = `
         class="button tertiary no-margin"
         href="/taxonomy?query=parent:9606"
       >
-        Browse all direct children
+        Browse all direct children (1)
       </a>
     </li>
     <li>

--- a/src/supporting-data/taxonomy/components/entry/__tests__/__snapshots__/ChildNavigation.spec.tsx.snap
+++ b/src/supporting-data/taxonomy/components/entry/__tests__/__snapshots__/ChildNavigation.spec.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChildNavigation should render, lots 1`] = `
+<DocumentFragment>
+  <ul
+    class="no-bullet"
+  >
+    <li>
+      <a
+        href="/taxonomy/0"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/1"
+      >
+        Primate calicivirus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/2"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/3"
+      >
+        Primate calicivirus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/4"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary no-margin"
+        href="/taxonomy?query=parent:9606"
+      >
+        5 more direct children
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary"
+        href="/taxonomy?query=ancestor:9606"
+      >
+        Browse all descendants
+      </a>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`ChildNavigation should render, many 1`] = `
+<DocumentFragment>
+  <ul
+    class="no-bullet"
+  >
+    <li>
+      <a
+        href="/taxonomy/0"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/1"
+      >
+        Primate calicivirus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/2"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/3"
+      >
+        Primate calicivirus
+      </a>
+    </li>
+    <li>
+      <a
+        href="/taxonomy/4"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary no-margin"
+        href="/taxonomy?query=parent:9606"
+      >
+        Browse all direct children
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary"
+        href="/taxonomy?query=ancestor:9606"
+      >
+        Browse all descendants
+      </a>
+    </li>
+  </ul>
+</DocumentFragment>
+`;
+
+exports[`ChildNavigation should render, one 1`] = `
+<DocumentFragment>
+  <ul
+    class="no-bullet"
+  >
+    <li>
+      <a
+        href="/taxonomy/11652"
+      >
+        Primate lentivirus group
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary no-margin"
+        href="/taxonomy?query=parent:9606"
+      >
+        Browse all direct children
+      </a>
+    </li>
+    <li>
+      <a
+        class="button tertiary"
+        href="/taxonomy?query=ancestor:9606"
+      >
+        Browse all descendants
+      </a>
+    </li>
+  </ul>
+</DocumentFragment>
+`;

--- a/src/supporting-data/taxonomy/components/entry/styles/child-navigation.module.css
+++ b/src/supporting-data/taxonomy/components/entry/styles/child-navigation.module.css
@@ -1,0 +1,3 @@
+.no-margin {
+  margin: 0;
+}


### PR DESCRIPTION
## Purpose
Taxonomy entry children navigation https://www.ebi.ac.uk/panda/jira/browse/TRM-27018

## Approach
Since we're not going to get all direct children in the initial payload, I opted to use the navigation as a "preview" of the corresponding search. Make it look like the ExpandableList component, but one will expand to the corresponding taxonomy search for either the direct children (through a "parent" search) or all the descendants (through an "ancestor" search)

## Testing
Added a test for the new ChildNavigation component

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
