### PR TITLE
Show ID mapping errors returned by backend in Tools dashboard

### DIFF
--- a/src/tools/id-mapping/types/idMappingSearchResults.ts
+++ b/src/tools/id-mapping/types/idMappingSearchResults.ts
@@ -31,7 +31,7 @@ export enum MappingErrorCode {
   Other = 50,
 }
 
-type MappingError = {
+export type MappingError = {
   code: MappingErrorCode;
   message: string;
 };

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -17,6 +17,7 @@ import { RunningJob, FinishedJob } from '../types/toolsJob';
 import { Status } from '../types/toolsStatuses';
 import { BlastResults } from '../blast/types/blastResults';
 import { JobTypes } from '../types/toolsJobTypes';
+import { MappingError } from '../id-mapping/types/idMappingSearchResults';
 
 const possibleStatuses = new Set(Object.values(Status));
 
@@ -75,6 +76,24 @@ const getCheckJobStatus =
       ) {
         // job was already finished, and is still in the same state on the server
         return;
+      }
+      if (job.type === JobTypes.ID_MAPPING && status === Status.FAILURE) {
+        const errorResponse: { jobStatus: Status; errors: MappingError[] } =
+          await response.json();
+        if (errorResponse) {
+          const error = errorResponse.errors[0];
+          dispatch(
+            updateJob(job.internalID, {
+              timeLastUpdate: Date.now(),
+              status: status as
+                | Status.NOT_FOUND
+                | Status.RUNNING
+                | Status.FAILURE
+                | Status.ERRORED,
+              errorDescription: error.message,
+            })
+          );
+        }
       }
       if (
         status === Status.NOT_FOUND ||

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -104,11 +104,7 @@ const getCheckJobStatus =
         dispatch(
           updateJob(job.internalID, {
             timeLastUpdate: Date.now(),
-            status: status as
-              | Status.NOT_FOUND
-              | Status.RUNNING
-              | Status.FAILURE
-              | Status.ERRORED,
+            status,
           })
         );
         return;

--- a/src/tools/state/getCheckJobStatus.ts
+++ b/src/tools/state/getCheckJobStatus.ts
@@ -85,11 +85,7 @@ const getCheckJobStatus =
           dispatch(
             updateJob(job.internalID, {
               timeLastUpdate: Date.now(),
-              status: status as
-                | Status.NOT_FOUND
-                | Status.RUNNING
-                | Status.FAILURE
-                | Status.ERRORED,
+              status,
               errorDescription: error.message,
             })
           );


### PR DESCRIPTION
## Purpose
We are not showing the failure messages for ID mapping jobs which is provided by Backend.
https://www.ebi.ac.uk/panda/jira/browse/TRM-28947

## Approach
Include the 'ErrorDescription' in the dispatch object

To review:
The error messages are not very helpful in case of error code 50

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
