### PR TITLE
'Did you mean...' search suggestion box style changes

### DIFF
--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -224,7 +224,7 @@ const ResultsData = ({
         <div className={styles['did-you-mean-wrapper']}>
           <DidYouMean
             suggestions={suggestions}
-            heading={<h2>Not what you were looking for?</h2>}
+            heading={<h2 className="small">Not what you were looking for?</h2>}
           />
         </div>
       )}

--- a/src/shared/components/results/styles/did-you-mean.module.scss
+++ b/src/shared/components/results/styles/did-you-mean.module.scss
@@ -2,6 +2,10 @@
   text-align: left;
 }
 
+.did-you-mean-message small {
+  font-size: 100%;
+}
+
 .suggestions {
   text-align: left;
   padding: 0.5rem 0.5rem 0rem;

--- a/src/shared/components/results/styles/results-data.module.scss
+++ b/src/shared/components/results/styles/results-data.module.scss
@@ -31,10 +31,11 @@
 
 .did-you-mean-wrapper {
   /* make sure the wrapper uses 100% of the remaining width */
-  width: calc(100vw - var(--sidebar-size));
+  width: calc(80vw - var(--sidebar-size));
   /* so that DidYouMean component is visually centred _before_ any scrolling */
   display: grid;
   padding-block: 10 * $global-padding 5 * $global-padding;
   justify-items: center;
   align-items: center;
+  margin: auto;
 }

--- a/src/shared/components/results/styles/results-data.module.scss
+++ b/src/shared/components/results/styles/results-data.module.scss
@@ -34,7 +34,7 @@
   width: calc(100vw - var(--sidebar-size));
   /* so that DidYouMean component is visually centred _before_ any scrolling */
   display: grid;
-  padding-block: 5 * $global-padding;
+  padding-block: 10 * $global-padding 5 * $global-padding;
   justify-items: center;
   align-items: center;
 }

--- a/src/shared/components/results/styles/results-data.module.scss
+++ b/src/shared/components/results/styles/results-data.module.scss
@@ -31,11 +31,10 @@
 
 .did-you-mean-wrapper {
   /* make sure the wrapper uses 100% of the remaining width */
-  width: calc(80vw - var(--sidebar-size));
+  width: calc(90vw - var(--sidebar-size));
   /* so that DidYouMean component is visually centred _before_ any scrolling */
   display: grid;
   padding-block: 10 * $global-padding 5 * $global-padding;
   justify-items: center;
   align-items: center;
-  margin: auto;
 }

--- a/src/shared/components/results/styles/results-data.module.scss
+++ b/src/shared/components/results/styles/results-data.module.scss
@@ -39,8 +39,6 @@
   justify-items: center;
   align-items: center;
 
-  position: sticky;
-
   @include fs-breakpoints('medium') {
     // a bit of room on the sides on medium screens
     width: calc(90vw - var(--sidebar-size));

--- a/src/shared/components/results/styles/results-data.module.scss
+++ b/src/shared/components/results/styles/results-data.module.scss
@@ -1,5 +1,6 @@
 @import 'franklin-sites/src/styles/colours';
 @import 'franklin-sites/src/styles/settings';
+@import 'franklin-sites/src/styles/mixins';
 
 @import '../../../styles/settings';
 
@@ -31,10 +32,17 @@
 
 .did-you-mean-wrapper {
   /* make sure the wrapper uses 100% of the remaining width */
-  width: calc(90vw - var(--sidebar-size));
+  width: 90vw;
   /* so that DidYouMean component is visually centred _before_ any scrolling */
   display: grid;
   padding-block: 10 * $global-padding 5 * $global-padding;
   justify-items: center;
   align-items: center;
+
+  position: sticky;
+
+  @include fs-breakpoints('medium') {
+    // a bit of room on the sides on medium screens
+    width: calc(90vw - var(--sidebar-size));
+  }
 }


### PR DESCRIPTION
## Purpose
Describe the problem or feature in addition to a link to the issue(s), including context where needed.
: Search suggestion box at the bottom has too big of a header, and smaller suggestions which are difficult to read. Also when there are few results (1 or generally less than 10) from the search, the box is too close to the results table which drifts users' focus on to the box instead of actual results.
ex) https://www.uniprot.org/uniprotkb?facets=model_organism:10116&query=erbeta

## Approach
How does this change address the problem?
: This fix balances the header and the content of the message, and adds some increased spacing between the bottom of the results table and the suggestion box

## Testing
What test(s) did you write to validate and verify your changes?

: checked on various search queries, including ones that do not give a suggestion 
ex) https://www.uniprot.org/uniprotkb?query=gene:erv

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
