### PR TITLE
2023 05 tools refactoring pr

### DIFF
--- a/src/tools/align/state/alignFormReducer.ts
+++ b/src/tools/align/state/alignFormReducer.ts
@@ -22,6 +22,24 @@ const isInvalid = (parsedSequences: SequenceObject[]) =>
   parsedSequences.some((parsedSequence) => !parsedSequence.valid) ||
   parsedSequences.length <= 1;
 
+const getJobName = (parsedSequences: SequenceObject[]) => {
+  const firstName = parsedSequences.find((item) => item.name)?.name;
+  if (firstName) {
+    let jobName = firstName;
+    if (parsedSequences.length > 1) {
+      jobName += ` +${parsedSequences.length - 1}`;
+    }
+    return jobName;
+  }
+  if (parsedSequences.length) {
+    return `${parsedSequences.length} ${pluralise(
+      'sequence',
+      parsedSequences.length
+    )}`;
+  }
+  return '';
+};
+
 export const getAlignFormInitialState = (
   defaultFormValues: Readonly<AlignFormValues>
 ): AlignFormState => ({
@@ -70,30 +88,14 @@ export const alignFormParsedSequencesReducer = (
   };
 
   // Set Job Name, if user didn't already set
-  let potentialJobName = '';
-  if (!formValues[AlignFields.name].userSelected) {
-    // if the user didn't manually change the title, autofill it
-    const firstName = parsedSequences.find((item) => item.name)?.name;
-    if (firstName) {
-      potentialJobName = firstName;
-      if (parsedSequences.length > 1) {
-        potentialJobName += ` +${parsedSequences.length - 1}`;
-      }
-    } else if (parsedSequences.length) {
-      potentialJobName = `${parsedSequences.length} ${pluralise(
-        'sequence',
-        parsedSequences.length
-      )}`;
-    }
-  }
-
   const name =
     formValues[AlignFields.name].userSelected &&
     formValues[AlignFields.name].selected
       ? formValues[AlignFields.name]
       : {
           ...formValues[AlignFields.name],
-          selected: potentialJobName,
+          userSelected: false,
+          selected: getJobName(parsedSequences),
         };
 
   // actual form fields

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -109,6 +109,7 @@ export const blastFormParsedSequencesReducer = (
       ? formValues[BlastFields.name]
       : {
           ...formValues[BlastFields.name],
+          userSelected: false,
           selected: parsedSequences[0]?.name || '',
         };
 

--- a/src/tools/id-mapping/state/idMappingFormReducer.ts
+++ b/src/tools/id-mapping/state/idMappingFormReducer.ts
@@ -22,6 +22,18 @@ export type IDMappingFormAction = ActionType<typeof idMappingFormActions>;
 const isInvalid = (ids: IDMappingFormValue['selected']) =>
   !Array.isArray(ids) || !ids.length || ids.length > ID_MAPPING_LIMIT;
 
+const getJobName = (parsedIDs: string[], formValues: IDMappingFormValues) => {
+  if (parsedIDs.length > 0) {
+    const firstParsedID = parsedIDs[0];
+    const fromDb = formValues[IDMappingFields.fromDb].selected;
+    const toDb = formValues[IDMappingFields.toDb].selected;
+    return `${firstParsedID}${
+      parsedIDs.length > 1 ? ` +${parsedIDs.length - 1}` : ''
+    } ${fromDb} → ${toDb}`;
+  }
+  return '';
+};
+
 export const getIDMappingFormInitialState = (
   defaultFormValues: Readonly<IDMappingFormValues>
 ): IDMappingFormState => ({
@@ -56,26 +68,14 @@ export const idMappingFormInputTextIDsReducer = (
   const submitDisabled = isInvalid(parsedIDs);
 
   // Set Job Name, if user didn't already set
-  let potentialJobName = '';
-  if (!formValues[IDMappingFields.name].userSelected) {
-    // if the user didn't manually change the title, autofill it
-    const firstParsedID = parsedIDs[0];
-    if (parsedIDs.length > 0) {
-      potentialJobName = `${firstParsedID}${
-        parsedIDs.length > 1 ? ` +${parsedIDs.length - 1}` : ''
-      } ${formValues[IDMappingFields.fromDb].selected} → ${
-        formValues[IDMappingFields.toDb].selected
-      }`;
-    }
-  }
-
   const name =
     formValues[IDMappingFields.name].userSelected &&
     formValues[IDMappingFields.name].selected
       ? formValues[IDMappingFields.name]
       : {
           ...formValues[IDMappingFields.name],
-          selected: potentialJobName,
+          userSelected: false,
+          selected: getJobName(parsedIDs, formValues),
         };
 
   // actual form fields

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, MouseEvent, useMemo, useRef, useReducer } from 'react';
+import { FC, FormEvent, MouseEvent, useRef, useReducer } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Chip, PageIntro, SpinnerIcon } from 'franklin-sites';
 import { sleep } from 'timing-functions';
@@ -27,7 +27,6 @@ import {
 } from '../state/peptideSearchFormActions';
 
 import { truncateTaxonLabel } from '../../utils';
-import splitAndTidyText from '../../../shared/utils/splitAndTidyText';
 
 import { JobTypes } from '../../types/toolsJobTypes';
 import { FormParameters } from '../types/peptideSearchFormParameters';
@@ -104,7 +103,7 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
   const history = useHistory();
   const reducedMotion = useReducedMotion();
 
-  const [{ peptideSequence, formValues, sending, submitDisabled }, dispatch] =
+  const [{ parsedSequences, formValues, sending, submitDisabled }, dispatch] =
     useReducer(
       getPeptideSearchFormDataReducer(defaultFormValues),
       getPeptideSearchFormInitialState(initialFormValues)
@@ -143,11 +142,6 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
       )
     );
   };
-
-  const parsedSequences = useMemo(
-    () => splitAndTidyText(peptideSequence),
-    [peptideSequence]
-  );
 
   // form event handlers
   const handleReset = (event: FormEvent) => {
@@ -244,7 +238,7 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
               aria-label="Protein sequence(s) of at least 2 aminoacids"
               placeholder="Protein sequence(s) of at least 2 aminoacids"
               className="tools-form-raw-text-input"
-              value={peptideSequence}
+              value={formValues[PeptideSearchFields.peps].selected as string}
               onChange={(event) =>
                 dispatch(updatePeptideSequences(event.target.value))
               }

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -26,6 +26,15 @@ const isInvalid = (parsedSequences: string[]) =>
   parsedSequences.length > PEPTIDE_SEARCH_LIMIT ||
   parsedSequences.some((parsedSequence) => parsedSequence.length < 2);
 
+const getJobNameFromSequences = (parsedSequences: string[]) => {
+  if (parsedSequences.length === 0) {
+    return '';
+  }
+  return `${truncate(parsedSequences[0])}${
+    parsedSequences.length > 1 ? ` +${parsedSequences.length - 1}` : ''
+  }`;
+};
+
 export const getPeptideSearchFormInitialState = (
   defaultFormValues: Readonly<PeptideSearchFormValues>
 ): PeptideSearchFormState => ({
@@ -65,15 +74,13 @@ export const peptideSearchFormSequenceReducer = (
 
   // Set Job Name, if user didn't already set
   const name =
-    (formValues[PeptideSearchFields.name].userSelected &&
-      formValues[PeptideSearchFields.name].selected) ||
-    parsedSequences.length === 0
+    formValues[PeptideSearchFields.name].userSelected &&
+    formValues[PeptideSearchFields.name].selected
       ? formValues[PeptideSearchFields.name]
       : {
           ...formValues[PeptideSearchFields.name],
-          selected: `${truncate(parsedSequences[0])}${
-            parsedSequences.length > 1 ? ` +${parsedSequences.length - 1}` : ''
-          }`,
+          userSelected: false,
+          selected: getJobNameFromSequences(parsedSequences),
         };
 
   // actual form fields

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -12,7 +12,7 @@ import {
 
 type PeptideSearchFormState = {
   formValues: PeptideSearchFormValues;
-  peptideSequence: string;
+  parsedSequences: string[];
   submitDisabled: boolean;
   sending: boolean;
 };
@@ -39,8 +39,7 @@ export const getPeptideSearchFormInitialState = (
       ),
     },
   },
-  peptideSequence:
-    (defaultFormValues[PeptideSearchFields.peps].selected as string) || '',
+  parsedSequences: [],
   // used when the form submission needs to be disabled
   submitDisabled: isInvalid(
     splitAndTidyText(
@@ -86,12 +85,11 @@ export const peptideSearchFormSequenceReducer = (
         };
 
   // actual form fields
-  const peps = formValues[PeptideSearchFields.peps].userSelected
-    ? formValues[PeptideSearchFields.peps]
-    : {
-        ...formValues[PeptideSearchFields.peps],
-        selected: formValues[PeptideSearchFields.peps].selected,
-      };
+  // Set peps to raw peptide sequence no matter what
+  const peps = {
+    ...formValues[PeptideSearchFields.peps],
+    selected: peptideSequence,
+  };
 
   const taxIds = formValues[PeptideSearchFields.taxIds].userSelected
     ? formValues[PeptideSearchFields.taxIds]
@@ -116,7 +114,7 @@ export const peptideSearchFormSequenceReducer = (
 
   return {
     ...state,
-    peptideSequence,
+    parsedSequences,
     submitDisabled,
     formValues: {
       ...formValues,

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -64,24 +64,16 @@ export const peptideSearchFormSequenceReducer = (
   const submitDisabled = isInvalid(parsedSequences);
 
   // Set Job Name, if user didn't already set
-  let potentialJobName = '';
-  if (!formValues[PeptideSearchFields.name].userSelected) {
-    // if the user didn't manually change the title, autofill it
-    const firstParsedSequence = parsedSequences[0];
-    if (parsedSequences.length > 0) {
-      potentialJobName = `${truncate(firstParsedSequence)}${
-        parsedSequences.length > 1 ? ` +${parsedSequences.length - 1}` : ''
-      }`;
-    }
-  }
-
   const name =
-    formValues[PeptideSearchFields.name].userSelected &&
-    formValues[PeptideSearchFields.name].selected
+    (formValues[PeptideSearchFields.name].userSelected &&
+      formValues[PeptideSearchFields.name].selected) ||
+    parsedSequences.length === 0
       ? formValues[PeptideSearchFields.name]
       : {
           ...formValues[PeptideSearchFields.name],
-          selected: potentialJobName,
+          selected: `${truncate(parsedSequences[0])}${
+            parsedSequences.length > 1 ? ` +${parsedSequences.length - 1}` : ''
+          }`,
         };
 
   // actual form fields

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -26,7 +26,7 @@ const isInvalid = (parsedSequences: string[]) =>
   parsedSequences.length > PEPTIDE_SEARCH_LIMIT ||
   parsedSequences.some((parsedSequence) => parsedSequence.length < 2);
 
-const getJobNameFromSequences = (parsedSequences: string[]) => {
+const getJobName = (parsedSequences: string[]) => {
   if (parsedSequences.length === 0) {
     return '';
   }
@@ -80,7 +80,7 @@ export const peptideSearchFormSequenceReducer = (
       : {
           ...formValues[PeptideSearchFields.name],
           userSelected: false,
-          selected: getJobNameFromSequences(parsedSequences),
+          selected: getJobName(parsedSequences),
         };
 
   // actual form fields

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -62,12 +62,12 @@ export const getPeptideSearchFormInitialState = (
 export const peptideSearchFormSequenceReducer = (
   state: PeptideSearchFormState,
   {
-    payload: peptideSequence,
+    payload: peptideSequences,
   }: ActionType<typeof peptideSearchFormActions.updatePeptideSequences>
 ) => {
   const { formValues } = state;
 
-  const parsedSequences = splitAndTidyText(peptideSequence);
+  const parsedSequences = splitAndTidyText(peptideSequences);
 
   // Set Submit Disabled according to sequence
   const submitDisabled = isInvalid(parsedSequences);
@@ -84,10 +84,10 @@ export const peptideSearchFormSequenceReducer = (
         };
 
   // actual form fields
-  // Set peps to raw peptide sequence no matter what
+  // Set peps to raw peptide sequences no matter what
   const peps = {
     ...formValues[PeptideSearchFields.peps],
-    selected: peptideSequence,
+    selected: peptideSequences,
   };
 
   const taxIds = formValues[PeptideSearchFields.taxIds].userSelected


### PR DESCRIPTION
- Noticed a bug with the job name setting that was in my original BLAST form reducer so fixed this along with the other reducers.
- Swapped `parsedSequences`, `peptideSequence` and `formValues[PeptideSearchFields.peps]` to reflect the original logic.