### PR TITLE
2022 14 db snp column

### DIFF
--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -46,6 +46,8 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   InterProEntry: (id) => `https://www.ebi.ac.uk/interpro/entry/InterPro/${id}/`,
   InterProSearch: (searchTerm) =>
     `https://www.ebi.ac.uk/interpro/search/text/${searchTerm}`,
+  // variants
+  variant: (id) => `https://web.expasy.org/variant_pages/${id}.html`,
   // citations
   DOI: (id) => `https://dx.doi.org/${id}`,
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -46,9 +46,11 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   InterProEntry: (id) => `https://www.ebi.ac.uk/interpro/entry/InterPro/${id}/`,
   InterProSearch: (searchTerm) =>
     `https://www.ebi.ac.uk/interpro/search/text/${searchTerm}`,
-  // variants
-  variant: (id) => `https://web.expasy.org/variant_pages/${id}.html`,
+  // variation
+  UniProt: (id) => `https://web.expasy.org/variant_pages/${id}.html`,
   dbSNP: (id) => `https://www.ncbi.nlm.nih.gov/snp/${id}`,
+  Ensembl: (id) =>
+    `http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${id}`,
   // citations
   DOI: (id) => `https://dx.doi.org/${id}`,
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -48,6 +48,7 @@ const externalUrls: Record<string, (id: string | number) => string> = {
     `https://www.ebi.ac.uk/interpro/search/text/${searchTerm}`,
   // variants
   variant: (id) => `https://web.expasy.org/variant_pages/${id}.html`,
+  dbSNP: (id) => `https://www.ncbi.nlm.nih.gov/snp/${id}`,
   // citations
   DOI: (id) => `https://dx.doi.org/${id}`,
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,

--- a/src/uniprotkb/adapters/uniProtkbConverter.ts
+++ b/src/uniprotkb/adapters/uniProtkbConverter.ts
@@ -102,6 +102,7 @@ export type UniProtkbUIModel = {
   annotationScore: AnnotationScoreValue;
   uniProtKBCrossReferences?: Xref[];
   lineages?: Lineage[];
+  features?: FeatureDatum[];
   [EntrySection.Function]: UIModel;
   [EntrySection.NamesAndTaxonomy]: NamesAndTaxonomyUIModel;
   [EntrySection.SubCellularLocation]: UIModel;
@@ -160,6 +161,7 @@ const uniProtKbConverter = (
     inactiveReason: dataCopy.inactiveReason,
     uniProtKBCrossReferences,
     lineages: dataCopy.lineages,
+    features: dataCopy.features,
     [EntrySection.Function]: convertFunction(
       dataCopy,
       databaseInfoMaps,

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -17,6 +17,21 @@ import { FeatureDatum } from './UniProtKBFeaturesView';
 import styles from './styles/variation-view.module.scss';
 import externalUrls from '../../../shared/config/externalUrls';
 
+export const uniprotVariantLink = (variant: FeatureDatum) => {
+  return variant.alternativeSequence?.originalSequence ||
+    variant.alternativeSequence?.alternativeSequences?.[0] ? (
+    <ExternalLink url={externalUrls.UniProt(variant.featureId || '')} noIcon>
+      {variant.alternativeSequence?.originalSequence || <em>missing</em>}
+      {'>'}
+      {variant.alternativeSequence?.alternativeSequences?.[0] || (
+        <em>missing</em>
+      )}
+    </ExternalLink>
+  ) : (
+    <em>missing</em>
+  );
+};
+
 export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
   const table = (
     <table>
@@ -47,24 +62,7 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
               <tr>
                 <td>{variant.featureId}</td>
                 <td>{position}</td>
-                <td className={styles.change}>
-                  {variant.alternativeSequence?.originalSequence ||
-                  variant.alternativeSequence?.alternativeSequences?.[0] ? (
-                    <ExternalLink
-                      url={externalUrls.variant(variant.featureId || '')}
-                      noIcon
-                    >
-                      {variant.alternativeSequence?.originalSequence || (
-                        <em>missing</em>
-                      )}
-                      {'>'}
-                      {variant.alternativeSequence
-                        ?.alternativeSequences?.[0] || <em>missing</em>}
-                    </ExternalLink>
-                  ) : (
-                    <em>missing</em>
-                  )}
-                </td>
+                <td className={styles.change}>{uniprotVariantLink(variant)}</td>
                 <td>
                   {description}
                   {rsID && (

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { InfoList, ExpandableList } from 'franklin-sites';
+import { InfoList, ExpandableList, ExternalLink } from 'franklin-sites';
 
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 import { XRef } from './XRefView';
@@ -15,6 +15,7 @@ import { Namespace } from '../../../shared/types/namespaces';
 import { FeatureDatum } from './UniProtKBFeaturesView';
 
 import styles from './styles/variation-view.module.scss';
+import externalUrls from '../../../shared/config/externalUrls';
 
 export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
   const table = (
@@ -43,14 +44,17 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
                 <td className={styles.change}>
                   {variant.alternativeSequence?.originalSequence ||
                   variant.alternativeSequence?.alternativeSequences?.[0] ? (
-                    <>
+                    <ExternalLink
+                      url={externalUrls.variant(variant.featureId || '')}
+                      noIcon
+                    >
                       {variant.alternativeSequence?.originalSequence || (
                         <em>missing</em>
                       )}
                       {'>'}
                       {variant.alternativeSequence
                         ?.alternativeSequences?.[0] || <em>missing</em>}
-                    </>
+                    </ExternalLink>
                   ) : (
                     <em>missing</em>
                   )}

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -35,6 +35,12 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
             position += `-${variant.location.end.value}`;
           }
 
+          let [description, rsID] = [variant.description, ''];
+          const dbSNPRegEx = /dbsnp:(rs\d*)/i;
+          if (description && dbSNPRegEx.test(description)) {
+            [description, rsID] = description.split(dbSNPRegEx).filter(Boolean);
+          }
+
           return (
             // eslint-disable-next-line react/no-array-index-key
             <Fragment key={i}>
@@ -60,7 +66,14 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
                   )}
                 </td>
                 <td>
-                  {variant.description}
+                  {description}
+                  {rsID && (
+                    <>
+                      <ExternalLink url={externalUrls.dbSNP(rsID)}>
+                        dbSNP:{rsID}
+                      </ExternalLink>
+                    </>
+                  )}
                   {variant.evidences && (
                     <UniProtKBEvidenceTag evidences={variant.evidences} />
                   )}

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -17,9 +17,9 @@ import { FeatureDatum } from './UniProtKBFeaturesView';
 import styles from './styles/variation-view.module.scss';
 import externalUrls from '../../../shared/config/externalUrls';
 
-export const uniprotVariantLink = (variant: FeatureDatum) => {
-  return variant.alternativeSequence?.originalSequence ||
-    variant.alternativeSequence?.alternativeSequences?.[0] ? (
+export const uniprotVariantLink = (variant: FeatureDatum) =>
+  variant.alternativeSequence?.originalSequence ||
+  variant.alternativeSequence?.alternativeSequences?.[0] ? (
     <ExternalLink url={externalUrls.UniProt(variant.featureId || '')} noIcon>
       {variant.alternativeSequence?.originalSequence || <em>missing</em>}
       {'>'}
@@ -30,7 +30,6 @@ export const uniprotVariantLink = (variant: FeatureDatum) => {
   ) : (
     <em>missing</em>
   );
-};
 
 export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
   const table = (
@@ -66,11 +65,9 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
                 <td>
                   {description}
                   {rsID && (
-                    <>
-                      <ExternalLink url={externalUrls.dbSNP(rsID)}>
-                        dbSNP:{rsID}
-                      </ExternalLink>
-                    </>
+                    <ExternalLink url={externalUrls.dbSNP(rsID)}>
+                      dbSNP:{rsID}
+                    </ExternalLink>
                   )}
                   {variant.evidences && (
                     <UniProtKBEvidenceTag evidences={variant.evidences} />

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -9,13 +9,13 @@ import DatatableWithToggle from '../../../shared/components/views/DatatableWithT
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 
 import { getEntryPath } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
 
 import { DiseaseComment } from '../../types/commentTypes';
 import { Namespace } from '../../../shared/types/namespaces';
 import { FeatureDatum } from './UniProtKBFeaturesView';
 
 import styles from './styles/variation-view.module.scss';
-import externalUrls from '../../../shared/config/externalUrls';
 
 export const uniprotVariantLink = (variant: FeatureDatum) =>
   variant.alternativeSequence?.originalSequence ||

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
@@ -131,10 +131,29 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
             <td
               class="change"
             >
-              Q&gt;P
+              <a
+                class="external-link"
+                href="https://web.expasy.org/variant_pages/VAR_019255.html"
+                rel="noopener"
+                target="_blank"
+              >
+                Q&gt;P
+              </a>
             </td>
             <td>
-              in dbSNP:rs13447459
+              in 
+              <a
+                class="external-link"
+                href="https://www.ncbi.nlm.nih.gov/snp/rs13447459"
+                rel="noopener"
+                target="_blank"
+              >
+                dbSNP:rs13447459
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
             </td>
           </tr>
           <tr>
@@ -147,10 +166,29 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
             <td
               class="change"
             >
-              I&gt;V
+              <a
+                class="external-link"
+                href="https://web.expasy.org/variant_pages/VAR_019256.html"
+                rel="noopener"
+                target="_blank"
+              >
+                I&gt;V
+              </a>
             </td>
             <td>
-              in dbSNP:rs13447492
+              in 
+              <a
+                class="external-link"
+                href="https://www.ncbi.nlm.nih.gov/snp/rs13447492"
+                rel="noopener"
+                target="_blank"
+              >
+                dbSNP:rs13447492
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
             </td>
           </tr>
         </tbody>

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -1472,27 +1472,26 @@ const getXrefColumn = (databaseName: string) => {
           })}
         </>
       );
-    } else {
-      const xrefs = data?.uniProtKBCrossReferences?.filter(
-        ({ database }) => database?.toLowerCase() === databaseName
-      );
-      const database = xrefs?.[0]?.database;
-      if (!database) {
-        // This is fine - the entry just doesn't have xrefs for this DB so just render nothing
-        return null;
-      }
-      const xrefsGoupedByDatabase = {
-        database,
-        xrefs,
-      };
-      return (
-        <DatabaseList
-          xrefsGoupedByDatabase={xrefsGoupedByDatabase}
-          primaryAccession={data.primaryAccession}
-          databaseToDatabaseInfo={databaseInfoMaps.databaseToDatabaseInfo}
-        />
-      );
     }
+    const xrefs = data?.uniProtKBCrossReferences?.filter(
+      ({ database }) => database?.toLowerCase() === databaseName
+    );
+    const database = xrefs?.[0]?.database;
+    if (!database) {
+      // This is fine - the entry just doesn't have xrefs for this DB so just render nothing
+      return null;
+    }
+    const xrefsGoupedByDatabase = {
+      database,
+      xrefs,
+    };
+    return (
+      <DatabaseList
+        xrefsGoupedByDatabase={xrefsGoupedByDatabase}
+        primaryAccession={data.primaryAccession}
+        databaseToDatabaseInfo={databaseInfoMaps.databaseToDatabaseInfo}
+      />
+    );
   };
   return {
     label: () => <Label />,

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -69,7 +69,9 @@ import {
 } from '../types/commentTypes';
 import { KeywordList } from '../components/protein-data-views/KeywordView';
 // import { DatabaseList } from '../components/protein-data-views/XRefView';
-import DiseaseInvolvementView from '../components/protein-data-views/DiseaseInvolvementView';
+import DiseaseInvolvementView, {
+  uniprotVariantLink,
+} from '../components/protein-data-views/DiseaseInvolvementView';
 import CatalyticActivityView, {
   getRheaId,
   isRheaReactionReference,
@@ -1437,25 +1439,60 @@ const getXrefColumn = (databaseName: string) => {
     if (!databaseInfoMaps) {
       return null;
     }
-    const xrefs = data?.uniProtKBCrossReferences?.filter(
-      ({ database }) => database?.toLowerCase() === databaseName
-    );
-    const database = xrefs?.[0]?.database;
-    if (!database) {
-      // This is fine - the entry just doesn't have xrefs for this DB so just render nothing
-      return null;
+
+    if (databaseName === 'dbsnp') {
+      const features = data?.features;
+      return (
+        <>
+          {features?.map((feature) => {
+            const { featureId, featureCrossReferences } = feature;
+            const dbSNPRef = featureCrossReferences?.[0];
+            return (
+              <div key={featureId}>
+                {dbSNPRef?.id && (
+                  <>
+                    {uniprotVariantLink(feature)}
+                    <span className={helper['no-wrap']}>
+                      {` ${dbSNPRef.id}`}
+                      {' ( '}
+                      <ExternalLink url={externalUrls.dbSNP(dbSNPRef.id)}>
+                        dbSNP
+                      </ExternalLink>
+                      {' | '}
+                      <ExternalLink url={externalUrls.Ensembl(dbSNPRef.id)}>
+                        Ensembl
+                      </ExternalLink>
+                      {' ) '}
+                    </span>
+                    <br />
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </>
+      );
+    } else {
+      const xrefs = data?.uniProtKBCrossReferences?.filter(
+        ({ database }) => database?.toLowerCase() === databaseName
+      );
+      const database = xrefs?.[0]?.database;
+      if (!database) {
+        // This is fine - the entry just doesn't have xrefs for this DB so just render nothing
+        return null;
+      }
+      const xrefsGoupedByDatabase = {
+        database,
+        xrefs,
+      };
+      return (
+        <DatabaseList
+          xrefsGoupedByDatabase={xrefsGoupedByDatabase}
+          primaryAccession={data.primaryAccession}
+          databaseToDatabaseInfo={databaseInfoMaps.databaseToDatabaseInfo}
+        />
+      );
     }
-    const xrefsGoupedByDatabase = {
-      database,
-      xrefs,
-    };
-    return (
-      <DatabaseList
-        xrefsGoupedByDatabase={xrefsGoupedByDatabase}
-        primaryAccession={data.primaryAccession}
-        databaseToDatabaseInfo={databaseInfoMaps.databaseToDatabaseInfo}
-      />
-    );
   };
   return {
     label: () => <Label />,

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -2052,7 +2052,52 @@ exports[`UniProtKBColumnConfiguration component should render column "xref_cptc"
 
 exports[`UniProtKBColumnConfiguration component should render column "xref_ctd": xref_ctd 1`] = `<DocumentFragment />`;
 
-exports[`UniProtKBColumnConfiguration component should render column "xref_dbsnp": xref_dbsnp 1`] = `<DocumentFragment />`;
+exports[`UniProtKBColumnConfiguration component should render column "xref_dbsnp": xref_dbsnp 1`] = `
+<DocumentFragment>
+  <div>
+    <a
+      class="external-link"
+      href="https://web.expasy.org/variant_pages/id value CHAIN.html"
+      rel="noopener"
+      target="_blank"
+    >
+      original value&gt;alternative value
+    </a>
+    <span
+      class="no-wrap"
+    >
+       db id ( 
+      <a
+        class="external-link"
+        href="https://www.ncbi.nlm.nih.gov/snp/db id"
+        rel="noopener"
+        target="_blank"
+      >
+        dbSNP
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+       | 
+      <a
+        class="external-link"
+        href="http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=db id"
+        rel="noopener"
+        target="_blank"
+      >
+        Ensembl
+        <test-file-stub
+          data-testid="external-link-icon"
+          width="12.5"
+        />
+      </a>
+       ) 
+    </span>
+    <br />
+  </div>
+</DocumentFragment>
+`;
 
 exports[`UniProtKBColumnConfiguration component should render column "xref_depod": xref_depod 1`] = `<DocumentFragment />`;
 


### PR DESCRIPTION
## Purpose
Display dbSNP cross references data(from FeatureCrossReferences unlike other xrefs). [JIRA](https://www.ebi.ac.uk/panda/jira/browse/TRM-28089)

## Approach
Information displayed are as follows:

- Variant change with link to UniProt variant page
- rsID
- Links to dbSNP and Ensembl

Description is there in the data but left out as it started to look cluttered. I will attach screenshot for reference.
Example in Legacy for one such with extra description - https://legacy.uniprot.org/uniprot/?query=database%3A%28type%3Adbsnp%29+AND+A0A1B0GTW7&sort=score

Links to dbSNP and UniProt variant pages are added in Disease and variants section following Elisabeth's comment in the JIRA.(http://localhost:8080/uniprotkb/P78363/entry#disease_variants)

## Testing
Updated the snapshots

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
