### PR TITLE
2022 10 mobile view click targets and homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "core-js": "3.21.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.200",
+    "franklin-sites": "0.0.202",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "7.0.1",

--- a/src/app/components/home-page/CoreData.tsx
+++ b/src/app/components/home-page/CoreData.tsx
@@ -91,7 +91,11 @@ const CoreData = () => (
     <h2 className="visually-hidden">UniProt core data</h2>
     <Tile
       title="Proteins"
-      className={cn('uniprot-grid-cell--span-3', styles['core-data-tile'])}
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3',
+        styles['core-data-tile']
+      )}
       subtitle="UniProt Knowledgebase"
       backgroundImage={
         <img
@@ -112,7 +116,10 @@ const CoreData = () => (
     </Tile>
     <Tile
       title="Species"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       subtitle="Proteomes"
       backgroundImage={
         <img
@@ -132,7 +139,10 @@ const CoreData = () => (
     </Tile>
     <Tile
       title="Protein Clusters"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       subtitle="UniRef"
       backgroundImage={
         <img
@@ -151,7 +161,10 @@ const CoreData = () => (
     </Tile>
     <Tile
       title="Sequence Archive"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       subtitle="UniParc"
       backgroundImage={
         <img

--- a/src/app/components/home-page/CoreData.tsx
+++ b/src/app/components/home-page/CoreData.tsx
@@ -118,7 +118,8 @@ const CoreData = () => (
       title="Species"
       className={cn(
         'uniprot-grid-cell--small-span-6',
-        'uniprot-grid-cell--medium-span-3'
+        'uniprot-grid-cell--medium-span-3',
+        styles['core-data-tile']
       )}
       subtitle="Proteomes"
       backgroundImage={
@@ -141,7 +142,8 @@ const CoreData = () => (
       title="Protein Clusters"
       className={cn(
         'uniprot-grid-cell--small-span-6',
-        'uniprot-grid-cell--medium-span-3'
+        'uniprot-grid-cell--medium-span-3',
+        styles['core-data-tile']
       )}
       subtitle="UniRef"
       backgroundImage={
@@ -163,7 +165,8 @@ const CoreData = () => (
       title="Sequence Archive"
       className={cn(
         'uniprot-grid-cell--small-span-6',
-        'uniprot-grid-cell--medium-span-3'
+        'uniprot-grid-cell--medium-span-3',
+        styles['core-data-tile']
       )}
       subtitle="UniParc"
       backgroundImage={

--- a/src/app/components/home-page/LatestNews.tsx
+++ b/src/app/components/home-page/LatestNews.tsx
@@ -66,7 +66,9 @@ const LatestNews = () => {
     >
       <div
         className={cn(
-          'uniprot-grid-cell--span-4',
+          'uniprot-grid-cell--small-span-12',
+          'uniprot-grid-cell--medium-span-4',
+          'uniprot-grid-cell--medium-offset-9',
           styles['latest-news__news-roll']
         )}
       >
@@ -215,35 +217,14 @@ const LatestNews = () => {
               </p>
             </article>
           </li>
-          <li>
-            <article>
-              <h3 className="tiny">
-                <Link
-                  to={generatePath(LocationToPath[Location.ReleaseNotesEntry], {
-                    accession: '2021-06-02-release',
-                  })}
-                >
-                  UniProt release 2021_03
-                </Link>
-              </h3>
-              <p
-                className={cn(
-                  styles['latest-news__abstract'],
-                  styles['latest-news__abstract--2-lines']
-                )}
-              >
-                The importance of being disordered | MobiDB-lite predictions for
-                intrinsically disordered regions | UniProtKB via AWS Open Data
-                and Amazo...
-              </p>
-            </article>
-          </li>
         </ul>
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-4',
-          styles['latest-news__middle']
+          'uniprot-grid-cell--small-span-12',
+          'uniprot-grid-cell--medium-span-4',
+          'uniprot-grid-cell--medium-offset-5',
+          styles['latest-news__blogspot']
         )}
       >
         <article>
@@ -312,7 +293,12 @@ const LatestNews = () => {
         </article>
       </div>
       <article
-        className={cn('uniprot-grid-cell--span-4', styles['latest-news__left'])}
+        className={cn(
+          'uniprot-grid-cell--small-span-12',
+          'uniprot-grid-cell--medium-span-4',
+          'uniprot-grid-cell--medium-offset-1',
+          styles['latest-news__spotlight']
+        )}
       >
         <h3>
           <ExternalLink

--- a/src/app/components/home-page/NeedHelp.tsx
+++ b/src/app/components/home-page/NeedHelp.tsx
@@ -125,12 +125,14 @@ const NeedHelp = () => {
         styles['home-page-section'],
         styles['need-help']
       )}
-      titleClassName="uniprot-grid-cell--span-12"
       noSidePadding
     >
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--medium-offset-10',
           styles['need-help__need-help-top']
         )}
       >
@@ -139,7 +141,10 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--medium-offset-10',
           styles['need-help__need-help-bottom']
         )}
       >
@@ -170,7 +175,10 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-1',
+          'uniprot-grid-cell--medium-offset-7',
           styles['need-help__attend-training-top']
         )}
       >
@@ -178,7 +186,10 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-1',
+          'uniprot-grid-cell--medium-offset-7',
           styles['need-help__attend-training-bottom']
         )}
       >
@@ -203,7 +214,10 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--medium-offset-4',
           styles['need-help__tutorial-videos-top']
         )}
       >
@@ -216,7 +230,10 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--medium-offset-4',
           styles['need-help__tutorial-videos-bottom']
         )}
       >
@@ -241,7 +258,9 @@ const NeedHelp = () => {
       </div>
       <div
         className={cn(
-          'uniprot-grid-cell--span-3',
+          'uniprot-grid-cell--small-span-6',
+          'uniprot-grid-cell--medium-span-3',
+          'uniprot-grid-cell--small-offset-1',
           styles['need-help__next-up']
         )}
       >

--- a/src/app/components/home-page/NeedHelp.tsx
+++ b/src/app/components/home-page/NeedHelp.tsx
@@ -131,7 +131,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--small-offset-1',
           'uniprot-grid-cell--medium-offset-10',
           styles['need-help__need-help-top']
         )}
