### PR TITLE
app.scss update for 'i' button fix on h3 headers

### DIFF
--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -81,6 +81,12 @@ protvista-manager {
   width: 100%;
 }
 
+@for $i from 1 through 6 {
+  h#{$i} {
+    display: inline-block;
+  }
+}
+
 // Debug utility to show heading levels
 // @for $i from 1 through 6 {
 //   h#{$i} {


### PR DESCRIPTION
make h1-6 headers all inline-blocks

## Purpose
Describe the problem or feature in addition to a link to the issue(s), including context where needed.
contextual help `i` buttons on `h3` tags are currently clickable across the width of the website

## Approach
How does this change address the problem?
This fix makes sure that the `i` buttons are only clickable on itself

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
