### PR TITLE
Display Kcat values of Kinetics as free text

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "protvista-sequence": "3.8.10",
     "protvista-tooltip": "3.8.4",
     "protvista-track": "3.8.10",
-    "protvista-uniprot": "2.10.4",
+    "protvista-uniprot": "2.10.5",
     "protvista-utils": "3.8.10",
     "protvista-variation": "3.8.10",
     "protvista-variation-adapter": "3.8.10",

--- a/src/help/config/featureTypeHelpMappings.ts
+++ b/src/help/config/featureTypeHelpMappings.ts
@@ -29,7 +29,7 @@ const FeatureTypeHelpMappings: Omit<Record<FeatureType, string>, 'Other'> = {
   Chain: 'chain',
   Peptide: 'peptide',
   'Modified residue': 'mod_res',
-  'Modified residue (large scale)': 'mod_res_large_scale',
+  'Modified residue (large scale data)': 'mod_res_large_scale',
   Lipidation: 'lipid',
   Glycosylation: 'carbohyd',
   'Disulfide bond': 'disulfid',

--- a/src/uniprotkb/adapters/ptmExchangeFeaturesConverter.ts
+++ b/src/uniprotkb/adapters/ptmExchangeFeaturesConverter.ts
@@ -60,7 +60,7 @@ const convertPtmExchangePtms = (
 
   return {
     source,
-    type: 'Modified residue (large scale)',
+    type: 'Modified residue (large scale data)',
     location: {
       start: { value: absolutePosition, modifier: 'EXACT' },
       end: { value: absolutePosition, modifier: 'EXACT' },

--- a/src/uniprotkb/components/entry/KineticsTableView.tsx
+++ b/src/uniprotkb/components/entry/KineticsTableView.tsx
@@ -201,89 +201,90 @@ export const extractFromFreeText = (data: KineticParameters) => {
       /([0-9]*[.])?[0-9]+([x*]10\(\d+\))?\s?[sec|min|h]+\s?\(-1\)/gi;
 
     data.note?.texts.forEach((text) => {
-      if (text.value.includes('kcat')) {
-        const kcatValues = text.value.split(kcatRegEx);
-        const evidencesForWhole = text.evidences;
-        const kcatsFreeText: string[] = [];
+      // if (text.value.includes('kcat')) {
+      //   const kcatValues = text.value.split(kcatRegEx);
+      //   const evidencesForWhole = text.evidences;
+      //   const kcatsFreeText: string[] = [];
 
-        kcatValues.forEach((value) => {
-          const constants = value.match(kcatConstantRegEx);
-          if (constants && constants?.length > 1) {
-            const [pubMed] = value.match(/\(pubmed:\d+\)/i) || [null];
+      //   kcatValues.forEach((value) => {
+      //     const constants = value.match(kcatConstantRegEx);
+      //     if (constants && constants?.length > 1) {
+      //       const [pubMed] = value.match(/\(pubmed:\d+\)/i) || [null];
 
-            // Exceptional case like P45470, B0F481
-            if (
-              value.includes('respectively') ||
-              (value.match(/and/g)?.length || 0) > 1
-            ) {
-              additionalNotes.push(value);
-            } else {
-              const substrates = value.split(/and/);
-              substrates?.forEach((v) => {
-                kcatsFreeText.push(pubMed ? `${v}${pubMed}` : v);
-              });
-            }
-          } else {
-            kcatsFreeText.push(value);
-          }
-        });
+      //       // Exceptional case like P45470, B0F481
+      //       if (
+      //         value.includes('respectively') ||
+      //         (value.match(/and/g)?.length || 0) > 1
+      //       ) {
+      //         additionalNotes.push(value);
+      //       } else {
+      //         const substrates = value.split(/and/);
+      //         substrates?.forEach((v) => {
+      //           kcatsFreeText.push(pubMed ? `${v}${pubMed}` : v);
+      //         });
+      //       }
+      //     } else {
+      //       kcatsFreeText.push(value);
+      //     }
+      //   });
 
-        kcatsFreeText.forEach((value) => {
-          const [constant] = value.match(kcatConstantRegEx) || [''];
+      //   kcatsFreeText.forEach((value) => {
+      //     const [constant] = value.match(kcatConstantRegEx) || [''];
 
-          if (constant.length > 0) {
-            const brokenSentence = value.split(kcatConstantRegEx);
-            let substrateInfo = '';
-            brokenSentence.forEach((s) => {
-              if (!s?.includes('kcat') || !kcatConstantRegEx.test(s)) {
-                substrateInfo = s;
-              }
-            });
+      //     if (constant.length > 0) {
+      //       const brokenSentence = value.split(kcatConstantRegEx);
+      //       let substrateInfo = '';
+      //       brokenSentence.forEach((s) => {
+      //         if (!s?.includes('kcat') || !kcatConstantRegEx.test(s)) {
+      //           substrateInfo = s;
+      //         }
+      //       });
 
-            const [info, pubMed] = substrateInfo.split('(PubMed:');
+      //       const [info, pubMed] = substrateInfo.split('(PubMed:');
 
-            let substrateNotes = info.split('(at')?.[0];
-            const phTempNotes = info.split('(at')?.[1];
+      //       let substrateNotes = info.split('(at')?.[0];
+      //       const phTempNotes = info.split('(at')?.[1];
 
-            const evidences: Evidence[] = [];
-            if (evidencesForWhole && pubMed) {
-              evidencesForWhole.forEach((e: Evidence) => {
-                if (e.id && pubMed.includes(e.id)) {
-                  evidences.push(e);
-                }
-              });
-            }
-            const ph = phTempNotes?.match(pHRegEx)?.[1];
-            const temp = phTempNotes?.match(tempRegEx)?.[1];
+      //       const evidences: Evidence[] = [];
+      //       if (evidencesForWhole && pubMed) {
+      //         evidencesForWhole.forEach((e: Evidence) => {
+      //           if (e.id && pubMed.includes(e.id)) {
+      //             evidences.push(e);
+      //           }
+      //         });
+      //       }
+      //       const ph = phTempNotes?.match(pHRegEx)?.[1];
+      //       const temp = phTempNotes?.match(tempRegEx)?.[1];
 
-            if (phTempNotes) {
-              const match =
-                `(${phTempNotes}`.match(captureWordsInParanthesis)?.[1] ||
-                phTempNotes;
-              if (['pH', 'degrees'].some((e) => match.includes(e))) {
-                substrateNotes += excludePhTemp(match);
-              } else {
-                // Add the additional info to the Notes column
-                substrateNotes += match;
-              }
-            }
+      //       if (phTempNotes) {
+      //         const match =
+      //           `(${phTempNotes}`.match(captureWordsInParanthesis)?.[1] ||
+      //           phTempNotes;
+      //         if (['pH', 'degrees'].some((e) => match.includes(e))) {
+      //           substrateNotes += excludePhTemp(match);
+      //         } else {
+      //           // Add the additional info to the Notes column
+      //           substrateNotes += match;
+      //         }
+      //       }
 
-            kcats.push({
-              key: `kcat${constant}`,
-              constant,
-              notes: substrateNotes !== '.' ? substrateNotes.trim() : undefined,
-              ph,
-              temp,
-              evidences,
-            });
-          } else {
-            additionalNotes.push(value);
-          }
-        });
-      }
-      if (!text.value.includes('kcat')) {
-        additionalNotes.push(text.value);
-      }
+      //       kcats.push({
+      //         key: `kcat${constant}`,
+      //         constant,
+      //         notes: substrateNotes !== '.' ? substrateNotes.trim() : undefined,
+      //         ph,
+      //         temp,
+      //         evidences,
+      //       });
+      //     } else {
+      //       additionalNotes.push(value);
+      //     }
+      //   });
+      // }
+      // if (!text.value.includes('kcat')) {
+      //   additionalNotes.push(text.value);
+      // }
+      additionalNotes.push(text.value);
     });
   }
 
@@ -298,7 +299,7 @@ export const KineticsTableView = ({ data }: { data: KineticParameters }) => {
     <>
       <KineticsTable columns={['KM', 'SUBSTRATE', ...columns]} data={km} />
       <KineticsTable columns={['Vmax', ...columns]} data={vmax} />
-      <KineticsTable columns={['kcat', ...columns]} data={kcats} />
+      {/* <KineticsTable columns={['kcat', ...columns]} data={kcats} /> */}
 
       {additionalNotes.map((note) => (
         <TextView key={note} comments={[{ value: note }]} />

--- a/src/uniprotkb/components/entry/KineticsTableView.tsx
+++ b/src/uniprotkb/components/entry/KineticsTableView.tsx
@@ -2,7 +2,6 @@ import useCustomElement from '../../../shared/hooks/useCustomElement';
 
 import { RichText, TextView } from '../protein-data-views/FreeTextView';
 import UniProtKBEvidenceTag from '../protein-data-views/UniProtKBEvidenceTag';
-import { needTextProcessingRE } from '../../utils';
 
 import { KineticParameters } from '../../adapters/functionConverter';
 import { Evidence } from '../../types/modelTypes';
@@ -15,7 +14,6 @@ const tempRegEx = /(([0-9]*[.])?[0-9]+)\sdegrees\scelsius/i;
 const muRegEx = /^u/;
 const captureWordsInParanthesis = /\(((.+)(?: \((.+)\))?)\)/;
 const removeLeadingTrailingComma = /(^,)|(,$)/g;
-const kineticsConstRegEx = /\(\d?[+-]\)|\(-\d\)|\(\d+\)/g;
 
 type KinecticsTableRow = {
   key: string;
@@ -62,19 +60,7 @@ const KineticsTable = ({
             {data.map((value) => (
               <tr key={value.key}>
                 <td className={helper['no-wrap']}>
-                  {value.constant
-                    ?.split(needTextProcessingRE)
-                    .map((part, index) =>
-                      // Support right formatting for scientific notations present in kinetic specific constants
-                      kineticsConstRegEx.test(part) ? (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <sup key={index}>
-                          {part.substring(1, part.length - 1)}
-                        </sup>
-                      ) : (
-                        part
-                      )
-                    )}
+                  <RichText>{value.constant}</RichText>
                 </td>
                 {hasSubstrate && (
                   <td>
@@ -121,8 +107,7 @@ const excludePhTemp = (str: string) => {
 export const extractFromFreeText = (data: KineticParameters) => {
   let km: KinecticsTableRow[] = [];
   let vmax: KinecticsTableRow[] = [];
-  const kcats: KinecticsTableRow[] = [];
-  const additionalNotes: string[] = [];
+  const notes: string[] = [];
 
   if (data.michaelisConstants) {
     km = data.michaelisConstants.map((km) => {
@@ -195,113 +180,24 @@ export const extractFromFreeText = (data: KineticParameters) => {
   }
 
   if (data.note?.texts) {
-    const kcatRegEx = /\.\s/;
-    // From the curation manual: kcat is expressed per unit of time, in sec(-1), min(-1) or h(-1).
-    const kcatConstantRegEx =
-      /([0-9]*[.])?[0-9]+([x*]10\(\d+\))?\s?[sec|min|h]+\s?\(-1\)/gi;
-
     data.note?.texts.forEach((text) => {
-      // if (text.value.includes('kcat')) {
-      //   const kcatValues = text.value.split(kcatRegEx);
-      //   const evidencesForWhole = text.evidences;
-      //   const kcatsFreeText: string[] = [];
-
-      //   kcatValues.forEach((value) => {
-      //     const constants = value.match(kcatConstantRegEx);
-      //     if (constants && constants?.length > 1) {
-      //       const [pubMed] = value.match(/\(pubmed:\d+\)/i) || [null];
-
-      //       // Exceptional case like P45470, B0F481
-      //       if (
-      //         value.includes('respectively') ||
-      //         (value.match(/and/g)?.length || 0) > 1
-      //       ) {
-      //         additionalNotes.push(value);
-      //       } else {
-      //         const substrates = value.split(/and/);
-      //         substrates?.forEach((v) => {
-      //           kcatsFreeText.push(pubMed ? `${v}${pubMed}` : v);
-      //         });
-      //       }
-      //     } else {
-      //       kcatsFreeText.push(value);
-      //     }
-      //   });
-
-      //   kcatsFreeText.forEach((value) => {
-      //     const [constant] = value.match(kcatConstantRegEx) || [''];
-
-      //     if (constant.length > 0) {
-      //       const brokenSentence = value.split(kcatConstantRegEx);
-      //       let substrateInfo = '';
-      //       brokenSentence.forEach((s) => {
-      //         if (!s?.includes('kcat') || !kcatConstantRegEx.test(s)) {
-      //           substrateInfo = s;
-      //         }
-      //       });
-
-      //       const [info, pubMed] = substrateInfo.split('(PubMed:');
-
-      //       let substrateNotes = info.split('(at')?.[0];
-      //       const phTempNotes = info.split('(at')?.[1];
-
-      //       const evidences: Evidence[] = [];
-      //       if (evidencesForWhole && pubMed) {
-      //         evidencesForWhole.forEach((e: Evidence) => {
-      //           if (e.id && pubMed.includes(e.id)) {
-      //             evidences.push(e);
-      //           }
-      //         });
-      //       }
-      //       const ph = phTempNotes?.match(pHRegEx)?.[1];
-      //       const temp = phTempNotes?.match(tempRegEx)?.[1];
-
-      //       if (phTempNotes) {
-      //         const match =
-      //           `(${phTempNotes}`.match(captureWordsInParanthesis)?.[1] ||
-      //           phTempNotes;
-      //         if (['pH', 'degrees'].some((e) => match.includes(e))) {
-      //           substrateNotes += excludePhTemp(match);
-      //         } else {
-      //           // Add the additional info to the Notes column
-      //           substrateNotes += match;
-      //         }
-      //       }
-
-      //       kcats.push({
-      //         key: `kcat${constant}`,
-      //         constant,
-      //         notes: substrateNotes !== '.' ? substrateNotes.trim() : undefined,
-      //         ph,
-      //         temp,
-      //         evidences,
-      //       });
-      //     } else {
-      //       additionalNotes.push(value);
-      //     }
-      //   });
-      // }
-      // if (!text.value.includes('kcat')) {
-      //   additionalNotes.push(text.value);
-      // }
-      additionalNotes.push(text.value);
+      notes.push(text.value);
     });
   }
 
-  return { km, vmax, kcats, additionalNotes };
+  return { km, vmax, notes };
 };
 
 export const KineticsTableView = ({ data }: { data: KineticParameters }) => {
-  const { km, vmax, kcats, additionalNotes } = extractFromFreeText(data);
+  const { km, vmax, notes } = extractFromFreeText(data);
   const columns = ['pH', 'TEMPERATURE[C]', 'NOTES', 'EVIDENCE'];
 
   return (
     <>
       <KineticsTable columns={['KM', 'SUBSTRATE', ...columns]} data={km} />
       <KineticsTable columns={['Vmax', ...columns]} data={vmax} />
-      {/* <KineticsTable columns={['kcat', ...columns]} data={kcats} /> */}
 
-      {additionalNotes.map((note) => (
+      {notes.map((note) => (
         <TextView key={note} comments={[{ value: note }]} />
       ))}
     </>

--- a/src/uniprotkb/components/entry/__tests__/KineticsTableView.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/KineticsTableView.spec.tsx
@@ -11,21 +11,11 @@ describe('Kinetics section', () => {
     expect(kmObj).toMatchSnapshot();
   });
 
-  it('Additional notes contain kcat expceptional case while kcat is empty', () => {
-    const { kcats, additionalNotes } = extractFromFreeText(mock.data2);
+  it('Kcat values are shown in notes', () => {
+    const { notes } = extractFromFreeText(mock.data2);
+    expect(notes).toMatchSnapshot();
 
-    expect(kcats).toHaveLength(0);
-    expect(additionalNotes).toMatchSnapshot();
-  });
-
-  it('Kcats should be populated when one or more values are combined in a sentence', () => {
-    const { kcats, additionalNotes } = extractFromFreeText(mock.data3);
-
-    expect(kcats).toHaveLength(2);
-    expect(additionalNotes).toHaveLength(0);
-
-    expect(kcats[0]).toMatchSnapshot();
-
-    expect(kcats[1]).toMatchSnapshot();
+    const { notes: kcatNotes } = extractFromFreeText(mock.data3);
+    expect(kcatNotes).toMatchSnapshot();
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/KineticsTableView.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/KineticsTableView.spec.tsx.snap
@@ -1,44 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Kinetics section Additional notes contain kcat expceptional case while kcat is empty 1`] = `
+exports[`Kinetics section Kcat values are shown in notes 1`] = `
 [
-  "kcat is 118.44 min(-1) and 20.80 min (-1) for glyoxalase activity with glyoxal (GO) and methylglyoxal (MGO) as substrate, respectively (at pH 7.4 and 37 degrees Celsius) (PubMed:26678554)",
-  "The apparent kcat of MGO and GO degradation is 0.29 sec(-1), and 0.42 sec(-1), respectively (at 22 degrees Celsius) (PubMed:26774339).",
+  "kcat is 118.44 min(-1) and 20.80 min (-1) for glyoxalase activity with glyoxal (GO) and methylglyoxal (MGO) as substrate, respectively (at pH 7.4 and 37 degrees Celsius) (PubMed:26678554). The apparent kcat of MGO and GO degradation is 0.29 sec(-1), and 0.42 sec(-1), respectively (at 22 degrees Celsius) (PubMed:26774339).",
 ]
 `;
 
-exports[`Kinetics section Kcats should be populated when one or more values are combined in a sentence 1`] = `
-{
-  "constant": "4.5 min(-1)",
-  "evidences": [
-    {
-      "evidenceCode": "ECO:0000269",
-      "id": "10606519",
-      "source": "PubMed",
-    },
-  ],
-  "key": "kcat4.5 min(-1)",
-  "notes": "with arsenate as substrate  2 uM arsenate",
-  "ph": undefined,
-  "temp": undefined,
-}
-`;
-
-exports[`Kinetics section Kcats should be populated when one or more values are combined in a sentence 2`] = `
-{
-  "constant": "9.9 min(-1)",
-  "evidences": [
-    {
-      "evidenceCode": "ECO:0000269",
-      "id": "10606519",
-      "source": "PubMed",
-    },
-  ],
-  "key": "kcat9.9 min(-1)",
-  "notes": "with arsenate as substrate  10 mM arsenate",
-  "ph": undefined,
-  "temp": undefined,
-}
+exports[`Kinetics section Kcat values are shown in notes 2`] = `
+[
+  "kcat is 4.5 min(-1) with arsenate as substrate (at 2 uM arsenate) and kcat is 9.9 min(-1) with arsenate as substrate (at 10 mM arsenate) (PubMed:10606519).",
+]
 `;
 
 exports[`Kinetics section should return respective rows for KM 1`] = `

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
           <span
             data-article-id="mod_res_large_scale"
           >
-            modified residue (large scale)
+            modified residue (large scale data)
           </span>
           .
         </p>
@@ -271,9 +271,9 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
                   >
                     <td
                       data-filter="type"
-                      data-filter-value="Modified residue (large scale)"
+                      data-filter-value="Modified residue (large scale data)"
                     >
-                      Modified residue (large scale)
+                      Modified residue (large scale data)
                     </td>
                     <td />
                     <td>
@@ -331,9 +331,9 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
                   >
                     <td
                       data-filter="type"
-                      data-filter-value="Modified residue (large scale)"
+                      data-filter-value="Modified residue (large scale data)"
                     >
-                      Modified residue (large scale)
+                      Modified residue (large scale data)
                     </td>
                     <td />
                     <td>
@@ -391,9 +391,9 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
                   >
                     <td
                       data-filter="type"
-                      data-filter-value="Modified residue (large scale)"
+                      data-filter-value="Modified residue (large scale data)"
                     >
-                      Modified residue (large scale)
+                      Modified residue (large scale data)
                     </td>
                     <td />
                     <td>

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -26,7 +26,6 @@ import {
   FreeTextType,
   TextWithEvidence,
 } from '../../types/commentTypes';
-import { map } from 'd3';
 
 const needsNewLineRE = /^\)\.\s+/;
 

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -26,6 +26,7 @@ import {
   FreeTextType,
   TextWithEvidence,
 } from '../../types/commentTypes';
+import { map } from 'd3';
 
 const needsNewLineRE = /^\)\.\s+/;
 
@@ -49,7 +50,7 @@ type RichTextProps = {
 
 export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
   <>
-    {children?.split(needTextProcessingRE).map((part, index, { length }) => {
+    {children?.split(needTextProcessingRE).map((part, index, mappedArr) => {
       // Capturing group will allow split to conserve that bit in the split parts
       // NOTE: rePubMed and reAC should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
       // it is not supported in Safari yet. It's OK, we just get more chunks when splitting
@@ -94,8 +95,14 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
           );
         }
       }
-
       if (reSubscript.test(part)) {
+        // Exceptional case to handle scientific notations present in kinetic specific constants. Example: 5.38x10(2) has be to superscript
+        if (mappedArr[index - 1].endsWith('x10')) {
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <sup key={index}>{part.substring(1, part.length - 1)}</sup>
+          );
+        }
         return (
           // eslint-disable-next-line react/no-array-index-key
           <sub key={index}>{part.substring(1, part.length - 1)}</sub>
@@ -120,7 +127,7 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
         );
       }
       // If the last section doesn't end with a period, add it
-      if (addPeriod && index + 1 === length && !part.endsWith('.')) {
+      if (addPeriod && index + 1 === mappedArr.length && !part.endsWith('.')) {
         return `${part}.`;
       }
       // use plain text as such

--- a/src/uniprotkb/components/protein-data-views/PtmExchangeEvidenceTag.tsx
+++ b/src/uniprotkb/components/protein-data-views/PtmExchangeEvidenceTag.tsx
@@ -112,12 +112,8 @@ const PtmExchangeEvidenceTag = ({
           This score has been used to reflect the strength of the evidence for
           this modified site following reanalysis of available datasets.
         </section>
-        <section>
-          <h5 className="small">Reanalyzed Sources</h5>
-          Coming soon
-        </section>
         <section className="styles.section">
-          <h5 className="small">Original Sources</h5>
+          <h5 className="small">Evidence</h5>
           <PtmExchangeEvidence evidences={originalEvidences} />
         </section>
       </section>

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/PtmExchangeEvidenceTag.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/PtmExchangeEvidenceTag.spec.tsx.snap
@@ -40,21 +40,13 @@ exports[`PtmExchangeEvidenceTag components should render 1`] = `
         </h5>
         This score has been used to reflect the strength of the evidence for this modified site following reanalysis of available datasets.
       </section>
-      <section>
-        <h5
-          class="small"
-        >
-          Reanalyzed Sources
-        </h5>
-        Coming soon
-      </section>
       <section
         class="styles.section"
       >
         <h5
           class="small"
         >
-          Original Sources
+          Evidence
         </h5>
         <div>
           <ul

--- a/src/uniprotkb/types/featureType.ts
+++ b/src/uniprotkb/types/featureType.ts
@@ -44,7 +44,10 @@ export type FamilyAndDomainsFeatures =
   | 'Zinc finger'
   | 'Coiled coil';
 
-type OtherType = 'Natural variant' | 'Modified residue (large scale)' | 'Other'; // For anything else
+type OtherType =
+  | 'Natural variant'
+  | 'Modified residue (large scale data)'
+  | 'Other'; // For anything else
 
 type FeatureType =
   | OtherType

--- a/yarn.lock
+++ b/yarn.lock
@@ -10008,10 +10008,10 @@ protvista-track@3.8.10, protvista-track@^3.8.10:
     lodash-es "^4.17.11"
     protvista-zoomable "^3.8.10"
 
-protvista-uniprot@2.10.4:
-  version "2.10.4"
-  resolved "https://registry.yarnpkg.com/protvista-uniprot/-/protvista-uniprot-2.10.4.tgz#1a688f09b1047f8bd07d819ce74b9053267155f2"
-  integrity sha512-24u4rtLS6xd6xKifdJUzE3ADJqNCEMmI+1cOJfbwcEg6uCtOSy+ebY/Pv0IYcQIVOT2WWjqI+WGiL/+EGUEWOg==
+protvista-uniprot@2.10.5:
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/protvista-uniprot/-/protvista-uniprot-2.10.5.tgz#dfa25f78bbc8c9daa6dbb6aa2420502bb02cb1de"
+  integrity sha512-IdrOLthRvKNrQy/+Jya7a3T0QSEokKI9y+WGtcRex2jTSFDzKHSdBSR4m5JZFZnUKNSBFN1//e6olUSvs0mSJA==
   dependencies:
     core-js "^3.13.0"
     data-loader "^2.9.1"


### PR DESCRIPTION
## Purpose
Replace the table for Kcat in kinetics with free text as before. 
JIRA - https://www.ebi.ac.uk/panda/jira/browse/TRM-29086

## Approach
Removed the table.
Added a condition in RichText component for handling superscript for scientific notation present in kcat constants.

Example entries to try:
A0A0B6CGH9
Q8BGC4
P04180

## Testing
Updated the test.

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
