### PR TITLE
Disease xrefs

### DIFF
--- a/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
+++ b/src/supporting-data/diseases/config/DiseasesColumnConfiguration.tsx
@@ -1,8 +1,12 @@
 import { Link } from 'react-router-dom';
-import { ExpandableList } from 'franklin-sites';
+import { ExpandableList, ExternalLink } from 'franklin-sites';
 
 import { getEntryPathFor } from '../../../app/config/urls';
 import { mapToLinks } from '../../../shared/components/MapTo';
+import { processUrlTemplate } from '../../../uniprotkb/components/protein-data-views/XRefView';
+import * as logging from '../../../shared/utils/logging';
+
+import databaseToDatabaseInfo from './databaseInfoMaps';
 
 import { DiseasesAPIModel } from '../adapters/diseasesConverter';
 import { ColumnConfiguration } from '../../../shared/types/columnConfiguration';
@@ -58,24 +62,41 @@ DiseasesColumnConfiguration.set(DiseasesColumn.alternativeNames, {
     ) : null,
 });
 
-// NOTE: should probably be links
 DiseasesColumnConfiguration.set(DiseasesColumn.crossReferences, {
   label: 'Cross references',
-  // TODO: https://www.ebi.ac.uk/panda/jira/browse/TRM-25838
   render: ({ crossReferences }) =>
-    crossReferences?.length ? (
+    Boolean(crossReferences?.length) && (
       <ExpandableList
         descriptionString="cross references"
         displayNumberOfHiddenItems
       >
-        {crossReferences?.map(
-          ({ databaseType, id, properties }) =>
-            `${databaseType}: ${id}${
-              properties?.length ? ` (${properties.join(', ')})` : ''
-            }`
-        )}
+        {crossReferences?.map(({ databaseType, id, properties }) => {
+          let idNode;
+          const databaseInfo = databaseToDatabaseInfo[databaseType];
+          if (databaseInfo) {
+            idNode = (
+              // eslint-disable-next-line uniprot-website/use-config-location
+              <ExternalLink
+                url={processUrlTemplate(databaseInfo.uriLink, { id })}
+              >
+                {id}
+              </ExternalLink>
+            );
+          } else {
+            logging.warn(
+              `Disease database information not found for ${databaseType}`
+            );
+            idNode = id;
+          }
+          return (
+            <span key={`${databaseType}-${id}`} className={helper['no-wrap']}>
+              {databaseType}: {idNode}
+              {`${properties?.length ? ` (${properties.join(', ')})` : ''}`}
+            </span>
+          );
+        })}
       </ExpandableList>
-    ) : null,
+    ),
 });
 
 DiseasesColumnConfiguration.set(DiseasesColumn.definition, {

--- a/src/supporting-data/diseases/config/__tests__/__snapshots__/DiseasesColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/diseases/config/__tests__/__snapshots__/DiseasesColumnConfiguration.spec.tsx.snap
@@ -39,19 +39,100 @@ exports[`DiseasesColumnConfiguration component should render column "cross_refer
     class="expandable-list no-bullet"
   >
     <li>
-      MIM: 120435 (phenotype)
+      <span
+        class="no-wrap"
+      >
+        MIM: 
+        <a
+          class="external-link"
+          href="https://www.omim.org/entry/120435"
+          rel="noopener"
+          target="_blank"
+        >
+          120435
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+         (phenotype)
+      </span>
     </li>
     <li>
-      MedGen: C0009405
+      <span
+        class="no-wrap"
+      >
+        MedGen: 
+        <a
+          class="external-link"
+          href="https://www.ncbi.nlm.nih.gov/medgen/C0009405"
+          rel="noopener"
+          target="_blank"
+        >
+          C0009405
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+      </span>
     </li>
     <li>
-      MedGen: C1333990
+      <span
+        class="no-wrap"
+      >
+        MedGen: 
+        <a
+          class="external-link"
+          href="https://www.ncbi.nlm.nih.gov/medgen/C1333990"
+          rel="noopener"
+          target="_blank"
+        >
+          C1333990
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+      </span>
     </li>
     <li>
-      MedGen: CN068508
+      <span
+        class="no-wrap"
+      >
+        MedGen: 
+        <a
+          class="external-link"
+          href="https://www.ncbi.nlm.nih.gov/medgen/CN068508"
+          rel="noopener"
+          target="_blank"
+        >
+          CN068508
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+      </span>
     </li>
     <li>
-      MeSH: D003123
+      <span
+        class="no-wrap"
+      >
+        MeSH: 
+        <a
+          class="external-link"
+          href="https://meshb.nlm.nih.gov/record/ui?ui=D003123"
+          rel="noopener"
+          target="_blank"
+        >
+          D003123
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+      </span>
     </li>
   </ul>
 </DocumentFragment>

--- a/src/supporting-data/diseases/config/databaseInfoMaps.ts
+++ b/src/supporting-data/diseases/config/databaseInfoMaps.ts
@@ -1,14 +1,14 @@
-export type DiseaseDatabaseInfoPoint = {
+export type DiseasesDatabaseInfoPoint = {
   name: string;
   displayName: string;
   uriLink: string;
 };
 
-export type DiseaseDatabaseToDatabaseInfo = {
-  [database: string]: DiseaseDatabaseInfoPoint;
+export type DiseasesDatabaseToDatabaseInfo = {
+  [database: string]: DiseasesDatabaseInfoPoint;
 };
 
-const allDatabases: DiseaseDatabaseInfoPoint[] = [
+const allDatabases: DiseasesDatabaseInfoPoint[] = [
   {
     name: 'MedGen',
     displayName: 'MedGen',
@@ -26,7 +26,7 @@ const allDatabases: DiseaseDatabaseInfoPoint[] = [
   },
 ];
 
-const databaseToDatabaseInfo: DiseaseDatabaseToDatabaseInfo =
+const databaseToDatabaseInfo: DiseasesDatabaseToDatabaseInfo =
   Object.fromEntries(allDatabases.map((db) => [db.name, db]));
 
 export default databaseToDatabaseInfo;

--- a/src/supporting-data/diseases/config/databaseInfoMaps.ts
+++ b/src/supporting-data/diseases/config/databaseInfoMaps.ts
@@ -1,0 +1,32 @@
+export type DiseaseDatabaseInfoPoint = {
+  name: string;
+  displayName: string;
+  uriLink: string;
+};
+
+export type DiseaseDatabaseToDatabaseInfo = {
+  [database: string]: DiseaseDatabaseInfoPoint;
+};
+
+const allDatabases: DiseaseDatabaseInfoPoint[] = [
+  {
+    name: 'MedGen',
+    displayName: 'MedGen',
+    uriLink: 'https://www.ncbi.nlm.nih.gov/medgen/%id',
+  },
+  {
+    name: 'MeSH',
+    displayName: 'MeSH',
+    uriLink: 'https://meshb.nlm.nih.gov/record/ui?ui=%id',
+  },
+  {
+    name: 'MIM',
+    displayName: 'MIM',
+    uriLink: 'https://www.omim.org/entry/%id',
+  },
+];
+
+const databaseToDatabaseInfo: DiseaseDatabaseToDatabaseInfo =
+  Object.fromEntries(allDatabases.map((db) => [db.name, db]));
+
+export default databaseToDatabaseInfo;


### PR DESCRIPTION
## Purpose
[Cross-ref links for Diseases](https://www.ebi.ac.uk/panda/jira/browse/TRM-25838)
This PR fixes the issue of diseases namespace entries having missing database links.

## Approach

- Downloaded all 6,127 diseases entries to determine there are three dbs:
```
{'MIM', 'MeSH', 'MedGen'}
```
Only `MIM` is in the uniprotkb db config so the others needed to be created.
- Hard coded the db configuration by looking at the legacy links (note that I deviated as it seems the legacy site has broken MeSH links). Created [ticket](https://www.ebi.ac.uk/panda/jira/browse/TRM-28081) for API to create on their end.
- Used db config in the column configuration
- Use `logging.warn` to capture when a db doesn't exist in the config.

I spent some time to trying to use the existing xref functionality in UniProtKB but in the end I decided I didn't want to create any changes there as it's all pretty precarious and UniProtKB-centric.

## Testing
Updated snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
