### PR TITLE
Advanced search form issue for _name / _id fields

### DIFF
--- a/src/query-builder/components/AutocompleteField.tsx
+++ b/src/query-builder/components/AutocompleteField.tsx
@@ -15,7 +15,7 @@ const AutocompleteField: FC<{
     () => initializer(field, initialValue) as string
   );
   const [selectedId, setSelectedId] = useState<string | undefined>(
-    () => initializer(field, initialValue) as string
+    () => initializer(field, initialValue, true) as string
   );
 
   const { autoComplete, term, label, id, autoCompleteQueryTerm } = field;

--- a/src/query-builder/utils/__tests__/fieldInitializer.spec.ts
+++ b/src/query-builder/utils/__tests__/fieldInitializer.spec.ts
@@ -1,0 +1,24 @@
+import initializer from '../fieldInitializer';
+
+import { idToSearchTerm } from '../../components/__tests__/__mocks__/configureSearchTerms';
+
+describe('field initializer', () => {
+  it('should return autocomplete name value when provided', () => {
+    expect(
+      initializer(idToSearchTerm.organism_name_field, {
+        organism_name: 'human',
+      })
+    ).toEqual('human');
+  });
+  it('should return autocomplete id value when provided', () => {
+    expect(
+      initializer(
+        idToSearchTerm.organism_name_field,
+        {
+          organism_id: '9606',
+        },
+        true
+      )
+    ).toEqual('9606');
+  });
+});

--- a/src/query-builder/utils/fieldInitializer.ts
+++ b/src/query-builder/utils/fieldInitializer.ts
@@ -21,14 +21,15 @@ const initializer = (
     return '*';
   }
 
-  // Deal with autocomplete fields (they use 'autoCompleteQueryTerm')
-  // instead of 'term'
+  // Deal with autocomplete fields as they have two terms with different behavior:
+  //   1. autoCompleteQueryTerm: for ID searches eg organism_id
+  //   2. term: for text searches eg organism_name
   if (initialValue && field.autoCompleteQueryTerm) {
     if (Object.keys(initialValue).includes(field.autoCompleteQueryTerm)) {
-      // Exact id search with _id suffix
+      // ID search
       return initialValue[field.autoCompleteQueryTerm];
     }
-    // Text search with _name suffix
+    // Text search
     return isAutoCompleteQueryId ? '' : initialValue[field.term];
   }
 

--- a/src/query-builder/utils/fieldInitializer.ts
+++ b/src/query-builder/utils/fieldInitializer.ts
@@ -5,7 +5,8 @@ const dateRange = /^\[(\*|\d{4}-\d{2}-\d{2}) TO (\*|\d{4}-\d{2}-\d{2})\]$/;
 
 const initializer = (
   field: SearchTermType,
-  initialValue?: QueryBit
+  initialValue?: QueryBit,
+  isAutoCompleteQueryId = false
 ): string | [from: string, to: string] => {
   // specific case for free text search
   if (field.term === 'All') {
@@ -22,12 +23,13 @@ const initializer = (
 
   // Deal with autocomplete fields (they use 'autoCompleteQueryTerm')
   // instead of 'term'
-  if (
-    initialValue &&
-    field.autoCompleteQueryTerm &&
-    initialValue[field.autoCompleteQueryTerm]
-  ) {
-    return initialValue[field.autoCompleteQueryTerm];
+  if (initialValue && field.autoCompleteQueryTerm) {
+    if (Object.keys(initialValue).includes(field.autoCompleteQueryTerm)) {
+      // Exact id search with _id suffix
+      return initialValue[field.autoCompleteQueryTerm];
+    }
+    // Text search with _name suffix
+    return isAutoCompleteQueryId ? '' : initialValue[field.term];
   }
 
   // no value? bail


### PR DESCRIPTION
## Purpose
Currently [a bug](https://www.ebi.ac.uk/panda/jira/browse/TRM-28780) in the query builder where queries with autocomplete text fields eg `organism_name:human` are not being initialized correctly.

## Approach
When initializing `value` and `selectedId` in `AutocompleteField` treat these differently:

- If the `queryBit` contains the `autoCompleteQueryTerm` then return this.
- Else if a name search return the normal field term (eg `organism_name`) unless `isAutoCompleteQueryId` is true in which case return an empty string.

## Testing
Added two unit tests.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
