### PR TITLE
Add warning message in download panel for more than 1000 matches

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -6,7 +6,7 @@ import cn from 'classnames';
 import ColumnSelect from '../column-select/ColumnSelect';
 import DownloadPreview from './DownloadPreview';
 import DownloadAPIURL, { DOWNLOAD_SIZE_LIMIT } from './DownloadAPIURL';
-import { MAX_FACETS } from '../../../tools/peptide-search/components/results/PeptideSearchResult';
+import { MAX_PEPTIDE_FACETS_OR_DOWNLOAD } from '../../../tools/peptide-search/components/results/PeptideSearchResult';
 
 import useColumnNames from '../../hooks/useColumnNames';
 import useJobFromUrl from '../../hooks/useJobFromUrl';
@@ -184,7 +184,7 @@ const Download: FC<DownloadProps> = ({
   // Peptide search download for matches exceeding the threshold
   const redirectToIDMapping =
     jobResultsLocation === Location.PeptideSearchResult &&
-    downloadCount > MAX_FACETS;
+    downloadCount > MAX_PEPTIDE_FACETS_OR_DOWNLOAD;
 
   return (
     <>
@@ -264,7 +264,8 @@ const Download: FC<DownloadProps> = ({
       {redirectToIDMapping && (
         <Message level="warning">
           To download the peptide search results of more than{' '}
-          <LongNumber>{MAX_FACETS}</LongNumber> matches, please use the{' '}
+          <LongNumber>{MAX_PEPTIDE_FACETS_OR_DOWNLOAD}</LongNumber> matches,
+          please use the{' '}
           <Link
             to={{
               pathname: LocationToPath[Location.IDMapping],

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -264,7 +264,7 @@ const Download: FC<DownloadProps> = ({
       {redirectToIDMapping && (
         <Message level="warning">
           To download the peptide search results of more than{' '}
-          <LongNumber>{MAX_FACETS}</LongNumber> matches, we recommend using{' '}
+          <LongNumber>{MAX_FACETS}</LongNumber> matches, please use the{' '}
           <Link
             to={{
               pathname: LocationToPath[Location.IDMapping],

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -263,7 +263,7 @@ const Download: FC<DownloadProps> = ({
       {/* Peptide search download for matches exceeding the threshold */}
       {redirectToIDMapping && (
         <Message level="warning">
-          To download the peptide search results of more than{' '}
+          To download peptide search results of more than{' '}
           <LongNumber>{MAX_PEPTIDE_FACETS_OR_DOWNLOAD}</LongNumber> matches,
           please use the{' '}
           <Link

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -6,6 +6,7 @@ import cn from 'classnames';
 import ColumnSelect from '../column-select/ColumnSelect';
 import DownloadPreview from './DownloadPreview';
 import DownloadAPIURL, { DOWNLOAD_SIZE_LIMIT } from './DownloadAPIURL';
+import { MAX_FACETS } from '../../../tools/peptide-search/components/results/PeptideSearchResult';
 
 import useColumnNames from '../../hooks/useColumnNames';
 import useJobFromUrl from '../../hooks/useJobFromUrl';
@@ -180,6 +181,11 @@ const Download: FC<DownloadProps> = ({
 
   const downloadCount = downloadAll ? totalNumberResults : nSelectedEntries;
 
+  // Peptide search download for matches exceeding the threshold
+  const redirectToIDMapping =
+    jobResultsLocation === Location.PeptideSearchResult &&
+    downloadCount > MAX_FACETS;
+
   return (
     <>
       <label htmlFor="data-selection-false">
@@ -190,7 +196,7 @@ const Download: FC<DownloadProps> = ({
           value="false"
           checked={!downloadAll}
           onChange={handleDownloadAllChange}
-          disabled={nSelectedEntries === 0}
+          disabled={nSelectedEntries === 0 || redirectToIDMapping}
         />
         Download selected (<LongNumber>{nSelectedEntries}</LongNumber>)
       </label>
@@ -202,6 +208,7 @@ const Download: FC<DownloadProps> = ({
           value="true"
           checked={downloadAll}
           onChange={handleDownloadAllChange}
+          disabled={redirectToIDMapping}
         />
         Download all (<LongNumber>{totalNumberResults}</LongNumber>)
       </label>
@@ -213,6 +220,7 @@ const Download: FC<DownloadProps> = ({
             data-testid="file-format-select"
             value={fileFormat}
             onChange={(e) => setFileFormat(e.target.value as FileFormat)}
+            disabled={redirectToIDMapping}
           >
             {fileFormats.map((format) => (
               <option value={format} key={format}>
@@ -234,6 +242,7 @@ const Download: FC<DownloadProps> = ({
               value="true"
               checked={compressed}
               onChange={handleCompressedChange}
+              disabled={redirectToIDMapping}
             />
             Yes
           </label>
@@ -245,11 +254,34 @@ const Download: FC<DownloadProps> = ({
               value="false"
               checked={!compressed}
               onChange={handleCompressedChange}
+              disabled={redirectToIDMapping}
             />
             No
           </label>
         </fieldset>
       )}
+      {/* Peptide search download for matches exceeding the threshold */}
+      {redirectToIDMapping && (
+        <Message level="warning">
+          To download the peptide search results of more than{' '}
+          <LongNumber>{MAX_FACETS}</LongNumber> matches, we recommend using{' '}
+          <Link
+            to={{
+              pathname: LocationToPath[Location.IDMapping],
+              state: {
+                parameters: {
+                  ids: accessions,
+                  name: `Peptide search matches`,
+                },
+              },
+            }}
+          >
+            ID Mapping
+          </Link>{' '}
+          service.
+        </Message>
+      )}
+
       {hasColumns && (
         <>
           <legend>Customize columns</legend>
@@ -268,12 +300,17 @@ const Download: FC<DownloadProps> = ({
           styles['action-buttons']
         )}
       >
-        <Button variant="tertiary" onClick={() => displayExtraContent('url')}>
+        <Button
+          variant="tertiary"
+          onClick={() => displayExtraContent('url')}
+          disabled={redirectToIDMapping}
+        >
           Generate URL for API
         </Button>
         <Button
           variant="tertiary"
           onClick={() => displayExtraContent('preview')}
+          disabled={redirectToIDMapping}
         >
           Preview{' '}
           {namespace === Namespace.unisave && !selectedEntries.length
@@ -287,7 +324,8 @@ const Download: FC<DownloadProps> = ({
         <a
           href={downloadCount > DOWNLOAD_SIZE_LIMIT ? undefined : downloadUrl}
           className={cn('button', 'primary', {
-            disabled: downloadCount > DOWNLOAD_SIZE_LIMIT,
+            disabled:
+              downloadCount > DOWNLOAD_SIZE_LIMIT || redirectToIDMapping,
           })}
           title={
             downloadCount > DOWNLOAD_SIZE_LIMIT

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -81,7 +81,7 @@ type Params = {
   subPage?: TabLocation;
 };
 
-const MAX_FACETS = 1_000;
+export const MAX_FACETS = 1_000;
 
 const PeptideSearchResult = ({
   toolsState,

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -30,7 +30,11 @@ import {
   Namespace,
   namespaceAndToolsLabels,
 } from '../../../../shared/types/namespaces';
-import { Location, changePathnameOnly } from '../../../../app/config/urls';
+import {
+  Location,
+  changePathnameOnly,
+  LocationToPath,
+} from '../../../../app/config/urls';
 import peptideSearchConverter from '../../adapters/peptideSearchConverter';
 
 import { UniProtkbAPIModel } from '../../../../uniprotkb/adapters/uniProtkbConverter';
@@ -81,7 +85,7 @@ type Params = {
   subPage?: TabLocation;
 };
 
-export const MAX_FACETS = 1_000;
+export const MAX_PEPTIDE_FACETS_OR_DOWNLOAD = 1_000;
 
 const PeptideSearchResult = ({
   toolsState,
@@ -125,7 +129,8 @@ const PeptideSearchResult = ({
     [jobResultData]
   );
 
-  const excessAccessions = accessions && accessions?.length > MAX_FACETS;
+  const excessAccessions =
+    accessions && accessions?.length > MAX_PEPTIDE_FACETS_OR_DOWNLOAD;
 
   // Query for facets
   const initialApiFacetUrl = useNSQuery({
@@ -247,8 +252,23 @@ const PeptideSearchResult = ({
           <Suspense fallback={<Loader />}>
             {excessAccessions && (
               <Message level="warning">
-                Filters are not supported for peptide results if there are more
-                than <LongNumber>{MAX_FACETS}</LongNumber> matches.
+                To filter the peptide search results of more than{' '}
+                <LongNumber>{MAX_PEPTIDE_FACETS_OR_DOWNLOAD}</LongNumber>{' '}
+                matches, please use the{' '}
+                <Link
+                  to={{
+                    pathname: LocationToPath[Location.IDMapping],
+                    state: {
+                      parameters: {
+                        ids: accessions,
+                        name: `Peptide search matches`,
+                      },
+                    },
+                  }}
+                >
+                  ID Mapping
+                </Link>{' '}
+                service.
               </Message>
             )}
 

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -252,7 +252,7 @@ const PeptideSearchResult = ({
           <Suspense fallback={<Loader />}>
             {excessAccessions && (
               <Message level="warning">
-                To filter the peptide search results of more than{' '}
+                To filter peptide search results of more than{' '}
                 <LongNumber>{MAX_PEPTIDE_FACETS_OR_DOWNLOAD}</LongNumber>{' '}
                 matches, please use the{' '}
                 <Link


### PR DESCRIPTION
## Purpose
Fix peptide search download for more than 1000 matches by redirecting to ID mapping
https://www.ebi.ac.uk/panda/jira/browse/TRM-28800

## Approach
A warning message with a link to ID mapping and all the things present in the download panel disabled.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
