### PR TITLE
Ligand description view

### DIFF
--- a/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
+++ b/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
@@ -15,6 +15,7 @@ import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
 import CSVView from '../../../uniprotkb/components/protein-data-views/CSVView';
 import CatalyticActivityView from '../../../uniprotkb/components/protein-data-views/CatalyticActivityView';
 import { CofactorView } from '../../../uniprotkb/components/entry/FunctionSection';
+import LigandDescriptionView from '../../../uniprotkb/components/protein-data-views/LigandDescriptionView';
 
 import listFormat from '../../../shared/utils/listFormat';
 import { pluralise } from '../../../shared/utils/utils';
@@ -42,7 +43,6 @@ import {
 } from '../../../uniprotkb/types/commentTypes';
 
 import styles from './styles/conditions-annotations.module.scss';
-import LigandDescriptionView from '../../../uniprotkb/components/protein-data-views/LigandDescriptionView';
 
 type AnnotationWithExceptions = Annotation & { exceptions?: RuleException[] };
 

--- a/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
+++ b/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../../uniprotkb/types/commentTypes';
 
 import styles from './styles/conditions-annotations.module.scss';
+import LigandDescriptionView from '../../../uniprotkb/components/protein-data-views/LigandDescriptionView';
 
 type AnnotationWithExceptions = Annotation & { exceptions?: RuleException[] };
 
@@ -553,45 +554,11 @@ function annotationsToInfoData(
                 </li>
                 {pf.ligand && (
                   <li>
-                    {pf.ligandPart && (
-                      <span>
-                        {pf.ligandPart.name}
-                        {pf.ligandPart.id && (
-                          <>
-                            {' ('}
-                            <ExternalLink
-                              url={externalUrls.ChEBI(
-                                pf.ligandPart.id.replace('ChEBI:', '')
-                              )}
-                            >
-                              {' '}
-                              {pf.ligandPart.id.replace('ChEBI:', '')}
-                            </ExternalLink>
-                            {') '}
-                          </>
-                        )}
-                        {pf.ligandPart.label}{' '}
-                        {pf.ligandPart.note && `; ${pf.ligandPart.note}`}
-                        {' of '}
-                      </span>
-                    )}
-                    {pf.ligand?.name}
-                    {pf.ligand.id && pf.ligand.id.startsWith('ChEBI') && (
-                      <>
-                        {' ('}
-                        <ExternalLink
-                          url={externalUrls.ChEBI(
-                            pf.ligand.id.replace('ChEBI:', '')
-                          )}
-                        >
-                          {' '}
-                          {pf.ligand.id.replace('ChEBI:', '')}
-                        </ExternalLink>
-                        {') '}
-                      </>
-                    )}
-                    {pf.ligand.label} {pf.ligand.note && `; ${pf.ligand.note}`}
-                    {pf.description && `; ${pf.description}`}
+                    <LigandDescriptionView
+                      ligand={pf.ligand}
+                      ligandPart={pf.ligandPart}
+                      description={pf.description}
+                    />
                   </li>
                 )}
               </div>

--- a/src/automatic-annotations/shared/model.ts
+++ b/src/automatic-annotations/shared/model.ts
@@ -2,7 +2,7 @@ import { Statistics } from '../../shared/types/apiModel';
 import {
   Ligand,
   LigandPart,
-} from '../../uniprotkb/components/protein-data-views/UniProtKBFeaturesView';
+} from '../../uniprotkb/components/protein-data-views/LigandDescriptionView';
 
 export type Information = {
   duplicates?: string[];

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2516,7 +2516,7 @@ exports[`Entry view should render 1`] = `
                     <sup>
                       2+
                     </sup>
-                     (
+                     A2 (
                     <a
                       href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3314\\""
                     >
@@ -2539,7 +2539,7 @@ exports[`Entry view should render 1`] = `
                     <sup>
                       2+
                     </sup>
-                     (
+                     A1 (
                     <a
                       href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3214\\""
                     >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2535,7 +2535,7 @@ exports[`Entry view should render 1`] = `
                         width="12.5"
                       />
                     </a>
-                    ) Some note of Ca
+                    ); Some note of Ca
                     <sup>
                       2+
                     </sup>
@@ -2558,7 +2558,7 @@ exports[`Entry view should render 1`] = `
                         width="12.5"
                       />
                     </a>
-                    ) Some note; description value 123
+                    ); Some note; description value 123
                     <button
                       aria-controls="48"
                       aria-expanded="false"
@@ -4137,7 +4137,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         width="12.5"
                       />
                     </a>
-                    ) 
+                    )
                     <button
                       aria-controls="21"
                       aria-expanded="false"
