### PR TITLE
Create and use inBasketMini to prevent queries etc incorrectly affecting basket downloads

### DIFF
--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -159,6 +159,7 @@ const BasketMiniViewTab = ({
         namespaceOverride={namespace}
         subsetsMap={subsetsMap}
         inBasket
+        inBasketMini
         notCustomisable
       />
       <ResultsData

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -43,6 +43,7 @@ type DownloadProps = {
   supportedFormats?: FileFormat[];
   notCustomisable?: boolean;
   excludeColumns?: boolean;
+  inBasketMini?: boolean;
 };
 
 type ExtraContent = 'url' | 'preview';
@@ -60,6 +61,7 @@ const Download: FC<DownloadProps> = ({
   supportedFormats,
   notCustomisable,
   excludeColumns = false,
+  inBasketMini = false,
 }) => {
   const { columnNames } = useColumnNames();
   const { search: queryParamFromUrl } = useLocation();
@@ -121,10 +123,6 @@ const Download: FC<DownloadProps> = ({
   }
 
   const downloadOptions: DownloadUrlOptions = {
-    query: urlQuery,
-    selectedFacets,
-    sortColumn,
-    sortDirection,
     fileFormat,
     compressed,
     selected: urlSelected,
@@ -133,6 +131,14 @@ const Download: FC<DownloadProps> = ({
     accessions,
     base: downloadBase,
   };
+
+  if (!inBasketMini) {
+    downloadOptions.query = urlQuery;
+    downloadOptions.selectedFacets = selectedFacets;
+    downloadOptions.sortColumn = sortColumn;
+    downloadOptions.sortDirection = sortDirection;
+  }
+
   if (hasColumns) {
     downloadOptions.columns = selectedColumns;
   }

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -63,6 +63,7 @@ type ResultsButtonsProps = {
   base?: string;
   disableCardToggle?: boolean; // Note: remove if we have card view for id mapping
   inBasket?: boolean;
+  inBasketMini?: boolean;
   notCustomisable?: boolean;
   subsetsMap?: Map<string, string>;
   supportedFormats?: FileFormat[];
@@ -79,6 +80,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   base,
   disableCardToggle = false,
   inBasket = false,
+  inBasketMini = false,
   notCustomisable = false,
   subsetsMap,
   supportedFormats,
@@ -214,6 +216,7 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
                 notCustomisable={notCustomisable}
                 supportedFormats={supportedFormats}
                 excludeColumns={excludeColumns}
+                inBasketMini={inBasketMini}
               />
             </ErrorBoundary>
           </SlidingPanel>

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -354,7 +354,7 @@ export type DownloadUrlOptions = {
   base?: string;
   query?: string;
   columns?: string[];
-  selectedFacets: SelectedFacet[];
+  selectedFacets?: SelectedFacet[];
   sortColumn?: SortableColumn;
   sortDirection?: SortDirection;
   fileFormat: FileFormat;


### PR DESCRIPTION
## Purpose
[Download entire basket is affected by last search query/URL](https://www.ebi.ac.uk/panda/jira/browse/TRM-29094)

## Approach
Create and use `inBasketMini` prop

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
