### PR TITLE
Catch ftp download

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -193,6 +193,7 @@ const Download: FC<DownloadProps> = ({
       <DownloadAPIURL
         // Remove the download attribute as it's unnecessary for API access
         apiURL={downloadUrl.replace('download=true&', '')}
+        ftpURL={ftpUrl}
         onCopy={onClose}
         count={downloadCount}
       />
@@ -216,7 +217,7 @@ const Download: FC<DownloadProps> = ({
     extraContentNode = (
       <>
         <h4>File Available On FTP Server</h4>
-        This file is available on the UniProt FTP server for download:
+        This file is available on the UniProt FTP server:
         <br />
         <ExternalLink url={ftpUrl}>{ftpUrl}</ExternalLink>
       </>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,6 +1,6 @@
 import { useState, FC, ChangeEvent, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Button, LongNumber, Message } from 'franklin-sites';
+import { Button, ExternalLink, LongNumber, Message } from 'franklin-sites';
 import cn from 'classnames';
 
 import ColumnSelect from '../column-select/ColumnSelect';
@@ -22,6 +22,7 @@ import {
   nsToFileFormatsResultsDownload,
 } from '../../config/resultsDownload';
 import defaultFormValues from '../../../tools/async-download/config/asyncDownloadFormData';
+import { getUniprotkbFtpUrl } from '../../config/ftpUrls';
 
 import { Location, LocationToPath } from '../../../app/config/urls';
 
@@ -50,7 +51,7 @@ type DownloadProps = {
   inBasketMini?: boolean;
 };
 
-type ExtraContent = 'url' | 'generate' | 'preview';
+type ExtraContent = 'url' | 'generate' | 'preview' | 'ftp';
 
 const Download: FC<DownloadProps> = ({
   query,
@@ -182,6 +183,9 @@ const Download: FC<DownloadProps> = ({
   const isLarge = downloadCount > DOWNLOAD_SIZE_LIMIT;
   const isUniprotkb = namespace === Namespace.uniprotkb;
   const isAsyncDownload = isLarge && isUniprotkb;
+  const ftpUrl =
+    namespace === Namespace.uniprotkb &&
+    getUniprotkbFtpUrl(downloadUrl, fileFormat);
 
   let extraContentNode: JSX.Element | undefined;
   if (extraContent === 'url') {
@@ -207,6 +211,15 @@ const Download: FC<DownloadProps> = ({
         previewUrl={previewUrl}
         previewFileFormat={previewFileFormat}
       />
+    );
+  } else if (extraContent === 'ftp' && ftpUrl) {
+    extraContentNode = (
+      <>
+        <h4>File Available On FTP Server</h4>
+        This file is available on the UniProt FTP server for download:
+        <br />
+        <ExternalLink url={ftpUrl}>{ftpUrl}</ExternalLink>
+      </>
     );
   }
 
@@ -352,7 +365,7 @@ const Download: FC<DownloadProps> = ({
         </Button>
         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <a
-          href={isAsyncDownload ? undefined : downloadUrl}
+          href={isAsyncDownload || ftpUrl ? undefined : downloadUrl}
           className={cn('button', 'primary')}
           title={
             isAsyncDownload
@@ -361,9 +374,15 @@ const Download: FC<DownloadProps> = ({
           }
           target="_blank"
           rel="noreferrer"
-          onClick={() =>
-            isAsyncDownload ? displayExtraContent('generate') : onClose()
-          }
+          onClick={() => {
+            if (ftpUrl) {
+              displayExtraContent('ftp');
+            } else if (isAsyncDownload) {
+              displayExtraContent('generate');
+            } else {
+              onClose();
+            }
+          }}
         >
           Download
         </a>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,5 +1,5 @@
 import { useState, FC, ChangeEvent, useCallback } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, generatePath, useLocation } from 'react-router-dom';
 import { Button, ExternalLink, LongNumber, Message } from 'franklin-sites';
 import cn from 'classnames';
 
@@ -184,8 +184,9 @@ const Download: FC<DownloadProps> = ({
   const isUniprotkb = namespace === Namespace.uniprotkb;
   const isAsyncDownload = isLarge && isUniprotkb;
   const ftpUrl =
-    namespace === Namespace.uniprotkb &&
-    getUniprotkbFtpUrl(downloadUrl, fileFormat);
+    namespace === Namespace.uniprotkb
+      ? getUniprotkbFtpUrl(downloadUrl, fileFormat)
+      : null;
 
   let extraContentNode: JSX.Element | undefined;
   if (extraContent === 'url') {
@@ -217,7 +218,15 @@ const Download: FC<DownloadProps> = ({
     extraContentNode = (
       <>
         <h4>File Available On FTP Server</h4>
-        This file is available on the UniProt FTP server:
+        This file is available compressed on the{' '}
+        <Link
+          to={generatePath(LocationToPath[Location.HelpEntry], {
+            accession: 'downloads',
+          })}
+        >
+          UniProt FTP server
+        </Link>
+        :
         <br />
         <ExternalLink url={ftpUrl}>{ftpUrl}</ExternalLink>
       </>

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -44,7 +44,7 @@ export const DOWNLOAD_SIZE_LIMIT = 10_000_000 as const;
 
 type Props = {
   apiURL: string;
-  ftpURL?: string;
+  ftpURL?: string | null;
   onCopy: () => void;
   count: number;
 };
@@ -82,7 +82,7 @@ const DownloadAPIURL = ({ apiURL, ftpURL, onCopy, count }: Props) => {
         <>
           <br />
           <h4>FTP URL</h4>
-          This file is available on the{' '}
+          This file is available compressed on the{' '}
           <Link
             to={generatePath(LocationToPath[Location.HelpEntry], {
               accession: 'downloads',

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -44,11 +44,12 @@ export const DOWNLOAD_SIZE_LIMIT = 10_000_000 as const;
 
 type Props = {
   apiURL: string;
+  ftpURL?: string;
   onCopy: () => void;
   count: number;
 };
 
-const DownloadAPIURL = ({ apiURL, onCopy, count }: Props) => {
+const DownloadAPIURL = ({ apiURL, ftpURL, onCopy, count }: Props) => {
   const scrollRef = useScrollIntoViewRef<HTMLDivElement>();
   const dispatch = useMessagesDispatch();
   const handleCopyURL = useCallback(
@@ -77,6 +78,31 @@ const DownloadAPIURL = ({ apiURL, onCopy, count }: Props) => {
 
   return (
     <div className={styles['api-url']} ref={scrollRef}>
+      {ftpURL && (
+        <>
+          <br />
+          <h4>FTP URL</h4>
+          This file is available on the{' '}
+          <Link
+            to={generatePath(LocationToPath[Location.HelpEntry], {
+              accession: 'downloads',
+            })}
+          >
+            UniProt FTP server
+          </Link>
+          <CodeBlock lightMode>{ftpURL}</CodeBlock>
+          <section className="button-group">
+            <Button
+              variant="primary"
+              className={styles['copy-button']}
+              onClick={() => handleCopyURL(ftpURL)}
+            >
+              <CopyIcon />
+              Copy
+            </Button>
+          </section>
+        </>
+      )}
       <h4>API URL {isStreamEndpoint && ' using the streaming endpoint'}</h4>
       {isStreamEndpoint &&
         'This endpoint is resource-heavy but will return all requested results.'}

--- a/src/shared/config/__tests__/ftpUrls.spec.ts
+++ b/src/shared/config/__tests__/ftpUrls.spec.ts
@@ -1,0 +1,37 @@
+import { simplifyQuery } from '../ftpUrls';
+
+describe('simplifyQuery', () => {
+  const testCases: [string, string | null][] = [
+    ['(((reviewed:false) and (*)))', 'reviewed:false'],
+    ['((reviewed:false) and (*))', 'reviewed:false'],
+    ['((reviewed:false) and *)', 'reviewed:false'],
+    ['(reviewed:false)   and  *', 'reviewed:false'],
+    ['(reviewed:false)', 'reviewed:false'],
+    ['reviewed:false', 'reviewed:false'],
+    ['(((reviewed:true) and (*)))', 'reviewed:true'],
+    ['((reviewed:true) and (*))', 'reviewed:true'],
+    ['((reviewed:true) and *)', 'reviewed:true'],
+    ['(reviewed:true) and *', 'reviewed:true'],
+    ['(reviewed:true)', 'reviewed:true'],
+    ['reviewed:true', 'reviewed:true'],
+    ['(((*) and (reviewed:false)))', 'reviewed:false'],
+    ['((*) and (reviewed:false))', 'reviewed:false'],
+    ['(* and (reviewed:false))', 'reviewed:false'],
+    ['* and (reviewed:false)', 'reviewed:false'],
+    ['(((*) and (reviewed:true)))', 'reviewed:true'],
+    ['((*) and (reviewed:true))', 'reviewed:true'],
+    ['(* and (reviewed:true))', 'reviewed:true'],
+    ['* and (reviewed:true)', 'reviewed:true'],
+    ['((reviewed:true) and *) and other stuff', null],
+    ['other stuff and ((reviewed:true) and *)', null],
+    ['and * other stuff and reviewed:false', null],
+    ['foo:bar', null],
+    ['*', null],
+  ];
+  test.each(testCases)(
+    'should simplify query %p → %p',
+    (query, simplifiedQuery) => {
+      expect(simplifyQuery(query)).toEqual(simplifiedQuery);
+    }
+  );
+});

--- a/src/shared/config/__tests__/ftpUrls.spec.ts
+++ b/src/shared/config/__tests__/ftpUrls.spec.ts
@@ -1,4 +1,5 @@
-import { simplifyQuery } from '../ftpUrls';
+import { getUniprotkbFtpUrl, simplifyQuery } from '../ftpUrls';
+import { FileFormat } from '../../types/resultsDownload';
 
 describe('simplifyQuery', () => {
   const testCases: [string, string | null][] = [
@@ -34,4 +35,25 @@ describe('simplifyQuery', () => {
       expect(simplifyQuery(query)).toEqual(simplifiedQuery);
     }
   );
+});
+
+describe('getUniprotkbFtpUrl', () => {
+  it('should generate FTP link', () => {
+    expect(
+      getUniprotkbFtpUrl(
+        'https://rest.uniprot.org/uniprotkb/stream?compressed=true&download=true&format=xml&query=(*) AND (reviewed:true)',
+        FileFormat.xml
+      )
+    ).toEqual(
+      'https://ftp.uniprot.org/pub/databases/uniprot/knowledgebase/complete/uniprot_sprot.xml.gz'
+    );
+  });
+  it('should not generate FTP link', () => {
+    expect(
+      getUniprotkbFtpUrl(
+        'https://rest.uniprot.org/uniprotkb/stream?compressed=true&download=true&format=fasta&query=(*)',
+        FileFormat.fastaCanonical
+      )
+    ).toEqual(null);
+  });
 });

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -33,6 +33,9 @@ const restQueryToFtpFilename = new Map([
   ['reviewed:false', 'uniprot_trembl'],
 ]);
 
+// This goes from an array of regexs with named capture groups to a
+// a template string which will replace the capture group name
+// eg $<bool> with the matched value.
 const reToSimple = new Map([
   [
     [
@@ -60,12 +63,10 @@ export const simplifyQuery = (query: string) => {
 export const getUniprotkbFtpUrl = (downloadUrl: string, format: FileFormat) => {
   const parsed = queryString.parseUrl(downloadUrl);
   const { query } = parsed.query;
-
   const q = Array.isArray(query) ? query[0] : query;
   if (!q) {
     return null;
   }
-
   const simplifiedQuery = simplifyQuery(q);
   if (!simplifiedQuery) {
     return null;

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -22,28 +22,29 @@ const ftpUrls = {
     ),
 };
 
-const restFormatToFtpFormat = {
-  [FileFormat.fastaCanonical]: 'fasta',
-  [FileFormat.text]: 'dat',
-  [FileFormat.xml]: 'xml',
-};
+const restFormatToFtpFormat = new Map([
+  [FileFormat.fastaCanonical, 'fasta'],
+  [FileFormat.text, 'dat'],
+  [FileFormat.xml, 'xml'],
+]);
 
-const restQueryToFtpFilename = {
-  'reviewed:true': 'uniprot_sprot',
-  'reviewed:false': 'uniprot_trembl',
-};
+const restQueryToFtpFilename = new Map([
+  ['reviewed:true', 'uniprot_sprot'],
+  ['reviewed:false', 'uniprot_trembl'],
+]);
+
+const simplifiedQuery = new Map([
+  ['(reviewed:true)', 'reviewed:true'],
+  ['(*) and (reviewed:true)', 'reviewed:true'],
+  ['(reviewed:true) and (*)', 'reviewed:true'],
+  ['(reviewed:false)', 'reviewed:false'],
+  ['(*) and (reviewed:false)', 'reviewed:false'],
+  ['(reviewed:false) and (*)', 'reviewed:false'],
+]);
 
 const simplifyQuery = (query: string) => {
-  const simplified = {
-    '(reviewed:true)': 'reviewed:true',
-    '(*) and (reviewed:true)': 'reviewed:true',
-    '(reviewed:true) and (*)': 'reviewed:true',
-    '(reviewed:false)': 'reviewed:false',
-    '(*) and (reviewed:false)': 'reviewed:false',
-    '(reviewed:false) and (*)': 'reviewed:false',
-  };
   const q = query.trim().toLowerCase();
-  return simplified[q] || q;
+  return simplifiedQuery.get(q) || q;
 };
 
 export const getUniprotkbFtpUrl = (downloadUrl: string, format: FileFormat) => {
@@ -53,11 +54,11 @@ export const getUniprotkbFtpUrl = (downloadUrl: string, format: FileFormat) => {
   if (!q) {
     return null;
   }
-  const ftpFilename = restQueryToFtpFilename[simplifyQuery(q)];
+  const ftpFilename = restQueryToFtpFilename.get(simplifyQuery(q));
   if (!ftpFilename) {
     return null;
   }
-  const ftpFormat = restFormatToFtpFormat[format];
+  const ftpFormat = restFormatToFtpFormat.get(format);
   if (!ftpFormat) {
     return null;
   }

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -1,5 +1,8 @@
 import { capitalize } from 'lodash-es';
 import joinUrl from 'url-join';
+import queryString from 'query-string';
+
+import { FileFormat } from '../types/resultsDownload';
 
 const ftpUniProt = 'https://ftp.uniprot.org/pub/databases/uniprot/';
 
@@ -17,6 +20,52 @@ const ftpUrls = {
       ftpUniProt,
       `/current_release/knowledgebase/pan_proteomes/${id}.fasta.gz`
     ),
+};
+
+const restFormatToFtpFormat = {
+  [FileFormat.fastaCanonical]: 'fasta',
+  [FileFormat.text]: 'dat',
+  [FileFormat.xml]: 'xml',
+};
+
+const restQueryToFtpFilename = {
+  'reviewed:true': 'uniprot_sprot',
+  'reviewed:false': 'uniprot_trembl',
+};
+
+const simplifyQuery = (query: string) => {
+  const simplified = {
+    '(reviewed:true)': 'reviewed:true',
+    '(*) and (reviewed:true)': 'reviewed:true',
+    '(reviewed:true) and (*)': 'reviewed:true',
+    '(reviewed:false)': 'reviewed:false',
+    '(*) and (reviewed:false)': 'reviewed:false',
+    '(reviewed:false) and (*)': 'reviewed:false',
+  };
+  const q = query.trim().toLowerCase();
+  return simplified[q] || q;
+};
+
+export const getUniprotkbFtpUrl = (downloadUrl: string, format: FileFormat) => {
+  const parsed = queryString.parseUrl(downloadUrl);
+  const { query } = parsed.query;
+  const q = Array.isArray(query) ? query[0] : query;
+  if (!q) {
+    return null;
+  }
+  const ftpFilename = restQueryToFtpFilename[simplifyQuery(q)];
+  if (!ftpFilename) {
+    return null;
+  }
+  const ftpFormat = restFormatToFtpFormat[format];
+  if (!ftpFormat) {
+    return null;
+  }
+  return joinUrl(
+    ftpUniProt,
+    'knowledgebase/complete',
+    `${ftpFilename}.${ftpFormat}.gz`
+  );
 };
 
 export default ftpUrls;


### PR DESCRIPTION
## Purpose
Catch when a user is downloading reviewed:true|false, either by facets or directly from query, in specific formats - fasta, text, xml - and direct them to download this from FTP.

## Approach

- Create a fn to simplify queries.
- Map simplified query to ftp filename conventions.
- Check fileformats exists at ftp
- Instruct user to download both in api urls and when clicking download button. Note this blocks stream download and async download.

## Testing
Tested

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
