### PR TITLE
Redirect to star search when query is nonexistent or is empty string.

### DIFF
--- a/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
+++ b/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`DatabaseCard tests should render the card component 1`] = `
               Category: 
             </strong>
             <a
-              href="/database?facets=category_exact:Sequence databases&query=*"
+              href="/database?facets=category_exact:Sequence databases"
             >
               Sequence databases
             </a>

--- a/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
+++ b/src/supporting-data/database/config/DatabaseColumnConfiguration.tsx
@@ -58,11 +58,9 @@ DatabaseColumnConfiguration.set(DatabaseColumn.category, {
       <Link
         to={({ search }) => {
           const [params] = getParamsFromURL(search);
-          const query = params.query ? params.query : '*';
           return getLocationObjForParams({
             pathname: LocationToPath[Location.DatabaseResults],
             ...params,
-            query,
             selectedFacets: [
               ...params.selectedFacets.filter(
                 ({ name }) => name !== 'category_exact'

--- a/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`DatabaseColumnConfiguration component should render column "abbrev": ab
 exports[`DatabaseColumnConfiguration component should render column "category": category 1`] = `
 <DocumentFragment>
   <a
-    href="/database?facets=category_exact:Sequence databases&query=*"
+    href="/database?facets=category_exact:Sequence databases"
   >
     Sequence databases
   </a>


### PR DESCRIPTION
## Purpose
Deal with situation where the results route doesn't have a `query=` url parameter or this is just blank.

https://www.ebi.ac.uk/panda/jira/browse/TRM-26268
https://www.ebi.ac.uk/panda/jira/browse/TRM-29073

## Approach
Add logic within `ResultsOrLanding` to detect absence of `query=` and add this in as `query=*`.

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
