### PR TITLE
Missing data

### DIFF
--- a/src/proteomes/components/entry/Components.tsx
+++ b/src/proteomes/components/entry/Components.tsx
@@ -22,8 +22,8 @@ const genomeAccessionDB = 'GenomeAccession' as const;
 const getIdKey = ({ name }: Component) => name;
 
 export const Components: FC<
-  Pick<ProteomesAPIModel, 'components' | 'id' | 'proteinCount'>
-> = ({ components, id, proteinCount }) => {
+  Pick<ProteomesAPIModel, 'components' | 'id' | 'proteinCount' | 'proteomeType'>
+> = ({ components, id, proteinCount, proteomeType }) => {
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
 
   const columns = useMemo<
@@ -91,6 +91,7 @@ export const Components: FC<
         selectedEntries={selectedEntries}
         proteinCount={proteinCount}
         id={id}
+        proteomeType={proteomeType}
       />
       <DataTable
         getIdKey={getIdKey}

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -15,6 +15,7 @@ import {
   ProteomesAPIModel,
 } from '../../adapters/proteomesConverter';
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
+import { fileFormatsResultsDownloadForRedundant } from '../../config/download';
 
 const DownloadComponent = lazy(
   () =>
@@ -24,10 +25,13 @@ const DownloadComponent = lazy(
 );
 
 const ComponentsButtons: FC<
-  Pick<ProteomesAPIModel, 'id' | 'components' | 'proteinCount'> & {
+  Pick<
+    ProteomesAPIModel,
+    'id' | 'components' | 'proteinCount' | 'proteomeType'
+  > & {
     selectedEntries: string[];
   }
-> = ({ id, components, selectedEntries, proteinCount }) => {
+> = ({ id, components, selectedEntries, proteinCount, proteomeType }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
   const allQuery = `(${UniProtKBColumn.proteome}:${id})`;
@@ -80,6 +84,11 @@ const ComponentsButtons: FC<
                 totalNumberResults={proteinCount}
                 onClose={() => setDisplayDownloadPanel(false)}
                 namespace={Namespace.uniprotkb}
+                supportedFormats={
+                  proteomeType === 'Redundant proteome'
+                    ? fileFormatsResultsDownloadForRedundant
+                    : undefined
+                }
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -7,6 +7,7 @@ import ErrorBoundary from '../../../shared/components/error-component/ErrorBound
 import lazy from '../../../shared/utils/lazy';
 
 import { createSelectedQueryString } from '../../../shared/config/apiUrls';
+import { fileFormatsResultsDownloadForRedundant } from '../../config/download';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../../shared/types/namespaces';
@@ -15,7 +16,6 @@ import {
   ProteomesAPIModel,
 } from '../../adapters/proteomesConverter';
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
-import { fileFormatsResultsDownloadForRedundant } from '../../config/download';
 
 const DownloadComponent = lazy(
   () =>

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -25,6 +25,8 @@ import {
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import '../../../shared/components/entry/styles/entry-page.scss';
+import AccessionView from '../../../shared/components/results/AccessionView';
+import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 
 const Entry = () => {
   const match = useRouteMatch<{ accession: string }>(
@@ -69,6 +71,19 @@ const Entry = () => {
         {' · '}
         <TaxonomyView data={mainData.data.taxonomy} noLink />
       </h1>
+      {transformedData.proteomeType === 'Redundant proteome' &&
+      transformedData.redundantTo ? (
+        <div>
+          <EntryTypeIcon entryType={transformedData.proteomeType} />
+          This proteome is redundant
+          <span data-article-id={'proteome_redundancy'} /> to{' '}
+          <AccessionView
+            id={transformedData.redundantTo}
+            namespace={Namespace.proteomes}
+          />
+          .
+        </div>
+      ) : null}
       <div className="button-group">
         <EntryDownload />
       </div>

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -76,7 +76,7 @@ const Entry = () => {
         <div>
           <EntryTypeIcon entryType={transformedData.proteomeType} />
           This proteome is redundant
-          <span data-article-id={'proteome_redundancy'} /> to{' '}
+          <span data-article-id="proteome_redundancy" /> to&nbsp;
           <AccessionView
             id={transformedData.redundantTo}
             namespace={Namespace.proteomes}

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -8,6 +8,8 @@ import HTMLHead from '../../../shared/components/HTMLHead';
 import EntryDownload from '../../../shared/components/entry/EntryDownload';
 import SingleColumnLayout from '../../../shared/components/layouts/SingleColumnLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
+import AccessionView from '../../../shared/components/results/AccessionView';
+import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 
 import apiUrls from '../../../shared/config/apiUrls';
 
@@ -25,8 +27,6 @@ import {
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import '../../../shared/components/entry/styles/entry-page.scss';
-import AccessionView from '../../../shared/components/results/AccessionView';
-import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 
 const Entry = () => {
   const match = useRouteMatch<{ accession: string }>(
@@ -75,8 +75,8 @@ const Entry = () => {
       transformedData.redundantTo ? (
         <div>
           <EntryTypeIcon entryType={transformedData.proteomeType} />
-          This proteome is redundant
-          <span data-article-id="proteome_redundancy" /> to&nbsp;
+          This proteome is{' '}
+          <span data-article-id="proteome_redundancy">redundant</span> to&nbsp;
           <AccessionView
             id={transformedData.redundantTo}
             namespace={Namespace.proteomes}

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -76,7 +76,7 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
       },
       {
         title: 'Strain',
-        content: data.strain && <span>{data.strain}</span>,
+        content: data.strain,
       },
       {
         title: (

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -75,6 +75,10 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
         ),
       },
       {
+        title: 'Strain',
+        content: data.strain && <span>{data.strain}</span>,
+      },
+      {
         title: (
           <span data-article-id="https://www.ensembl.org/Help/Faq?id=216">
             Genome assembly and annotation

--- a/src/proteomes/components/entry/__tests__/Components.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/Components.spec.tsx
@@ -14,6 +14,7 @@ describe('Components view', () => {
         components={data.components}
         id={data.id}
         proteinCount={data.proteinCount}
+        proteomeType={data.proteomeType}
       />
     );
     expect(asFragment()).toMatchSnapshot();

--- a/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
@@ -29,6 +29,7 @@ describe('ComponentsButtons', () => {
           components={components as Component[]}
           selectedEntries={selectedComponents}
           proteinCount={100}
+          proteomeType="Reference and representative proteome"
         />
       );
       const link = screen.getByRole<HTMLAnchorElement>('link', {
@@ -46,7 +47,12 @@ describe('ComponentsButtons', () => {
 
   it('should render nothing when no components are passed', () => {
     const { container } = customRender(
-      <ComponentsButtons id="id" proteinCount={100} selectedEntries={[]} />
+      <ComponentsButtons
+        id="id"
+        proteinCount={100}
+        selectedEntries={[]}
+        proteomeType="Reference and representative proteome"
+      />
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -58,6 +64,7 @@ describe('ComponentsButtons', () => {
         proteinCount={100}
         selectedEntries={[]}
         components={getComponents(10) as Component[]}
+        proteomeType="Reference and representative proteome"
       />
     );
     const downloadButton = screen.getByRole('button', { name: 'Download' });

--- a/src/proteomes/config/ProteomesEntryConfig.tsx
+++ b/src/proteomes/config/ProteomesEntryConfig.tsx
@@ -16,8 +16,13 @@ const ProteomesEntryConfig: {
   },
   {
     id: EntrySection.Components,
-    sectionContent: ({ components, id, proteinCount }) => (
-      <Components components={components} id={id} proteinCount={proteinCount} />
+    sectionContent: ({ components, id, proteinCount, proteomeType }) => (
+      <Components
+        components={components}
+        id={id}
+        proteinCount={proteinCount}
+        proteomeType={proteomeType}
+      />
     ),
   },
   {

--- a/src/proteomes/config/download.ts
+++ b/src/proteomes/config/download.ts
@@ -16,3 +16,5 @@ export const fileFormatEntryDownload = [
   FileFormat.tsv,
   FileFormat.list,
 ];
+
+export const fileFormatsResultsDownloadForRedundant = [FileFormat.fasta];

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -39,6 +39,7 @@ type DownloadProps = {
   onClose: () => void;
   accessions?: string[];
   base?: string;
+  supportedFormats?: FileFormat[];
 };
 
 type ExtraContent = 'url' | 'preview';
@@ -53,11 +54,13 @@ const Download: FC<DownloadProps> = ({
   namespace,
   accessions,
   base,
+  supportedFormats,
 }) => {
   const { columnNames } = useColumnNames();
   const { search: queryParamFromUrl } = useLocation();
 
-  const fileFormats = nsToFileFormatsResultsDownload[namespace];
+  const fileFormats =
+    supportedFormats || nsToFileFormatsResultsDownload[namespace];
 
   const [selectedColumns, setSelectedColumns] = useState<Column[]>(columnNames);
   // Defaults to "download all" if no selection

--- a/src/supporting-data/diseases/components/entry/Entry.tsx
+++ b/src/supporting-data/diseases/components/entry/Entry.tsx
@@ -29,6 +29,7 @@ const columns = [
   DiseasesColumn.definition,
   DiseasesColumn.acronym,
   DiseasesColumn.alternativeNames,
+  DiseasesColumn.keywords,
   DiseasesColumn.crossReferences,
 ];
 


### PR DESCRIPTION
## Purpose
- Missing fields in proteome entry such as strain and the replacement proteome info for redundant proteome are added.
- The keywords field in diseases are exposed too.
- The download format for Redundant proteomes is set to only FASTA like in the current website.

## Approach
Added an optional property 'supportedFileFormats' in Download component to allow exceptions.

## Testing
Below tests were changed to reflect the latest changes
- src/proteomes/components/entry/__tests__/Components.spec.tsx
- src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
