### PR TITLE
xrefs: gencc, clingen, refseq, ncbi nucleotide

### DIFF
--- a/src/proteomes/components/entry/Components.tsx
+++ b/src/proteomes/components/entry/Components.tsx
@@ -51,7 +51,7 @@ export const Components: FC<
               <Fragment key={id}>
                 {index ? ', ' : ''}
                 <ExternalLink
-                  url={externalUrls.ENABrowser(id as string)}
+                  url={externalUrls.NCBINucleotide(id as string)}
                   key={id}
                 >
                   {id}

--- a/src/proteomes/components/entry/__tests__/__snapshots__/Components.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/Components.spec.tsx.snap
@@ -99,7 +99,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000663"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000663"
                   rel="noopener"
                   target="_blank"
                 >
@@ -145,7 +145,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000664"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000664"
                   rel="noopener"
                   target="_blank"
                 >
@@ -191,7 +191,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000665"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000665"
                   rel="noopener"
                   target="_blank"
                 >
@@ -237,7 +237,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000666"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000666"
                   rel="noopener"
                   target="_blank"
                 >
@@ -283,7 +283,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000667"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000667"
                   rel="noopener"
                   target="_blank"
                 >
@@ -329,7 +329,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000668"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000668"
                   rel="noopener"
                   target="_blank"
                 >
@@ -375,7 +375,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000669"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000669"
                   rel="noopener"
                   target="_blank"
                 >
@@ -421,7 +421,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000670"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000670"
                   rel="noopener"
                   target="_blank"
                 >
@@ -467,7 +467,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000671"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000671"
                   rel="noopener"
                   target="_blank"
                 >
@@ -513,7 +513,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000672"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000672"
                   rel="noopener"
                   target="_blank"
                 >
@@ -559,7 +559,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000673"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000673"
                   rel="noopener"
                   target="_blank"
                 >
@@ -605,7 +605,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000674"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000674"
                   rel="noopener"
                   target="_blank"
                 >
@@ -651,7 +651,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000675"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000675"
                   rel="noopener"
                   target="_blank"
                 >
@@ -697,7 +697,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000676"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000676"
                   rel="noopener"
                   target="_blank"
                 >
@@ -743,7 +743,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000677"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000677"
                   rel="noopener"
                   target="_blank"
                 >
@@ -789,7 +789,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000678"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000678"
                   rel="noopener"
                   target="_blank"
                 >
@@ -835,7 +835,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000679"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000679"
                   rel="noopener"
                   target="_blank"
                 >
@@ -881,7 +881,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000680"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000680"
                   rel="noopener"
                   target="_blank"
                 >
@@ -927,7 +927,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000681"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000681"
                   rel="noopener"
                   target="_blank"
                 >
