### PR TITLE
hide all references to tools and basket in mobile view

### DIFF
--- a/src/app/components/home-page/AnalysisTools.tsx
+++ b/src/app/components/home-page/AnalysisTools.tsx
@@ -22,7 +22,8 @@ const AnalysisTools = () => (
       'uniprot-grid',
       'uniprot-grid--centered',
       'uniprot-grid--with-bleed',
-      styles['home-page-section']
+      styles['home-page-section'],
+      styles['no-small']
     )}
     titleClassName="uniprot-grid-cell--span-12"
     noSidePadding

--- a/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
+++ b/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
@@ -625,7 +625,7 @@ exports[`non-critical HomePage component should render 1`] = `
     </article>
   </section>
   <section
-    class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section"
+    class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section no-small"
   >
     <h2
       class="uniprot-grid-cell--span-12 hero-container__title big"

--- a/src/app/components/home-page/styles/non-critical.module.scss
+++ b/src/app/components/home-page/styles/non-critical.module.scss
@@ -1,5 +1,6 @@
 @import 'franklin-sites/src/styles/colours';
 @import 'franklin-sites/src/styles/settings';
+@import 'franklin-sites/src/styles/mixins';
 @import '../../../../shared/styles/mixins';
 
 .home-page-section {
@@ -161,6 +162,14 @@ $latest-news-height: 18rem;
 
       -webkit-line-clamp: 4;
     }
+  }
+}
+
+.no-small {
+  display: none;
+
+  @include fs-breakpoints('medium') {
+    display: grid;
   }
 }
 

--- a/src/shared/components/action-buttons/AddToBasket.tsx
+++ b/src/shared/components/action-buttons/AddToBasket.tsx
@@ -10,6 +10,8 @@ import { fromCleanMapper } from '../../utils/getIdKeyForNamespace';
 import { pluralise } from '../../utils/utils';
 import { Namespace } from '../../types/namespaces';
 
+import helper from '../../styles/helper.module.scss';
+
 type AddToBasketButtonProps = {
   selectedEntries: string | string[];
   setSelectedEntries?: Dispatch<SetStateAction<string[]>>;
@@ -112,6 +114,7 @@ const AddToBasketButton = ({
       title={title}
       disabled={disabled}
       onClick={finalRemove ? removeFromBasket : addToBasket}
+      className={helper['no-small']}
     >
       <BasketIcon />
       {finalRemove ? 'Remove' : 'Add'}

--- a/src/shared/components/action-buttons/ToolsButton.tsx
+++ b/src/shared/components/action-buttons/ToolsButton.tsx
@@ -4,6 +4,8 @@ import { Button } from 'franklin-sites';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
+import helper from '../../styles/helper.module.scss';
+
 type ToolsButtonProps = {
   selectedEntries: string[];
   sequence?: string;
@@ -39,6 +41,7 @@ const ToolsButton: FC<ToolsButtonProps> = ({
               search: searchParams.toString(),
             }
       }
+      className={helper['no-small']}
     >
       {children}
     </Button>

--- a/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/shared/components/entry/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -6,14 +6,14 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
     class="button-group"
   >
     <a
-      class="button tertiary"
+      class="button tertiary no-small"
       href="/blast?ids=P05067-1%2CP05067-2"
       title="Run 2 BLAST jobs against the selected entries"
     >
       BLAST 2 isoforms
     </a>
     <a
-      class="button tertiary"
+      class="button tertiary no-small"
       href="/align?ids=P05067-1%2CP05067-2"
       title="Run an Align job against 2 entries"
     >
@@ -203,7 +203,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
         Download
       </a>
       <button
-        class="button tertiary"
+        class="button tertiary no-small"
         title="Add 1 entry to the basket"
         type="button"
       >

--- a/src/shared/components/layouts/SecondaryItems.tsx
+++ b/src/shared/components/layouts/SecondaryItems.tsx
@@ -18,6 +18,7 @@ import {
   SlidingPanel,
   Loader,
 } from 'franklin-sites';
+import cn from 'classnames';
 
 import ErrorBoundary from '../error-component/ErrorBoundary';
 
@@ -35,6 +36,7 @@ import { Namespace } from '../../types/namespaces';
 import { Status } from '../../../tools/types/toolsStatuses';
 import { ContactLocationState } from '../../../contact/adapters/contactFormAdapter';
 
+import helper from '../../styles/helper.module.scss';
 import styles from './styles/secondary-items.module.scss';
 
 const BasketMiniView = lazy(
@@ -116,7 +118,7 @@ const ToolsDashboard = () => {
           setDisplay(true);
         }}
         title="Tools dashboard"
-        className={styles['secondary-item']}
+        className={cn(styles['secondary-item'], helper['no-small'])}
         onPointerOver={Dashboard.preload}
         onFocus={Dashboard.preload}
       >
@@ -203,7 +205,7 @@ export const Basket = () => {
           setDisplay(true);
         }}
         title="Basket"
-        className={styles['secondary-item']}
+        className={cn(styles['secondary-item'], helper['no-small'])}
         onPointerOver={BasketMiniView.preload}
         onFocus={BasketMiniView.preload}
       >

--- a/src/shared/components/layouts/UniProtFooter.tsx
+++ b/src/shared/components/layouts/UniProtFooter.tsx
@@ -208,7 +208,7 @@ const FooterShortcuts = () => (
         </li>
       </ul>
     </li>
-    <li>
+    <li className={helper['no-small']}>
       <span className={footer.shortcuts__title}>Tools</span>
       <ul className="no-bullet">
         <li>

--- a/src/shared/components/layouts/UniProtHeader.tsx
+++ b/src/shared/components/layouts/UniProtHeader.tsx
@@ -65,7 +65,7 @@ const HeaderContent = ({ isHomePage }: { isHomePage: boolean }) => {
         toolsLinks
       ) : (
         // otherwise display all tools links in a dropdown
-        <li>
+        <li className={styles['no-small']}>
           <Dropdown
             visibleElement={<Button variant="tertiary">Tools</Button>}
             propChangeToClose={location}

--- a/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
+++ b/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
@@ -214,7 +214,9 @@ exports[`HomePage component should render 1`] = `
             </li>
           </ul>
         </li>
