### PR TITLE
add scroll to top functionality

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -267,6 +267,15 @@ const ContextualHelp = lazy(() =>
   )
 );
 
+const BackToTheTop = lazy(() =>
+  sleep(1000).then(
+    () =>
+      import(
+        /* webpackChunkName: "back-to-the-top" */ '../../shared/components/BackToTheTop'
+      )
+  )
+);
+
 // Helper component to render a landing page or the results page depending on
 // the presence of absence of a querystring
 const ResultsOrLanding =
@@ -488,6 +497,11 @@ const App = () => {
       <Suspense fallback={null}>
         <ErrorBoundary fallback={null}>
           <ContextualHelp />
+        </ErrorBoundary>
+      </Suspense>
+      <Suspense fallback={null}>
+        <ErrorBoundary fallback={null}>
+          <BackToTheTop />
         </ErrorBoundary>
       </Suspense>
     </>

--- a/src/shared/components/BackToTheTop.tsx
+++ b/src/shared/components/BackToTheTop.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+import { Button } from 'franklin-sites';
+import cn from 'classnames';
+
+import useScrollInfo from '../hooks/useScrollInfo';
+
+import styles from './styles/back-to-the-top.module.scss';
+
+const BackToTheTop = () => {
+  const { direction, scrollY } = useScrollInfo();
+
+  const visible = direction === 'up' && scrollY > 750;
+
+  return (
+    <Button
+      title="scroll to the top of the page"
+      className={cn(styles.button, { [styles.visible]: visible })}
+      onClick={() => window.scrollTo(0, 0)}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+    >
+      ⬆
+    </Button>
+  );
+};
+
+export default memo(BackToTheTop);

--- a/src/shared/components/styles/back-to-the-top.module.scss
+++ b/src/shared/components/styles/back-to-the-top.module.scss
@@ -1,0 +1,25 @@
+@import 'franklin-sites/src/styles/common/z-index';
+
+.button:global(.button) {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: $z-index-high + 3;
+  margin: 0;
+
+  pointer-events: none;
+
+  transform: translateY(2rem);
+  opacity: 0;
+
+  transition-duration: 0.25s;
+  transition-timing-function: ease-out;
+  transition-property: transform, opacity;
+
+  &.visible {
+    pointer-events: initial;
+
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/src/shared/hooks/useScrollInfo.ts
+++ b/src/shared/hooks/useScrollInfo.ts
@@ -1,0 +1,54 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { schedule, sleep } from 'timing-functions';
+
+type Direction = null | 'up' | 'down';
+
+const useScrollInfo = (): { direction: Direction; scrollY: number } => {
+  const [direction, setDirection] = useState<Direction>(null);
+  const [previousScrollY, setPreviousScrollY] = useState(0);
+  // Keep it also in a ref as we don't want to create a new function everytime
+  const previousScrollYRef = useRef(previousScrollY);
+
+  const willCheckFlag = useRef(false);
+  const inactiveTimeout = useRef<number | null>(null);
+
+  // Function to do a scroll position check
+  const updateScrollDirection = useCallback(async () => {
+    // First thing, remove scheduling flag, we'll handle it now
+    willCheckFlag.current = false;
+    if (inactiveTimeout.current) {
+      // Cancel any inactivity timeout callback
+      window.clearTimeout(inactiveTimeout.current);
+    }
+    const currentScrollY = window.scrollY;
+    const direction =
+      previousScrollYRef.current - currentScrollY > 0 ? 'up' : 'down';
+    previousScrollYRef.current = currentScrollY;
+    setPreviousScrollY(currentScrollY);
+    setDirection(direction);
+    // If inactive after 5 seconds, set direction to null
+    inactiveTimeout.current = window.setTimeout(() => {
+      setDirection(null);
+    }, 5000);
+  }, []);
+
+  useEffect(() => {
+    const scrollHandler = async () => {
+      // Check if we already scheduled a scroll check
+      if (!willCheckFlag.current) {
+        willCheckFlag.current = true;
+        await sleep(500); // wait a bit
+        await schedule(500); // make sure to not interrupt anything important
+        updateScrollDirection();
+      }
+    };
+    window.addEventListener('scroll', scrollHandler, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', scrollHandler);
+    };
+  }, [updateScrollDirection]);
+
+  return { direction, scrollY: previousScrollY };
+};
+
+export default useScrollInfo;


### PR DESCRIPTION
## Purpose
Scroll to top functionality https://www.ebi.ac.uk/panda/jira/browse/TRM-26192

## Approach
1 lazy-loaded component for a scroll-to-top button + custom logic to get scroll direction and position from a hook.

Heuristics:
 - If scrolling up, display the button
 - After a cutoff of time without scrolling, set direction to null, hence hiding the button
 - If too close to the top (hardcoded height), don't display the button anyway

## Testing
Not sure how to automatically test this. Manual testing for now.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why

Note: I did that now because I wanted to experiment with removing the sidebar on narrow screens and put the content at the top of the page, hence the need to have a shortcut to the top of the page before. (see branch [experiment-remove_sidebar](https://github.com/ebi-uniprot/uniprot-website/tree/experiment-remove_sidebar))
