### PR TITLE
2022 13 revise eco codes

### DIFF
--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -289,7 +289,7 @@ exports[`Entry view should render 1`] = `
             <button
               aria-controls="4"
               aria-expanded="false"
-              class="svg-colour-unreviewed evidence-tag"
+              class="svg-colour-reviewed evidence-tag"
               data-testid="evidence-tag-trigger"
               type="button"
             >
@@ -300,7 +300,7 @@ exports[`Entry view should render 1`] = `
               <span
                 class="evidence-tag__label"
               >
-                1 automatic annotation
+                PROSITE-ProRule annotation
               </span>
             </button>
             <div
@@ -312,7 +312,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="5"
             aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
+            class="svg-colour-reviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -323,7 +323,7 @@ exports[`Entry view should render 1`] = `
             <span
               class="evidence-tag__label"
             >
-              1 automatic annotation
+              PROSITE-ProRule annotation
             </span>
           </button>
           <div
@@ -388,7 +388,7 @@ exports[`Entry view should render 1`] = `
                   <button
                     aria-controls="6"
                     aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
+                    class="svg-colour-reviewed evidence-tag"
                     data-testid="evidence-tag-trigger"
                     type="button"
                   >
@@ -399,7 +399,7 @@ exports[`Entry view should render 1`] = `
                     <span
                       class="evidence-tag__label"
                     >
-                      1 automatic annotation
+                      PROSITE-ProRule annotation
                     </span>
                   </button>
                   <div
@@ -459,7 +459,7 @@ exports[`Entry view should render 1`] = `
                   <button
                     aria-controls="7"
                     aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
+                    class="svg-colour-reviewed evidence-tag"
                     data-testid="evidence-tag-trigger"
                     type="button"
                   >
@@ -470,7 +470,7 @@ exports[`Entry view should render 1`] = `
                     <span
                       class="evidence-tag__label"
                     >
-                      1 automatic annotation
+                      PROSITE-ProRule annotation
                     </span>
                   </button>
                   <div
@@ -498,7 +498,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="8"
             aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
+            class="svg-colour-reviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -509,7 +509,7 @@ exports[`Entry view should render 1`] = `
             <span
               class="evidence-tag__label"
             >
-              1 automatic annotation
+              PROSITE-ProRule annotation
             </span>
           </button>
           <div
@@ -528,7 +528,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="9"
             aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
+            class="svg-colour-reviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -539,7 +539,7 @@ exports[`Entry view should render 1`] = `
             <span
               class="evidence-tag__label"
             >
-              1 automatic annotation
+              PROSITE-ProRule annotation
             </span>
           </button>
           <div
@@ -558,7 +558,7 @@ exports[`Entry view should render 1`] = `
           <button
             aria-controls="10"
             aria-expanded="false"
-            class="svg-colour-unreviewed evidence-tag"
+            class="svg-colour-reviewed evidence-tag"
             data-testid="evidence-tag-trigger"
             type="button"
           >
@@ -569,7 +569,7 @@ exports[`Entry view should render 1`] = `
             <span
               class="evidence-tag__label"
             >
-              1 automatic annotation
+              PROSITE-ProRule annotation
             </span>
           </button>
           <div
@@ -679,7 +679,7 @@ exports[`Entry view should render 1`] = `
                   <button
                     aria-controls="11"
                     aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
+                    class="svg-colour-reviewed evidence-tag"
                     data-testid="evidence-tag-trigger"
                     type="button"
                   >
@@ -690,7 +690,7 @@ exports[`Entry view should render 1`] = `
                     <span
                       class="evidence-tag__label"
                     >
-                      1 automatic annotation
+                      PROSITE-ProRule annotation
                     </span>
                   </button>
                   <div
@@ -722,7 +722,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="12"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -733,7 +733,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -795,7 +795,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="13"
                   aria-expanded="false"
-                  class="svg-colour-unreviewed evidence-tag"
+                  class="svg-colour-reviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -806,7 +806,7 @@ exports[`Entry view should render 1`] = `
                   <span
                     class="evidence-tag__label"
                   >
-                    1 automatic annotation
+                    PROSITE-ProRule annotation
                   </span>
                 </button>
                 <div