@@ -973,7 +973,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000682"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000682"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1019,7 +1019,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000683"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000683"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1065,7 +1065,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000684"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000684"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1111,7 +1111,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000685"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000685"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1157,7 +1157,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000686"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000686"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1203,7 +1203,7 @@ exports[`Components view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/J01415"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/J01415"
                   rel="noopener"
                   target="_blank"
                 >

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -400,7 +400,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000663"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000663"
                   rel="noopener"
                   target="_blank"
                 >
@@ -446,7 +446,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000664"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000664"
                   rel="noopener"
                   target="_blank"
                 >
@@ -492,7 +492,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000665"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000665"
                   rel="noopener"
                   target="_blank"
                 >
@@ -538,7 +538,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000666"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000666"
                   rel="noopener"
                   target="_blank"
                 >
@@ -584,7 +584,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000667"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000667"
                   rel="noopener"
                   target="_blank"
                 >
@@ -630,7 +630,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000668"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000668"
                   rel="noopener"
                   target="_blank"
                 >
@@ -676,7 +676,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000669"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000669"
                   rel="noopener"
                   target="_blank"
                 >
@@ -722,7 +722,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000670"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000670"
                   rel="noopener"
                   target="_blank"
                 >
@@ -768,7 +768,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000671"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000671"
                   rel="noopener"
                   target="_blank"
                 >
@@ -814,7 +814,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000672"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000672"
                   rel="noopener"
                   target="_blank"
                 >
@@ -860,7 +860,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000673"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000673"
                   rel="noopener"
                   target="_blank"
                 >
@@ -906,7 +906,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000674"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000674"
                   rel="noopener"
                   target="_blank"
                 >
@@ -952,7 +952,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000675"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000675"
                   rel="noopener"
                   target="_blank"
                 >
@@ -998,7 +998,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000676"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000676"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1044,7 +1044,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000677"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000677"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1090,7 +1090,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000678"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000678"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1136,7 +1136,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000679"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000679"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1182,7 +1182,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000680"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000680"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1228,7 +1228,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000681"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000681"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1274,7 +1274,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000682"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000682"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1320,7 +1320,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000683"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000683"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1366,7 +1366,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000684"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000684"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1412,7 +1412,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000685"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000685"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1458,7 +1458,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/CM000686"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/CM000686"
                   rel="noopener"
                   target="_blank"
                 >
@@ -1504,7 +1504,7 @@ exports[`EntryMain view should render 1`] = `
               >
                 <a
                   class="external-link"
-                  href="//www.ebi.ac.uk/ena/browser/view/J01415"
+                  href="https://www.ncbi.nlm.nih.gov/nuccore/J01415"
                   rel="noopener"
                   target="_blank"
                 >

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -7,8 +7,8 @@ const externalUrls: Record<string, (id: string | number) => string> = {
     `//www.ebi.ac.uk/QuickGO/annotations?geneProductId=${id}`,
   NCBI: (id) =>
     `https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?lvl=0&id=${id}`,
+  NCBINucleotide: (id) => `https://www.ncbi.nlm.nih.gov/nuccore/${id}`,
   ENA: (id) => `//www.ebi.ac.uk/ena/data/view/${id}`,
-  ENABrowser: (id) => `//www.ebi.ac.uk/ena/browser/view/${id}`,
   // protein centric
   InterPro: (id) => `https://www.ebi.ac.uk/interpro/protein/${id}`,
   Pfam: (id) => `http://pfam.xfam.org/protein/${id}`,

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -7659,7 +7659,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                     </a>
                     <a
                       class="external-link"
-                      href="https://www.ncbi.nlm.nih.gov/nuccore/%necleotideId"
+                      href="https://www.ncbi.nlm.nih.gov/nuccore/NZ_WKPS01000046.1"
                       rel="noopener"
                       target="_blank"
                     >

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -7657,7 +7657,18 @@ exports[`Entry view should render for non-human entry 1`] = `
                         width="12.5"
                       />
                     </a>
-                    NZ_WKPS01000046.1
+                    <a
+                      class="external-link"
+                      href="https://www.ncbi.nlm.nih.gov/nuccore/%necleotideId"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      NZ_WKPS01000046.1
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
                   </li>
                 </ul>
               </div>

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -172,7 +172,7 @@ export const XRef = ({
   let text = id;
   if (implicit) {
     if (databaseType === 'SWISS-MODEL-Workspace') {
-      text = 'SWISS-MODEL-Workspace';
+      text = 'Submit a new modelling project…';
     } else if (
       (databaseType === 'ClinGen' || databaseType === 'GenCC') &&
       properties?.id

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -80,7 +80,7 @@ export const getPropertyLinkAttributes = (
   }
   const attribute = getDatabaseInfoAttribute(attributes, property);
   const id = xref.properties?.[property];
-  if (!id || !attribute || !attribute.uriLink) {
+  if (!id || !attribute?.uriLink) {
     return null;
   }
   const url = processUrlTemplate(attribute.uriLink, { [property]: id });
@@ -103,6 +103,7 @@ const propertyKeySet = new Set<PropertyKey>([
   PropertyKey.GeneId,
   PropertyKey.RefSeqNucleotideId,
   PropertyKey.RefSeqProteinId,
+  PropertyKey.NucleotideSequenceId,
 ]);
 
 export const XRef = ({

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -169,14 +169,18 @@ export const XRef = ({
     params.crc64 = crc64;
   }
 
-  let text;
+  let text = id;
   if (implicit) {
-    text =
-      databaseType === 'SWISS-MODEL-Workspace'
-        ? 'Submit a new modelling project…'
-        : 'Search…';
-  } else {
-    text = id;
+    if (databaseType === 'SWISS-MODEL-Workspace') {
+      text = 'SWISS-MODEL-Workspace';
+    } else if (
+      (databaseType === 'ClinGen' || databaseType === 'GenCC') &&
+      properties?.id
+    ) {
+      text = properties?.id;
+    } else {
+      text = 'Search…';
+    }
   }
 
   // Remove links from the xref which are the same (ie same url and text).

--- a/src/uniprotkb/config/database.ts
+++ b/src/uniprotkb/config/database.ts
@@ -64,6 +64,8 @@ export const getEntrySectionToDatabaseNames = (
     'DMDM',
     'Allergome',
     'PHI-base',
+    'ClinGen', // Implicit
+    'GenCC', // Implicit
   ]);
   entrySectionToDatabaseNames.set(
     EntrySection.Expression,

--- a/src/uniprotkb/utils/__tests__/__mocks__/databaseInfo.ts
+++ b/src/uniprotkb/utils/__tests__/__mocks__/databaseInfo.ts
@@ -4,7 +4,7 @@ import { DatabaseInfo } from '../../../types/databaseRefs';
 // showing it for when it is up and running again. Until then it will have no uriLink.
 
 // Source: /configure/uniprotkb/allDatabases
-// Retrieved: 2022-06-17
+// Retrieved: 2022-08-11
 const databaseInfo: DatabaseInfo = [
   {
     name: 'EMBL',
@@ -107,7 +107,7 @@ const databaseInfo: DatabaseInfo = [
       {
         name: 'NucleotideSequenceId',
         xmlTag: 'nucleotide sequence ID',
-        uriLink: 'https://www.ncbi.nlm.nih.gov/nuccore/%necleotideId',
+        uriLink: 'https://www.ncbi.nlm.nih.gov/nuccore/%NucleotideSequenceId',
       },
     ],
   },
@@ -327,7 +327,8 @@ const databaseInfo: DatabaseInfo = [
     name: 'IntAct',
     displayName: 'IntAct',
     category: 'PPI',
-    uriLink: 'https://www.ebi.ac.uk/intact/interactors/id:%id*',
+    uriLink:
+      'https://www.ebi.ac.uk/intact/search?query=id:%primaryAccession*#interactor',
     attributes: [
       {
         name: 'Interactions',

--- a/src/uniprotkb/utils/__tests__/__snapshots__/database.spec.ts.snap
+++ b/src/uniprotkb/utils/__tests__/__snapshots__/database.spec.ts.snap
@@ -1524,7 +1524,7 @@ Object {
       "category": "PPI",
       "displayName": "IntAct",
       "name": "IntAct",
-      "uriLink": "https://www.ebi.ac.uk/intact/interactors/id:%id*",
+      "uriLink": "https://www.ebi.ac.uk/intact/search?query=id:%primaryAccession*#interactor",
     },
     "InterPro": Object {
       "attributes": Array [
@@ -2325,7 +2325,7 @@ Object {
       "attributes": Array [
         Object {
           "name": "NucleotideSequenceId",
-          "uriLink": "https://www.ncbi.nlm.nih.gov/nuccore/%necleotideId",
+          "uriLink": "https://www.ncbi.nlm.nih.gov/nuccore/%NucleotideSequenceId",
           "xmlTag": "nucleotide sequence ID",
         },
       ],

--- a/src/uniprotkb/utils/__tests__/__snapshots__/database.spec.ts.snap
+++ b/src/uniprotkb/utils/__tests__/__snapshots__/database.spec.ts.snap
@@ -2976,6 +2976,8 @@ Object {
       "DMDM",
       "Allergome",
       "PHI-base",
+      "ClinGen",
+      "GenCC",
     ],
     "expression": Array [
       "Bgee",

--- a/src/uniprotkb/utils/__tests__/xrefUtils.spec.ts
+++ b/src/uniprotkb/utils/__tests__/xrefUtils.spec.ts
@@ -31,6 +31,11 @@ describe('xrefUtils tests', () => {
             id: 'HGNC:620',
             properties: { GeneName: 'APP' },
           },
+          {
+            database: 'HGNC',
+            id: 'HGNC:621',
+            properties: { GeneName: 'APP' },
+          },
         ],
         ['APP', 'A4', 'AD1']
       )
@@ -48,17 +53,27 @@ describe('xrefUtils tests', () => {
       {
         database: 'GenAtlas',
         implicit: true,
-        properties: { GeneName: 'APP', id: 'HGNC:620' },
+        properties: { GeneName: 'APP' },
       },
       {
         database: 'ClinGen',
         implicit: true,
-        properties: { GeneName: 'APP', id: 'HGNC:620' },
+        properties: { id: 'HGNC:620' },
+      },
+      {
+        database: 'ClinGen',
+        implicit: true,
+        properties: { id: 'HGNC:621' },
       },
       {
         database: 'GenCC',
         implicit: true,
-        properties: { GeneName: 'APP', id: 'HGNC:620' },
+        properties: { id: 'HGNC:620' },
+      },
+      {
+        database: 'GenCC',
+        implicit: true,
+        properties: { id: 'HGNC:621' },
       },
       {
         database: 'SWISS-MODEL-Workspace',

--- a/src/uniprotkb/utils/xrefUtils.ts
+++ b/src/uniprotkb/utils/xrefUtils.ts
@@ -34,12 +34,12 @@ export const getDRImplicitXrefs = (
 ) => {
   // Get DR line contingent-implicit xrefs
   const implicitDatabaseDRPresenceCheck = Object.fromEntries(
-    Object.keys(implicitDatabaseDRAbsence).map((xref) => [xref, false])
+    Object.keys(implicitDatabaseDRPresence).map((xref) => [xref, false])
   );
   const implicitDatabaseDRAbsenceCheck = Object.fromEntries(
     Object.keys(implicitDatabaseDRAbsence).map((xref) => [xref, true])
   );
-  const implicitDatabaseDRPresenceData: { [key: string]: Xref } = {};
+  const implicitDatabaseDRPresenceData: { [key: string]: Xref[] } = {};
   xrefs.forEach((xref) => {
     const { database: name } = xref;
     if (!name) {
@@ -47,13 +47,17 @@ export const getDRImplicitXrefs = (
     }
     if (name in implicitDatabaseDRPresenceCheck) {
       implicitDatabaseDRPresenceCheck[name] = true;
-      implicitDatabaseDRPresenceData[name] = xref;
+      if (name in implicitDatabaseDRPresenceData) {
+        implicitDatabaseDRPresenceData[name].push(xref);
+      } else {
+        implicitDatabaseDRPresenceData[name] = [xref];
+      }
     }
     if (name in implicitDatabaseDRAbsenceCheck) {
       implicitDatabaseDRAbsenceCheck[name] = false;
     }
   });
-
+  const geneName = geneNames?.[0];
   const foundXrefs: Xref[] = [];
   [
     [implicitDatabaseDRPresenceCheck, implicitDatabaseDRPresence],
@@ -68,22 +72,26 @@ export const getDRImplicitXrefs = (
         implicitNames.forEach((implicitName) => {
           const xref = implicitDatabaseXRefs.get(implicitName);
           if (xref) {
-            const property: Record<string, string> = {};
-            const geneName = geneNames?.[0];
-            if (geneName) {
-              property.GeneName = geneName;
-            }
             // ClinGen and GenCC HGNC-contingent implicit xrefs require the HGNC ids to form URL
-            if (name === 'HGNC') {
-              const { id } = implicitDatabaseDRPresenceData[name];
-              if (id) {
-                property.id = id;
-              }
+            if (
+              name === 'HGNC' &&
+              (implicitName === 'ClinGen' || implicitName === 'GenCC') &&
+              implicitDatabaseDRPresenceData[name]
+            ) {
+              implicitDatabaseDRPresenceData[name].forEach(({ id }) => {
+                if (id) {
+                  foundXrefs.push({
+                    ...xref,
+                    properties: { id },
+                  });
+                }
+              });
+            } else {
+              foundXrefs.push({
+                ...xref,
+                properties: { GeneName: geneName },
+              });
             }
-            foundXrefs.push({
-              ...xref,
-              properties: property,
-            });
           }
         });
       }

--- a/src/uniprotkb/utils/xrefUtils.ts
+++ b/src/uniprotkb/utils/xrefUtils.ts
@@ -58,6 +58,10 @@ export const getDRImplicitXrefs = (
     }
   });
   const geneName = geneNames?.[0];
+  const properties: Record<string, string> = {};
+  if (geneName) {
+    properties.GeneName = geneName;
+  }
   const foundXrefs: Xref[] = [];
   [
     [implicitDatabaseDRPresenceCheck, implicitDatabaseDRPresence],
@@ -89,7 +93,7 @@ export const getDRImplicitXrefs = (
             } else {
               foundXrefs.push({
                 ...xref,
-                properties: { GeneName: geneName },
+                properties,
               });
             }
           }

--- a/src/uniprotkb/utils/xrefUtils.ts
+++ b/src/uniprotkb/utils/xrefUtils.ts
@@ -33,14 +33,12 @@ export const getDRImplicitXrefs = (
   geneNames: string[]
 ) => {
   // Get DR line contingent-implicit xrefs
-  const implicitDatabaseDRPresenceCheck: { [key: string]: boolean } = {};
-  Object.keys(implicitDatabaseDRPresence).forEach((xref) => {
-    implicitDatabaseDRPresenceCheck[xref] = false;
-  });
-  const implicitDatabaseDRAbsenceCheck: { [key: string]: boolean } = {};
-  Object.keys(implicitDatabaseDRAbsence).forEach((xref) => {
-    implicitDatabaseDRAbsenceCheck[xref] = true;
-  });
+  const implicitDatabaseDRPresenceCheck = Object.fromEntries(
+    Object.keys(implicitDatabaseDRAbsence).map((xref) => [xref, false])
+  );
+  const implicitDatabaseDRAbsenceCheck = Object.fromEntries(
+    Object.keys(implicitDatabaseDRAbsence).map((xref) => [xref, true])
+  );
   const implicitDatabaseDRPresenceData: { [key: string]: Xref } = {};
   xrefs.forEach((xref) => {
     const { database: name } = xref;


### PR DESCRIPTION
## Purpose
Fix a few xref issues:

1. GenCC & ClinGen must have as many links as there are HGNC IDs
2. GenCC & ClinGen must have HGNC IDs for URL text
3. GenCC & ClinGen must be located in Disease & Variants entry page section (as well as all xrefs tab)
Jiras for above three points:
- https://www.ebi.ac.uk/panda/jira/browse/TRM-27783
- https://www.ebi.ac.uk/panda/jira/browse/TRM-28048

4. Fix RefSeq link (https://www.ebi.ac.uk/panda/jira/browse/TRM-28297)
5. Update proteomes link to NCBI nucleotides (https://www.ebi.ac.uk/panda/jira/browse/TRM-28298)

## Approach

1. Add exception to creation of implicit xref to explicitly check if GenCC & ClinGen and if so add an xref for of the HGNC IDs
2. Add exception to xref view render to handle GenCC & ClinGen case
3. Add GenCC & ClinGen to Disease & Variants section in xref config
4. Add NucleotideSequenceId to allowed propertyKeySet
5. Remove ENABrowser and add NCBI nucleotides

## Testing
Updated tests. Specifically note that GenAtlas no longer has `properties.id` but this has actually never been needed (only gene name).

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
