### PR TITLE
Pass notCustomisable to Download and condition on this to generate URL.

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -41,6 +41,7 @@ type DownloadProps = {
   accessions?: string[];
   base?: string;
   supportedFormats?: FileFormat[];
+  notCustomisable?: boolean;
 };
 
 type ExtraContent = 'url' | 'preview';
@@ -56,6 +57,7 @@ const Download: FC<DownloadProps> = ({
   accessions,
   base,
   supportedFormats,
+  notCustomisable,
 }) => {
   const { columnNames } = useColumnNames();
   const { search: queryParamFromUrl } = useLocation();
@@ -109,7 +111,7 @@ const Download: FC<DownloadProps> = ({
   // endpoint while the stream endpoint is required for downloads
   let downloadBase = base;
   if (jobResultsLocation === Location.IDMappingResult) {
-    if (jobResultsNamespace) {
+    if (jobResultsNamespace && !notCustomisable) {
       downloadBase = downloadBase?.replace('/results/', '/results/stream/');
     } else {
       downloadBase = downloadBase?.replace('/results/', '/stream/');

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -186,6 +186,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
                 onClose={() => setDisplayDownloadPanel(false)}
                 namespace={namespace}
                 base={base}
+                notCustomisable={notCustomisable}
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -330,7 +330,9 @@ const IDMappingResult = () => {
         >
           <Suspense fallback={<Loader />}>
             <IDMappingResultTable
-              namespaceOverride={namespaceOverride}
+              namespaceOverride={
+                notCustomisable ? Namespace.idmapping : namespaceOverride
+              }
               resultsDataObject={resultsDataObject}
               detailsData={detailsData}
               notCustomisable={notCustomisable}


### PR DESCRIPTION
## Purpose
[Incorrect ID mapping download url for large uniprot jobs](https://www.ebi.ac.uk/panda/jira/browse/TRM-28328)

## Approach
Pass `notCustomisable` to `Download` and condition on this to generate URL.

## Testing
Just in the browser:

ID mapping 360,382 results found for EMBL-GenBank-DDBJ → UniProtKB
003cd880ca7033a5c8685b9d2376c1772ffe84bf

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
