### PR TITLE
mobile view, remove feature viewer tabs & update sliding panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "core-js": "3.21.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.198",
+    "franklin-sites": "0.0.199",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "7.0.1",

--- a/src/help/components/contextual/ContextualHelpContainer.tsx
+++ b/src/help/components/contextual/ContextualHelpContainer.tsx
@@ -112,7 +112,6 @@ const ContextualHelpContainer = ({ articlePath, onClose }: Props) => {
     <SlidingPanel
       title={<NavigationBar localHistory={localHistoryRef.current} />}
       onClose={onClose}
-      withCloseButton
       className={styles['contextual-help-panel']}
       size="small"
       position="right"

--- a/src/shared/components/layouts/SecondaryItems.tsx
+++ b/src/shared/components/layouts/SecondaryItems.tsx
@@ -142,7 +142,6 @@ const ToolsDashboard = () => {
               <ToolboxIcon width="0.8em" /> Tool results
             </Link>
           }
-          withCloseButton
           position="right"
           size="medium"
           onClose={close}
@@ -233,7 +232,6 @@ export const Basket = () => {
               <BasketIcon width="0.8em" /> My Basket
             </Link>
           }
-          withCloseButton
           position="right"
           size="medium"
           onClose={close}

--- a/src/tools/blast/components/results/HSPDetailPanel.tsx
+++ b/src/tools/blast/components/results/HSPDetailPanel.tsx
@@ -142,7 +142,6 @@ const HSPDetailPanel = ({
   return (
     <SlidingPanel
       title={title}
-      withCloseButton
       position="bottom"
       className={containerClass}
       onClose={onClose}

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, Suspense } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, Redirect, useHistory } from 'react-router-dom';
 import { InPageNav, Loader, Tabs, Tab } from 'franklin-sites';
 import cn from 'classnames';
 import qs from 'query-string';
@@ -32,6 +32,7 @@ import useDataApi from '../../../shared/hooks/useDataApi';
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 import { useMessagesDispatch } from '../../../shared/contexts/Messages';
 import useMatchWithRedirect from '../../../shared/hooks/useMatchWithRedirect';
+import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
 
 import { addMessage } from '../../../messages/state/messagesActions';
 
@@ -115,6 +116,7 @@ const Entry = () => {
     TabLocation.Entry,
     legacyToNewSubPages
   );
+  const smallScreen = useSmallScreen();
 
   const { loading, data, status, error, redirectedTo, progress } =
     useDataApi<UniProtkbAPIModel>(
@@ -394,32 +396,44 @@ const Entry = () => {
         </Tab>
         <Tab
           title={
-            <Link
-              className={historyOldEntry ? helper.disabled : undefined}
-              tabIndex={historyOldEntry ? -1 : undefined}
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                match.params.accession,
-                TabLocation.FeatureViewer
-              )}
-            >
-              Feature viewer
-            </Link>
+            smallScreen ? null : (
+              <Link
+                className={historyOldEntry ? helper.disabled : undefined}
+                tabIndex={historyOldEntry ? -1 : undefined}
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  match.params.accession,
+                  TabLocation.FeatureViewer
+                )}
+              >
+                Feature viewer
+              </Link>
+            )
           }
           id={TabLocation.FeatureViewer}
           onPointerOver={FeatureViewer.preload}
           onFocus={FeatureViewer.preload}
         >
-          <Suspense fallback={<Loader />}>
-            <HTMLHead
-              title={[
-                pageTitle,
-                'Feature viewer',
-                searchableNamespaceLabels[Namespace.uniprotkb],
-              ]}
+          {smallScreen ? (
+            <Redirect
+              to={getEntryPath(
+                Namespace.uniprotkb,
+                match.params.accession,
+                TabLocation.Entry
+              )}
             />
-            <FeatureViewer accession={match.params.accession} />
-          </Suspense>
+          ) : (
+            <Suspense fallback={<Loader />}>
+              <HTMLHead
+                title={[
+                  pageTitle,
+                  'Feature viewer',
+                  searchableNamespaceLabels[Namespace.uniprotkb],
+                ]}
+              />
+              <FeatureViewer accession={match.params.accession} />
+            </Suspense>
+          )}
         </Tab>
         <Tab
           title={

--- a/yarn.lock
+++ b/yarn.lock
@@ -6572,10 +6572,10 @@ foundation-sites@6.7.4:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.7.4.tgz#495ddb3b7014ae33df3bf7cc1f9fe74b2cfd572e"
   integrity sha512-2QPaZJ0Od0DyklhQyKC3zPbr8AAUXSkr1scZJrQTgj/KTLresuCgUBfi7ft32NlOWhuqVXisjOgTE8N5EPS3cg==
 
-franklin-sites@0.0.198:
-  version "0.0.198"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.198.tgz#205aab50821d5d64cd7932c76e0786897695e00b"
-  integrity sha512-dNH75MqNltRrBoENoC4JFN8RNml3wvMydVtwgiAXZqAJf3etyWiimu0Ez5qibNbIcKglk5fOYoVBHT8+Eh14YQ==
+franklin-sites@0.0.199:
+  version "0.0.199"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.199.tgz#c28119bb5f934d503b2402124a314819c77928ff"
+  integrity sha512-4OTAzesdpCOZIsiJZVqX9quA/o786cnSlziVN2cZEl+R+a0TCqHOr3wCsNrhHeQT9EmueZQ/nhMiX8gsEmCs3g==
   dependencies:
     "@tippyjs/react" "4.2.6"
     classnames "2.3.1"


### PR DESCRIPTION
## Purpose
Remove feature viewer tabs https://www.ebi.ac.uk/panda/jira/browse/TRM-28224
Make sliding panels span the whole width of the screen https://www.ebi.ac.uk/panda/jira/browse/TRM-28226

## Approach
Update franklin with the change for SlidingPanel
Update tabs to not render the tab title on small screens, and redirect to entry subpage if someone ended up there anyway (from a link I guess)

## Testing
Manual tests

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