@@ -4382,7 +4382,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         width="12.5"
                       />
                     </a>
-                    ) 
+                    )
                     <button
                       aria-controls="26"
                       aria-expanded="false"

--- a/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
+++ b/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+import { RichText } from './FreeTextView';
+import ExternalLink from '../../../shared/components/ExternalLink';
+
+import { LocationToPath, Location } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
+
+// For Ligand and LigandPart context refer to:
+// https://github.com/ebi-uniprot/uniprot-manual/blob/main/release-notes/2022-08-03-release.md#structuring-of-binding-site-annotations
+
+// A good example with well populated Ligand fields is Q9ZGI5
+export type Ligand = {
+  name: string;
+  id?: string;
+  label?: string;
+  note?: string;
+};
+
+export type LigandPart = {
+  name?: string;
+  id?: string;
+  label?: string;
+  note?: string;
+};
+
+type LigandViewProps = {
+  ligand: Ligand | LigandPart;
+};
+const LigandView = ({ ligand }: LigandViewProps) => {
+  const id = ligand.id?.replace('ChEBI:', '');
+  return (
+    <>
+      <RichText>{ligand.name}</RichText>
+      {ligand?.label && ` ${ligand?.label}`}
+      {id && (
+        <>
+          {' ('}
+          <Link
+            to={{
+              pathname: LocationToPath[Location.UniProtKBResults],
+              search: `query=ft_binding:"${id}"`,
+            }}
+          >
+            UniProtKB
+          </Link>
+          {' | '}
+          <ExternalLink url={externalUrls.ChEBI(id)}>ChEBI</ExternalLink>
+          {') '}
+        </>
+      )}
+      <RichText>{ligand?.note}</RichText>
+    </>
+  );
+};
+
+type Props = {
+  ligand: Ligand;
+  ligandPart?: LigandPart;
+  description?: ReactNode;
+};
+
+const LigandDescriptionView = ({ ligand, ligandPart, description }: Props) => (
+  <>
+    {ligandPart && (
+      <>
+        <LigandView ligand={ligandPart} key="ligandPart" />
+        {' of '}
+      </>
+    )}
+    {ligand && <LigandView ligand={ligand} key="ligand" />}
+    {description && (
+      <>
+        {'; '}
+        {typeof description === 'string' ? (
+          <RichText>{description}</RichText>
+        ) : (
+          description
+        )}
+      </>
+    )}
+  </>
+);
+
+export default LigandDescriptionView;

--- a/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
+++ b/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
@@ -33,7 +33,7 @@ const LigandView = ({ ligand }: LigandViewProps) => {
   return (
     <>
       <RichText>{ligand.name}</RichText>
-      {ligand?.label && ` ${ligand?.label}`}
+      {ligand.label && ` ${ligand.label}`}
       {id && (
         <>
           {' ('}
@@ -50,7 +50,7 @@ const LigandView = ({ ligand }: LigandViewProps) => {
           {') '}
         </>
       )}
-      <RichText>{ligand?.note}</RichText>
+      <RichText>{ligand.note}</RichText>
     </>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
+++ b/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
@@ -46,8 +46,7 @@ const LigandView = ({ ligand }: LigandViewProps) => {
             UniProtKB
           </Link>
           {' | '}
-          <ExternalLink url={externalUrls.ChEBI(id)}>ChEBI</ExternalLink>
-          {')'}
+          <ExternalLink url={externalUrls.ChEBI(id)}>ChEBI</ExternalLink>)
         </>
       )}
       {ligand.note && <RichText>{`; ${ligand.note}`}</RichText>}

--- a/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
+++ b/src/uniprotkb/components/protein-data-views/LigandDescriptionView.tsx
@@ -47,10 +47,10 @@ const LigandView = ({ ligand }: LigandViewProps) => {
           </Link>
           {' | '}
           <ExternalLink url={externalUrls.ChEBI(id)}>ChEBI</ExternalLink>
-          {') '}
+          {')'}
         </>
       )}
