### PR TITLE
add map to feature to UniRef entries + change ID mapping form

### DIFF
--- a/src/shared/components/__tests__/MapTo.spec.tsx
+++ b/src/shared/components/__tests__/MapTo.spec.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { MapToDropdown, MapToDropdownBasic } from '../MapTo';
+
+import customRender from '../../__test-helpers__/customRender';
+
+describe('MapToDropdownBasic', () => {
+  it('should render the basic component', () => {
+    const { asFragment } = customRender(
+      <MapToDropdownBasic
+        config={[
+          {
+            key: 'uniparcCount',
+            to: { pathname: '/path' },
+            count: 10,
+            label: 'UniParc',
+          },
+        ]}
+      >
+        Map to
+      </MapToDropdownBasic>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(asFragment()).toMatchSnapshot();
+  });
+});
+
+describe('MapToDropdown', () => {
+  it('should render the advanced component with basic config', () => {
+    const { asFragment } = customRender(
+      <MapToDropdown
+        statistics={{
+          reviewedProteinCount: 10,
+          unreviewedProteinCount: 608,
+        }}
+        accession="ARBA00013665"
+      />,
+      {
+        route: '/unirule/ARBA00013665',
+      }
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/shared/components/__tests__/__snapshots__/MapTo.spec.tsx.snap
+++ b/src/shared/components/__tests__/__snapshots__/MapTo.spec.tsx.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MapToDropdown should render the advanced component with basic config 1`] = `
+<DocumentFragment>
+  <div
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="dropdown"
+  >
+    <button
+      class="button tertiary"
+      type="button"
+    >
+      View proteins
+    </button>
+    <div
+      class="dropdown__content"
+    >
+      <ul>
+        <li>
+          <a
+            href="/uniprotkb?query=(source:ARBA00013665)"
+          >
+            UniProtKB (618)
+          </a>
+        </li>
+        <li>
+          <a
+            href="/uniprotkb?facets=reviewed:true&query=(source:ARBA00013665)"
+          >
+            UniProtKB reviewed (Swiss-Prot) (10)
+          </a>
+        </li>
+        <li>
+          <a
+            href="/uniprotkb?facets=reviewed:false&query=(source:ARBA00013665)"
+          >
+            UniProtKB unreviewed (TrEMBL) (608)
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`MapToDropdownBasic should render the basic component 1`] = `
+<DocumentFragment>
+  <div
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="dropdown"
+  >
+    <button
+      class="button tertiary"
+      type="button"
+    >
+      Map to
+    </button>
+    <div
+      class="dropdown__content"
+    >
+      <ul>
+        <li>
+          <a
+            href="/path"
+          >
+            UniParc (10)
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -123,8 +123,11 @@ const AlignForm = ({ initialFormValues }: Props) => {
   );
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
-  // flag to see if the user manually changed the title
-  const [jobNameEdited, setJobNameEdited] = useState(false);
+  // flag to see if a title has been set (either user, or predefined)
+  const [jobNameEdited, setJobNameEdited] = useState(
+    // default to true if it's been set through the history state
+    Boolean(initialFormValues[AlignFields.name].selected)
+  );
   // store parsed sequence objects
   const [parsedSequences, setParsedSequences] = useState<SequenceObject[]>(
     sequenceProcessor(

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -155,8 +155,11 @@ const BlastForm = ({ initialFormValues }: Props) => {
   );
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
-  // flag to see if the user manually changed the title
-  const [jobNameEdited, setJobNameEdited] = useState(false);
+  // flag to see if a title has been set (either user, or predefined)
+  const [jobNameEdited, setJobNameEdited] = useState(
+    // default to true if it's been set through the history state
+    Boolean(initialFormValues[BlastFields.name].selected)
+  );
   // store parsed sequence objects
   const [parsedSequences, setParsedSequences] = useState<SequenceObject[]>(
     sequenceProcessor(

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -258,7 +258,7 @@ const IDMappingForm = ({ initialFormValues, formConfigData }: Props) => {
     });
   };
 
-  useEffect(() => setSubmitDisabled(textIDs.trim().length === 0), [textIDs]);
+  useEffect(() => setSubmitDisabled(isInvalid(parsedIDs)), [parsedIDs]);
 
   useTextFileInput({
     inputRef: fileInputRef,

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -331,9 +331,17 @@ const IDMappingForm = ({ initialFormValues, formConfigData }: Props) => {
               data-hj-allow
             />
             {parsedIDs.length > 0 && (
-              <Message level="info">
+              <Message
+                level={parsedIDs.length > ID_MAPPING_LIMIT ? 'failure' : 'info'}
+              >
                 Your input contains <LongNumber>{parsedIDs.length}</LongNumber>
                 {pluralise(' ID', parsedIDs.length)}
+                {parsedIDs.length > ID_MAPPING_LIMIT && (
+                  <>
+                    . Only up to <LongNumber>{ID_MAPPING_LIMIT}</LongNumber>{' '}
+                    supported
+                  </>
+                )}
               </Message>
             )}
           </section>

--- a/src/tools/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
+++ b/src/tools/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`IDMappingForm test Renders the form 1`] = `
         class="tools-form-section__item tools-form-section__item--full-width"
       >
         <legend>
-          Enter your IDs or
+          Enter one of more IDs (100,000 max). You may also
           <label
             class="tools-form-section__file-input"
           >

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -111,8 +111,11 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
   const [submitDisabled, setSubmitDisabled] = useState(true);
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
-  // flag to see if the user manually changed the title
-  const [jobNameEdited, setJobNameEdited] = useState(false);
+  // flag to see if a title has been set (either user, or predefined)
+  const [jobNameEdited, setJobNameEdited] = useState(
+    // default to true if it's been set through the history state
+    Boolean(initialFormValues[PeptideSearchFields.name].selected)
+  );
 
   // actual form fields
   const [peps, setPeps] = useState<

--- a/src/uniref/components/entry/Entry.tsx
+++ b/src/uniref/components/entry/Entry.tsx
@@ -11,10 +11,7 @@ import BasketStatus from '../../../basket/BasketStatus';
 import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
 import BlastButton from '../../../shared/components/action-buttons/Blast';
 import EntryDownload from '../../../shared/components/entry/EntryDownload';
-import {
-  MapToConfig,
-  MapToDropdownBasic,
-} from '../../../shared/components/MapTo';
+import { MapToDropdownBasic } from '../../../shared/components/MapTo';
 
 import SideBarLayout from '../../../shared/components/layouts/SideBarLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';

--- a/src/uniref/components/entry/Entry.tsx
+++ b/src/uniref/components/entry/Entry.tsx
@@ -1,5 +1,6 @@
 import { useRouteMatch } from 'react-router-dom';
 import { Loader } from 'franklin-sites';
+import { partition } from 'lodash-es';
 
 import HTMLHead from '../../../shared/components/HTMLHead';
 import EntryTitle from '../../../shared/components/entry/EntryTitle';
@@ -10,6 +11,10 @@ import BasketStatus from '../../../basket/BasketStatus';
 import AddToBasketButton from '../../../shared/components/action-buttons/AddToBasket';
 import BlastButton from '../../../shared/components/action-buttons/Blast';
 import EntryDownload from '../../../shared/components/entry/EntryDownload';
+import {
+  MapToConfig,
+  MapToDropdownBasic,
+} from '../../../shared/components/MapTo';
 
 import SideBarLayout from '../../../shared/components/layouts/SideBarLayout';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
@@ -73,6 +78,11 @@ const Entry = () => {
 
   const transformedData = uniRefConverter(data);
 
+  const [uniParcMembers, uniProtKBMembers] = partition(
+    transformedData.members,
+    (member) => member.startsWith('UPI')
+  );
+
   return (
     <SideBarLayout
       sidebar={<MembersFacets accession={accession} />}
@@ -100,6 +110,42 @@ const Entry = () => {
             }
             <EntryDownload nResults={transformedData.memberCount} />
             <AddToBasketButton selectedEntries={accession} />
+            <MapToDropdownBasic
+              config={[
+                {
+                  key: 'proteinCount',
+                  count: uniProtKBMembers.length,
+                  label: 'UniProtKB',
+                  to: {
+                    pathname: LocationToPath[Location.IDMapping],
+                    state: {
+                      parameters: {
+                        ids: uniProtKBMembers,
+                        name: `${accession} UniProtKB members`,
+                      },
+                    },
+                  },
+                },
+                {
+                  key: 'uniparcCount',
+                  count: uniParcMembers.length,
+                  label: 'UniParc',
+                  to: {
+                    pathname: LocationToPath[Location.IDMapping],
+                    state: {
+                      parameters: {
+                        ids: uniParcMembers,
+                        from: 'UniParc',
+                        to: 'UniParc',
+                        name: `${accession} UniParc members`,
+                      },
+                    },
+                  },
+                },
+              ]}
+            >
+              Map to proteins
+            </MapToDropdownBasic>
           </div>
         </ErrorBoundary>
       }


### PR DESCRIPTION
## Purpose
Add the UniRef map to feature using ID Mapping [TRM-28956](https://www.ebi.ac.uk/panda/jira/browse/TRM-28956)

## Approach
Refactor and reuse the "MapTo" dropdown
Prepopulate an ID mapping form with the corresponding data and the correct from/to fields
Fix and prepopulate the job name field
Refactor tools forms for consistency and for the above name prepopulation fix

## Testing
Manual testing + added unit test for snapshots of links being generated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