-        <li>
+        <li
+          class="no-small"
+        >
           <span
             class="shortcuts__title"
           >

--- a/src/shared/components/layouts/styles/footer.module.scss
+++ b/src/shared/components/layouts/styles/footer.module.scss
@@ -30,7 +30,9 @@ footer.footer {
     }
 
     &__members {
-      display: flex;
+      @include fs-breakpoints('medium') {
+        display: flex;
+      }
       align-items: center;
 
       :not(:last-child) {

--- a/src/shared/components/layouts/styles/secondary-items.module.scss
+++ b/src/shared/components/layouts/styles/secondary-items.module.scss
@@ -1,5 +1,6 @@
 @import 'franklin-sites/src/styles/common/z-index';
 @import 'franklin-sites/src/styles/colours';
+@import 'franklin-sites/src/styles/mixins';
 
 .secondary-item {
   position: relative;

--- a/src/shared/components/layouts/styles/single-column-layout.scss
+++ b/src/shared/components/layouts/styles/single-column-layout.scss
@@ -1,3 +1,5 @@
+@import 'franklin-sites/src/styles/mixins';
+
 .single-column-layout {
   min-height: 100%;
   display: flex;
@@ -5,7 +7,18 @@
   align-items: center;
 
   & > * {
-    width: 80vw;
+    // maximize use of space on smaller screens
+    width: 95vw;
     max-width: 160ch;
+
+    @include fs-breakpoints('medium') {
+      // a bit of room on the sides on medium screens
+      width: 90vw;
+    }
+
+    @include fs-breakpoints('large') {
+      // even more room on the sides on large screens
+      width: 80vw;
+    }
   }
 }

--- a/src/shared/components/layouts/styles/uniprot-header.module.scss
+++ b/src/shared/components/layouts/styles/uniprot-header.module.scss
@@ -14,6 +14,14 @@
     /* TODO: find a better way to align this */
     transform: translateY(-2px);
   }
+
+  .no-small {
+    display: none;
+
+    @include fs-breakpoints('medium') {
+      display: inline-block;
+    }
+  }
 }
 
 .logo {

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -10,6 +10,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import useNS from '../../hooks/useNS';
 import useColumns, { ColumnDescriptor } from '../../hooks/useColumns';
 import useViewMode from '../../hooks/useViewMode';
+import { useSmallScreen } from '../../hooks/useMatchMedia';
 
 import { getIdKeyFor } from '../../utils/getIdKeyForNamespace';
 import { getParamsFromURL } from '../../../uniprotkb/utils/resultsUtils';
@@ -69,6 +70,8 @@ const ResultsData = ({
     hasMoreData,
     progress,
   } = resultsDataObject;
+
+  const smallScreen = useSmallScreen();
 
   // All complex values that only change when the namespace changes
   const [getIdKey, getEntryPathForEntry, cardRenderer] = useMemo(() => {
@@ -155,7 +158,7 @@ const ResultsData = ({
           data={allResults}
           loading={loading}
           dataRenderer={cardRenderer}
-          onSelectionChange={setSelectedItemFromEvent}
+          onSelectionChange={smallScreen ? undefined : setSelectedItemFromEvent}
           onLoadMoreItems={handleLoadMoreRows}
           hasMoreData={hasMoreData}
           loaderComponent={loadComponent}
@@ -169,7 +172,9 @@ const ResultsData = ({
             columns={columns}
             data={allResults}
             loading={loading}
-            onSelectionChange={setSelectedItemFromEvent}
+            onSelectionChange={
+              smallScreen ? undefined : setSelectedItemFromEvent
+            }
             onHeaderClick={updateColumnSort}
             onLoadMoreItems={handleLoadMoreRows}
             hasMoreData={hasMoreData}

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -20,6 +20,7 @@ import useJobFromUrl from '../../hooks/useJobFromUrl';
 import useIDMappingDetails from '../../hooks/useIDMappingDetails';
 import useStructuredData from '../../hooks/useStructuredData';
 import { useMessagesDispatch } from '../../contexts/Messages';
+import { useSmallScreen } from '../../hooks/useMatchMedia';
 
 import lazy from '../../utils/lazy';
 import { addMessage } from '../../../messages/state/messagesActions';
@@ -137,6 +138,11 @@ const webSiteSchemaFor = (namespace: Searchspace): WithContext<WebSite> => ({
   } as SearchAction,
 });
 
+type MainSearchSecondaryButton = {
+  label: string;
+  action: () => void;
+};
+
 const SearchContainer: FC<
   Props & Exclude<HTMLAttributes<HTMLDivElement>, 'role'>
 > = ({ isOnHomePage, searchspace, onSearchspaceChange, ...props }) => {
@@ -213,32 +219,39 @@ const SearchContainer: FC<
     setSearchTerm(example);
   };
 
+  const smallScreen = useSmallScreen();
   const secondaryButtons = useMemo(
-    () => [
-      {
-        label:
-          // TODO:
-          // <span
-          //   onPointerOver={QueryBuilder.preload}
-          //   onFocus={QueryBuilder.preload}
-          // >
-          //   Advanced
-          // </span>
-          'Advanced',
-        action: () => {
-          setDisplayQueryBuilder((value) => !value);
+    () =>
+      [
+        {
+          label:
+            // TODO:
+            // <span
+            //   onPointerOver={QueryBuilder.preload}
+            //   onFocus={QueryBuilder.preload}
+            // >
+            //   Advanced
+            // </span>
+            'Advanced',
+          action: () => {
+            setDisplayQueryBuilder((value) => !value);
+          },
         },
-      },
-      {
-        label: 'List',
-        action: () => {
-          history.push({
-            pathname: LocationToPath[Location.IDMapping],
-          });
-        },
-      },
-    ],
-    [history]
+        smallScreen
+          ? null
+          : {
+              label: 'List',
+              action: () => {
+                history.push({
+                  pathname: LocationToPath[Location.IDMapping],
+                });
+              },
+            },
+      ].filter(
+        (x: MainSearchSecondaryButton | null): x is MainSearchSecondaryButton =>
+          Boolean(x)
+      ),
+    [history, smallScreen]
   );
 
   // reset the text content when there is a navigation to reflect what is in the
@@ -291,18 +304,6 @@ const SearchContainer: FC<
                 </>
               )}
             </div>
-            {/* 
-            Note: if user testing validates the "list" link in the input
-            remove this
-            <div>
-              <Button
-                variant="tertiary"
-                element={Link}
-                to={LocationToPath[Location.IDMapping]}
-              >
-                Search with a list of IDs
-              </Button>
-            </div> */}
           </div>
         )}
       </section>

--- a/src/shared/hooks/useMatchMedia.ts
+++ b/src/shared/hooks/useMatchMedia.ts
@@ -51,3 +51,8 @@ export const useReducedMotion = () =>
      */
     '(prefers-reduced-motion: reduce)'
   );
+
+// Small screen (as defined in Franklin)
+
+export const useSmallScreen = () =>
+  useMatchMedia('only screen and (max-width: 640px)');

--- a/src/shared/styles/helper.module.scss
+++ b/src/shared/styles/helper.module.scss
@@ -1,3 +1,5 @@
+@import 'franklin-sites/src/styles/mixins';
+
 .stale,
 .disabled {
   opacity: 0.5;
@@ -19,4 +21,15 @@
 
 .no-text-transform {
   text-transform: none;
+}
+
+.no-small {
+  &,
+  &:global(.button) {
+    display: none;
+
+    @include fs-breakpoints('medium') {
+      display: initial;
+    }
+  }
 }

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -89,7 +89,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
               class="button-group results-buttons"
             >
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least one entry to run a BLAST job"
                 type="button"
@@ -97,7 +97,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                 BLAST
               </button>
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least 2 entries to run an Align job"
                 type="button"
@@ -120,7 +120,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                 Download
               </button>
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least one entry to add to the basket"
                 type="button"
@@ -517,7 +517,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
               class="button-group results-buttons"
             >
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least one entry to run a BLAST job"
                 type="button"
@@ -525,7 +525,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                 BLAST
               </button>
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least 2 entries to run an Align job"
                 type="button"
@@ -548,7 +548,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                 Download
               </button>
               <button
-                class="button tertiary disabled"
+                class="button tertiary disabled no-small"
                 disabled=""
                 title="Select at least one entry to add to the basket"
                 type="button"

--- a/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
+++ b/src/uniprotkb/components/entry/ComputationallyMappedSequences.tsx
@@ -1,4 +1,4 @@
-import { useMemo, FC, ReactNode } from 'react';
+import { useMemo, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { DataTable, Message } from 'franklin-sites';
 
@@ -10,10 +10,11 @@ import AccessionView from '../../../shared/components/results/AccessionView';
 import EntryTypeIcon from '../../../shared/components/entry/EntryTypeIcon';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
-import apiUrls from '../../../shared/config/apiUrls';
 import useItemSelect from '../../../shared/hooks/useItemSelect';
+import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
 
 import { pluralise } from '../../../shared/utils/utils';
+import apiUrls from '../../../shared/config/apiUrls';
 
 import { Location, LocationToPath } from '../../../app/config/urls';
 import { Namespace } from '../../../shared/types/namespaces';
@@ -41,49 +42,47 @@ type GeneCentricData = {
   proteomeId: string;
 };
 
-const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
-  primaryAccession,
-}) => {
-  const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
+const columns: Array<{
+  label: ReactNode;
+  name: string;
+  render: (data: ProteinEntryLight) => ReactNode;
+}> = [
+  {
+    label: 'Entry',
+    name: 'accession',
+    render: ({ id }) => (
+      <AccessionView id={id} namespace={Namespace.uniprotkb} />
+    ),
+  },
+  {
+    label: null,
+    name: 'reviewed',
+    render: ({ entryType }) => <EntryTypeIcon entryType={entryType} />,
+  },
+  {
+    label: 'Entry name',
+    name: 'uniProtkbId',
+    render: ({ uniProtkbId }) => uniProtkbId,
+  },
+  {
+    label: 'Gene name',
+    name: 'gene_name',
+    render: ({ geneName }) => geneName,
+  },
+  {
+    label: 'Length',
+    name: 'length',
+    render: ({ sequence }) => sequence.length,
+  },
+];
 
-  const columns = useMemo<
-    Array<{
-      label: ReactNode;
-      name: string;
-      render: (data: ProteinEntryLight) => ReactNode;
-    }>
-  >(
-    () => [
-      {
-        label: 'Entry',
-        name: 'accession',
-        render: ({ id }) => (
-          <AccessionView id={id} namespace={Namespace.uniprotkb} />
-        ),
-      },
-      {
-        label: null,
-        name: 'reviewed',
-        render: ({ entryType }) => <EntryTypeIcon entryType={entryType} />,
-      },
-      {
-        label: 'Entry name',
-        name: 'uniProtkbId',
-        render: ({ uniProtkbId }) => uniProtkbId,
-      },
-      {
-        label: 'Gene name',
-        name: 'gene_name',
-        render: ({ geneName }) => geneName,
-      },
-      {
-        label: 'Length',
-        name: 'length',
-        render: ({ sequence }) => sequence.length,
-      },
-    ],
-    []
-  );
+const ComputationalyMappedSequences = ({
+  primaryAccession,
+}: {
+  primaryAccession: string;
+}) => {
+  const smallScreen = useSmallScreen();
+  const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
 
   // Hooks
   const { data, loading, error, status } = useDataApi<GeneCentricData>(
@@ -150,7 +149,9 @@ const ComputationalyMappedSequences: FC<{ primaryAccession: string }> = ({
             density="compact"
             columns={columns}
             data={filteredData}
-            onSelectionChange={setSelectedItemFromEvent}
+            onSelectionChange={
+              smallScreen ? undefined : setSelectedItemFromEvent
+            }
           />
         </>
       )}

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/ComputationallyMappedSequences.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/ComputationallyMappedSequences.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`Computationally mapped isoforms should render correctly 1`] = `
       class="button-group"
     >
       <button
-        class="button tertiary disabled"
+        class="button tertiary disabled no-small"
         disabled=""
         title="Select at least one entry to run a BLAST job"
         type="button"
@@ -25,7 +25,7 @@ exports[`Computationally mapped isoforms should render correctly 1`] = `
         BLAST
       </button>
       <button
-        class="button tertiary disabled"
+        class="button tertiary disabled no-small"
         disabled=""
         title="Select at least 2 entries to run an Align job"
         type="button"
@@ -33,7 +33,7 @@ exports[`Computationally mapped isoforms should render correctly 1`] = `
         Align
       </button>
       <button
-        class="button tertiary disabled"
+        class="button tertiary disabled no-small"
         disabled=""
         title="Select at least one entry to add to the basket"
         type="button"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -277,14 +277,14 @@ exports[`Entry basic should render main 1`] = `
               class="button-group"
             >
               <a
-                class="button tertiary"
+                class="button tertiary no-small"
                 href="/blast?ids=P21802"
                 title="Run a BLAST job against P21802"
               >
                 BLAST
               </a>
               <a
-                class="button tertiary"
+                class="button tertiary no-small"
                 href="/align?ids=P21802%2CisoID1"
                 title="Run an Align job against 2 entries"
               >
@@ -304,7 +304,7 @@ exports[`Entry basic should render main 1`] = `
                 </button>
               </div>
               <button
-                class="button tertiary"
+                class="button tertiary no-small"
                 title="Add 1 entry to the basket"
                 type="button"
               >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2992,14 +2992,14 @@ exports[`Entry view should render 1`] = `
           class="button-group"
         >
           <a
-            class="button tertiary"
+            class="button tertiary no-small"
             href="/blast?ids=isoID1"
             title="Run a BLAST job against isoID1"
           >
             BLAST 1 isoform
           </a>
           <button
-            class="button tertiary disabled"
+            class="button tertiary disabled no-small"
             disabled=""
             title="Select at least 2 entries to run an Align job"
             type="button"
@@ -6832,7 +6832,7 @@ exports[`Entry view should render for non-human entry 1`] = `
               Download
             </a>
             <button
-              class="button tertiary"
+              class="button tertiary no-small"
               title="Add 1 entry to the basket"
               type="button"
             >

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -10,6 +10,8 @@ import FeaturesView, {
   ProcessedFeature,
 } from '../../../shared/components/views/FeaturesView';
 
+import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
+
 import listFormat from '../../../shared/utils/listFormat';
 import { getEntryPath, getURLToJobWithData } from '../../../app/config/urls';
 
@@ -118,6 +120,8 @@ const UniProtKBFeaturesView = ({
     [features, sequence]
   );
 
+  const smallScreen = useSmallScreen();
+
   if (processedData.length === 0) {
     return null;
   }
@@ -134,7 +138,11 @@ const UniProtKBFeaturesView = ({
           <th>ID</th>
           <th>Position(s)</th>
           <th>Description</th>
-          <th>{/* Intentionaly left blank */}</th>
+          {smallScreen ? null : (
+            <th>
+              {/* Intentionally left blank, corresponds to tools/basket */}
+            </th>
+          )}
         </tr>
       </thead>
       <tbody>
@@ -189,27 +197,29 @@ const UniProtKBFeaturesView = ({
                     : feature.description}
                   <UniProtKBEvidenceTag evidences={feature.evidences} />
                 </td>
-                <td>
-                  {/* Not using React Router link as this is copied into the table DOM */}
-                  {feature.end - feature.start >= 2 && (
-                    <Button
-                      element="a"
-                      variant="tertiary"
-                      title="BLAST the sequence corresponding to this feature"
-                      href={getURLToJobWithData(
-                        JobTypes.BLAST,
-                        primaryAccession,
-                        {
-                          start: feature.start,
-                          end: feature.end,
-                        }
-                      )}
-                    >
-                      BLAST
-                    </Button>
-                  )}
-                  {/* <Button>Add</Button> */}
-                </td>
+                {smallScreen ? null : (
+                  <td>
+                    {/* Not using React Router link as this is copied into the table DOM */}
+                    {feature.end - feature.start >= 2 && (
+                      <Button
+                        element="a"
+                        variant="tertiary"
+                        title="BLAST the sequence corresponding to this feature"
+                        href={getURLToJobWithData(
+                          JobTypes.BLAST,
+                          primaryAccession,
+                          {
+                            start: feature.start,
+                            end: feature.end,
+                          }
+                        )}
+                      >
+                        BLAST
+                      </Button>
+                    )}
+                    {/* <Button>Add</Button> */}
+                  </td>
+                )}
               </tr>
               {feature.sequence && (
                 <tr

--- a/src/uniref/components/entry/MembersSection.tsx
+++ b/src/uniref/components/entry/MembersSection.tsx
@@ -12,6 +12,7 @@ import MemberLink from './MemberLink';
 import useDataApi from '../../../shared/hooks/useDataApi';
 import usePrefetch from '../../../shared/hooks/usePrefetch';
 import useItemSelect from '../../../shared/hooks/useItemSelect';
+import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
 
 import { pluralise } from '../../../shared/utils/utils';
 import getNextURLFromHeaders from '../../../shared/utils/getNextURLFromHeaders';
@@ -304,6 +305,7 @@ export const MembersSection = ({
     }));
   }, [data, headers]);
 
+  const smallScreen = useSmallScreen();
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
 
   const { total, nextUrl } = metadata;
@@ -340,7 +342,7 @@ export const MembersSection = ({
         data={allResults}
         getIdKey={getKey}
         density="compact"
-        onSelectionChange={setSelectedItemFromEvent}
+        onSelectionChange={smallScreen ? undefined : setSelectedItemFromEvent}
       />
     </Card>
   );


### PR DESCRIPTION
## Purpose
disable all tools and basket references in mobile view https://www.ebi.ac.uk/panda/jira/browse/TRM-28221

## Approach
Use of media query, as defined in Franklin, in 2 ways:
- Use directly in CSS through mixin
- Use in JavaScript
Create abstraction for both ways and try to reused wherever possible

## Testing
Manual testing on narrow screen + updated snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
