### PR TITLE
2022 13 revise ECO codes for GO evidence tags

### DIFF
--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -233,12 +233,12 @@ const GoRibbon = ({
                   <ExternalLink url={externalUrls.QuickGO(goTerm.id)}>
                     {goTerm.termDescription || goTerm.id}
                   </ExternalLink>
+                  <GOTermEvidenceTag
+                    evidence={goTerm.properties?.GoEvidenceType}
+                  />
                   <UniProtKBEvidenceTag
                     evidences={goTerm.evidences}
                     goTermEvidence
-                  />
-                  <GOTermEvidenceTag
-                    evidence={goTerm.properties?.GoEvidenceType}
                   />
                 </td>
               </tr>
@@ -280,6 +280,12 @@ const GoRibbon = ({
       {!!filteredGoTerms.length && (
         <DatatableWithToggle>{table}</DatatableWithToggle>
       )}
+      <ExternalLink
+        url={externalUrls.QuickGOAnnotations(primaryAccession)}
+        className={styles['quickgo-link']}
+      >
+        Complete GO annotation on QuickGO{' '}
+      </ExternalLink>
     </div>
   );
 };

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -233,7 +233,10 @@ const GoRibbon = ({
                   <ExternalLink url={externalUrls.QuickGO(goTerm.id)}>
                     {goTerm.termDescription || goTerm.id}
                   </ExternalLink>
-                  <UniProtKBEvidenceTag evidences={goTerm.evidences} />
+                  <UniProtKBEvidenceTag
+                    evidences={goTerm.evidences}
+                    goTermEvidence
+                  />
                   <GOTermEvidenceTag
                     evidence={goTerm.properties?.GoEvidenceType}
                   />

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -4602,6 +4602,18 @@ exports[`Entry view should render for non-human entry 1`] = `
               Expand table
             </button>
           </div>
+          <a
+            class="external-link quickgo-link"
+            href="//www.ebi.ac.uk/QuickGO/annotations?geneProductId=P0DTR4"
+            rel="noopener"
+            target="_blank"
+          >
+            Complete GO annotation on QuickGO 
+            <test-file-stub
+              data-testid="external-link-icon"
+              width="12.5"
+            />
+          </a>
         </div>
         <h3
           data-article-id="keywords"

--- a/src/uniprotkb/components/entry/styles/go-ribbon.module.scss
+++ b/src/uniprotkb/components/entry/styles/go-ribbon.module.scss
@@ -22,3 +22,7 @@
     width: initial;
   }
 }
+
+.quickgo-link {
+  font-size: small;
+}

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -10,10 +10,13 @@ import {
   getEvidenceCodeData,
   EvidenceData,
   getEcoNumberFromString,
+  publicationCountRenderer,
+  labels,
 } from '../../config/evidenceCodes';
 import { allEntryPages } from '../../../app/config/urls';
 
 import { Evidence } from '../../types/modelTypes';
+import { pluralise } from '../../../shared/utils/utils';
 
 export enum EvidenceTagSourceTypes {
   PUBMED = 'PubMed',
@@ -99,7 +102,12 @@ const UniProtKBEvidenceTag = ({
         }
         const preferrredLabel =
           evidenceData.labelRender?.(references) ||
-          (goTermEvidence ? evidenceData.description : evidenceData.label);
+          (goTermEvidence
+            ? `${references.length} ${pluralise(
+                labels.PUBLICATION,
+                references.length
+              )}`
+            : evidenceData.label);
         return (
           <EvidenceTag
             label={preferrredLabel}

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -25,12 +25,14 @@ export type UniProtEvidenceTagContentProps = {
   evidenceCode: string;
   evidenceData: EvidenceData;
   evidences?: Evidence[];
+  useDescriptionAsLabel?: Boolean;
 };
 
 export const UniProtEvidenceTagContent = ({
   evidenceCode,
   evidenceData,
   evidences,
+  useDescriptionAsLabel,
 }: UniProtEvidenceTagContentProps) => {
   if (!evidences?.length) {
     return null;
@@ -44,8 +46,7 @@ export const UniProtEvidenceTagContent = ({
   return (
     <div>
       <h5 data-article-id={`evidences#${evidenceCode}`}>
-        {evidenceData.label}
-        <small>({evidenceData.description})</small>
+        {useDescriptionAsLabel ? evidenceData.description : evidenceData.label}
       </h5>
       {publicationReferences && (
         <UniProtKBEntryPublications
@@ -75,7 +76,13 @@ export const UniProtEvidenceTagContent = ({
   );
 };
 
-const UniProtKBEvidenceTag = ({ evidences }: { evidences?: Evidence[] }) => {
+const UniProtKBEvidenceTag = ({
+  evidences,
+  goTermEvidence,
+}: {
+  evidences?: Evidence[];
+  goTermEvidence?: Boolean;
+}) => {
   const entryPageMatch = useRouteMatch(allEntryPages);
   if (!entryPageMatch || !evidences) {
     return null;
@@ -90,9 +97,12 @@ const UniProtKBEvidenceTag = ({ evidences }: { evidences?: Evidence[] }) => {
         if (!evidenceData) {
           return null;
         }
+        const preferrredLabel =
+          evidenceData.labelRender?.(references) ||
+          (goTermEvidence ? evidenceData.description : evidenceData.label);
         return (
           <EvidenceTag
-            label={evidenceData.labelRender?.(references) || evidenceData.label}
+            label={preferrredLabel}
             className={
               evidenceData.manual
                 ? 'svg-colour-reviewed'
@@ -104,6 +114,7 @@ const UniProtKBEvidenceTag = ({ evidences }: { evidences?: Evidence[] }) => {
               evidenceCode={evidenceCode}
               evidenceData={evidenceData}
               evidences={references}
+              useDescriptionAsLabel={goTermEvidence}
             />
           </EvidenceTag>
         );

--- a/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/UniProtKBEvidenceTag.tsx
@@ -5,18 +5,17 @@ import { EvidenceTag, ExpandableList } from 'franklin-sites';
 
 import UniProtKBEntryPublications from './UniProtKBEntryPublications';
 import EvidenceLink from '../../config/evidenceUrls';
+import { pluralise } from '../../../shared/utils/utils';
 
 import {
   getEvidenceCodeData,
   EvidenceData,
   getEcoNumberFromString,
-  publicationCountRenderer,
   labels,
 } from '../../config/evidenceCodes';
 import { allEntryPages } from '../../../app/config/urls';
 
 import { Evidence } from '../../types/modelTypes';
-import { pluralise } from '../../../shared/utils/utils';
 
 export enum EvidenceTagSourceTypes {
   PUBMED = 'PubMed',
@@ -28,7 +27,7 @@ export type UniProtEvidenceTagContentProps = {
   evidenceCode: string;
   evidenceData: EvidenceData;
   evidences?: Evidence[];
-  useDescriptionAsLabel?: Boolean;
+  useDescriptionAsLabel?: boolean;
 };
 
 export const UniProtEvidenceTagContent = ({
@@ -84,7 +83,7 @@ const UniProtKBEvidenceTag = ({
   goTermEvidence,
 }: {
   evidences?: Evidence[];
-  goTermEvidence?: Boolean;
+  goTermEvidence?: boolean;
 }) => {
   const entryPageMatch = useRouteMatch(allEntryPages);
   if (!entryPageMatch || !evidences) {

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/UniProtEvidenceTag.spec.tsx.snap
@@ -55,10 +55,7 @@ exports[`UniProtKBEvidenceTag components should render automatic  2`] = `
       <h5
         data-article-id="evidences#ECO:0000313"
       >
-        Automatic assertion inferred from database entries 
-        <small>
-          (Automatically imported)
-        </small>
+        Automatic assertion inferred from database entries
       </h5>
       <ul
         class="expandable-list no-bullet"
@@ -127,10 +124,7 @@ exports[`UniProtKBEvidenceTag components should render automatic annotation 2`] 
       <h5
         data-article-id="evidences#ECO:0000255"
       >
-        Manual assertion according to rules 
-        <small>
-          (Inferred from sequence model)
-        </small>
+        Manual assertion according to rules
       </h5>
       <ul
         class="expandable-list no-bullet"
@@ -212,10 +206,7 @@ exports[`UniProtKBEvidenceTag components should render publications count 2`] = 
       <h5
         data-article-id="evidences#ECO:0000269"
       >
-        Manual assertion based on experiment 
-        <small>
-          (Inferred from experiment)
-        </small>
+        Manual assertion based on experiment
       </h5>
       <div
         class="loader-container"

--- a/src/uniprotkb/config/evidenceCodes.ts
+++ b/src/uniprotkb/config/evidenceCodes.ts
@@ -41,7 +41,7 @@ export const ecoCode = {
 
 export type EcoCode = keyof typeof ecoCode;
 
-enum labels {
+export enum labels {
   IMPORTED = 'Imported',
   COMBINED = 'Combined sources',
   INTERPRO = 'InterPro annotation',


### PR DESCRIPTION
## Purpose
The current label 'Manual assertion' that is shown for the GO evidence tag is more UniProtKBEvidence related and is also inconsistent. https://www.ebi.ac.uk/panda/jira/browse/TRM-27775

## Approach
{
manual: true/false,
label: '',
description: ''
}

From the above evidence data schema, label is used for UniProtKB related tags and description only for GO evidences. Getting rid of one is a possible solution but we don't know for sure which are common to both and not want to end up deleting a potential right one. 

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