@@ -143,7 +143,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--small-offset-1',
           'uniprot-grid-cell--medium-offset-10',
           styles['need-help__need-help-bottom']
         )}
@@ -177,7 +177,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-1',
+          'uniprot-grid-cell--small-offset-7',
           'uniprot-grid-cell--medium-offset-7',
           styles['need-help__attend-training-top']
         )}
@@ -188,7 +188,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-1',
+          'uniprot-grid-cell--small-offset-7',
           'uniprot-grid-cell--medium-offset-7',
           styles['need-help__attend-training-bottom']
         )}
@@ -216,7 +216,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--small-offset-1',
           'uniprot-grid-cell--medium-offset-4',
           styles['need-help__tutorial-videos-top']
         )}
@@ -232,7 +232,7 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--small-offset-1',
           'uniprot-grid-cell--medium-offset-4',
           styles['need-help__tutorial-videos-bottom']
         )}
@@ -260,7 +260,8 @@ const NeedHelp = () => {
         className={cn(
           'uniprot-grid-cell--small-span-6',
           'uniprot-grid-cell--medium-span-3',
-          'uniprot-grid-cell--small-offset-1',
+          'uniprot-grid-cell--small-offset-7',
+          'uniprot-grid-cell--medium-offset-1',
           styles['need-help__next-up']
         )}
       >

--- a/src/app/components/home-page/SupportingData.tsx
+++ b/src/app/components/home-page/SupportingData.tsx
@@ -22,59 +22,93 @@ const SupportingData = () => (
     titleClassName="uniprot-grid-cell--span-12"
     noSidePadding
   >
-    <div className="uniprot-grid-cell--span-3">
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
       <h2 className={styles['supporting-data__header']}>Supporting Data</h2>
     </div>
-    <div className="uniprot-grid-cell--span-3">
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
       <DecoratedListItem compact altStyle>
         <Link to={getNamespaceTo(Location.TaxonomyResults)}>Taxonomy</Link>
       </DecoratedListItem>
     </div>
-    <div className="uniprot-grid-cell--span-3">
-      <DecoratedListItem compact altStyle>
-        <Link to={getNamespaceTo(Location.LocationsResults)}>
-          Subcellular locations
-        </Link>
-      </DecoratedListItem>
-    </div>
-    <div className="uniprot-grid-cell--span-3">
-      <DecoratedListItem compact altStyle>
-        <Link to={getNamespaceTo(Location.UniRuleResults)}>
-          UniRule automatic annotation
-        </Link>
-      </DecoratedListItem>
-    </div>
     <div
-      className="uniprot-grid-cell--span-3"
-      style={{ display: 'inline-flex' }}
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
     >
-      <DecoratedListItem compact altStyle inline>
-        <Link to={getNamespaceTo(Location.DiseasesResults)}>Diseases</Link>
-      </DecoratedListItem>
       <DecoratedListItem compact altStyle inline>
         <Link to={getNamespaceTo(Location.KeywordsResults)}>Keywords</Link>
       </DecoratedListItem>
     </div>
-    <div className="uniprot-grid-cell--span-3">
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
       <DecoratedListItem compact altStyle>
         <Link to={getNamespaceTo(Location.CitationsResults)}>
           Literature Citations
         </Link>
       </DecoratedListItem>
     </div>
-    <div className="uniprot-grid-cell--span-3">
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
+      <DecoratedListItem compact altStyle inline>
+        <Link to={getNamespaceTo(Location.DiseasesResults)}>
+          Human diseases
+        </Link>
+      </DecoratedListItem>
+    </div>
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
       <DecoratedListItem compact altStyle>
         <Link to={getNamespaceTo(Location.DatabaseResults)}>
           Cross-referenced databases
         </Link>
       </DecoratedListItem>
     </div>
-    <div className="uniprot-grid-cell--span-3">
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-4',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
       <DecoratedListItem compact altStyle>
-        {/* TODO: update link */}
-        <Link to={getNamespaceTo(Location.ARBAResults)}>
-          ARBA automatic annotation
+        <Link to={getNamespaceTo(Location.LocationsResults)}>
+          Subcellular locations
         </Link>
+      </DecoratedListItem>
+    </div>
+    <div
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
+    >
+      <DecoratedListItem compact altStyle>
+        Automatic annotations:{' '}
+        <Link to={getNamespaceTo(Location.UniRuleResults)}>UniRule</Link>
+        {' & '}
+        <Link to={getNamespaceTo(Location.ARBAResults)}>ARBA</Link>
       </DecoratedListItem>
     </div>
   </HeroContainer>

--- a/src/app/components/home-page/UniProtData.tsx
+++ b/src/app/components/home-page/UniProtData.tsx
@@ -29,7 +29,10 @@ const UniProtData = () => (
   >
     <Tile
       title="FTP Download"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       backgroundImage={
         <img
           src={FTPIllustration}
@@ -47,7 +50,10 @@ const UniProtData = () => (
     </Tile>
     <Tile
       title="Technical Documentation"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       backgroundImage={
         <img
           src={TechDocIllustration}
@@ -67,7 +73,10 @@ const UniProtData = () => (
     </Tile>
     <Tile
       title="Programmatic Access"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       backgroundImage={
         <img
           src={ProgrammaticIllustration}
@@ -87,7 +96,10 @@ const UniProtData = () => (
     </Tile>
     <Tile
       title="Submit Data"
-      className="uniprot-grid-cell--span-3"
+      className={cn(
+        'uniprot-grid-cell--small-span-6',
+        'uniprot-grid-cell--medium-span-3'
+      )}
       backgroundImage={
         <img
           src={SubmitDataIllustration}

--- a/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
+++ b/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
@@ -51,8 +51,8 @@ exports[`non-critical HomePage component should render 1`] = `
       UniProt core data
     </h2>
     <div
-      class="uniprot-grid-cell--span-3 core-data-tile tile tile-gradient"
-      style="--tile-background: #00639a; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 core-data-tile tile tile-gradient"
+      style="--tile-background: #00639a;"
     >
       <div
         aria-hidden="true"
@@ -126,8 +126,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #e56358; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #e56358;"
     >
       <div
         aria-hidden="true"
@@ -165,8 +165,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #f2994c; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #f2994c;"
     >
       <div
         aria-hidden="true"
@@ -204,8 +204,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #88c19d; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #88c19d;"
     >
       <div
         aria-hidden="true"
@@ -247,7 +247,7 @@ exports[`non-critical HomePage component should render 1`] = `
     class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section"
   >
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
       <h2
         class="supporting-data__header"
@@ -256,7 +256,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </h2>
     </div>
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
       <div
         class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
@@ -273,56 +273,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </div>
     </div>
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
-      <div
-        class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
-      >
-        <div
-          class="decorated-list-item__content"
-        >
-          <a
-            href="/locations?query=*"
-          >
-            Subcellular locations
-          </a>
-        </div>
-      </div>
-    </div>
-    <div
-      class="uniprot-grid-cell--span-3"
-    >
-      <div
-        class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
-      >
-        <div
-          class="decorated-list-item__content"
-        >
-          <a
-            href="/unirule?query=*"
-          >
-            UniRule automatic annotation
-          </a>
-        </div>
-      </div>
-    </div>
-    <div
-      class="uniprot-grid-cell--span-3"
-      style="display: inline-flex;"
-    >
-      <div
-        class="decorated-list-item decorated-list-item--compact decorated-list-item--inline decorated-list-item--alt-style"
-      >
-        <div
-          class="decorated-list-item__content"
-        >
-          <a
-            href="/diseases?query=*"
-          >
-            Diseases
-          </a>
-        </div>
-      </div>
       <div
         class="decorated-list-item decorated-list-item--compact decorated-list-item--inline decorated-list-item--alt-style"
       >
@@ -338,7 +290,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </div>
     </div>
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
       <div
         class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
@@ -355,7 +307,24 @@ exports[`non-critical HomePage component should render 1`] = `
       </div>
     </div>
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
+    >
+      <div
+        class="decorated-list-item decorated-list-item--compact decorated-list-item--inline decorated-list-item--alt-style"
+      >
+        <div
+          class="decorated-list-item__content"
+        >
+          <a
+            href="/diseases?query=*"
+          >
+            Human diseases
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
       <div
         class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
@@ -372,7 +341,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </div>
     </div>
     <div
-      class="uniprot-grid-cell--span-3"
+      class="uniprot-grid-cell--small-span-4 uniprot-grid-cell--medium-span-3"
     >
       <div
         class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
@@ -381,9 +350,33 @@ exports[`non-critical HomePage component should render 1`] = `
           class="decorated-list-item__content"
         >
           <a
+            href="/locations?query=*"
+          >
+            Subcellular locations
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3"
+    >
+      <div
+        class="decorated-list-item decorated-list-item--compact decorated-list-item--alt-style"
+      >
+        <div
+          class="decorated-list-item__content"
+        >
+          Automatic annotations: 
+          <a
+            href="/unirule?query=*"
+          >
+            UniRule
+          </a>
+           & 
+          <a
             href="/arba?query=*"
           >
-            ARBA automatic annotation
+            ARBA
           </a>
         </div>
       </div>
@@ -393,7 +386,7 @@ exports[`non-critical HomePage component should render 1`] = `
     class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section latest-news"
   >
     <div
-      class="uniprot-grid-cell--span-4 latest-news__news-roll"
+      class="uniprot-grid-cell--small-span-12 uniprot-grid-cell--medium-span-4 uniprot-grid-cell--medium-offset-9 latest-news__news-roll"
     >
       <div
         class="latest-news__news-roll-heading"
@@ -500,28 +493,10 @@ exports[`non-critical HomePage component should render 1`] = `
             </p>
           </article>
         </li>
-        <li>
-          <article>
-            <h3
-              class="tiny"
-            >
-              <a
-                href="/release-notes/2021-06-02-release"
-              >
-                UniProt release 2021_03
-              </a>
-            </h3>
-            <p
-              class="latest-news__abstract latest-news__abstract--2-lines"
-            >
-              The importance of being disordered | MobiDB-lite predictions for intrinsically disordered regions | UniProtKB via AWS Open Data and Amazo...
-            </p>
-          </article>
-        </li>
       </ul>
     </div>
     <div
-      class="uniprot-grid-cell--span-4 latest-news__middle"
+      class="uniprot-grid-cell--small-span-12 uniprot-grid-cell--medium-span-4 uniprot-grid-cell--medium-offset-5 latest-news__blogspot"
     >
       <article>
         <a
@@ -595,7 +570,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </article>
     </div>
     <article
-      class="uniprot-grid-cell--span-4 latest-news__left"
+      class="uniprot-grid-cell--small-span-12 uniprot-grid-cell--medium-span-4 uniprot-grid-cell--medium-offset-1 latest-news__spotlight"
     >
       <h3>
         <a
@@ -640,7 +615,7 @@ exports[`non-critical HomePage component should render 1`] = `
     </h2>
     <div
       class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #00A6D5; width: 100%;"
+      style="--tile-background: #00A6D5;"
     >
       <div
         aria-hidden="true"
@@ -674,7 +649,7 @@ exports[`non-critical HomePage component should render 1`] = `
     </div>
     <div
       class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #B8CE48; width: 100%;"
+      style="--tile-background: #B8CE48;"
     >
       <div
         aria-hidden="true"
@@ -708,7 +683,7 @@ exports[`non-critical HomePage component should render 1`] = `
     </div>
     <div
       class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #357B92; width: 100%;"
+      style="--tile-background: #357B92;"
     >
       <div
         aria-hidden="true"
@@ -742,7 +717,7 @@ exports[`non-critical HomePage component should render 1`] = `
     </div>
     <div
       class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #A748BD; width: 100%;"
+      style="--tile-background: #A748BD;"
     >
       <div
         aria-hidden="true"
@@ -779,7 +754,7 @@ exports[`non-critical HomePage component should render 1`] = `
     class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section need-help"
   >
     <div
-      class="uniprot-grid-cell--span-3 need-help__need-help-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-10 need-help__need-help-top"
     >
       <h2>
         Need help?
@@ -789,7 +764,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </p>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 need-help__need-help-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-10 need-help__need-help-bottom"
     >
       <a
         class="help-center-link"
@@ -829,7 +804,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 need-help__attend-training-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-7 need-help__attend-training-top"
     >
       <img
         alt=""
@@ -840,7 +815,7 @@ exports[`non-critical HomePage component should render 1`] = `
       />
     </div>
     <div
-      class="uniprot-grid-cell--span-3 need-help__attend-training-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-7 need-help__attend-training-bottom"
     >
       <h2
         class="small"
@@ -876,10 +851,10 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 need-help__tutorial-videos-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-top"
     />
     <div
-      class="uniprot-grid-cell--span-3 need-help__tutorial-videos-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-bottom"
     >
       <a
         class="external-link"
@@ -916,7 +891,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 need-help__next-up"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 need-help__next-up"
     >
       <div
         class="loader-container"
@@ -938,8 +913,8 @@ exports[`non-critical HomePage component should render 1`] = `
       UniProt data
     </h2>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #4e5a71; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #4e5a71;"
     >
       <div
         aria-hidden="true"
@@ -974,8 +949,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #4e5a71; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #4e5a71;"
     >
       <div
         aria-hidden="true"
@@ -1008,8 +983,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #4e5a71; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #4e5a71;"
     >
       <div
         aria-hidden="true"
@@ -1042,8 +1017,8 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--span-3 tile tile-gradient"
-      style="--tile-background: #4e5a71; width: 100%;"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      style="--tile-background: #4e5a71;"
     >
       <div
         aria-hidden="true"

--- a/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
+++ b/src/app/components/home-page/__tests__/__snapshots__/NonCritical.spec.tsx.snap
@@ -126,7 +126,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 core-data-tile tile tile-gradient"
       style="--tile-background: #e56358;"
     >
       <div
@@ -165,7 +165,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 core-data-tile tile tile-gradient"
       style="--tile-background: #f2994c;"
     >
       <div
@@ -204,7 +204,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </small>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 tile tile-gradient"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 core-data-tile tile tile-gradient"
       style="--tile-background: #88c19d;"
     >
       <div
@@ -754,7 +754,7 @@ exports[`non-critical HomePage component should render 1`] = `
     class="hero-container uniprot-grid uniprot-grid--centered uniprot-grid--with-bleed home-page-section need-help"
   >
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-10 need-help__need-help-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-10 need-help__need-help-top"
     >
       <h2>
         Need help?
@@ -764,7 +764,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </p>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-10 need-help__need-help-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-10 need-help__need-help-bottom"
     >
       <a
         class="help-center-link"
@@ -804,7 +804,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-7 need-help__attend-training-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-7 need-help__attend-training-top"
     >
       <img
         alt=""
@@ -815,7 +815,7 @@ exports[`non-critical HomePage component should render 1`] = `
       />
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-7 need-help__attend-training-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-7 need-help__attend-training-bottom"
     >
       <h2
         class="small"
@@ -851,10 +851,10 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-top"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-top"
     />
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-bottom"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 uniprot-grid-cell--medium-offset-4 need-help__tutorial-videos-bottom"
     >
       <a
         class="external-link"
@@ -891,7 +891,7 @@ exports[`non-critical HomePage component should render 1`] = `
       </a>
     </div>
     <div
-      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-1 need-help__next-up"
+      class="uniprot-grid-cell--small-span-6 uniprot-grid-cell--medium-span-3 uniprot-grid-cell--small-offset-7 uniprot-grid-cell--medium-offset-1 need-help__next-up"
     >
       <div
         class="loader-container"

--- a/src/app/components/home-page/styles/non-critical.module.scss
+++ b/src/app/components/home-page/styles/non-critical.module.scss
@@ -5,6 +5,14 @@
 
 .home-page-section {
   margin-bottom: $global-margin * 2;
+
+  /* A "small tablet" breakpoint */
+  @media only screen and (max-width: 900px) and (min-width: 640px) {
+    :global(.tile__description) {
+      /* Make the description part taller to fit everything */
+      transform: translate(0);
+    }
+  }
 }
 
 .core-data-tile {

--- a/src/app/components/home-page/styles/non-critical.module.scss
+++ b/src/app/components/home-page/styles/non-critical.module.scss
@@ -46,8 +46,9 @@
 $latest-news-height: 18rem;
 
 .latest-news {
-  grid-template-rows: calc(#{$latest-news-height} - #{$global-padding});
-  height: $latest-news-height;
+  @include fs-breakpoints('medium') {
+    height: $latest-news-height;
+  }
 
   h3,
   h4 {
@@ -60,13 +61,13 @@ $latest-news-height: 18rem;
   // Mess up with the order of cells in order to have the title in the last
   // "visible" cell cover semantically all 3 cells
   & > * {
-    grid-row-start: 1;
+    @include fs-breakpoints('medium') {
+      grid-row-start: 1;
+    }
     margin-bottom: $global-padding;
   }
 
-  &__left {
-    grid-column-start: 1 !important;
-
+  &__spotlight {
     padding: 0 $global-padding;
     background: $colour-sky-white;
 
@@ -75,8 +76,7 @@ $latest-news-height: 18rem;
     }
   }
 
-  &__middle {
-    grid-column-start: 5 !important;
+  &__blogspot {
     overflow: hidden;
 
     & > * {
@@ -97,7 +97,9 @@ $latest-news-height: 18rem;
     margin-bottom: 0;
     display: flex;
     flex-direction: column;
-    max-height: calc(#{$latest-news-height} - #{$global-padding});
+    @include fs-breakpoints('medium') {
+      max-height: calc(#{$latest-news-height} - #{$global-padding});
+    }
 
     &-heading {
       display: flex;
@@ -184,8 +186,12 @@ $latest-news-height: 18rem;
   }
 
   &__next-up {
-    grid-column: 1 / span 3 !important;
-    grid-row: 1 / span 2;
+    grid-row: 3 / span 2;
+
+    @include fs-breakpoints('medium') {
+      grid-row-start: 1;
+    }
+
     align-self: stretch;
     background: $colour-sky-white;
 
@@ -229,16 +235,24 @@ $latest-news-height: 18rem;
     }
   }
 
-  &__tutorial-videos-top,
-  &__tutorial-videos-bottom {
-    grid-column-start: 4 !important;
+  &__tutorial-videos-top {
+    grid-row-start: 3;
+
+    @include fs-breakpoints('medium') {
+      grid-row-start: 1;
+    }
   }
 
   &__tutorial-videos-bottom {
     align-self: start;
-    grid-row-start: 2;
+    grid-row-start: 4;
+
+    @include fs-breakpoints('medium') {
+      grid-row-start: 2;
+    }
 
     a {
+      margin-block: 1ch;
       display: block;
       line-height: 2;
     }
@@ -246,8 +260,6 @@ $latest-news-height: 18rem;
 
   &__attend-training-top,
   &__attend-training-bottom {
-    grid-column-start: 7 !important;
-
     h2 > svg {
       color: $colour-sapphire-blue;
     }
@@ -265,11 +277,6 @@ $latest-news-height: 18rem;
 
   &__attend-training-bottom {
     grid-row-start: 2;
-  }
-
-  &__need-help-top,
-  &__need-help-bottom {
-    grid-column-start: 10 !important;
   }
 
   &__need-help-top {

--- a/src/shared/components/layouts/styles/contact.module.scss
+++ b/src/shared/components/layouts/styles/contact.module.scss
@@ -2,8 +2,11 @@
 
 .social {
   white-space: nowrap;
+  display: flex;
+  gap: 0.5em;
 
   svg {
+    height: 2em;
     fill: $colour-weldon-blue;
     color: $colour-weldon-blue;
   }

--- a/src/shared/components/layouts/styles/footer.module.scss
+++ b/src/shared/components/layouts/styles/footer.module.scss
@@ -87,8 +87,13 @@ footer.footer {
     }
 
     li {
-      margin-bottom: 1em;
-      line-height: initial;
+      padding-block: 0.2em;
+
+      * > a {
+        display: inline-block;
+        padding-block: 0.5em;
+        line-height: initial;
+      }
     }
 
     &__title {
@@ -96,7 +101,6 @@ footer.footer {
       font-size: 1rem;
       display: block;
       padding-bottom: 1ch;
-      margin-bottom: 1ch;
       border-bottom: 1px solid $colour-weldon-blue;
       font-weight: bold;
     }

--- a/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
+++ b/src/shared/components/results/__tests__/__snapshots__/ResultsData.spec.tsx.snap
@@ -105,30 +105,35 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0560"
                   >
-                     #Oxidoreductase
+                    #Oxidoreductase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
+                   
                   <a
                     href="/keywords/KW-0360"
                   >
-                     #Hereditary hemolytic anemia
+                    #Hereditary hemolytic anemia
                   </a>
                 </div>
               </small>
@@ -285,10 +290,11 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0378"
                   >
-                     #Hydrolase
+                    #Hydrolase
                   </a>
                 </div>
               </small>
@@ -415,20 +421,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0560"
                   >
-                     #Oxidoreductase
+                    #Oxidoreductase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -555,35 +564,41 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0406"
                   >
-                     #Ion transport
+                    #Ion transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0739"
                   >
-                     #Sodium transport
+                    #Sodium transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0769"
                   >
-                     #Symport
+                    #Symport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
                 </div>
               </small>
@@ -728,20 +743,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0418"
                   >
-                     #Kinase
+                    #Kinase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0808"
                   >
-                     #Transferase
+                    #Transferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0324"
                   >
-                     #Glycolysis
+                    #Glycolysis
                   </a>
                 </div>
               </small>
@@ -874,25 +892,29 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0548"
                   >
-                     #Nucleotidyltransferase
+                    #Nucleotidyltransferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0808"
                   >
-                     #Transferase
+                    #Transferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -1019,35 +1041,41 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0413"
                   >
-                     #Isomerase
+                    #Isomerase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0900"
                   >
-                     #Congenital disorder of glycosylation
+                    #Congenital disorder of glycosylation
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
+                   
                   <a
                     href="/keywords/KW-0322"
                   >
-                     #Glycogen storage disease
+                    #Glycogen storage disease
                   </a>
                 </div>
               </small>
@@ -1204,20 +1232,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0413"
                   >
-                     #Isomerase
+                    #Isomerase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -1362,35 +1393,41 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0406"
                   >
-                     #Ion transport
+                    #Ion transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0739"
                   >
-                     #Sodium transport
+                    #Sodium transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0769"
                   >
-                     #Symport
+                    #Symport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
                 </div>
               </small>
@@ -1529,35 +1566,41 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0378"
                   >
-                     #Hydrolase
+                    #Hydrolase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0511"
                   >
-                     #Multifunctional enzyme
+                    #Multifunctional enzyme
                   </a>
+                   
                   <a
                     href="/keywords/KW-0560"
                   >
-                     #Oxidoreductase
+                    #Oxidoreductase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
                 </div>
               </small>
@@ -1702,25 +1745,29 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0010"
                   >
-                     #Activator
+                    #Activator
                   </a>
+                   
                   <a
                     href="/keywords/KW-0309"
                   >
-                     #Germination
+                    #Germination
                   </a>
+                   
                   <a
                     href="/keywords/KW-0804"
                   >
-                     #Transcription
+                    #Transcription
                   </a>
+                   
                   <a
                     href="/keywords/KW-0805"
                   >
-                     #Transcription regulation
+                    #Transcription regulation
                   </a>
                 </div>
               </small>
@@ -1853,20 +1900,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0653"
                   >
-                     #Protein transport
+                    #Protein transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0833"
                   >
-                     #Ubl conjugation pathway
+                    #Ubl conjugation pathway
                   </a>
                 </div>
               </small>
@@ -1993,45 +2043,53 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0898"
                   >
-                     #Cataract
+                    #Cataract
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
+                   
                   <a
                     href="/keywords/KW-1023"
                   >
-                     #Dystonia
+                    #Dystonia
                   </a>
+                   
                   <a
                     href="/keywords/KW-0887"
                   >
-                     #Epilepsy
+                    #Epilepsy
                   </a>
+                   
                   <a
                     href="/keywords/KW-0360"
                   >
-                     #Hereditary hemolytic anemia
+                    #Hereditary hemolytic anemia
                   </a>
+                   
                   <a
                     href="/keywords/KW-0991"
                   >
-                     #Intellectual disability
+                    #Intellectual disability
                   </a>
                 </div>
               </small>
@@ -2176,25 +2234,29 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0378"
                   >
-                     #Hydrolase
+                    #Hydrolase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0312"
                   >
-                     #Gluconeogenesis
+                    #Gluconeogenesis
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
+                   
                   <a
                     href="/keywords/KW-0322"
                   >
-                     #Glycogen storage disease
+                    #Glycogen storage disease
                   </a>
                 </div>
               </small>
@@ -2339,25 +2401,29 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0548"
                   >
-                     #Nucleotidyltransferase
+                    #Nucleotidyltransferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0808"
                   >
-                     #Transferase
+                    #Transferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
+                   
                   <a
                     href="/keywords/KW-0887"
                   >
-                     #Epilepsy
+                    #Epilepsy
                   </a>
                 </div>
               </small>
@@ -2514,15 +2580,17 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>
@@ -2643,20 +2711,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0413"
                   >
-                     #Isomerase
+                    #Isomerase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -2789,25 +2860,29 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0413"
                   >
-                     #Isomerase
+                    #Isomerase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0808"
                   >
-                     #Transferase
+                    #Transferase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -2940,20 +3015,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0413"
                   >
-                     #Isomerase
+                    #Isomerase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0119"
                   >
-                     #Carbohydrate metabolism
+                    #Carbohydrate metabolism
                   </a>
+                   
                   <a
                     href="/keywords/KW-0313"
                   >
-                     #Glucose metabolism
+                    #Glucose metabolism
                   </a>
                 </div>
               </small>
@@ -3080,15 +3158,17 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>
@@ -3203,15 +3283,17 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>
@@ -3332,20 +3414,23 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0378"
                   >
-                     #Hydrolase
+                    #Hydrolase
                   </a>
+                   
                   <a
                     href="/keywords/KW-0312"
                   >
-                     #Gluconeogenesis
+                    #Gluconeogenesis
                   </a>
+                   
                   <a
                     href="/keywords/KW-0225"
                   >
-                     #Disease variant
+                    #Disease variant
                   </a>
                 </div>
               </small>
@@ -3478,30 +3563,35 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0217"
                   >
-                     #Developmental protein
+                    #Developmental protein
                   </a>
+                   
                   <a
                     href="/keywords/KW-0221"
                   >
-                     #Differentiation
+                    #Differentiation
                   </a>
+                   
                   <a
                     href="/keywords/KW-0744"
                   >
-                     #Spermatogenesis
+                    #Spermatogenesis
                   </a>
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>
@@ -3628,15 +3718,17 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>
@@ -3775,15 +3867,17 @@ exports[`ResultsData component should render the card view with the correct numb
                 <div
                   class="keyword-view--inline"
                 >
+                   
                   <a
                     href="/keywords/KW-0762"
                   >
-                     #Sugar transport
+                    #Sugar transport
                   </a>
+                   
                   <a
                     href="/keywords/KW-0813"
                   >
-                     #Transport
+                    #Transport
                   </a>
                 </div>
               </small>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -2932,10 +2932,11 @@ exports[`Entry view should render 1`] = `
                   class="expandable-list no-bullet"
                 >
                   <li>
+                     
                     <a
                       href="/keywords/KW-11111"
                     >
-                       #keyword value
+                      #keyword value
                     </a>
                     <button
                       aria-controls="49"
@@ -4827,17 +4828,19 @@ exports[`Entry view should render for non-human entry 1`] = `
                   class="expandable-list no-bullet"
                 >
                   <li>
+                     
                     <a
                       href="/keywords/KW-0326"
                     >
-                       #Glycosidase
+                      #Glycosidase
                     </a>
                   </li>
                   <li>
+                     
                     <a
                       href="/keywords/KW-0378"
                     >
-                       #Hydrolase
+                      #Hydrolase
                     </a>
                   </li>
                 </ul>
@@ -4860,10 +4863,11 @@ exports[`Entry view should render for non-human entry 1`] = `
                   class="expandable-list no-bullet"
                 >
                   <li>
+                     
                     <a
                       href="/keywords/KW-0479"
                     >
-                       #Metal-binding
+                      #Metal-binding
                     </a>
                   </li>
                 </ul>
@@ -6513,10 +6517,11 @@ exports[`Entry view should render for non-human entry 1`] = `
                   class="expandable-list no-bullet"
                 >
                   <li>
+                     
                     <a
                       href="/keywords/KW-0732"
                     >
-                       #Signal
+                      #Signal
                     </a>
                   </li>
                 </ul>
@@ -7608,10 +7613,11 @@ exports[`Entry view should render for non-human entry 1`] = `
                   class="expandable-list no-bullet"
                 >
                   <li>
+                     
                     <a
                       href="/keywords/KW-0002"
                     >
-                       #3D-structure
+                      #3D-structure
                     </a>
                   </li>
                 </ul>

--- a/src/uniprotkb/components/protein-data-views/KeywordView.tsx
+++ b/src/uniprotkb/components/protein-data-views/KeywordView.tsx
@@ -26,7 +26,7 @@ export const KeywordItem = ({ id, value }: KeywordItempProps) => {
   if (!id || !value) {
     return null;
   }
-  return <Link to={getEntryPath(Namespace.keywords, id)}>{` #${value}`}</Link>;
+  return <Link to={getEntryPath(Namespace.keywords, id)}>#{value}</Link>;
 };
 
 export const KeywordList = ({ keywords, idOnly, inline }: KeywordListProps) => {
@@ -38,6 +38,7 @@ export const KeywordList = ({ keywords, idOnly, inline }: KeywordListProps) => {
     return (
       // eslint-disable-next-line react/no-array-index-key
       <Fragment key={index}>
+        {' '}
         <KeywordItem id={id} value={idOnly ? id : name} />
         {!inline && <UniProtKBEvidenceTag evidences={evidences} />}
       </Fragment>

--- a/src/uniprotkb/components/protein-data-views/styles/keyword-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/keyword-view.module.scss
@@ -2,6 +2,11 @@
   &--inline {
     display: flex;
     flex-wrap: wrap;
-    gap: 1ch;
+    margin-block: 1ch;
+    gap: 1.5ch;
+
+    & > * {
+      padding-block: 0.5ch;
+    }
   }
 }

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1913,10 +1913,11 @@ exports[`UniProtKBColumnConfiguration component should render column "keyword": 
     class="expandable-list no-bullet"
   >
     <li>
+       
       <a
         href="/keywords/KW-11111"
       >
-         #keyword value
+        #keyword value
       </a>
       <button
         aria-controls="0"
@@ -1951,10 +1952,11 @@ exports[`UniProtKBColumnConfiguration component should render column "keywordid"
     class="expandable-list no-bullet"
   >
     <li>
+       
       <a
         href="/keywords/KW-11111"
       >
-         #KW-11111
+        #KW-11111
       </a>
       <button
         aria-controls="0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6602,10 +6602,10 @@ foundation-sites@6.7.5:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.7.5.tgz#6bc2bdd06819e6ed4d7fd8e3090246a0b6ac81c0"
   integrity sha512-MEjAENdF/IV2XQvlQmg20o+iDTyyWu0N/j440e8fKbEylbKxARzgg5S7vcnxtjukC1Lqg+rRm7ZDSSyGhVVoUQ==
 
-franklin-sites@0.0.200:
-  version "0.0.200"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.200.tgz#c93fb223fd5f8cffa44309c73754ed859f73b37a"
-  integrity sha512-OqAf96GsXaitVw0JjVUvwPVR1a1DmtdD6aUtIK+g9IegJVj95BZQEuHdb/YjfguZ+o7e1FNpF4cwi2V4Hr70Vw==
+franklin-sites@0.0.202:
+  version "0.0.202"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.202.tgz#336b6c169223735b1c6b2e2bdb5c8163596dd1ba"
+  integrity sha512-3OzGK0T3zO2U17ZyuukjNavnDbIDkYti++K+E8zHf0S+leUxZof0hmKD1iY2cklKzj7t7SMF6gcV3W4Gobg7zQ==
   dependencies:
     "@tippyjs/react" "4.2.6"
     classnames "2.3.1"


### PR DESCRIPTION
## Purpose
Mobile view for homepage https://www.ebi.ac.uk/panda/jira/browse/TRM-28225
+ fix too small click targets reported by Google Search Console

## Approach
- Use new classes in franklin to define different grid layout depending on breakpoints
  - Mainly: when 4 tiles, switch to 2 tiles per row on 2 rows
  - Add "in-between" breakpoint for when the middle size is too tight but we don't want to trigger mobile view yet
- Refactor home page content to have a better reflow when going in mobile view
- Create new specific rules for mobile view
- Check links that were reported by Google Search Console as too small or touch target overlapping with others and adjust both size (padding, for bigger click target) and spacing between them (to avoid clicking on the wrong one with touch)
  - Played with values until validated by local lighthouse audit (audit: Snapshot / Mobile / SEO)

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
