### PR TITLE
Blast form reducer

### DIFF
--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -360,7 +360,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
       dispatch(updateFormState('parsedSequences', parsedSequences));
       dispatch(updateFormState(BlastFields.sequence, rawSequence));
       setSubmitDisabled(isInvalid(parsedSequences));
-      dispatch(updateFormState(BlastFields.program));
     },
     [jobNameEdited, state]
   );

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -141,7 +141,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
   const [{ parsedSequences, formValues, sending, submitDisabled }, dispatch] =
     useReducer(
-      getBlastFormDataReducer(initialFormValues),
+      getBlastFormDataReducer(defaultFormValues),
       getBlastFormInitialState(initialFormValues)
     );
 

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -75,11 +75,7 @@ import { SelectedTaxon } from '../../types/toolsFormData';
 import sticky from '../../../shared/styles/sticky.module.scss';
 import '../../styles/ToolsForm.scss';
 
-const BLAST_LIMIT = 20;
-const isInvalid = (parsedSequences: SequenceObject[]) =>
-  !parsedSequences.length ||
-  parsedSequences.length > BLAST_LIMIT ||
-  parsedSequences.some((parsedSequence) => !parsedSequence.valid);
+export const BLAST_LIMIT = 20;
 
 const title = namespaceAndToolsLabels[JobTypes.BLAST];
 
@@ -156,15 +152,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
     getBlastFormDataInit(defaultFormValues)
   );
 
-  // used when the form submission needs to be disabled
-  const [submitDisabled, setSubmitDisabled] = useState(() =>
-    // default sequence value will tell us if submit should be disabled or not
-    isInvalid(
-      sequenceProcessor(
-        `${initialFormValues[BlastFields.sequence].selected || ''}`
-      )
-    )
-  );
   // used when the form is about to be submitted to the server
   const [sending, setSending] = useState(false);
   // flag to see if a title has been set (either user, or predefined)
@@ -268,7 +255,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
       return;
     }
 
-    setSubmitDisabled(true);
+    dispatch(updateFormState('submitDisabled', true));
     setSending(true);
 
     // here we should just transform input values into FormParameters,
@@ -359,7 +346,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
       }
       dispatch(updateFormState('parsedSequences', parsedSequences));
       dispatch(updateFormState(BlastFields.sequence, rawSequence));
-      setSubmitDisabled(isInvalid(parsedSequences));
     },
     [jobNameEdited, state]
   );
@@ -529,7 +515,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
               <button
                 className="button primary"
                 type="submit"
