### PR TITLE
Use 500 for chunk size in API pagination url.

### DIFF
--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -1,6 +1,7 @@
 import { Button, CodeBlock, CopyIcon } from 'franklin-sites';
 import { useCallback, useEffect } from 'react';
 import { generatePath, Link } from 'react-router-dom';
+import queryString from 'query-string';
 
 import { useMessagesDispatch } from '../../contexts/Messages';
 
@@ -49,6 +50,12 @@ const DownloadAPIURL = ({
   );
 
   const isStreamEndpoint = apiURL.includes('/stream');
+  const parsed = queryString.parseUrl(apiURL);
+  const batchSize = 500;
+  const searchEndpoint = queryString.stringifyUrl({
+    url: parsed.url.replace('/stream', '/search'),
+    query: { ...parsed.query, size: batchSize },
+  });
 
   return (
     <div className={styles['api-url']}>
@@ -70,8 +77,8 @@ const DownloadAPIURL = ({
         <>
           <br />
           <h4>API URL using the search endpoint</h4>
-          This endpoint is lighter and returns chunks of 25 results by default
-          at a time and requires&nbsp;
+          This endpoint is lighter and returns chunks of {batchSize} at a time
+          and requires&nbsp;
           <Link
             to={generatePath(LocationToPath[Location.HelpEntry], {
               accession: 'pagination',
@@ -79,17 +86,12 @@ const DownloadAPIURL = ({
           >
             pagination
           </Link>
-          .
-          <CodeBlock lightMode>
-            {apiURL.replace('/stream', '/search')}
-          </CodeBlock>
+          .<CodeBlock lightMode>{searchEndpoint}</CodeBlock>
           <section className="button-group">
             <Button
               variant="primary"
               className={styles['copy-button']}
-              onClick={() =>
-                handleCopyURL(apiURL.replace('/stream', '/search'))
-              }
+              onClick={() => handleCopyURL(searchEndpoint)}
             >
               <CopyIcon />
               Copy


### PR DESCRIPTION
## Purpose
Discussing with @LeonardoGonzales that through testing having a batch size of 500 is much quicker for the users:

```
Query:NOD2 HUMAN (n=1109)
25 4.5s
100 2.1s
500 1.3s
==========
Query:organism_id:2697049 (n=7042)
25 25.8s
100 14.8s
500 11.7s
==========
Query:organism_id:9606 (n=204907)
25 1305.8s
100 862.5s
500 649.3s
```
so this should be set when providing the pagination/search API URL.

## Approach
Updated the DownloadAPIURL component to have a batch size of 500.

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
