### PR TITLE
ErrorComponent in results page

### DIFF
--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -12,6 +12,7 @@ import ResultsData from './ResultsData';
 import ResultsFacets from './ResultsFacets';
 import SideBarLayout from '../layouts/SideBarLayout';
 import NoResultsPage from '../error-pages/NoResultsPage';
+import ErrorHandler from '../error-pages/ErrorHandler';
 import ErrorBoundary from '../error-component/ErrorBoundary';
 import ResultsDataHeader from './ResultsDataHeader';
 import SearchSuggestions from './SearchSuggestions';
@@ -82,6 +83,10 @@ const Results = () => {
         <Loader progress={resultsDataProgress} />
       </>
     );
+  }
+
+  if (!resultsDataObject.allResults.length && resultsDataObject.error) {
+    return <ErrorHandler status={resultsDataObject.status} />;
   }
 
   const { suggestions } = facetApiObject.data || {};

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { AxiosError } from 'axios';
 
 import usePrefetch from './usePrefetch';
 import useDataApi from './useDataApi';
@@ -16,6 +17,8 @@ export type PaginatedResults = {
   handleLoadMoreRows: () => void;
   total?: number;
   failedIds?: string[];
+  error?: AxiosError<{ messages?: string[] }>;
+  status?: number | undefined;
 };
 
 const usePagination = <T extends APIModel, R extends APIModel>(
@@ -37,7 +40,7 @@ const usePagination = <T extends APIModel, R extends APIModel>(
     setUrl(initialApiUrl);
   }, [initialApiUrl]);
 
-  const { data, loading, progress, headers } = useDataApi<
+  const { data, loading, progress, headers, error, status } = useDataApi<
     SearchResults<APIModel> & {
       failedIds?: string[];
     }
@@ -73,6 +76,8 @@ const usePagination = <T extends APIModel, R extends APIModel>(
     handleLoadMoreRows,
     total,
     failedIds: data?.failedIds,
+    error,
+    status,
   };
 };
 


### PR DESCRIPTION
## Purpose
add error and status return values from usePagination in order to show an error when the API returns an error

## Approach
usePagination was not exposing any error or status, so expose them in order to be able to use them to show the appropriate error message.

This will show the error message if there is an error while loading the 1st page.

Note that this will surface the error and status of the current page being loaded, but the added condition of checking if there are results in the array should prevent replacing the already loaded data in the event of one of the subsequence page load failing. At the moment this is not handled I believe, and I'm assuming it would either show the Loader component forever or just stop adding to the list as if all results were shown. @dlrice if you want to have a go at this specific case feel free to do so, I just have to stop now and won't have more time to work on it.

## Testing
Manual test during a API load test => show 503 error message on full page

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