-                disabled={submitDisabled}
+                disabled={state.submitDisabled}
                 onClick={submitBlastJob}
               >
                 {state.parsedSequences.length <= 1

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -1,6 +1,5 @@
 import {
   FC,
-  useState,
   FormEvent,
   MouseEvent,
   useRef,
@@ -150,9 +149,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
     getBlastFormDataInit(initialFormValues)
   );
 
-  // used when the form is about to be submitted to the server
-  const [sending, setSending] = useState(false);
-
   // actual form fields
   const excludeTaxonField = excludeTaxonForDB(
     state[BlastFields.database].selected
@@ -211,8 +207,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
       return;
     }
 
-    dispatch(updateFormState('submitDisabled', true));
-    setSending(true);
+    dispatch(updateFormState('sending', true));
 
     // here we should just transform input values into FormParameters,
     // transformation of FormParameters into ServerParameters happens in the
@@ -449,7 +444,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
             className={cn('tools-form-section', sticky['sticky-bottom-right'])}
           >
             <section className="button-group tools-form-section__buttons">
-              {sending && !reducedMotion && (
+              {state.sending && !reducedMotion && (
                 <>
                   <SpinnerIcon />
                   &nbsp;

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -161,12 +161,9 @@ const BlastForm = ({ initialFormValues }: Props) => {
   );
 
   // actual form fields
-  const [database, setDatabase] = useState(
-    initialFormValues[
-      BlastFields.database
-    ] as BlastFormValues[BlastFields.database]
+  const excludeTaxonField = excludeTaxonForDB(
+    state[BlastFields.database].selected
   );
-  const excludeTaxonField = excludeTaxonForDB(database.selected);
   // TODO: to eventually incorporate into the form
   const [negativeTaxIDs, setNegativeTaxIDs] = useState(
     initialFormValues[
@@ -231,7 +228,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setDatabase(defaultFormValues[BlastFields.database]);
     setNegativeTaxIDs(defaultFormValues[BlastFields.excludedtaxons]);
     setThreshold(defaultFormValues[BlastFields.threshold]);
     setFilter(defaultFormValues[BlastFields.filter]);
@@ -265,7 +261,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
       stype: state[BlastFields.stype].selected as SType,
       program: state[BlastFields.program].selected as FormParameters['program'],
       sequence: state[BlastFields.sequence].selected as Sequence,
-      database: database.selected as Database,
+      database: state[BlastFields.database].selected as Database,
       taxIDs: excludeTaxonField
         ? []
         : (state[BlastFields.taxons].selected as SelectedTaxon[]),
@@ -407,7 +403,12 @@ const BlastForm = ({ initialFormValues }: Props) => {
             />
           </section>
           <section className="tools-form-section">
-            <FormSelect formValue={database} updateFormValue={setDatabase} />
+            <FormSelect
+              formValue={state[BlastFields.database]}
+              updateFormValue={(value) =>
+                dispatch(updateFormState(BlastFields.database, value))
+              }
+            />
             <section
               className={cn(
                 'tools-form-section__item',

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -164,12 +164,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
   const excludeTaxonField = excludeTaxonForDB(
     state[BlastFields.database].selected
   );
-  // TODO: to eventually incorporate into the form
-  const [negativeTaxIDs, setNegativeTaxIDs] = useState(
-    initialFormValues[
-      BlastFields.excludedtaxons
-    ] as BlastFormValues[BlastFields.excludedtaxons]
-  );
+  // TODO: to eventually incorporate negativeTaxIDs into the form
   const [threshold, setThreshold] = useState(
     initialFormValues[
       BlastFields.threshold
@@ -228,7 +223,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setNegativeTaxIDs(defaultFormValues[BlastFields.excludedtaxons]);
     setThreshold(defaultFormValues[BlastFields.threshold]);
     setFilter(defaultFormValues[BlastFields.filter]);
     setGapped(defaultFormValues[BlastFields.gapped]);
@@ -267,7 +261,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
         : (state[BlastFields.taxons].selected as SelectedTaxon[]),
       negativeTaxIDs: excludeTaxonField
         ? []
-        : (negativeTaxIDs.selected as SelectedTaxon[]),
+        : (state[BlastFields.excludedtaxons].selected as SelectedTaxon[]),
       threshold: threshold.selected as Exp,
       // remove "auto", and transform into corresponding matrix
       matrix:

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -167,9 +167,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
   // TODO: to eventually incorporate negativeTaxIDs into the form
 
-  const [hits, setHits] = useState(
-    initialFormValues[BlastFields.hits] as BlastFormValues[BlastFields.hits]
-  );
   const [hsps, setHsps] = useState(
     initialFormValues[BlastFields.hsps] as BlastFormValues[BlastFields.hsps]
   );
@@ -214,7 +211,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setHits(defaultFormValues[BlastFields.hits]);
     setHsps(defaultFormValues[BlastFields.hsps]);
 
     setJobName(defaultFormValues[BlastFields.name]);
@@ -259,7 +255,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
       filter: state[BlastFields.filter].selected as Filter,
       gapped: state[BlastFields.gapped].selected as GapAlign,
       // transform string into number
-      hits: parseInt(hits.selected as string, 10) as Scores,
+      hits: parseInt(state[BlastFields.hits].selected as string, 10) as Scores,
       hsps: (parseInt(hsps.selected as string, 10) || undefined) as HSPs,
     };
 

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -27,7 +27,7 @@ import InitialFormParametersProvider from '../../components/InitialFormParameter
 
 import { addMessage } from '../../../messages/state/messagesActions';
 import {
-  getBlastFormDataInit,
+  getBlastFormDataInitialState,
   getBlastFormDataReducer,
 } from '../state/blastFormReducer';
 
@@ -38,7 +38,7 @@ import { useMessagesDispatch } from '../../../shared/contexts/Messages';
 
 import { truncateTaxonLabel } from '../../utils';
 import { createJob } from '../../state/toolsActions';
-import { updateFormState } from '../state/blastFormActions';
+import { resetFormState, updateFormState } from '../state/blastFormActions';
 
 import { JobTypes } from '../../types/toolsJobTypes';
 import { FormParameters } from '../types/blastFormParameters';
@@ -145,8 +145,8 @@ const BlastForm = ({ initialFormValues }: Props) => {
   const reducedMotion = useReducedMotion();
 
   const [state, dispatch] = useReducer(
-    getBlastFormDataReducer(getBlastFormDataInit(initialFormValues)),
-    getBlastFormDataInit(initialFormValues)
+    getBlastFormDataReducer(getBlastFormDataInitialState(initialFormValues)),
+    getBlastFormDataInitialState(initialFormValues)
   );
 
   // actual form fields
@@ -154,9 +154,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
     state[BlastFields.database].selected
   );
 
-  // TODO: to eventually incorporate negativeTaxIDs into the form
-
-  console.log(state);
+  // TODO: eventually incorporate negativeTaxIDs into the form
 
   // taxon field handlers
   const updateTaxonFormValue = (path: string, id?: string) => {
@@ -191,7 +189,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
     event.preventDefault();
 
     // reset all form state to defaults
-    dispatch({ type: 'reset' });
+    dispatch(resetFormState());
 
     // imperatively reset SequenceSearchLoader... 😷
     // eslint-disable-next-line no-unused-expressions

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -167,10 +167,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
   // TODO: to eventually incorporate negativeTaxIDs into the form
 
-  const [hsps, setHsps] = useState(
-    initialFormValues[BlastFields.hsps] as BlastFormValues[BlastFields.hsps]
-  );
-
   console.log(state);
 
   // extra job-related fields
@@ -211,7 +207,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setHsps(defaultFormValues[BlastFields.hsps]);
 
     setJobName(defaultFormValues[BlastFields.name]);
 
@@ -256,7 +251,10 @@ const BlastForm = ({ initialFormValues }: Props) => {
       gapped: state[BlastFields.gapped].selected as GapAlign,
       // transform string into number
       hits: parseInt(state[BlastFields.hits].selected as string, 10) as Scores,
-      hsps: (parseInt(hsps.selected as string, 10) || undefined) as HSPs,
+      hsps:
+        state[BlastFields.hsps].selected === 'All'
+          ? undefined
+          : (parseInt(state[BlastFields.hsps].selected as string, 10) as HSPs),
     };
 
     const multipleParameters = state.parsedSequences.map((parsedSequence) => ({

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -164,11 +164,9 @@ const BlastForm = ({ initialFormValues }: Props) => {
   const excludeTaxonField = excludeTaxonForDB(
     state[BlastFields.database].selected
   );
+
   // TODO: to eventually incorporate negativeTaxIDs into the form
 
-  const [gapped, setGapped] = useState(
-    initialFormValues[BlastFields.gapped] as BlastFormValues[BlastFields.gapped]
-  );
   const [hits, setHits] = useState(
     initialFormValues[BlastFields.hits] as BlastFormValues[BlastFields.hits]
   );
@@ -216,7 +214,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setGapped(defaultFormValues[BlastFields.gapped]);
     setHits(defaultFormValues[BlastFields.hits]);
     setHsps(defaultFormValues[BlastFields.hsps]);
 
@@ -260,7 +257,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
           ? getAutoMatrixFor(state.parsedSequences[0]?.sequence)
           : (state[BlastFields.matrix].selected as Matrix),
       filter: state[BlastFields.filter].selected as Filter,
-      gapped: gapped.selected as GapAlign,
+      gapped: state[BlastFields.gapped].selected as GapAlign,
       // transform string into number
       hits: parseInt(hits.selected as string, 10) as Scores,
       hsps: (parseInt(hsps.selected as string, 10) || undefined) as HSPs,

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -165,11 +165,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
     state[BlastFields.database].selected
   );
   // TODO: to eventually incorporate negativeTaxIDs into the form
-  const [threshold, setThreshold] = useState(
-    initialFormValues[
-      BlastFields.threshold
-    ] as BlastFormValues[BlastFields.threshold]
-  );
+
   const [filter, setFilter] = useState(
     initialFormValues[BlastFields.filter] as BlastFormValues[BlastFields.filter]
   );
@@ -223,7 +219,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setThreshold(defaultFormValues[BlastFields.threshold]);
     setFilter(defaultFormValues[BlastFields.filter]);
     setGapped(defaultFormValues[BlastFields.gapped]);
     setHits(defaultFormValues[BlastFields.hits]);
@@ -262,7 +257,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
       negativeTaxIDs: excludeTaxonField
         ? []
         : (state[BlastFields.excludedtaxons].selected as SelectedTaxon[]),
-      threshold: threshold.selected as Exp,
+      threshold: state[BlastFields.threshold].selected as Exp,
       // remove "auto", and transform into corresponding matrix
       matrix:
         state[BlastFields.matrix].selected === 'auto'

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -166,9 +166,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
   );
   // TODO: to eventually incorporate negativeTaxIDs into the form
 
-  const [filter, setFilter] = useState(
-    initialFormValues[BlastFields.filter] as BlastFormValues[BlastFields.filter]
-  );
   const [gapped, setGapped] = useState(
     initialFormValues[BlastFields.gapped] as BlastFormValues[BlastFields.gapped]
   );
@@ -219,7 +216,6 @@ const BlastForm = ({ initialFormValues }: Props) => {
 
     // reset all form state to defaults
     dispatch({ type: 'reset' });
-    setFilter(defaultFormValues[BlastFields.filter]);
     setGapped(defaultFormValues[BlastFields.gapped]);
     setHits(defaultFormValues[BlastFields.hits]);
     setHsps(defaultFormValues[BlastFields.hsps]);
@@ -263,7 +259,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
         state[BlastFields.matrix].selected === 'auto'
           ? getAutoMatrixFor(state.parsedSequences[0]?.sequence)
           : (state[BlastFields.matrix].selected as Matrix),
-      filter: filter.selected as Filter,
+      filter: state[BlastFields.filter].selected as Filter,
       gapped: gapped.selected as GapAlign,
       // transform string into number
       hits: parseInt(hits.selected as string, 10) as Scores,

--- a/src/tools/blast/components/__tests__/BlastForm.spec.tsx
+++ b/src/tools/blast/components/__tests__/BlastForm.spec.tsx
@@ -66,7 +66,7 @@ describe('BlastForm test', () => {
     expect(jobNameField.value).toBe('some_FASTA_header');
   });
 
-  it("Don't set a name automatically when user entered one", () => {
+  it("Doesn't set a name automatically when user entered one", () => {
     const textArea = screen.getByTestId('sequence-submission-input');
     const jobNameField = screen.getByRole<HTMLSelectElement>('textbox', {
       name: 'Name your BLAST job',
@@ -79,6 +79,31 @@ describe('BlastForm test', () => {
       target: { value: `>some_FASTA_header extra info\n${aaSequence}` },
     });
     expect(jobNameField.value).toBe('My job name');
+  });
+
+  it("Doesn't set the program automatically when user selected one", () => {
+    const textArea = screen.getByTestId('sequence-submission-input');
+    const programSelect = screen.getByRole<HTMLSelectElement>('combobox', {
+      name: 'Program',
+    });
+    fireEvent.change(programSelect, {
+      target: { value: 'blastx' },
+    });
+    expect(programSelect.value).toBe('blastx');
+    fireEvent.change(textArea, {
+      target: { value: `>some_FASTA_header extra info\n${aaSequence}` },
+    });
+    expect(programSelect.value).toBe('blastx');
+  });
+
+  it("Doesn't set the sequence type automatically when user selected one", () => {
+    const textArea = screen.getByTestId('sequence-submission-input');
+    const sequenceTypeSelect = screen.getByRole<HTMLSelectElement>('combobox', {
+      name: 'Sequence type',
+    });
+    fireEvent.change(sequenceTypeSelect, { target: { value: 'dna' } });
+    fireEvent.change(textArea, { target: { value: aaSequence } });
+    expect(sequenceTypeSelect.value).toBe('dna');
   });
 
   it('Informs the user about the automatic matrix based on the sequence', () => {

--- a/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
+++ b/src/tools/blast/components/__tests__/__snapshots__/BlastForm.spec.tsx.snap
@@ -462,8 +462,8 @@ exports[`BlastForm test Renders the form 1`] = `
               HSPs per hit
               <select>
                 <option
-                  data-testid="HSPs per hit-undefined"
-                  value="undefined"
+                  data-testid="HSPs per hit-All"
+                  value="All"
                 >
                   All
                 </option>

--- a/src/tools/blast/config/BlastFormData.ts
+++ b/src/tools/blast/config/BlastFormData.ts
@@ -11,6 +11,7 @@ export type BlastFormValue = {
   values?: Readonly<
     Array<{ label?: string; value?: string | boolean | number }>
   >;
+  userSelected?: boolean;
 };
 
 export enum BlastFields {

--- a/src/tools/blast/config/BlastFormData.ts
+++ b/src/tools/blast/config/BlastFormData.ts
@@ -76,6 +76,7 @@ const formData: Readonly<BlastFormValues> = deepFreeze({
   },
   [BlastFields.taxons]: {
     fieldName: 'taxIDs',
+    selected: [],
   },
   [BlastFields.excludedtaxons]: {
     fieldName: 'negativeTaxIDs',

--- a/src/tools/blast/config/BlastFormData.ts
+++ b/src/tools/blast/config/BlastFormData.ts
@@ -77,7 +77,6 @@ const formData: Readonly<BlastFormValues> = deepFreeze({
   },
   [BlastFields.taxons]: {
     fieldName: 'taxIDs',
-    selected: [],
   },
   [BlastFields.excludedtaxons]: {
     fieldName: 'negativeTaxIDs',
@@ -104,7 +103,7 @@ const formData: Readonly<BlastFormValues> = deepFreeze({
       // "auto" will be replaced by the correct matrix value on submission
       // but we need to have a distinc value here to not have 2 <option> with
       // same values
-      { label: 'Auto - PAM30', value: 'auto' },
+      { label: 'Auto - BLOSUM62', value: 'auto' },
       { value: 'BLOSUM45' },
       { value: 'BLOSUM62' },
       { value: 'BLOSUM80' },

--- a/src/tools/blast/config/BlastFormData.ts
+++ b/src/tools/blast/config/BlastFormData.ts
@@ -143,9 +143,9 @@ const formData: Readonly<BlastFormValues> = deepFreeze({
   },
   [BlastFields.hsps]: {
     fieldName: 'hsps',
-    selected: undefined,
+    selected: 'All',
     values: [
-      { value: undefined, label: 'All' },
+      { value: 'All' },
       { value: 1 },
       { value: 2 },
       { value: 5 },

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,20 +1,21 @@
 // import { BlastFormValue } from '../config/BlastFormData';
 import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
 import { action } from 'typesafe-actions';
-import { BlastFormValue } from '../config/BlastFormData';
+import { BlastFields, BlastFormValue } from '../config/BlastFormData';
 
-import { BlastFormActionPayloadId } from './blastFormReducer';
-
-export const UPDATE = 'UPDATE';
+export const UPDATE_SELECTED = 'UPDATE_SELECTED';
+export const UPDATE_PARSED_SEQUENCES = 'UPDATE_PARSED_SEQUENCES';
+export const UPDATE_SENDING = 'UPDATE_SENDING';
 export const RESET = 'RESET';
 
-export type BlastUpdateFormValue =
-  | BlastFormValue['selected']
-  | SequenceObject[];
+export const updateSelected = (
+  id: BlastFields,
+  selected: BlastFormValue['selected']
+) => action(UPDATE_SELECTED, { id, selected });
 
-export const updateFormState = (
-  id: BlastFormActionPayloadId,
-  value: BlastUpdateFormValue
-) => action(UPDATE, { id, value });
+export const updateParsedSequences = (parsedSequences: SequenceObject[]) =>
+  action(UPDATE_PARSED_SEQUENCES, parsedSequences);
+
+export const updateSending = () => action(UPDATE_SENDING);
 
 export const resetFormState = () => action(RESET);

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,0 +1,4 @@
+export const updateValue = (id, value: any) => ({
+  type: 'update',
+  payload: { id, value },
+});

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,6 +1,20 @@
 // import { BlastFormValue } from '../config/BlastFormData';
+import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
+import { action } from 'typesafe-actions';
+import { BlastFormValue } from '../config/BlastFormData';
 
-export const updateFormState = (id, value) => ({
-  type: 'update',
-  payload: { id, value },
-});
+import { BlastFormActionPayloadId } from './blastFormReducer';
+
+export const UPDATE = 'UPDATE';
+export const RESET = 'RESET';
+
+export type BlastUpdateFormValue =
+  | BlastFormValue['selected']
+  | SequenceObject[];
+
+export const updateFormState = (
+  id: BlastFormActionPayloadId,
+  value: BlastUpdateFormValue
+) => action(UPDATE, { id, value });
+
+export const resetFormState = () => action(RESET);

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,4 +1,6 @@
-export const updateValue = (id, value: any) => ({
+import { BlastFormValue } from '../config/BlastFormData';
+
+export const updateFormState = (id, value) => ({
   type: 'update',
   payload: { id, value },
 });

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,4 +1,4 @@
-import { BlastFormValue } from '../config/BlastFormData';
+// import { BlastFormValue } from '../config/BlastFormData';
 
 export const updateFormState = (id, value) => ({
   type: 'update',

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -1,14 +1,26 @@
 import { sequenceProcessor } from 'franklin-sites';
-import { getAutoMatrixFor } from '../components/BlastForm';
+import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
+import { BLAST_LIMIT, getAutoMatrixFor } from '../components/BlastForm';
 
 import { BlastFormValues, BlastFields } from '../config/BlastFormData';
+
+const isInvalid = (parsedSequences: SequenceObject[]) =>
+  !parsedSequences.length ||
+  parsedSequences.length > BLAST_LIMIT ||
+  parsedSequences.some((parsedSequence) => !parsedSequence.valid);
 
 export const getBlastFormDataInit = (
   defaultFormValues: Readonly<BlastFormValues>
 ) => ({
   ...defaultFormValues,
   parsedSequences: sequenceProcessor(
-    `${defaultFormValues[BlastFields.sequence].selected}` || ''
+    `${defaultFormValues[BlastFields.sequence].selected || ''}`
+  ),
+  // used when the form submission needs to be disabled
+  submitDisabled: isInvalid(
+    sequenceProcessor(
+      `${defaultFormValues[BlastFields.sequence].selected || ''}`
+    )
   ),
 });
 
@@ -19,6 +31,10 @@ export const blastFormDataUpdateReducer = (state, action) => {
   switch (id) {
     case 'parsedSequences': {
       const parsedSequences = value;
+
+      // Set Submit Disabled according to sequence
+      const submitDisabled = isInvalid(parsedSequences);
+
       // Set the "Auto" matrix according to sequence
       const autoMatrix = getAutoMatrixFor(parsedSequences[0]?.sequence);
       const matrix = {
@@ -30,20 +46,24 @@ export const blastFormDataUpdateReducer = (state, action) => {
           ),
         ],
       };
+
       // Set Program according to sequence
       const mightBeDNA = parsedSequences[0]?.likelyType === 'na';
       const program = {
         ...state[BlastFields.program],
         selected: mightBeDNA ? 'blastx' : 'blastp',
       };
+
       // Set Sequence Type according to sequence
       const stype = {
         ...state[BlastFields.stype],
         selected: mightBeDNA ? 'dna' : 'protein',
       };
+
       return {
         ...state,
         parsedSequences,
+        submitDisabled,
         [BlastFields.matrix]: matrix,
         [BlastFields.program]: program,
         [BlastFields.stype]: stype,

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -1,0 +1,65 @@
+import { sequenceProcessor } from 'franklin-sites';
+
+import { BlastFormValues, BlastFields } from '../config/BlastFormData';
+
+export const getBlastFormDataInit = (
+  defaultFormValues: Readonly<BlastFormValues>
+) => ({
+  ...defaultFormValues,
+  parsedSequences: sequenceProcessor(
+    `${defaultFormValues[BlastFields.sequence].selected}` || ''
+  ),
+});
+
+export const blastFormDataUpdateReducer = (state, action) => {
+  const { payload } = action;
+  switch (payload.id) {
+    case BlastFields.stype: {
+      const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
+      const selected = mightBeDNA ? 'dna' : 'protein';
+      if (state[BlastFields.stype].selected === selected) {
+        return state;
+      }
+      return {
+        ...state,
+        [BlastFields.stype]: {
+          ...state[BlastFields.stype],
+          selected,
+        },
+      };
+    }
+    case BlastFields.program: {
+      const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
+      // If value explicitly provided use this otherwise we want protein by default
+      const selected =
+        payload.value.selected || (mightBeDNA ? 'blastx' : 'blastp');
+      if (state[BlastFields.program].selected === selected) {
+        // avoid unecessary rerender by keeping the same object
+        return state;
+      }
+      return {
+        ...state,
+        [BlastFields.program]: {
+          ...state[BlastFields.program],
+          selected,
+        },
+      };
+    }
+    case 'parsedSequences':
+      return { ...state, parsedSequences: payload.value };
+    default:
+      return state;
+  }
+};
+
+export const getBlastFormDataReducer =
+  (defaultFormValues: Readonly<BlastFormValues>) => (state, action) => {
+    switch (action.type) {
+      case 'update':
+        return blastFormDataUpdateReducer(state, action);
+      case 'reset':
+        return defaultFormValues;
+      default:
+        return state;
+    }
+  };

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -1,4 +1,5 @@
 import { sequenceProcessor } from 'franklin-sites';
+import { getAutoMatrixFor } from '../components/BlastForm';
 
 import { BlastFormValues, BlastFields } from '../config/BlastFormData';
 
@@ -30,6 +31,9 @@ export const blastFormDataUpdateReducer = (state, action) => {
         },
       };
     }
+    // case BlastFields.matrix: {
+
+    // }
     case BlastFields.program: {
       const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
       // If value explicitly provided use this otherwise we want protein by default
@@ -46,8 +50,23 @@ export const blastFormDataUpdateReducer = (state, action) => {
         },
       };
     }
-    case 'parsedSequences':
-      return { ...state, parsedSequences: value };
+    case 'parsedSequences': {
+      // set the "Auto" matrix to the have the correct label depending on sequence
+      const autoMatrix = getAutoMatrixFor(value[0]?.sequence);
+      return {
+        ...state,
+        parsedSequences: value,
+        [BlastFields.matrix]: {
+          ...state[BlastFields.matrix],
+          values: [
+            { label: `Auto - ${autoMatrix}`, value: 'auto' },
+            ...state[BlastFields.matrix].values.filter(
+              (option) => option.value !== 'auto'
+            ),
+          ],
+        },
+      };
+    }
     default: {
       return {
         ...state,

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -13,6 +13,11 @@ export const getBlastFormDataInit = (
   defaultFormValues: Readonly<BlastFormValues>
 ) => ({
   ...defaultFormValues,
+  [BlastFields.name]: {
+    ...defaultFormValues[BlastFields.name],
+    // default to true if it's been set through the history state
+    userSelected: Boolean(defaultFormValues[BlastFields.name].selected),
+  },
   parsedSequences: sequenceProcessor(
     `${defaultFormValues[BlastFields.sequence].selected || ''}`
   ),
@@ -22,11 +27,7 @@ export const getBlastFormDataInit = (
       `${defaultFormValues[BlastFields.sequence].selected || ''}`
     )
   ),
-  [BlastFields.name]: {
-    ...defaultFormValues[BlastFields.name],
-    // default to true if it's been set through the history state
-    userSelected: Boolean(defaultFormValues[BlastFields.name].selected),
-  },
+  sending: false,
 });
 
 export const blastFormDataUpdateReducer = (state, action) => {
@@ -84,7 +85,6 @@ export const blastFormDataUpdateReducer = (state, action) => {
             ...state[BlastFields.name],
             selected: parsedSequences[0]?.name || '',
           };
-      console.log('here');
       return {
         ...state,
         parsedSequences,
@@ -96,6 +96,13 @@ export const blastFormDataUpdateReducer = (state, action) => {
         [BlastFields.stype]: stype,
       };
     }
+    case 'sending':
+      // used when the form is about to be submitted to the server
+      return {
+        ...state,
+        submitDisabled: true,
+        sending: true,
+      };
     default: {
       return {
         ...state,

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -12,8 +12,10 @@ export const getBlastFormDataInit = (
 });
 
 export const blastFormDataUpdateReducer = (state, action) => {
-  const { payload } = action;
-  switch (payload.id) {
+  const {
+    payload: { id, value },
+  } = action;
+  switch (id) {
     case BlastFields.stype: {
       const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
       const selected = mightBeDNA ? 'dna' : 'protein';
@@ -31,8 +33,7 @@ export const blastFormDataUpdateReducer = (state, action) => {
     case BlastFields.program: {
       const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
       // If value explicitly provided use this otherwise we want protein by default
-      const selected =
-        payload.value.selected || (mightBeDNA ? 'blastx' : 'blastp');
+      const selected = value?.selected || (mightBeDNA ? 'blastx' : 'blastp');
       if (state[BlastFields.program].selected === selected) {
         // avoid unecessary rerender by keeping the same object
         return state;
@@ -46,9 +47,16 @@ export const blastFormDataUpdateReducer = (state, action) => {
       };
     }
     case 'parsedSequences':
-      return { ...state, parsedSequences: payload.value };
-    default:
-      return state;
+      return { ...state, parsedSequences: value };
+    default: {
+      return {
+        ...state,
+        [id]: {
+          ...state[id],
+          selected: value.selected,
+        },
+      };
+    }
   }
 };
 

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -69,22 +69,20 @@ export const blastFormParsedSequencesReducer = (
   // Set Submit Disabled according to sequence
   const submitDisabled = isInvalid(parsedSequences);
 
-  // Set the "Auto" matrix according to sequence if user didn't already set
-  // TODO: still update values even if user selected
-  const matrix = formValues[BlastFields.matrix].userSelected
-    ? formValues[BlastFields.matrix]
-    : {
-        ...formValues[BlastFields.matrix],
-        values: [
-          {
-            label: `Auto - ${getAutoMatrixFor(parsedSequences[0]?.sequence)}`,
-            value: 'auto',
-          },
-          ...(formValues[BlastFields.matrix].values || []).filter(
-            (option) => option.value !== 'auto'
-          ),
-        ],
-      };
+  // Set the "Auto" matrix according to sequence. The selected value
+  // isn't changed just which of the values is marked as auto.
+  const matrix = {
+    ...formValues[BlastFields.matrix],
+    values: [
+      {
+        label: `Auto - ${getAutoMatrixFor(parsedSequences[0]?.sequence)}`,
+        value: 'auto',
+      },
+      ...(formValues[BlastFields.matrix].values || []).filter(
+        (option) => option.value !== 'auto'
+      ),
+    ],
+  };
 
   const mightBeDNA = parsedSequences[0]?.likelyType === 'na';
 

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -53,7 +53,7 @@ export const blastFormDataUpdateReducer = (state, action) => {
         ...state,
         [id]: {
           ...state[id],
-          selected: value.selected,
+          selected: value,
         },
       };
     }

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -74,7 +74,7 @@ export const blastFormDataUpdateReducer = (state, action) => {
         ...state,
         [id]: {
           ...state[id],
-          selected: value,
+          selected: value.selected,
         },
       };
     }

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -17,54 +17,36 @@ export const blastFormDataUpdateReducer = (state, action) => {
     payload: { id, value },
   } = action;
   switch (id) {
-    case BlastFields.stype: {
-      const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
-      const selected = mightBeDNA ? 'dna' : 'protein';
-      if (state[BlastFields.stype].selected === selected) {
-        return state;
-      }
-      return {
-        ...state,
-        [BlastFields.stype]: {
-          ...state[BlastFields.stype],
-          selected,
-        },
-      };
-    }
-    // case BlastFields.matrix: {
-
-    // }
-    case BlastFields.program: {
-      const mightBeDNA = state.parsedSequences[0]?.likelyType === 'na';
-      // If value explicitly provided use this otherwise we want protein by default
-      const selected = value?.selected || (mightBeDNA ? 'blastx' : 'blastp');
-      if (state[BlastFields.program].selected === selected) {
-        // avoid unecessary rerender by keeping the same object
-        return state;
-      }
-      return {
-        ...state,
-        [BlastFields.program]: {
-          ...state[BlastFields.program],
-          selected,
-        },
-      };
-    }
     case 'parsedSequences': {
-      // set the "Auto" matrix to the have the correct label depending on sequence
-      const autoMatrix = getAutoMatrixFor(value[0]?.sequence);
+      const parsedSequences = value;
+      // Set the "Auto" matrix according to sequence
+      const autoMatrix = getAutoMatrixFor(parsedSequences[0]?.sequence);
+      const matrix = {
+        ...state[BlastFields.matrix],
+        values: [
+          { label: `Auto - ${autoMatrix}`, value: 'auto' },
+          ...state[BlastFields.matrix].values.filter(
+            (option) => option.value !== 'auto'
+          ),
+        ],
+      };
+      // Set Program according to sequence
+      const mightBeDNA = parsedSequences[0]?.likelyType === 'na';
+      const program = {
+        ...state[BlastFields.program],
+        selected: mightBeDNA ? 'blastx' : 'blastp',
+      };
+      // Set Sequence Type according to sequence
+      const stype = {
+        ...state[BlastFields.stype],
+        selected: mightBeDNA ? 'dna' : 'protein',
+      };
       return {
         ...state,
-        parsedSequences: value,
-        [BlastFields.matrix]: {
-          ...state[BlastFields.matrix],
-          values: [
-            { label: `Auto - ${autoMatrix}`, value: 'auto' },
-            ...state[BlastFields.matrix].values.filter(
-              (option) => option.value !== 'auto'
-            ),
-          ],
-        },
+        parsedSequences,
+        [BlastFields.matrix]: matrix,
+        [BlastFields.program]: program,
+        [BlastFields.stype]: stype,
       };
     }
     default: {

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -79,12 +79,13 @@ export const blastFormDataUpdateReducer = (state, action) => {
       };
 
       // Set Job Name if the user didn't manually set this
-      const name = state[BlastFields.name].userSelected
-        ? state[BlastFields.name]
-        : {
-            ...state[BlastFields.name],
-            selected: parsedSequences[0]?.name || '',
-          };
+      const name =
+        state[BlastFields.name].userSelected && state[BlastFields.name].selected
+          ? state[BlastFields.name]
+          : {
+              ...state[BlastFields.name],
+              selected: parsedSequences[0]?.name || '',
+            };
       return {
         ...state,
         parsedSequences,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -439,6 +439,9 @@ module.exports = (env, argv) => {
       compress: true,
       host: 'localhost',
       historyApiFallback: true,
+      devMiddleware: {
+        stats: 'errors-only',
+      },
       open: {
         // use a browser specified in the user's environment, otherwise use default
         app: process.env.BROWSER,


### PR DESCRIPTION
## Purpose
[BLAST form: stop changing automatic fields if user manually changed them](https://www.ebi.ac.uk/panda/jira/browse/TRM-29006)

## Approach

- Use `useReducer`
- Set `userSelected` when user selects a form value to know if value can be automatically updated.
- Show `errors-only` for webpack dev server in attempt to minimize output and keep track of localhost port.

## Testing
Updated

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
