### PR TITLE
apply some of the points discussed for better page tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
           dimension1: 'result_view',
           metric1: 'result_view_set',
         },
+        send_page_view: false,
       });
     </script>
     <!-- Hotjar Tracking Code for https://beta.uniprot.org -->

--- a/src/app/components/home-page/HomePage.tsx
+++ b/src/app/components/home-page/HomePage.tsx
@@ -12,6 +12,7 @@ import { HeroHeader, Loader, CitedIcon } from 'franklin-sites';
 
 import SearchContainer from '../../../shared/components/search/SearchContainer';
 import ErrorBoundary from '../../../shared/components/error-component/ErrorBoundary';
+import HTMLHead from '../../../shared/components/HTMLHead';
 
 import { useReducedMotion } from '../../../shared/hooks/useMatchMedia';
 
@@ -152,6 +153,8 @@ const HomePageHeader = memo(() => {
 
 const HomePage = () => (
   <main>
+    {/* Activate the HTML head logic, but no title, so uses default */}
+    <HTMLHead />
     <h1 className="visually-hidden">UniProt website home page</h1>
     <ErrorBoundary>
       <HomePageHeader />

--- a/src/shared/components/HTMLHead.tsx
+++ b/src/shared/components/HTMLHead.tsx
@@ -8,10 +8,11 @@ const isTruthy = (value: InputValue): value is number | string =>
 
 type Props = {
   title?: InputValue | InputValue[];
+  titleLoading?: boolean;
   children?: ReactNode;
 };
 
-const HTMLHead = ({ title, children }: Props) => {
+const HTMLHead = ({ title, titleLoading, children }: Props) => {
   let renderedTitle: string | undefined;
   if (title) {
     if (Array.isArray(title)) {
@@ -23,7 +24,8 @@ const HTMLHead = ({ title, children }: Props) => {
 
   return (
     <Helmet>
-      {renderedTitle ? <title>{renderedTitle}</title> : null}
+      {/* If titleLoading undefined, or false, then set as "loaded" */}
+      <title data-loaded={!titleLoading}>{renderedTitle}</title>
       {children}
     </Helmet>
   );

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -73,6 +73,7 @@ const Results = () => {
       title={`${params.query} in ${
         searchableNamespaceLabels[ns as SearchableNamespace]
       }${total !== undefined ? ` (${total})` : ''}`}
+      titleLoading={resultsDataInitialLoading}
     />
   );
 


### PR DESCRIPTION
## Purpose
Try to get more accurate page view values and better tracking in general

## Approach
Rely on a mutation observer to check when the page changes. When the page is loaded, a data attribute is changed to declare that the page is loaded and can be tracked, and make sure to not duplicate measurements by checking the href did change. Deactivate any kind of automatic logging from gtag, all is handled manually in our code.

## Testing
Manual testing, console.log betweek lines 53 and 54 of file `src/index.tsx`.

Check for correct number of logs on:
- Initial pages vs website navigation
- Result pages
- Entry pages and subpages
- Tool result pages and subpages
- Home page
- Common redirects (/uniprot/<accession> -> /uniprotkb/<accession>/entry should log once)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