@@ -837,7 +837,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="14"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -848,7 +848,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -860,7 +860,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="15"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -871,7 +871,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -885,7 +885,7 @@ exports[`Entry view should render 1`] = `
                       <button
                         aria-controls="16"
                         aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
+                        class="svg-colour-reviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -896,7 +896,7 @@ exports[`Entry view should render 1`] = `
                         <span
                           class="evidence-tag__label"
                         >
-                          1 automatic annotation
+                          PROSITE-ProRule annotation
                         </span>
                       </button>
                       <div
@@ -963,7 +963,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="17"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -974,7 +974,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -986,7 +986,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="18"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -997,7 +997,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1013,7 +1013,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="19"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1024,7 +1024,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1036,7 +1036,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="20"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1047,7 +1047,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1081,7 +1081,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="21"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1092,7 +1092,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1121,7 +1121,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="22"
                   aria-expanded="false"
-                  class="svg-colour-unreviewed evidence-tag"
+                  class="svg-colour-reviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1132,7 +1132,7 @@ exports[`Entry view should render 1`] = `
                   <span
                     class="evidence-tag__label"
                   >
-                    1 automatic annotation
+                    PROSITE-ProRule annotation
                   </span>
                 </button>
                 <div
@@ -1163,7 +1163,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="23"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1174,7 +1174,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1207,7 +1207,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="24"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1218,7 +1218,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1257,7 +1257,7 @@ exports[`Entry view should render 1`] = `
                   <button
                     aria-controls="25"
                     aria-expanded="false"
-                    class="svg-colour-unreviewed evidence-tag"
+                    class="svg-colour-reviewed evidence-tag"
                     data-testid="evidence-tag-trigger"
                     type="button"
                   >
@@ -1268,7 +1268,7 @@ exports[`Entry view should render 1`] = `
                     <span
                       class="evidence-tag__label"
                     >
-                      1 automatic annotation
+                      PROSITE-ProRule annotation
                     </span>
                   </button>
                   <div
@@ -1300,7 +1300,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="26"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1311,7 +1311,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1373,7 +1373,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="27"
                   aria-expanded="false"
-                  class="svg-colour-unreviewed evidence-tag"
+                  class="svg-colour-reviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1384,7 +1384,7 @@ exports[`Entry view should render 1`] = `
                   <span
                     class="evidence-tag__label"
                   >
-                    1 automatic annotation
+                    PROSITE-ProRule annotation
                   </span>
                 </button>
                 <div
@@ -1415,7 +1415,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="28"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1426,7 +1426,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1438,7 +1438,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="29"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1449,7 +1449,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1463,7 +1463,7 @@ exports[`Entry view should render 1`] = `
                       <button
                         aria-controls="30"
                         aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
+                        class="svg-colour-reviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -1474,7 +1474,7 @@ exports[`Entry view should render 1`] = `
                         <span
                           class="evidence-tag__label"
                         >
-                          1 automatic annotation
+                          PROSITE-ProRule annotation
                         </span>
                       </button>
                       <div
@@ -1537,7 +1537,7 @@ exports[`Entry view should render 1`] = `
                 <button
                   aria-controls="31"
                   aria-expanded="false"
-                  class="svg-colour-unreviewed evidence-tag"
+                  class="svg-colour-reviewed evidence-tag"
                   data-testid="evidence-tag-trigger"
                   type="button"
                 >
@@ -1548,7 +1548,7 @@ exports[`Entry view should render 1`] = `
                   <span
                     class="evidence-tag__label"
                   >
-                    1 automatic annotation
+                    PROSITE-ProRule annotation
                   </span>
                 </button>
                 <div
@@ -1579,7 +1579,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="32"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1590,7 +1590,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -1623,7 +1623,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="33"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -1634,7 +1634,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -2760,7 +2760,7 @@ exports[`Entry view should render 1`] = `
                     <button
                       aria-controls="48"
                       aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
+                      class="svg-colour-reviewed evidence-tag"
                       data-testid="evidence-tag-trigger"
                       type="button"
                     >
@@ -2771,7 +2771,7 @@ exports[`Entry view should render 1`] = `
                       <span
                         class="evidence-tag__label"
                       >
