### PR TITLE
Related help

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "core-js": "3.21.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.202",
+    "franklin-sites": "0.0.203",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "7.0.1",

--- a/src/help/components/entry/Entry.tsx
+++ b/src/help/components/entry/Entry.tsx
@@ -20,6 +20,7 @@ import qs from 'query-string';
 import HTMLHead from '../../../shared/components/HTMLHead';
 import SingleColumnLayout from '../../../shared/components/layouts/SingleColumnLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
+import RelatedArticles from './RelatedArticles';
 
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 
@@ -256,6 +257,9 @@ const HelpEntry = ({
         <HelpEntryContent data={data} />
       </Card>
       {!isReleaseNotes && dateNode}
+      {!loading && accession && data.categories?.length ? (
+        <RelatedArticles current={accession} categories={data.categories} />
+      ) : null}
     </SingleColumnLayout>
   );
 };

--- a/src/help/components/entry/RelatedArticles.tsx
+++ b/src/help/components/entry/RelatedArticles.tsx
@@ -1,0 +1,80 @@
+import { DataListWithLoader } from 'franklin-sites';
+
+import HelpCard from '../results/HelpCard';
+
+import usePagination from '../../../shared/hooks/usePagination';
+
+import { help as helpURL } from '../../../shared/config/apiUrls';
+import { pluralise } from '../../../shared/utils/utils';
+
+import { HelpAPIModel, HelpUIModel } from '../../adapters/helpConverter';
+
+const getIdKey = (article: HelpUIModel) => article.id;
+
+const cardRenderer = (article: HelpUIModel) => (
+  <HelpCard id={article.id} title={article.title} />
+);
+
+const RelatedArticles = ({
+  current,
+  categories,
+}: {
+  current: string;
+  categories: string[];
+}) => {
+  // Query for help articles for all categories for this article
+  const initialANDApiUrl = helpURL.search({
+    query: `${categories
+      .map((category) => `category:"${category}"`)
+      .join(' AND ')} AND NOT id:${current}`,
+    facets: null,
+    fields: ['id', 'title'],
+  });
+  const andPayload = usePagination<HelpAPIModel, HelpUIModel>(initialANDApiUrl);
+
+  const useOR = andPayload.total === 0;
+
+  // (Bigger) query for help articles if nothing with "AND"
+  const initialORApiUrl = useOR
+    ? helpURL.search({
+        query: `(${categories
+          .map((category) => `category:"${category}"`)
+          .join(' OR ')}) AND NOT id:${current}`,
+        facets: null,
+        fields: ['id', 'title'],
+      })
+    : undefined;
+
+  const orPayload = usePagination<HelpAPIModel, HelpUIModel>(initialORApiUrl);
+
+  let payload = andPayload;
+  if (useOR) {
+    payload = orPayload;
+  }
+
+  if (payload.initialLoading || !payload.total) {
+    return null;
+  }
+
+  return (
+    <>
+      <h2>
+        Not what you are looking for? Here{' '}
+        {pluralise('is', payload.total, 'are')}{' '}
+        {payload.total > 25 ? 'some' : payload.total} related{' '}
+        {pluralise('article', payload.total)}
+      </h2>
+      <DataListWithLoader
+        getIdKey={getIdKey}
+        data={payload.allResults}
+        loading={payload.initialLoading}
+        dataRenderer={cardRenderer}
+        onLoadMoreItems={payload.handleLoadMoreRows}
+        hasMoreData={payload.hasMoreData}
+        // clickToLoad
+      />
+    </>
+  );
+};
+
+export default RelatedArticles;

--- a/src/help/components/entry/RelatedArticles.tsx
+++ b/src/help/components/entry/RelatedArticles.tsx
@@ -29,12 +29,14 @@ const RelatedArticles = ({
       .join(' AND ')} AND NOT id:${current}`,
     facets: null,
     fields: ['id', 'title'],
+    size: '5',
   });
   const andPayload = usePagination<HelpAPIModel, HelpUIModel>(initialANDApiUrl);
 
-  const useOR = andPayload.total === 0;
+  // Use OR query if no result with AND and there is more that 1 linked category
+  const useOR = andPayload.total === 0 && categories.length > 1;
 
-  // (Bigger) query for help articles if nothing with "AND"
+  // (Bigger) query for help articles
   const initialORApiUrl = useOR
     ? helpURL.search({
         query: `(${categories
@@ -42,6 +44,7 @@ const RelatedArticles = ({
           .join(' OR ')}) AND NOT id:${current}`,
         facets: null,
         fields: ['id', 'title'],
+        size: '5',
       })
     : undefined;
 
@@ -58,12 +61,7 @@ const RelatedArticles = ({
 
   return (
     <>
-      <h2>
-        Not what you are looking for? Here{' '}
-        {pluralise('is', payload.total, 'are')}{' '}
-        {payload.total > 25 ? 'some' : payload.total} related{' '}
-        {pluralise('article', payload.total)}
-      </h2>
+      <h2>related {pluralise('article', payload.total)}</h2>
       <DataListWithLoader
         getIdKey={getIdKey}
         data={payload.allResults}
@@ -71,7 +69,7 @@ const RelatedArticles = ({
         dataRenderer={cardRenderer}
         onLoadMoreItems={payload.handleLoadMoreRows}
         hasMoreData={payload.hasMoreData}
-        // clickToLoad
+        clickToLoad="Load more articles"
       />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6602,10 +6602,10 @@ foundation-sites@6.7.5:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.7.5.tgz#6bc2bdd06819e6ed4d7fd8e3090246a0b6ac81c0"
   integrity sha512-MEjAENdF/IV2XQvlQmg20o+iDTyyWu0N/j440e8fKbEylbKxARzgg5S7vcnxtjukC1Lqg+rRm7ZDSSyGhVVoUQ==
 
-franklin-sites@0.0.202:
-  version "0.0.202"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.202.tgz#336b6c169223735b1c6b2e2bdb5c8163596dd1ba"
-  integrity sha512-3OzGK0T3zO2U17ZyuukjNavnDbIDkYti++K+E8zHf0S+leUxZof0hmKD1iY2cklKzj7t7SMF6gcV3W4Gobg7zQ==
+franklin-sites@0.0.203:
+  version "0.0.203"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.203.tgz#a90ee714559f39a087db86bd90c3be5c93279b81"
+  integrity sha512-Bew7GgAijXYPI+6IOVdBh8LlNfDNC7CGWSqg800BnbOY/TAN6NzXlTEosxGk9Y9P7Hol6q4Qr8RZVOIU0ijDxQ==
   dependencies:
     "@tippyjs/react" "4.2.6"
     classnames "2.3.1"


### PR DESCRIPTION
## Purpose
Add related help articles at the bottom of each help article

## Approach
Reuse same approach as the related proteins logic
The logic is based on the categories in the metadata of the articles:
- It is getting all the categories for a given article
- It does the query of: give me all help articles containing all of the categories, minus the article we are viewing.
- If there are any matching, it displays those.
- If there are none, it tries the query of: give me all help articles containing any of the categories, minus the article we are viewing.
- If there are any matching, it displays those.
- If there are none, it displays nothing.

## Testing
Manual checks of the help pages

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
