### PR TITLE
Side button relocation 2

### DIFF
--- a/patch
+++ b/patch
@@ -1,0 +1,82 @@
+diff --git a/src/help/components/contextual/SideButtons.tsx b/src/help/components/contextual/SideButtons.tsx
+index 70f820dcd..0e1c57f71 100644
+--- a/src/help/components/contextual/SideButtons.tsx
++++ b/src/help/components/contextual/SideButtons.tsx
+@@ -5,7 +5,8 @@ import { sleep } from 'timing-functions';
+ 
+ import { LocationToPath, Location } from '../../../app/config/urls';
+ 
+-import styles from './styles/side-buttons.module.scss';
++import sideButtonStyles from './styles/side-buttons.module.scss';
++import baseStyles from '../../../shared/components/layouts/styles/base-layout.module.scss';
+ 
+ type Props = {
+   displayHelp: boolean;
+@@ -16,6 +17,36 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
+   const [displayFeedback, setDisplayFeedback] = useState(false);
+ 
+   useEffect(() => {
++    // Checking if there is a scroll bar
++    const mainContent = document?.querySelector<HTMLElement>(
++      `.${baseStyles['main-content']}`
++    );
++    const scrollBarWidth =
++      mainContent && mainContent.offsetWidth - mainContent.clientWidth;
++
++    if (scrollBarWidth) {
++      const hjButton = document.querySelector<HTMLElement>(
++        '#_hj_feedback_container div button'
++      );
++
++      const sideButton = document?.querySelector<HTMLElement>(
++        `.${sideButtonStyles['side-button']}`
++      );
++      const sideButtonHelp = document?.querySelector<HTMLElement>(
++        `.${sideButtonStyles.help}`
++      );
++
++      if (hjButton) {
++        hjButton.style.right = '17px';
++      }
++      if (sideButton) {
++        sideButton.style.right = '17px';
++      }
++      if (sideButtonHelp) {
++        sideButtonHelp.style.right = '17px';
++      }
++    }
++
+     sleep(3000).then(() => {
+       // If there's already Hotjar's feedback, don't do anything
+       if (document.querySelector('._hj_feedback_container')) {
+@@ -26,11 +57,15 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
+   });
+ 
+   return (
+-    <span className={styles.container}>
++    <span className={sideButtonStyles.container}>
+       <a
+-        className={cn(styles['side-button'], styles.feedback, {
+-          [styles.visible]: displayFeedback,
+-        })}
++        className={cn(
++          sideButtonStyles['side-button'],
++          sideButtonStyles.feedback,
++          {
++            [sideButtonStyles.visible]: displayFeedback,
++          }
++        )}
+         target="_blank"
+         href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
+         rel="noopener noreferrer"
+@@ -42,8 +77,8 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
+         to={LocationToPath[Location.HelpResults]}
+         onClick={onClick}
+         tabIndex={-1}
+-        className={cn(styles['side-button'], styles.help, {
+-          [styles.visible]: displayHelp,
++        className={cn(sideButtonStyles['side-button'], sideButtonStyles.help, {
++          [sideButtonStyles.visible]: displayHelp,
+         })}
+       >
+         Help

--- a/src/help/components/contextual/SideButtons.tsx
+++ b/src/help/components/contextual/SideButtons.tsx
@@ -5,7 +5,8 @@ import { sleep } from 'timing-functions';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
-import styles from './styles/side-buttons.module.scss';
+import sideButtonStyles from './styles/side-buttons.module.scss';
+import baseStyles from '../../../shared/components/layouts/styles/base-layout.module.scss';
 
 type Props = {
   displayHelp: boolean;
@@ -16,6 +17,36 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
   const [displayFeedback, setDisplayFeedback] = useState(false);
 
   useEffect(() => {
+    // Checking if there is a scroll bar
+    const mainContent = document?.querySelector<HTMLElement>(
+      `.${baseStyles['main-content']}`
+    );
+    const scrollBarWidth =
+      mainContent && mainContent.offsetWidth - mainContent.clientWidth;
+
+    if (scrollBarWidth) {
+      const hjButton = document.querySelector<HTMLElement>(
+        '#_hj_feedback_container div button'
+      );
+
+      const sideButton = document?.querySelector<HTMLElement>(
+        `.${sideButtonStyles['side-button']}`
+      );
+      const sideButtonHelp = document?.querySelector<HTMLElement>(
+        `.${sideButtonStyles.help}`
+      );
+
+      if (hjButton) {
+        hjButton.style.right = '17px';
+      }
+      if (sideButton) {
+        sideButton.style.right = '17px';
+      }
+      if (sideButtonHelp) {
+        sideButtonHelp.style.right = '17px';
+      }
+    }
+
     sleep(3000).then(() => {
       // If there's already Hotjar's feedback, don't do anything
       if (document.querySelector('._hj_feedback_container')) {
@@ -26,11 +57,15 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
   });
 
   return (
-    <span className={styles.container}>
+    <span className={sideButtonStyles.container}>
       <a
-        className={cn(styles['side-button'], styles.feedback, {
-          [styles.visible]: displayFeedback,
-        })}
+        className={cn(
+          sideButtonStyles['side-button'],
+          sideButtonStyles.feedback,
+          {
+            [sideButtonStyles.visible]: displayFeedback,
+          }
+        )}
         target="_blank"
         href="https://goo.gl/forms/VrAGbqg2XFg6Mpbh1"
         rel="noopener noreferrer"
@@ -42,8 +77,8 @@ const SideButtons = ({ displayHelp, onClick }: Props) => {
         to={LocationToPath[Location.HelpResults]}
         onClick={onClick}
         tabIndex={-1}
-        className={cn(styles['side-button'], styles.help, {
-          [styles.visible]: displayHelp,
+        className={cn(sideButtonStyles['side-button'], sideButtonStyles.help, {
+          [sideButtonStyles.visible]: displayHelp,
         })}
       >
         Help


### PR DESCRIPTION
## Purpose
Describe the problem or feature in addition to a link to the issue(s), including context where needed.
Feedback and help buttons are covering the scroll bar, which users have complained. 

## Approach
How does this change address the problem?
If the scroll bar exists, it moves the feedback and help buttons 17px from the right.
If the scroll bar is like a "mac" style where it only appears on scroll, the buttons are unmoved

## Testing
What test(s) did you write to validate and verify your changes?
Help and fallback feedback button (google forms) were checked. 
HotJar feedback button code is there, but needs check in live because it is not able to test in localhost

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