-      <RichText>{ligand.note}</RichText>
+      {ligand.note && <RichText>{`; ${ligand.note}`}</RichText>}
     </>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBFeaturesView.tsx
@@ -11,18 +11,15 @@ import FeaturesView, {
 } from '../../../shared/components/views/FeaturesView';
 import { RichText } from './FreeTextView';
 import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
-import ExternalLink from '../../../shared/components/ExternalLink';
+import LigandDescriptionView, {
+  Ligand,
+  LigandPart,
+} from './LigandDescriptionView';
 
 import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
 
 import listFormat from '../../../shared/utils/listFormat';
-import {
-  getEntryPath,
-  getURLToJobWithData,
-  LocationToPath,
-  Location,
-} from '../../../app/config/urls';
-import externalUrls from '../../../shared/config/externalUrls';
+import { getEntryPath, getURLToJobWithData } from '../../../app/config/urls';
 
 import { Evidence } from '../../types/modelTypes';
 import FeatureType from '../../types/featureType';
@@ -54,23 +51,6 @@ export type FeatureData = {
   ligandPart?: LigandPart;
 }[];
 
-// For Ligand and LigandPart context refer to https://github.com/ebi-uniprot/uniprot-manual/blob/main/release-notes/2022-08-03-release.md#structuring-of-binding-site-annotations
-
-export type Ligand = {
-  name: string;
-  id?: string;
-  label?: string;
-  note?: string;
-};
-
-// Example: O14744
-export type LigandPart = {
-  name?: string;
-  id?: string;
-  label?: string;
-  note?: string;
-};
-
 export type ProtvistaFeature = {
   type: string;
   description: ReactNode;
@@ -87,32 +67,6 @@ type FeatureProps = {
   features: FeatureData;
   withTitle?: boolean;
   withDataTable?: boolean;
-};
-
-const Ligand = ({ ligand }: { ligand: Ligand | LigandPart }) => {
-  const id = ligand.id?.replace('ChEBI:', '');
-  return (
-    <>
-      <RichText>{ligand.name}</RichText>
-      {id && (
-        <>
-          {' ('}
-          <Link
-            to={{
-              pathname: LocationToPath[Location.UniProtKBResults],
-              search: `query=ft_binding:"${id}"`,
-            }}
-          >
-            UniProtKB
-          </Link>
-          {' | '}
-          <ExternalLink url={externalUrls.ChEBI(id)}>ChEBI</ExternalLink>
-          {') '}
-        </>
-      )}
-      <RichText>{ligand?.note}</RichText>
-    </>
-  );
 };
 
 export const processFeaturesData = (
@@ -148,23 +102,13 @@ export const processFeaturesData = (
       );
     }
 
-    if (feature.ligand || feature.ligandPart) {
+    if (feature.ligand) {
       description = (
-        <>
-          {feature.ligandPart && (
-            <>
-              <Ligand ligand={feature.ligandPart} key={2} />
-              {' of '}
-            </>
-          )}
-          {feature.ligand && <Ligand ligand={feature.ligand} key={1} />}
-          {description && typeof description === 'string' && (
-            <>
-              {'; '}
-              <RichText>{description}</RichText>
-            </>
-          )}
-        </>
+        <LigandDescriptionView
+          ligand={feature.ligand}
+          ligandPart={feature.ligandPart}
+          description={description}
+        />
       );
     }
 

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1700,7 +1700,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
               width="12.5"
             />
           </a>
-          ) Some note of Ca
+          ); Some note of Ca
           <sup>
             2+
           </sup>
@@ -1723,7 +1723,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
               width="12.5"
             />
           </a>
-          ) Some note; description value 123
+          ); Some note; description value 123
           <button
             aria-controls="0"
             aria-expanded="false"

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1681,7 +1681,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
           <sup>
             2+
           </sup>
-           (
+           A2 (
           <a
             href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3314\\""
           >
@@ -1704,7 +1704,7 @@ exports[`UniProtKBColumnConfiguration component should render column "ft_chain":
           <sup>
             2+
           </sup>
-           (
+           A1 (
           <a
             href="/uniprotkb?query=ft_binding:\\"ChEBICHEBI:3214\\""
           >


### PR DESCRIPTION
## Purpose
Same ligand view was appearing in both uniprotkb and unirule which can be unified.

## Approach
Create single view

## Testing
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
