### PR TITLE
fix download for BLAST results

### DIFF
--- a/src/tools/blast/components/results/BlastResult.tsx
+++ b/src/tools/blast/components/results/BlastResult.tsx
@@ -10,7 +10,7 @@ import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler
 import ErrorBoundary from '../../../../shared/components/error-component/ErrorBoundary';
 import HSPDetailPanel, { HSPDetailPanelProps } from './HSPDetailPanel';
 import BlastResultSidebar from './BlastResultSidebar';
-import ResultsButtons from '../../../../shared/components/results/ResultsButtons';
+import ResultButtons from '../../../components/ResultButtons';
 
 import useDataApi, {
   UseDataAPIState,
@@ -331,13 +331,14 @@ const BlastResult = () => {
   }
 
   const actionBar = (
-    <ResultsButtons
-      namespaceOverride={namespace}
-      disableCardToggle
-      total={resultTableData?.hits.length || 0}
-      loadedTotal={resultTableData?.hits.length || 0}
+    <ResultButtons
+      namespace={namespace}
+      jobType={jobType}
+      jobId={match.params.id}
       selectedEntries={selectedEntries}
-      accessions={accessionsFilteredByLocalFacets}
+      inputParamsData={inputParamsData.data}
+      nHits={blastData.hits.length}
+      isTableResultsFiltered={blastData?.hits.length !== hitsFiltered.length}
     />
   );
 

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -13,6 +13,7 @@ import AlignButton from '../../shared/components/action-buttons/Align';
 import MapIDButton from '../../shared/components/action-buttons/MapID';
 import AddToBasketButton from '../../shared/components/action-buttons/AddToBasket';
 import ErrorBoundary from '../../shared/components/error-component/ErrorBoundary';
+import CustomiseButton from '../../shared/components/action-buttons/CustomiseButton';
 
 import { serverParametersToFormParameters } from '../adapters/parameters';
 
@@ -165,6 +166,9 @@ const ResultButtons = ({
           Download
         </Button>
         <AddToBasketButton selectedEntries={selectedEntries} />
+        {jobType === JobTypes.BLAST && (
+          <CustomiseButton namespace={namespace} />
+        )}
         <ResubmitButton inputParamsData={inputParamsData} jobType={jobType} />
       </div>
     </>


### PR DESCRIPTION
## Purpose
BLAST result download issue related to the latest column customisation (https://www.ebi.ac.uk/panda/jira/browse/TRM-28740)

## Approach
The previous resultdownload component(exclusively for Align and BLAST) is restored, with a minor change

- Additional customise columns button is added. 
- Toggle card/table is not applicable anyway (not included)
- As part of it, resubmit feature is back

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
