### PR TITLE
2022 09 add basket to subsets

### DIFF
--- a/src/basket/BasketFullView.tsx
+++ b/src/basket/BasketFullView.tsx
@@ -36,14 +36,11 @@ const BasketFullView = () => {
   const namespace = fullViewMatch?.params.namespace || Namespace.uniprotkb;
   const subBasket = basket.get(namespace) || new Set();
   const accessions = Array.from(subBasket);
+
   const subsetsMap = new Map();
   accessions.forEach((acc) => {
-    const { id } = acc.match(reIds)?.groups || {};
-    if (id) {
-      subsetsMap.set(acc, id);
-    } else {
-      subsetsMap.set(acc, acc);
-    }
+    const { id } = acc.match(reIds)?.groups || { acc };
+    subsetsMap.set(acc, id);
   });
 
   // Below here similar (but not identical) to the Results component
@@ -52,7 +49,7 @@ const BasketFullView = () => {
 
   // Query for facets
   const initialApiFacetUrl = useNSQuery({
-    accessions: Array.from(subsetsMap.values()),
+    accessions: Array.from(subsetsMap.values()), // Passing accessions without modifications in case of subsets
     overrideNS: namespace,
     withFacets: true,
     withColumns: false,
@@ -69,7 +66,7 @@ const BasketFullView = () => {
 
   // Query for basket data
   const initialApiUrl = useNSQuery({
-    accessions: Array.from(subsetsMap.values()),
+    accessions: Array.from(subsetsMap.values()), // Passing accessions without modifications in case of subsets
     overrideNS: namespace,
     withFacets: false,
   });
@@ -103,6 +100,7 @@ const BasketFullView = () => {
     return <Loader progress={resultsDataProgress} />;
   }
 
+  // Replacing the full accession including subsets in the resultsData
   if (resultsDataObject.allResults.length) {
     resultsDataObject.allResults.forEach((r, index) => {
       if (namespace == Namespace.uniprotkb) {

--- a/src/basket/BasketFullView.tsx
+++ b/src/basket/BasketFullView.tsx
@@ -15,6 +15,7 @@ import useNSQuery from '../shared/hooks/useNSQuery';
 import useDataApiWithStale from '../shared/hooks/useDataApiWithStale';
 
 import { reIds } from '../tools/utils/urls';
+import { updateResultsWithAccessionSubsets } from './BasketMiniView';
 
 import { LocationToPath, Location, basketNamespaces } from '../app/config/urls';
 
@@ -101,13 +102,11 @@ const BasketFullView = () => {
   }
 
   // Replacing the full accession including subsets in the resultsData
-  if (resultsDataObject.allResults.length) {
-    resultsDataObject.allResults.forEach((r, index) => {
-      if (namespace == Namespace.uniprotkb) {
-        r.primaryAccession = accessions[index];
-      }
-    });
-  }
+  resultsDataObject.allResults = updateResultsWithAccessionSubsets(
+    resultsDataObject.allResults,
+    namespace,
+    accessions
+  );
 
   return (
     <SideBarLayout

--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -62,16 +62,15 @@ export const updateResultsWithAccessionSubsets = (
   results: APIModel[],
   namespace: Namespace,
   accessions: string[]
-) => {
-  return results.map((r, index) => {
+) =>
+  results.map((r, index) => {
     if (namespace === Namespace.uniprotkb) {
-      const entry: UniProtkbAPIModel = { ...r };
+      const entry = { ...r } as UniProtkbAPIModel;
       entry.primaryAccession = accessions[index];
       return entry;
     }
     return r;
   });
-};
 
 const BasketMiniViewTab = ({
   accessions,

--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -69,8 +69,19 @@ const BasketMiniViewTab = ({
     setSelectedEntries([]);
   }, [namespace, setSelectedEntries]);
 
+  const reIds = /(?<id>\w+-?\d*)(\[(?<start>\d+)-(?<end>\d+)\])?/;
+
+  const trimmedAccessions = accessions.map((acc) => {
+    const { id } = acc.match(reIds)?.groups || {};
+    if (id) {
+      return id;
+    } else {
+      return acc;
+    }
+  });
+
   const initialApiUrl = useNSQuery({
-    accessions,
+    accessions: trimmedAccessions,
     overrideNS: namespace,
     withFacets: false,
     withColumns: false,
@@ -94,6 +105,13 @@ const BasketMiniViewTab = ({
       ),
     [namespace, columnNames, databaseInfoMaps]
   );
+  if (resultsDataObject.allResults.length) {
+    resultsDataObject.allResults.forEach((r, index) => {
+      if ((namespace = Namespace.uniprotkb)) {
+        r.primaryAccession = accessions[index];
+      }
+    });
+  }
 
   return (
     <>

--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -27,6 +27,7 @@ import { APIModel } from '../shared/types/apiModel';
 import { UniProtKBColumn } from '../uniprotkb/types/columnTypes';
 import { UniRefColumn } from '../uniref/config/UniRefColumnConfiguration';
 import { UniParcColumn } from '../uniparc/config/UniParcColumnConfiguration';
+import { UniProtkbAPIModel } from '../uniprotkb/adapters/uniProtkbConverter';
 
 import helper from '../shared/styles/helper.module.scss';
 import styles from './styles/basket-mini-view.module.scss';
@@ -55,6 +56,21 @@ type BasketMiniViewTabProps = {
   columnNames: Array<UniProtKBColumn | UniRefColumn | UniParcColumn>;
   setBasket: Dispatch<SetStateAction<Basket>>;
   closePanel: () => void;
+};
+
+export const updateResultsWithAccessionSubsets = (
+  results: APIModel[],
+  namespace: Namespace,
+  accessions: string[]
+) => {
+  return results.map((r, index) => {
+    if (namespace === Namespace.uniprotkb) {
+      const entry: UniProtkbAPIModel = { ...r };
+      entry.primaryAccession = accessions[index];
+      return entry;
+    }
+    return r;
+  });
 };
 
 const BasketMiniViewTab = ({
@@ -105,13 +121,11 @@ const BasketMiniViewTab = ({
   );
 
   // Replacing the full accession including subsets in the resultsData
-  if (resultsDataObject.allResults.length) {
-    resultsDataObject.allResults.forEach((r, index) => {
-      if (namespace == Namespace.uniprotkb) {
-        r.primaryAccession = accessions[index];
-      }
-    });
-  }
+  resultsDataObject.allResults = updateResultsWithAccessionSubsets(
+    resultsDataObject.allResults,
+    namespace,
+    accessions
+  );
 
   return (
     <>

--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -66,12 +66,8 @@ const BasketMiniViewTab = ({
 }: BasketMiniViewTabProps) => {
   const subsetsMap = new Map();
   accessions.forEach((acc) => {
-    const { id } = acc.match(reIds)?.groups || {};
-    if (id) {
-      subsetsMap.set(acc, id);
-    } else {
-      subsetsMap.set(acc, acc);
-    }
+    const { id } = acc.match(reIds)?.groups || { acc };
+    subsetsMap.set(acc, id);
   });
 
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
@@ -83,7 +79,7 @@ const BasketMiniViewTab = ({
   }, [namespace, setSelectedEntries]);
 
   const initialApiUrl = useNSQuery({
-    accessions: Array.from(subsetsMap.values()),
+    accessions: Array.from(subsetsMap.values()), // Passing accessions without modifications in case of subsets
     overrideNS: namespace,
     withFacets: false,
     withColumns: false,
@@ -108,6 +104,7 @@ const BasketMiniViewTab = ({
     [namespace, columnNames, databaseInfoMaps]
   );
 
+  // Replacing the full accession including subsets in the resultsData
   if (resultsDataObject.allResults.length) {
     resultsDataObject.allResults.forEach((r, index) => {
       if (namespace == Namespace.uniprotkb) {

--- a/src/shared/components/results/AccessionView.tsx
+++ b/src/shared/components/results/AccessionView.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const AccessionView = ({ id, namespace, entryType }: Props) => {
-  const { id: acc, start, end } = id.match(reIds)?.groups || { id };
+  const { id: acc, start, end } = (id && id.match(reIds)?.groups) || { id };
 
   return (
     <span className={cn(helper['no-wrap'], styles['accession-view'])}>

--- a/src/shared/components/results/AccessionView.tsx
+++ b/src/shared/components/results/AccessionView.tsx
@@ -39,7 +39,7 @@ const AccessionView = ({ id, namespace, entryType }: Props) => {
       </Link>
       {start && end && (
         <span>
-          [{start}]-[{end}]
+          [{start}-{end}]
         </span>
       )}
       <BasketStatus id={id} />

--- a/src/shared/components/results/AccessionView.tsx
+++ b/src/shared/components/results/AccessionView.tsx
@@ -6,6 +6,8 @@ import EntryTypeIcon, { EntryType } from '../entry/EntryTypeIcon';
 
 import { getEntryPath } from '../../../app/config/urls';
 
+import { reIds } from '../../../tools/utils/urls';
+
 import { Namespace, SearchableNamespace } from '../../types/namespaces';
 
 import helper from '../../styles/helper.module.scss';
@@ -18,8 +20,7 @@ type Props = {
 };
 
 const AccessionView = ({ id, namespace, entryType }: Props) => {
-  const reIds = /(?<acc>\w+-?\d*)(\[(?<start>\d+)-(?<end>\d+)\])?/;
-  const { acc, start, end } = id.match(reIds)?.groups || {};
+  const { id: acc, start, end } = id.match(reIds)?.groups || { id };
 
   return (
     <span className={cn(helper['no-wrap'], styles['accession-view'])}>
@@ -27,14 +28,14 @@ const AccessionView = ({ id, namespace, entryType }: Props) => {
       <Link
         to={getEntryPath(
           namespace,
-          acc ? acc : id,
+          acc,
           namespace === Namespace.uniprotkb || namespace === Namespace.uniparc
             ? 'entry'
             : undefined
         )}
         className={styles.accession}
       >
-        {acc ? acc : id}
+        {acc}
       </Link>
       {start && end && (
         <span>

--- a/src/shared/components/results/AccessionView.tsx
+++ b/src/shared/components/results/AccessionView.tsx
@@ -17,23 +17,33 @@ type Props = {
   entryType?: string | EntryType;
 };
 
-const AccessionView = ({ id, namespace, entryType }: Props) => (
-  <span className={cn(helper['no-wrap'], styles['accession-view'])}>
-    {entryType && <EntryTypeIcon entryType={entryType} />}
-    <Link
-      to={getEntryPath(
-        namespace,
-        id,
-        namespace === Namespace.uniprotkb || namespace === Namespace.uniparc
-          ? 'entry'
-          : undefined
+const AccessionView = ({ id, namespace, entryType }: Props) => {
+  const reIds = /(?<acc>\w+-?\d*)(\[(?<start>\d+)-(?<end>\d+)\])?/;
+  const { acc, start, end } = id.match(reIds)?.groups || {};
+
+  return (
+    <span className={cn(helper['no-wrap'], styles['accession-view'])}>
+      {entryType && <EntryTypeIcon entryType={entryType} />}
+      <Link
+        to={getEntryPath(
+          namespace,
+          acc ? acc : id,
+          namespace === Namespace.uniprotkb || namespace === Namespace.uniparc
+            ? 'entry'
+            : undefined
+        )}
+        className={styles.accession}
+      >
+        {acc ? acc : id}
+      </Link>
+      {start && end && (
+        <span>
+          [{start}]-[{end}]
+        </span>
       )}
-      className={styles.accession}
-    >
-      {id}
-    </Link>
-    <BasketStatus id={id} />
-  </span>
-);
+      <BasketStatus id={id} />
+    </span>
+  );
+};
 
 export default AccessionView;

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -63,7 +63,7 @@ type ResultsButtonsProps = {
   disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
   inBasket?: boolean;
   notCustomisable?: boolean;
-  subsetsMap: Map<string, string>;
+  subsetsMap?: Map<string, string>;
 };
 
 const ResultsButtons: FC<ResultsButtonsProps> = ({
@@ -159,10 +159,10 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
 
   const isMain = mainNamespaces.has(namespace);
 
-  // Download and ID mapping expects accessions without modifications
-  const selectedAccessions = Array.from(
-    new Set(selectedEntries.map((e) => subsetsMap.get(e) || e))
-  );
+  // Download and ID mapping expects accessions without modifications (applicable in Basket views)
+  const selectedAccWithoutSubset = subsetsMap
+    ? Array.from(new Set(selectedEntries.map((e) => subsetsMap.get(e) || e)))
+    : selectedEntries;
 
   return (
     <>
@@ -176,8 +176,12 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
           >
             <ErrorBoundary>
               <DownloadComponent
-                selectedEntries={selectedAccessions}
-                accessions={Array.from(new Set(subsetsMap.values()))} // Passing all accessions without modifications to Download
+                selectedEntries={selectedAccWithoutSubset}
+                accessions={
+                  subsetsMap
+                    ? Array.from(new Set(subsetsMap?.values()))
+                    : accessions
+                } // Passing all accessions without modifications to Download
                 totalNumberResults={total}
                 onClose={() => setDisplayDownloadPanel(false)}
                 namespace={namespace}
@@ -196,7 +200,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
         )}
         {isMain && namespace !== Namespace.proteomes && (
           <MapIDButton
-            selectedEntries={selectedAccessions}
+            selectedEntries={selectedAccWithoutSubset}
             namespace={namespace}
           />
         )}

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -63,6 +63,7 @@ type ResultsButtonsProps = {
   disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
   inBasket?: boolean;
   notCustomisable?: boolean;
+  subsetsMap: Map<string, string>;
 };
 
 const ResultsButtons: FC<ResultsButtonsProps> = ({
@@ -76,6 +77,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   disableCardToggle = false,
   inBasket = false,
   notCustomisable = false,
+  subsetsMap,
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
@@ -157,6 +159,11 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
 
   const isMain = mainNamespaces.has(namespace);
 
+  // Download and ID mapping expects accessions without modifications
+  const selectedAccessions = Array.from(
+    new Set(selectedEntries.map((e) => subsetsMap.get(e) || e))
+  );
+
   return (
     <>
       {displayDownloadPanel && (
@@ -169,8 +176,8 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
           >
             <ErrorBoundary>
               <DownloadComponent
-                selectedEntries={selectedEntries}
-                accessions={accessions}
+                selectedEntries={selectedAccessions}
+                accessions={Array.from(new Set(subsetsMap.values()))} // Passing all accessions without modifications to Download
                 totalNumberResults={total}
                 onClose={() => setDisplayDownloadPanel(false)}
                 namespace={namespace}
@@ -189,7 +196,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
         )}
         {isMain && namespace !== Namespace.proteomes && (
           <MapIDButton
-            selectedEntries={selectedEntries}
+            selectedEntries={selectedAccessions}
             namespace={namespace}
           />
         )}

--- a/src/shared/components/results/__tests__/AccessionView.spec.tsx
+++ b/src/shared/components/results/__tests__/AccessionView.spec.tsx
@@ -29,4 +29,11 @@ describe('AccessionView', () => {
       screen.queryByTitle(/reference Proteome entry/)
     ).not.toBeInTheDocument();
   });
+
+  it('should link only the accession leaving out the subset', () => {
+    const { asFragment } = customRender(
+      <AccessionView id="P59594[424-494]" namespace={Namespace.uniprotkb} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/shared/components/results/__tests__/__snapshots__/AccessionView.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/AccessionView.spec.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AccessionView should link only the accession leaving out the subset 1`] = `
+<DocumentFragment>
+  <span
+    class="no-wrap accession-view"
+  >
+    <a
+      class="accession"
+      href="/uniprotkb/P59594/entry"
+    >
+      P59594
+    </a>
+    <span>
+      [424-494]
+    </span>
+  </span>
+</DocumentFragment>
+`;

--- a/src/tools/utils/urls.ts
+++ b/src/tools/utils/urls.ts
@@ -1,4 +1,4 @@
-const reIds = /(?<id>\w+-?\d*)(\[(?<start>\d+)-(?<end>\d+)\])?/;
+export const reIds = /(?<id>\w+-?\d*)(\[(?<start>\d+)-(?<end>\d+)\])?/;
 // Note: also supporting isoform in regex
 
 export type IdMaybeWithRange = {

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2514,13 +2514,25 @@ exports[`Entry view should render 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P21802[2-8]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P21802[2-8]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -4112,13 +4124,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[180-402]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[180-402]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -4326,13 +4350,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[494-605]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[494-605]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -4388,13 +4424,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[502-765]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[502-765]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -4450,13 +4498,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[515-772]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[515-772]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -5579,13 +5639,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[1-27]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[1-27]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -5623,13 +5695,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     A type blood N-acetyl-alpha-D-galactosamine deacetylase
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[28-772]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[28-772]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -5980,13 +6064,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[180-402]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[180-402]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -6042,13 +6138,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[494-605]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[494-605]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -6104,13 +6212,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[502-765]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[502-765]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr
@@ -6166,13 +6286,25 @@ exports[`Entry view should render for non-human entry 1`] = `
                     />
                   </td>
                   <td>
-                    <a
-                      class="button tertiary"
-                      href="/blast?ids=P0DTR4[515-772]"
-                      title="BLAST the sequence corresponding to this feature"
+                    <div
+                      class="button-group"
                     >
-                      BLAST
-                    </a>
+                      <a
+                        class="button tertiary"
+                        href="/blast?ids=P0DTR4[515-772]"
+                        title="BLAST the sequence corresponding to this feature"
+                      >
+                        BLAST
+                      </a>
+                      <button
+                        class="button tertiary"
+                        title="Add 1 entry to the basket"
+                        type="button"
+                      >
+                        <test-file-stub />
+                        Add
+                      </button>
+                    </div>
                   </td>
                 </tr>
                 <tr

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2525,7 +2525,7 @@ exports[`Entry view should render 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -4135,7 +4135,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -4361,7 +4361,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -4435,7 +4435,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -4509,7 +4509,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -5650,7 +5650,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -5706,7 +5706,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -6075,7 +6075,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -6149,7 +6149,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -6223,7 +6223,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >
@@ -6297,7 +6297,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         BLAST
                       </a>
                       <button
-                        class="button tertiary"
+                        class="button tertiary no-small"
                         title="Add 1 entry to the basket"
                         type="button"
                       >

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -193,7 +193,7 @@ const UniProtKBFeaturesView = ({
                 <td>
                   {/* Not using React Router link as this is copied into the table DOM */}
                   {feature.end - feature.start >= 2 && (
-                    <>
+                    <div className={'button-group'}>
                       <Button
                         element="a"
                         variant="tertiary"
@@ -212,9 +212,8 @@ const UniProtKBFeaturesView = ({
                       <AddToBasketButton
                         selectedEntries={`${primaryAccession}[${feature.start}-${feature.end}]`}
                       />
-                    </>
+                    </div>
                   )}
-                  {/* <Button>Add</Button> */}
                 </td>
               </tr>
               {feature.sequence && (

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -193,7 +193,7 @@ const UniProtKBFeaturesView = ({
                 <td>
                   {/* Not using React Router link as this is copied into the table DOM */}
                   {feature.end - feature.start >= 2 && (
-                    <div className={'button-group'}>
+                    <div className="button-group">
                       <Button
                         element="a"
                         variant="tertiary"

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -9,6 +9,7 @@ import FeaturesView, {
   LocationModifier,
   ProcessedFeature,
 } from '../../../shared/components/views/FeaturesView';
+import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
 
 import listFormat from '../../../shared/utils/listFormat';
 import { getEntryPath, getURLToJobWithData } from '../../../app/config/urls';
@@ -192,21 +193,26 @@ const UniProtKBFeaturesView = ({
                 <td>
                   {/* Not using React Router link as this is copied into the table DOM */}
                   {feature.end - feature.start >= 2 && (
-                    <Button
-                      element="a"
-                      variant="tertiary"
-                      title="BLAST the sequence corresponding to this feature"
-                      href={getURLToJobWithData(
-                        JobTypes.BLAST,
-                        primaryAccession,
-                        {
-                          start: feature.start,
-                          end: feature.end,
-                        }
-                      )}
-                    >
-                      BLAST
-                    </Button>
+                    <>
+                      <Button
+                        element="a"
+                        variant="tertiary"
+                        title="BLAST the sequence corresponding to this feature"
+                        href={getURLToJobWithData(
+                          JobTypes.BLAST,
+                          primaryAccession,
+                          {
+                            start: feature.start,
+                            end: feature.end,
+                          }
+                        )}
+                      >
+                        BLAST
+                      </Button>
+                      <AddToBasketButton
+                        selectedEntries={`${primaryAccession}[${feature.start}-${feature.end}]`}
+                      />
+                    </>
                   )}
                   {/* <Button>Add</Button> */}
                 </td>

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
@@ -92,13 +92,25 @@ exports[`FeaturesView component it renders without crashing 1`] = `
               />
             </td>
             <td>
-              <a
-                class="button tertiary"
-                href="/blast?ids=P05067[1-17]"
-                title="BLAST the sequence corresponding to this feature"
+              <div
+                class="button-group"
               >
-                BLAST
-              </a>
+                <a
+                  class="button tertiary"
+                  href="/blast?ids=P05067[1-17]"
+                  title="BLAST the sequence corresponding to this feature"
+                >
+                  BLAST
+                </a>
+                <button
+                  class="button tertiary"
+                  title="Add 1 entry to the basket"
+                  type="button"
+                >
+                  <test-file-stub />
+                  Add
+                </button>
+              </div>
             </td>
           </tr>
           <tr

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/FeaturesView.spec.tsx.snap
@@ -103,7 +103,7 @@ exports[`FeaturesView component it renders without crashing 1`] = `
                   BLAST
                 </a>
                 <button
-                  class="button tertiary"
+                  class="button tertiary no-small"
                   title="Add 1 entry to the basket"
                   type="button"
                 >

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1683,7 +1683,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
               BLAST
             </a>
             <button
-              class="button tertiary"
+              class="button tertiary no-small"
               title="Add 1 entry to the basket"
               type="button"
             >

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1672,13 +1672,25 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
           />
         </td>
         <td>
-          <a
-            class="button tertiary"
-            href="/blast?ids=P21802[2-8]"
-            title="BLAST the sequence corresponding to this feature"
+          <div
+            class="button-group"
           >
-            BLAST
-          </a>
+            <a
+              class="button tertiary"
+              href="/blast?ids=P21802[2-8]"
+              title="BLAST the sequence corresponding to this feature"
+            >
+              BLAST
+            </a>
+            <button
+              class="button tertiary"
+              title="Add 1 entry to the basket"
+              type="button"
+            >
+              <test-file-stub />
+              Add
+            </button>
+          </div>
         </td>
       </tr>
       <tr


### PR DESCRIPTION
## Purpose
Add basket button for features spanning >1 amino acid along with the existing BLAST button

## Approach
The modifications subset is stores as a string in the Basket.
A Map of subset to accession is passed to `ResultsButton` to deal with exceptions like ID mapping and Download functions.

## Testing
Additional test added to AccessionView to see how the ids with ranges are shown
Other snapshots updated with the Add Basket button

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
