### PR TITLE
2022 06 variants in diseases

### DIFF
--- a/src/uniprotkb/adapters/sectionConverter.ts
+++ b/src/uniprotkb/adapters/sectionConverter.ts
@@ -1,5 +1,9 @@
 import { getXrefsForSection, XrefUIModel } from '../utils/xrefUtils';
-import Comment, { CommentType, FreeTextComment } from '../types/commentTypes';
+import Comment, {
+  CommentType,
+  DiseaseComment,
+  FreeTextComment,
+} from '../types/commentTypes';
 import {
   getKeywordsForCategories,
   KeywordUIModel,
@@ -11,6 +15,8 @@ import FeatureType from '../types/featureType';
 import { UniProtkbAPIModel } from './uniProtkbConverter';
 import { Xref } from '../../shared/types/apiModel';
 import { DatabaseInfoMaps } from '../utils/database';
+
+export const reDiseaseAcronym = /^in (?<acronym>[^;]+);/i;
 
 export type UIModel = {
   commentsData: Map<CommentType, Comment[] | undefined>;
@@ -37,12 +43,37 @@ export const convertSection = (
 
   const { comments, keywords, features, genes, organism, uniProtkbId } = data;
   if (sectionComments && comments) {
-    sectionComments.forEach((commentType) => {
-      convertedData.commentsData.set(
-        commentType,
-        comments.filter((comment) => comment.commentType === commentType)
+    const naturalVariants = features?.filter(
+      (variant) => variant.type === 'Natural variant'
+    );
+    for (const commentType of sectionComments) {
+      const commentsOfType = comments.filter(
+        (comment) => comment.commentType === commentType
       );
-    });
+      if (commentType === 'DISEASE' && naturalVariants) {
+        // Tie natural variants to specific diseases (not all will match)
+        for (const variant of naturalVariants) {
+          // Extract acronym from the description
+          const acronym =
+            variant.description?.match(reDiseaseAcronym)?.groups?.acronym;
+          if (acronym && variant.featureId) {
+            // Find a disease with that acronym and assign it this variant
+            const comment = (commentsOfType as DiseaseComment[]).find(
+              (comment) => comment.disease?.acronym === acronym
+            );
+            if (comment) {
+              // Assign to object because this bit of code might run multiple
+              // times so adding to a list might create duplicate variants
+              if (!comment.variants) {
+                comment.variants = {};
+              }
+              comment.variants[variant.featureId] = variant;
+            }
+          }
+        }
+      }
+      convertedData.commentsData.set(commentType, commentsOfType);
+    }
   }
   if (sectionKeywords && keywords) {
     convertedData.keywordData = getKeywordsForCategories(

--- a/src/uniprotkb/components/entry/DiseaseAndDrugsSection.tsx
+++ b/src/uniprotkb/components/entry/DiseaseAndDrugsSection.tsx
@@ -1,7 +1,8 @@
+import { lazy } from 'react';
 import { Card } from 'franklin-sites';
 
+import LazyComponent from '../../../shared/components/LazyComponent';
 import XRefView from '../protein-data-views/XRefView';
-import VariationView from '../protein-data-views/VariationView';
 import FreeTextView from '../protein-data-views/FreeTextView';
 import FeaturesView from '../protein-data-views/UniProtKBFeaturesView';
 import DiseaseInvolvementView from '../protein-data-views/DiseaseInvolvementView';
@@ -13,6 +14,13 @@ import EntrySection, {
 import { UIModel } from '../../adapters/sectionConverter';
 
 import { DiseaseComment, FreeTextComment } from '../../types/commentTypes';
+
+const VariationView = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "variation-view" */ '../protein-data-views/VariationView'
+    )
+);
 
 type Props = {
   data: UIModel;
@@ -82,7 +90,9 @@ const DiseaseAndDrugsSection = ({
         features={data.featuresData}
         sequence={sequence}
       />
-      <VariationView primaryAccession={primaryAccession} title="Variants" />
+      <LazyComponent fallback="Variants" rootMargin="50px">
+        <VariationView primaryAccession={primaryAccession} title="Variants" />
+      </LazyComponent>
       <KeywordView keywords={data.keywordData} />
       <XRefView xrefs={data.xrefData} primaryAccession={primaryAccession} />
     </Card>

--- a/src/uniprotkb/components/entry/__tests__/EntryMain.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/EntryMain.spec.tsx
@@ -17,6 +17,10 @@ jest.mock('../similar-proteins/SimilarProteinsSection', () => ({
   __esModule: true,
   default: () => '{{ SimilarProteinsSection }}',
 }));
+jest.mock('../../protein-data-views/VariationView', () => ({
+  __esModule: true,
+  default: () => '{{ VariationView }} ',
+}));
 
 describe('Entry view', () => {
   beforeAll(() => {

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2343,15 +2343,7 @@ exports[`Entry view should render 1`] = `
             id="48"
           />
         </div>
-        <div
-          class="loader-container"
-        >
-          <test-file-stub
-            classname="loader"
-            height="100"
-            width="100"
-          />
-        </div>
+        Variants
       </div>
     </div>
   </section>
@@ -5378,13 +5370,55 @@ exports[`Entry view should render for non-human entry 1`] = `
           </protvista-datatable>
         </protvista-manager>
         <div
-          class="loader-container"
+          class="error-component"
         >
-          <test-file-stub
-            classname="loader"
-            height="100"
-            width="100"
-          />
+          <div
+            class="message message--failure"
+            role="status"
+          >
+            <div
+              class="message__side-border"
+            />
+            <test-file-stub
+              height="1.125em"
+              width="1.125em"
+            />
+            <section
+              class="message__content"
+            >
+              <small>
+                <h5>
+                  An unexpected issue occurred
+                </h5>
+                <p>
+                  You can try to reload the page, use the rest of this page, or go back to the previous page.
+                </p>
+                <p>
+                  If the error persists, please 
+                  <a
+                    href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    report this bug here
+                  </a>
+                  .
+                </p>
+                <p>
+                  If you still need it, the 
+                  <a
+                    class="external-link"
+                    href="https://legacy.uniprot.org"
+                    rel="noopener nofollow"
+                    target="_blank"
+                  >
+                    legacy version of the website is available here
+                  </a>
+                   until the 2022_02 release.
+                </p>
+              </small>
+            </section>
+          </div>
         </div>
       </div>
     </div>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5369,57 +5369,7 @@ exports[`Entry view should render for non-human entry 1`] = `
             </table>
           </protvista-datatable>
         </protvista-manager>
-        <div
-          class="error-component"
-        >
-          <div
-            class="message message--failure"
-            role="status"
-          >
-            <div
-              class="message__side-border"
-            />
-            <test-file-stub
-              height="1.125em"
-              width="1.125em"
-            />
-            <section
-              class="message__content"
-            >
-              <small>
-                <h5>
-                  An unexpected issue occurred
-                </h5>
-                <p>
-                  You can try to reload the page, use the rest of this page, or go back to the previous page.
-                </p>
-                <p>
-                  If the error persists, please 
-                  <a
-                    href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    report this bug here
-                  </a>
-                  .
-                </p>
-                <p>
-                  If you still need it, the 
-                  <a
-                    class="external-link"
-                    href="https://legacy.uniprot.org"
-                    rel="noopener nofollow"
-                    target="_blank"
-                  >
-                    legacy version of the website is available here
-                  </a>
-                   until the 2022_02 release.
-                </p>
-              </small>
-            </section>
-          </div>
-        </div>
+        {{ VariationView }} 
       </div>
     </div>
   </section>

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, Fragment, lazy, useRef, useEffect, useState } from 'react';
+import { useMemo, Fragment, useRef, useEffect, useState } from 'react';
 import { Loader } from 'franklin-sites';
 import joinUrl from 'url-join';
 import { groupBy, intersection, union } from 'lodash-es';
@@ -7,9 +7,9 @@ import cn from 'classnames';
 import { ProteinsAPIVariation } from 'protvista-variation-adapter/dist/es/variants';
 import { transformData, TransformedVariant } from 'protvista-variation-adapter';
 
+import VisualVariationView from './VisualVariationView';
 import ExternalLink from '../../../shared/components/ExternalLink';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
-import LazyComponent from '../../../shared/components/LazyComponent';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 import useCustomElement from '../../../shared/hooks/useCustomElement';
@@ -17,13 +17,6 @@ import useCustomElement from '../../../shared/hooks/useCustomElement';
 import apiUrls from '../../../shared/config/apiUrls';
 
 import styles from './styles/variation-view.module.scss';
-
-const VisualVariationView = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "visual-variation-view" */ './VisualVariationView'
-    )
-);
 
 const sortByLocation = (a: TransformedVariant, b: TransformedVariant) => {
   const aStart = +a.start;
@@ -115,9 +108,10 @@ const VariationView = ({
   title,
   onlyTable = false,
 }: VariationViewProps) => {
-  const { loading, data, error, status } = useDataApi<ProteinsAPIVariation>(
-    joinUrl(apiUrls.variation, primaryAccession)
-  );
+  const { loading, data, progress, error, status } =
+    useDataApi<ProteinsAPIVariation>(
+      joinUrl(apiUrls.variation, primaryAccession)
+    );
 
   const [filters, setFilters] = useState([]);
   const managerRef = useRef<HTMLElement>(null);
@@ -181,7 +175,12 @@ const VariationView = ({
   );
 
   if (loading) {
-    return <Loader />;
+    return (
+      <div>
+        {title && <h3>{title}</h3>}
+        <Loader progress={progress} />
+      </div>
+    );
   }
 
   if (error && status !== 404) {
@@ -472,11 +471,7 @@ const VariationView = ({
         attributes="highlight displaystart displayend activefilters filters selectedid"
         ref={managerRef}
       >
-        {!onlyTable && (
-          <LazyComponent rootMargin="50px">
-            <VisualVariationView {...transformedData} />
-          </LazyComponent>
-        )}
+        {!onlyTable && <VisualVariationView {...transformedData} />}
         <dataTableElement.name filter-scroll>{table}</dataTableElement.name>
       </managerElement.name>
     </div>

--- a/src/uniprotkb/components/protein-data-views/__tests__/VariationView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/VariationView.spec.tsx
@@ -6,6 +6,11 @@ import VariationView from '../VariationView';
 import useDataApi from '../../../../shared/hooks/useDataApi';
 
 jest.mock('../../../../shared/hooks/useDataApi');
+// Mock this because this is only the visual bit and jest has issues with ES
+jest.mock('../VisualVariationView', () => ({
+  __esModule: true,
+  default: () => null,
+}));
 
 describe('VariationView component', () => {
   it('renders on loading', async () => {

--- a/src/uniprotkb/components/protein-data-views/__tests__/__mocks__/diseaseInvolvementUIData.ts
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__mocks__/diseaseInvolvementUIData.ts
@@ -25,6 +25,60 @@ const mock: DiseaseComment[] = [
         },
       ],
     },
+    variants: {
+      VAR_019255: {
+        type: 'Natural variant',
+        location: {
+          start: {
+            value: 23,
+            modifier: 'EXACT',
+          },
+          end: {
+            value: 23,
+            modifier: 'EXACT',
+          },
+        },
+        description: 'in dbSNP:rs13447459',
+        evidences: [
+          {
+            evidenceCode: 'ECO:0000269',
+            source: 'Reference',
+            id: 'Ref.4',
+          },
+        ],
+        featureId: 'VAR_019255',
+        alternativeSequence: {
+          originalSequence: 'Q',
+          alternativeSequences: ['P'],
+        },
+      },
+      VAR_019256: {
+        type: 'Natural variant',
+        location: {
+          start: {
+            value: 99,
+            modifier: 'EXACT',
+          },
+          end: {
+            value: 99,
+            modifier: 'EXACT',
+          },
+        },
+        description: 'in dbSNP:rs13447492',
+        evidences: [
+          {
+            evidenceCode: 'ECO:0000269',
+            source: 'Reference',
+            id: 'Ref.4',
+          },
+        ],
+        featureId: 'VAR_019256',
+        alternativeSequence: {
+          originalSequence: 'I',
+          alternativeSequences: ['V'],
+        },
+      },
+    },
   },
 ];
 

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
@@ -94,5 +94,108 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
       </div>
     </li>
   </ul>
+  <h5>
+    Natural variants in AD
+  </h5>
+  <protvista-datatable
+    filter-scroll="true"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Variant ID
+          </th>
+          <th>
+            Position(s)
+          </th>
+          <th>
+            Change
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            VAR_019255
+          </td>
+          <td>
+            23
+          </td>
+          <td
+            class="change"
+          >
+            Q&gt;P
+          </td>
+          <td>
+            in dbSNP:rs13447459
+            <button
+              aria-controls="0"
+              aria-expanded="false"
+              class="svg-colour-reviewed evidence-tag"
+              data-testid="evidence-tag-trigger"
+              type="button"
+            >
+              <test-file-stub
+                height="12"
+                width="12"
+              />
+              <span
+                class="evidence-tag__label"
+              >
+                1 publication
+              </span>
+            </button>
+            <div
+              class="evidence-tag-content "
+              data-testid="evidence-tag-content"
+              id="0"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            VAR_019256
+          </td>
+          <td>
+            99
+          </td>
+          <td
+            class="change"
+          >
+            I&gt;V
+          </td>
+          <td>
+            in dbSNP:rs13447492
+            <button
+              aria-controls="1"
+              aria-expanded="false"
+              class="svg-colour-reviewed evidence-tag"
+              data-testid="evidence-tag-trigger"
+              type="button"
+            >
+              <test-file-stub
+                height="12"
+                width="12"
+              />
+              <span
+                class="evidence-tag__label"
+              >
+                1 publication
+              </span>
+            </button>
+            <div
+              class="evidence-tag-content "
+              data-testid="evidence-tag-content"
+              id="1"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </protvista-datatable>
 </DocumentFragment>
 `;

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/VariationView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/VariationView.spec.tsx.snap
@@ -278,14 +278,16 @@ exports[`VariationView component renders on error 1`] = `
 
 exports[`VariationView component renders on loading 1`] = `
 <DocumentFragment>
-  <div
-    class="loader-container"
-  >
-    <test-file-stub
-      classname="loader"
-      height="100"
-      width="100"
-    />
+  <div>
+    <div
+      class="loader-container"
+    >
+      <test-file-stub
+        classname="loader"
+        height="100"
+        width="100"
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable camelcase */
+import { lazy } from 'react';
+import { Link } from 'react-router-dom';
 import {
   ExpandableList,
   LongNumber,
@@ -6,9 +8,9 @@ import {
   Sequence,
   SequenceTools,
 } from 'franklin-sites';
-import { Link } from 'react-router-dom';
 import { omit } from 'lodash-es';
 
+import LazyComponent from '../../shared/components/LazyComponent';
 import ExternalLink from '../../shared/components/ExternalLink';
 import SimpleView from '../../shared/components/views/SimpleView';
 import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
@@ -73,7 +75,6 @@ import CatalyticActivityView, {
   getRheaId,
   isRheaReactionReference,
 } from '../components/protein-data-views/CatalyticActivityView';
-import VariationView from '../components/protein-data-views/VariationView';
 import {
   structureFeaturesToColumns,
   StructureUIModel,
@@ -112,6 +113,13 @@ import { Interactant } from '../adapters/interactionConverter';
 import { ValueWithEvidence } from '../types/modelTypes';
 
 import helper from '../../shared/styles/helper.module.scss';
+
+const VariationView = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "variation-view" */ '../components/protein-data-views/VariationView'
+    )
+);
 
 export const defaultColumns = [
   UniProtKBColumn.accession,
@@ -470,7 +478,9 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.ftVariant, {
     'variant'
   ),
   render: (data) => (
-    <VariationView primaryAccession={data.primaryAccession} onlyTable />
+    <LazyComponent fallback="Variants">
+      <VariationView primaryAccession={data.primaryAccession} onlyTable />
+    </LazyComponent>
   ),
 });
 

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1329,15 +1329,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_var_seq
 
 exports[`UniProtKBColumnConfiguration component should render column "ft_variant": ft_variant 1`] = `
 <DocumentFragment>
-  <div
-    class="loader-container"
-  >
-    <test-file-stub
-      classname="loader"
-      height="100"
-      width="100"
-    />
-  </div>
+  Variants
 </DocumentFragment>
 `;
 

--- a/src/uniprotkb/types/commentTypes.ts
+++ b/src/uniprotkb/types/commentTypes.ts
@@ -117,6 +117,7 @@ export type DiseaseType = {
 export interface DiseaseComment extends GenericComment<'DISEASE'> {
   disease?: DiseaseType;
   note?: { texts?: TextWithEvidence[] };
+  variants?: Record<string, FeatureData[0]>;
 }
 
 export enum InteractionType {


### PR DESCRIPTION
## Purpose
Add variations from UniProt website API (as opposed to the Proteins API) right below the related diseases

## Approach
Merge the "Natural Variants" with their corresponding diseases using the description as a key to match against the disease "acronym". Display a table below the disease.

Move the section with all the variations in a lazy loader in order to save the Proteins API network call (which can be used) and the corresponding rendering. This has the consequence of disabling the ctrl-f feature for this area (until the user scrolls to it) but ctrl-f is still available for UniProt-curated variations associated with a disease.

Note that not all "Natural Variants" have a disease associated with them, so they can't be linked to a disease.

## Testing
Updated mocks and snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