-                        1 automatic annotation
+                        PROSITE-ProRule annotation
                       </span>
                     </button>
                     <div
@@ -4245,7 +4245,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       <button
                         aria-controls="28"
                         aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
+                        class="svg-colour-reviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -4256,7 +4256,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         <span
                           class="evidence-tag__label"
                         >
-                          1 automatic annotation
+                          PROSITE-ProRule annotation
                         </span>
                       </button>
                       <div
@@ -5744,7 +5744,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                       <button
                         aria-controls="53"
                         aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
+                        class="svg-colour-reviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -5755,7 +5755,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                         <span
                           class="evidence-tag__label"
                         >
-                          1 automatic annotation
+                          PROSITE-ProRule annotation
                         </span>
                       </button>
                       <div

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
@@ -575,7 +575,7 @@ exports[`ProteinProcessingSection should render when no PTMeXchange is available
                       <button
                         aria-controls="1"
                         aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
+                        class="svg-colour-reviewed evidence-tag"
                         data-testid="evidence-tag-trigger"
                         type="button"
                       >
@@ -586,7 +586,7 @@ exports[`ProteinProcessingSection should render when no PTMeXchange is available
                         <span
                           class="evidence-tag__label"
                         >
-                          1 automatic annotation
+                          Sequence analysis
                         </span>
                       </button>
                       <div

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -44,7 +44,8 @@ export const UniProtEvidenceTagContent = ({
   return (
     <div>
       <h5 data-article-id={`evidences#${evidenceCode}`}>
-        {evidenceData.label} <small>({evidenceData.description})</small>
+        {evidenceData.label}
+        {/* {evidenceData.label} <small>({evidenceData.content})</small> */}
       </h5>
       {publicationReferences && (
         <UniProtKBEntryPublications

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -45,7 +45,7 @@ export const UniProtEvidenceTagContent = ({
     <div>
       <h5 data-article-id={`evidences#${evidenceCode}`}>
         {evidenceData.label}
-        {/* {evidenceData.label} <small>({evidenceData.content})</small> */}
+        {/* {evidenceData.label} <small>({evidenceData.description})</small> */}
       </h5>
       {publicationReferences && (
         <UniProtKBEntryPublications

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -45,7 +45,7 @@ export const UniProtEvidenceTagContent = ({
     <div>
       <h5 data-article-id={`evidences#${evidenceCode}`}>
         {evidenceData.label}
-        {/* {evidenceData.label} <small>({evidenceData.description})</small> */}
+        <small>({evidenceData.description})</small>
       </h5>
       {publicationReferences && (
         <UniProtKBEntryPublications

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/PtmExchangeEvidenceTag.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/PtmExchangeEvidenceTag.spec.tsx.snap
@@ -32,7 +32,7 @@ exports[`PtmExchangeEvidenceTag components should render 1`] = `
       >
         Automatic assertion inferred from combination of experimental and computational evidence 
         <small>
-          (Information inferred from a combination of experimental and computational evidence, without manual validation)
+          (Combinatorial evidence used in automatic assertion)
         </small>
       </h5>
       <section>

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
@@ -55,7 +55,7 @@ exports[`UniProtKBEvidenceTag components should render automatic  2`] = `
       <h5
         data-article-id="evidences#ECO:0000313"
       >
-        Automatic assertion inferred from database entries 
+        Automatic assertion inferred from database entries
         <small>
           (Automatically imported)
         </small>
@@ -77,7 +77,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 1`] 
   <button
     aria-controls="0"
     aria-expanded="false"
-    class="svg-colour-unreviewed evidence-tag"
+    class="svg-colour-reviewed evidence-tag"
     data-testid="evidence-tag-trigger"
     type="button"
   >
@@ -88,7 +88,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 1`] 
     <span
       class="evidence-tag__label"
     >
-      1 automatic annotation
+      PROSITE-ProRule annotation
     </span>
   </button>
   <div
@@ -104,7 +104,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 2`] 
   <button
     aria-controls="0"
     aria-expanded="true"
-    class="svg-colour-unreviewed evidence-tag"
+    class="svg-colour-reviewed evidence-tag"
     data-testid="evidence-tag-trigger"
     type="button"
   >
@@ -115,7 +115,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 2`] 
     <span
       class="evidence-tag__label"
     >
-      1 automatic annotation
+      PROSITE-ProRule annotation
     </span>
   </button>
   <div
@@ -127,7 +127,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 2`] 
       <h5
         data-article-id="evidences#ECO:0000255"
       >
-        Automatic assertion according to rules 
+        Manual assertion according to rules
         <small>
           (Inferred from sequence model)
         </small>
@@ -212,7 +212,7 @@ exports[`UniProtKBEvidenceTag components should render publications count 2`] = 
       <h5
         data-article-id="evidences#ECO:0000269"
       >
-        Manual assertion based on experiment 
+        Manual assertion based on experiment
         <small>
           (Inferred from experiment)
         </small>

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -50,6 +50,8 @@ enum labels {
   PUBLICATION = 'publication',
   AA = 'automatic annotation',
   SEQ_ANA = 'Sequence analysis',
+  UNIRULE_ANA = 'UniRule annotation', // HAMAP-Rule (taken from Legacy as reference)
+  PROSITE_RULE = 'PROSITE-ProRule annotation',
 }
 
 const publicationCountRenderer = (evidences: Evidence[]) => {
@@ -73,132 +75,145 @@ const rulesCountRenderer = (evidences: Evidence[]) => {
   return `${length} ${pluralise(labels.AA, length)}`;
 };
 
+const manualLabelRenderer = (evidences: Evidence[]) => {
+  let label = labels.SEQ_ANA;
+  for (const evidence of evidences) {
+    const source = evidence.source;
+    if (source === 'PROSITE-ProRule') {
+      label = labels.PROSITE_RULE;
+    } else if (source === 'HAMAP-Rule') {
+      label = labels.UNIRULE_ANA;
+    }
+  }
+  return label;
+};
+
 export const ecoCodeToData = {
   [ecoCode.EXP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from experiment',
+    content: 'Inferred from experiment',
     labelRender: publicationCountRenderer,
   },
   [ecoCode.HTP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from high throughput experiment',
+    content: 'Inferred from high throughput experiment',
   },
   [ecoCode.IDA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from direct assay',
+    content: 'Inferred from direct assay',
   },
   [ecoCode.HDA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from high throughput direct assay',
+    content: 'Inferred from high throughput direct assay',
   },
   [ecoCode.IPI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from physical interaction',
+    content: 'Inferred from physical interaction',
   },
   [ecoCode.IMP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from mutant phenotype',
+    content: 'Inferred from mutant phenotype',
   },
   [ecoCode.HMP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from high throughput mutant phenotype',
+    content: 'Inferred from high throughput mutant phenotype',
   },
   [ecoCode.IGI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from genetic interaction',
+    content: 'Inferred from genetic interaction',
   },
   [ecoCode.HGI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from high throughput genetic interaction',
+    content: 'Inferred from high throughput genetic interaction',
   },
   [ecoCode.IEP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from expression pattern',
+    content: 'Inferred from expression pattern',
   },
   [ecoCode.HEP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from high throughput expression pattern',
+    content: 'Inferred from high throughput expression pattern',
   },
   [ecoCode.ISS]: {
     manual: true,
     label: 'Manual assertion inferred from sequence similarity',
-    description:
+    content:
       'Inferred from sequence or structural similarity (Not an exact ECO match)',
     labelRender: () => labels.SIMILARITY,
   },
   [ecoCode.ISO]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from sequence orthology',
+    content: 'Inferred from sequence orthology',
   },
   [ecoCode.ISA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from sequence alignment',
+    content: 'Inferred from sequence alignment',
   },
   [ecoCode.ISM]: {
-    manual: false,
-    label: 'Automatic assertion according to rules',
-    description: 'Inferred from sequence model',
-    labelRender: rulesCountRenderer,
+    manual: true,
+    label: 'Manual assertion according to rules',
+    content: 'Inferred from sequence model',
+    labelRender: manualLabelRenderer,
   },
   [ecoCode.IGC]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from genomic context',
+    content: 'Inferred from genomic context',
   },
   [ecoCode.IBA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from biological aspect of ancestor',
+    content: 'Inferred from biological aspect of ancestor',
   },
   [ecoCode.IBD]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from biological aspect of descendant',
+    content: 'Inferred from biological aspect of descendant',
   },
   [ecoCode.IKR]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from key residues',
+    content: 'Inferred from key residues',
   },
   [ecoCode.IRD]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from rapid divergence',
+    content: 'Inferred from rapid divergence',
   },
   [ecoCode.RCA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description:
+    content:
       'Inferred from reviewed computational analysis (Not an exact ECO match) ',
   },
   [ecoCode.TAS]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Traceable author statement',
+    content: 'Traceable author statement',
   },
   [ecoCode.NAS]: {
     manual: true,
     label: 'Manual assertion based on opinion',
-    description: 'Non-traceable author statement',
+    content: 'Non-traceable author statement',
     labelRender: publicationCountRenderer,
   },
   [ecoCode.IC]: {
     manual: true,
-    label: 'Manual assertion inferred from experiment',
-    description: 'Inferred by curator',
+    label: 'Manual assertion inferred by curator',
+    content: 'Inferred by curator',
     labelRender: (evidences: Evidence[]) =>
       evidences.some((evidence) => evidence.source)
         ? publicationCountRenderer(evidences)
@@ -207,55 +222,55 @@ export const ecoCodeToData = {
   [ecoCode.ND]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'No biological data available',
+    content: 'No biological data available',
   },
   [ecoCode.IEA]: {
     manual: false,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from electronic annotation',
+    content: 'Inferred from electronic annotation',
   },
   [ecoCode.MI]: {
     manual: true,
     label: 'Manual assertion inferred from database entries',
-    description: 'Manually imported',
+    content: 'Manually imported',
     labelRender: () => labels.IMPORTED,
   },
   [ecoCode.AI]: {
     manual: false,
     label: 'Automatic assertion inferred from database entries',
-    description: 'Automatically imported',
+    content: 'Automatically imported',
     labelRender: () => labels.IMPORTED,
   },
   [ecoCode.AA]: {
     manual: false,
     label: 'Automatic assertion according to rules',
-    description: 'Automatically inferred from sequence model',
+    content: 'Automatically inferred from sequence model',
     labelRender: rulesCountRenderer,
   },
   [ecoCode.MIXM]: {
     manual: true,
     label:
       'Manual assertion inferred from combination of experimental and computational evidence',
-    description: 'Combinatorial evidence used in manual assertion',
+    content: 'Combinatorial evidence used in manual assertion',
     labelRender: () => labels.COMBINED,
   },
   [ecoCode.MIXA]: {
     manual: false,
     label:
       'Automatic assertion inferred from combination of experimental and computational evidence',
-    description: 'Combinatorial evidence used in automatic assertion',
+    content: 'Combinatorial evidence used in automatic assertion',
     labelRender: () => labels.COMBINED,
   },
   [ecoCode.SGNM]: {
     manual: true,
     label: 'Manual assertion inferred from signature match',
-    description:
+    content:
       'Match to InterPro member signature evidence used in manual assertion',
   },
   [ecoCode.SGNA]: {
     manual: false,
     label: 'Automatic assertion inferred from signature match',
-    description:
+    content:
       'Match to InterPro member signature evidence used in automatic assertion',
     labelRender: () => labels.INTERPRO,
   },
@@ -264,7 +279,7 @@ export const ecoCodeToData = {
 export type EvidenceData = {
   manual: boolean;
   label: string;
-  description: string;
+  content: string;
   labelRender?: (evidences: Evidence[]) => string;
 };
 

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -92,128 +92,128 @@ export const ecoCodeToData = {
   [ecoCode.EXP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from experiment',
+    description: 'Inferred from experiment',
     labelRender: publicationCountRenderer,
   },
   [ecoCode.HTP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from high throughput experiment',
+    description: 'Inferred from high throughput experiment',
   },
   [ecoCode.IDA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from direct assay',
+    description: 'Inferred from direct assay',
   },
   [ecoCode.HDA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from high throughput direct assay',
+    description: 'Inferred from high throughput direct assay',
   },
   [ecoCode.IPI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from physical interaction',
+    description: 'Inferred from physical interaction',
   },
   [ecoCode.IMP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from mutant phenotype',
+    description: 'Inferred from mutant phenotype',
   },
   [ecoCode.HMP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from high throughput mutant phenotype',
+    description: 'Inferred from high throughput mutant phenotype',
   },
   [ecoCode.IGI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from genetic interaction',
+    description: 'Inferred from genetic interaction',
   },
   [ecoCode.HGI]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from high throughput genetic interaction',
+    description: 'Inferred from high throughput genetic interaction',
   },
   [ecoCode.IEP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from expression pattern',
+    description: 'Inferred from expression pattern',
   },
   [ecoCode.HEP]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from high throughput expression pattern',
+    description: 'Inferred from high throughput expression pattern',
   },
   [ecoCode.ISS]: {
     manual: true,
     label: 'Manual assertion inferred from sequence similarity',
-    content:
+    description:
       'Inferred from sequence or structural similarity (Not an exact ECO match)',
     labelRender: () => labels.SIMILARITY,
   },
   [ecoCode.ISO]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from sequence orthology',
+    description: 'Inferred from sequence orthology',
   },
   [ecoCode.ISA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from sequence alignment',
+    description: 'Inferred from sequence alignment',
   },
   [ecoCode.ISM]: {
     manual: true,
     label: 'Manual assertion according to rules',
-    content: 'Inferred from sequence model',
+    description: 'Inferred from sequence model',
     labelRender: manualLabelRenderer,
   },
   [ecoCode.IGC]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from genomic context',
+    description: 'Inferred from genomic context',
   },
   [ecoCode.IBA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from biological aspect of ancestor',
+    description: 'Inferred from biological aspect of ancestor',
   },
   [ecoCode.IBD]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from biological aspect of descendant',
+    description: 'Inferred from biological aspect of descendant',
   },
   [ecoCode.IKR]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from key residues',
+    description: 'Inferred from key residues',
   },
   [ecoCode.IRD]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from rapid divergence',
+    description: 'Inferred from rapid divergence',
   },
   [ecoCode.RCA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content:
+    description:
       'Inferred from reviewed computational analysis (Not an exact ECO match) ',
   },
   [ecoCode.TAS]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'Traceable author statement',
+    description: 'Traceable author statement',
   },
   [ecoCode.NAS]: {
     manual: true,
     label: 'Manual assertion based on opinion',
-    content: 'Non-traceable author statement',
+    description: 'Non-traceable author statement',
     labelRender: publicationCountRenderer,
   },
   [ecoCode.IC]: {
     manual: true,
     label: 'Manual assertion inferred by curator',
-    content: 'Inferred by curator',
+    description: 'Inferred by curator',
     labelRender: (evidences: Evidence[]) =>
       evidences.some((evidence) => evidence.source)
         ? publicationCountRenderer(evidences)
@@ -222,55 +222,55 @@ export const ecoCodeToData = {
   [ecoCode.ND]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    content: 'No biological data available',
+    description: 'No biological data available',
   },
   [ecoCode.IEA]: {
     manual: false,
     label: 'Manual assertion based on experiment',
-    content: 'Inferred from electronic annotation',
+    description: 'Inferred from electronic annotation',
   },
   [ecoCode.MI]: {
     manual: true,
     label: 'Manual assertion inferred from database entries',
-    content: 'Manually imported',
+    description: 'Manually imported',
     labelRender: () => labels.IMPORTED,
   },
   [ecoCode.AI]: {
     manual: false,
     label: 'Automatic assertion inferred from database entries',
-    content: 'Automatically imported',
+    description: 'Automatically imported',
     labelRender: () => labels.IMPORTED,
   },
   [ecoCode.AA]: {
     manual: false,
     label: 'Automatic assertion according to rules',
-    content: 'Automatically inferred from sequence model',
+    description: 'Automatically inferred from sequence model',
     labelRender: rulesCountRenderer,
   },
   [ecoCode.MIXM]: {
     manual: true,
     label:
       'Manual assertion inferred from combination of experimental and computational evidence',
-    content: 'Combinatorial evidence used in manual assertion',
+    description: 'Combinatorial evidence used in manual assertion',
     labelRender: () => labels.COMBINED,
   },
   [ecoCode.MIXA]: {
     manual: false,
     label:
       'Automatic assertion inferred from combination of experimental and computational evidence',
-    content: 'Combinatorial evidence used in automatic assertion',
+    description: 'Combinatorial evidence used in automatic assertion',
     labelRender: () => labels.COMBINED,
   },
   [ecoCode.SGNM]: {
     manual: true,
     label: 'Manual assertion inferred from signature match',
-    content:
+    description:
       'Match to InterPro member signature evidence used in manual assertion',
   },
   [ecoCode.SGNA]: {
     manual: false,
     label: 'Automatic assertion inferred from signature match',
-    content:
+    description:
       'Match to InterPro member signature evidence used in automatic assertion',
     labelRender: () => labels.INTERPRO,
   },
@@ -279,7 +279,7 @@ export const ecoCodeToData = {
 export type EvidenceData = {
   manual: boolean;
   label: string;
-  content: string;
+  description: string;
   labelRender?: (evidences: Evidence[]) => string;
 };
 

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -33,12 +33,10 @@ export const ecoCode = {
   MI: 312,
   AI: 313,
   AA: 256,
-  MIXM: 244,
-  MIXA: 213,
+  MIXM: 7744,
+  MIXA: 7829,
   SGNM: 260,
   SGNA: 259,
-  CMBA: 7829,
-  CMBM: 7744,
 };
 
 export type EcoCode = keyof typeof ecoCode;
@@ -258,22 +256,6 @@ export const ecoCodeToData = {
     description:
       'Match to InterPro member signature evidence used in automatic assertion',
     labelRender: () => labels.INTERPRO,
-  },
-  [ecoCode.CMBA]: {
-    manual: false,
-    label:
-      'Automatic assertion inferred from combination of experimental and computational evidence',
-    description:
-      'Information inferred from a combination of experimental and computational evidence, without manual validation',
-    labelRender: () => labels.COMBINED,
-  },
-  [ecoCode.CMBM]: {
-    manual: true,
-    label:
-      'Manual assertion inferred from combination of experimental and computational evidence',
-    description:
-      'Combinatorial computational and experimental evidence used in manual assertion.',
-    labelRender: () => labels.COMBINED,
   },
 };
 

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -78,7 +78,7 @@ const rulesCountRenderer = (evidences: Evidence[]) => {
 const manualLabelRenderer = (evidences: Evidence[]) => {
   let label = labels.SEQ_ANA;
   for (const evidence of evidences) {
-    const source = evidence.source;
+    const { source } = evidence;
     if (source === 'PROSITE-ProRule') {
       label = labels.PROSITE_RULE;
     } else if (source === 'HAMAP-Rule') {

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -133,7 +133,8 @@ export const ecoCodeToData = {
   [ecoCode.ISS]: {
     manual: true,
     label: 'Manual assertion inferred from sequence similarity',
-    description: 'Inferred from sequence or structural similarity',
+    description:
+      'Inferred from sequence or structural similarity (Not an exact ECO match)',
     labelRender: () => labels.SIMILARITY,
   },
   [ecoCode.ISO]: {
@@ -180,7 +181,8 @@ export const ecoCodeToData = {
   [ecoCode.RCA]: {
     manual: true,
     label: 'Manual assertion based on experiment',
-    description: 'Inferred from reviewed computational analysis',
+    description:
+      'Inferred from reviewed computational analysis (Not an exact ECO match) ',
   },
   [ecoCode.TAS]: {
     manual: true,


### PR DESCRIPTION
## Purpose
Show Reviewed instead of automatic annotation evidence tag. (https://www.ebi.ac.uk/panda/jira/browse/TRM-26900)

## Approach
I have added two evidence labels (legacy as reference)
UNIRULE_ANA = 'UniRule annotation', 
PROSITE_RULE = 'PROSITE-ProRule annotation'

Documentation: https://www.uniprot.org/help/evidence_table

## Testing
Example entries to test: Q92824, Q9D659, W7L9E0

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
