### PR TITLE
2022 08 row selection fix

### DIFF
--- a/src/shared/hooks/__tests__/useItemSelect.spec.ts
+++ b/src/shared/hooks/__tests__/useItemSelect.spec.ts
@@ -1,17 +1,21 @@
 import { waitFor } from '@testing-library/react';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
+
+import getCustomRenderHook from '../../__test-helpers__/customRenderHook';
 
 import useItemSelect from '../useItemSelect';
 
 describe('useItemSelect', () => {
+  const customRenderHook = getCustomRenderHook(() => useItemSelect());
+
   it('should return correct default selectedItems, setSelectedItemFromEvent', () => {
-    const { result } = renderHook(() => useItemSelect());
+    const { result } = customRenderHook();
     expect(result.current[0]).toEqual([]);
     expect(typeof result.current[1]).toBe('function');
   });
 
   it('should add and remove item', async () => {
-    const { result } = renderHook(() => useItemSelect());
+    const { result } = customRenderHook();
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.dataset.id = 'id1';

--- a/src/shared/hooks/__tests__/useJobFromUrl.spec.tsx
+++ b/src/shared/hooks/__tests__/useJobFromUrl.spec.tsx
@@ -1,16 +1,9 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
+import getCustomRenderHook from '../../__test-helpers__/customRenderHook';
+
 import useJobFromUrl from '../useJobFromUrl';
 
 describe('useInitialFormParameters', () => {
-  const customRenderHook = (path: string) => {
-    const history = createMemoryHistory();
-    history.push(path);
-    return renderHook(() => useJobFromUrl(), {
-      wrapper: ({ children }) => <Router history={history}>{children}</Router>,
-    });
-  };
+  const customRenderHook = getCustomRenderHook(() => useJobFromUrl());
 
   it('should return correct job data from ID mapping results URL', () => {
     const { result } = customRenderHook(
@@ -21,6 +14,7 @@ describe('useInitialFormParameters', () => {
     expect(jobResultsLocation).toEqual('IDMappingResult');
     expect(jobResultsNamespace).toEqual('uniparc');
   });
+
   it('should return correct job data from a peptide search URL', () => {
     const { result } = customRenderHook('peptide-search/jobid');
     const { jobId, jobResultsLocation, jobResultsNamespace } = result.current;

--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -185,7 +185,6 @@ const BlastResult = () => {
   const location = useLocation();
   const match = useMatchWithRedirect<Params>(Location.BlastResult, TabLocation);
 
-  const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
   const [hspDetailPanel, setHspDetailPanel] = useState<Except<
     HSPDetailPanelProps,
     'namespace'
@@ -269,6 +268,11 @@ const BlastResult = () => {
         ]
       )
     );
+
+  const loading =
+    blastLoading || (localFacetsChangedSelection && accessionsLoading);
+
+  const [selectedEntries, setSelectedItemFromEvent] = useItemSelect(loading);
 
   // filter BLAST results according to facets (through accession endpoint and other BLAST facets facets)
   const filteredBlastData =
@@ -377,10 +381,7 @@ const BlastResult = () => {
           <Suspense fallback={<Loader />}>
             <ErrorBoundary>
               <BlastResultTable
-                loading={
-                  blastLoading ||
-                  (localFacetsChangedSelection && accessionsLoading)
-                }
+                loading={loading}
                 data={resultTableData}
                 setSelectedItemFromEvent={setSelectedItemFromEvent}
                 setHspDetailPanel={setHspDetailPanel}

--- a/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
+++ b/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
@@ -2,10 +2,10 @@ import queryString from 'query-string';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
+import getCustomRenderHook from '../../../shared/__test-helpers__/customRenderHook';
+
 import { LocationToPath, Location } from '../../../app/config/urls';
 import useInitialFormParameters from '../useInitialFormParameters';
-
-import getCustomRenderHook from '../../../shared/__test-helpers__/customRenderHook';
 
 import defaultAlignFormValues from '../../align/config/AlignFormData';
 import defaultPeptideSearchFormValues from '../../peptide-search/config/PeptideSearchFormData';
@@ -15,6 +15,7 @@ describe('useInitialFormParameters: Align', () => {
   const customRenderHook = getCustomRenderHook(() =>
     useInitialFormParameters(defaultAlignFormValues)
   );
+
   it('should return defaultAlignFormValues if nothing in history state or url parameters', () => {
     const { result } = customRenderHook();
     expect(result.current.initialFormValues).toEqual(defaultAlignFormValues);


### PR DESCRIPTION
## Purpose
Fix entries getting "stuck" in table selection after the content of the table has changed https://www.ebi.ac.uk/panda/jira/browse/TRM-26979

## Approach
Given that a table content change is correlated with a URL location change, listen to that in order to empty/reset the list of entries.
Some tables go through a "stale" state then display a subset of the previous content (e.g.: BLAST results facets), for these cases, the hook will try to reuse the checkboxes that are currently rendered and checked in order to keep them in the list of selected entries, but will only do so after the optional "loading" flag passed to it is set to false.

## Testing
Manual tests + updated existing tests to not fail because of the new dependency to the global location state

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
