### PR TITLE
Ligand links

### DIFF
--- a/src/shared/components/views/FeaturesView.tsx
+++ b/src/shared/components/views/FeaturesView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, lazy, useMemo } from 'react';
+import { Fragment, lazy, ReactNode, useMemo } from 'react';
 import TransformedVariant from 'protvista-variation-adapter';
 
 import LazyComponent from '../LazyComponent';
@@ -35,7 +35,7 @@ export type ProcessedFeature = {
   startModifier?: LocationModifier;
   endModifier?: LocationModifier;
   type: FeatureType;
-  description?: string;
+  description?: ReactNode;
   evidences?: Evidence[];
   sequence?: string;
   locations?: { fragments: Fragment[] }[];

--- a/src/tools/utils/feature.ts
+++ b/src/tools/utils/feature.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import urljoin from 'url-join';
 import { ProcessedFeature } from '../../shared/components/views/FeaturesView';
 import { getEvidenceLink } from '../../uniprotkb/config/evidenceUrls';
@@ -21,7 +22,7 @@ type TooltipFeature = {
   end: number;
   ftId?: string;
   evidences?: Evidence[];
-  description?: string;
+  description?: ReactNode;
 };
 
 export const prepareFeatureForTooltip = (

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2516,11 +2516,49 @@ exports[`Entry view should render 1`] = `
                     <sup>
                       2+
                     </sup>
-                    ; Some note; Cu
+                     (
+                    <a
+                      href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3214\\""
+                    >
+                      UniProtKB
+                    </a>
+                     | 
+                    <a
+                      class="external-link"
+                      href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=ChEBICHEBI:3214"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      ChEBI
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    ) Some note; Cu
                     <sup>
                       2+
                     </sup>
-                    ; Some note
+                     (
+                    <a
+                      href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3314\\""
+                    >
+                      UniProtKB
+                    </a>
+                     | 
+                    <a
+                      class="external-link"
+                      href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=ChEBICHEBI:3314"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      ChEBI
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    ) Some note
                     <button
                       aria-controls="48"
                       aria-expanded="false"
@@ -4080,7 +4118,26 @@ exports[`Entry view should render for non-human entry 1`] = `
                     126
                   </td>
                   <td>
-                    a divalent metal cation
+                    a divalent metal cation (
+                    <a
+                      href="/uniprotkb?query=ft_binding:\\"CHEBI:60240\\""
+                    >
+                      UniProtKB
+                    </a>
+                     | 
+                    <a
+                      class="external-link"
+                      href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:60240"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      ChEBI
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    ) 
                     <button
                       aria-controls="21"
                       aria-expanded="false"
@@ -4306,7 +4363,26 @@ exports[`Entry view should render for non-human entry 1`] = `
                     278
                   </td>
                   <td>
-                    a divalent metal cation
+                    a divalent metal cation (
+                    <a
+                      href="/uniprotkb?query=ft_binding:\\"CHEBI:60240\\""
+                    >
+                      UniProtKB
+                    </a>
+                     | 
+                    <a
+                      class="external-link"
+                      href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:60240"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      ChEBI
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                    ) 
                     <button
                       aria-controls="26"
                       aria-expanded="false"

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1681,11 +1681,49 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
           <sup>
             2+
           </sup>
-          ; Some note; Cu
+           (
+          <a
+            href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3214\\""
+          >
+            UniProtKB
+          </a>
+           | 
+          <a
+            class="external-link"
+            href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=ChEBICHEBI:3214"
+            rel="noopener"
+            target="_blank"
+          >
+            ChEBI
+            <test-file-stub
+              data-testid="external-link-icon"
+              width="12.5"
+            />
+          </a>
+          ) Some note; Cu
           <sup>
             2+
           </sup>
-          ; Some note
+           (
+          <a
+            href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3314\\""
+          >
+            UniProtKB
+          </a>
+           | 
+          <a
+            class="external-link"
+            href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=ChEBICHEBI:3314"
+            rel="noopener"
+            target="_blank"
+          >
+            ChEBI
+            <test-file-stub
+              data-testid="external-link-icon"
+              width="12.5"
+            />
+          </a>
+          ) Some note
           <button
             aria-controls="0"
             aria-expanded="false"


### PR DESCRIPTION
## Purpose
Add links to search for ligand/ligandPart in uniprotkb and chebi

## Approach
- `description` is now a `ReactNode` which includes these links
- slight refactoring of the table cell render

## Testing
- Update snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
