### PR TITLE
Fix job name behaviour for BLAST and Align

### DIFF
--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -110,7 +110,7 @@ export const blastFormParsedSequencesReducer = (
       : {
           ...formValues[BlastFields.name],
           userSelected: false,
-          // Set the job name empty when there are multiple seqeunces copy-pasted
+          // Set the job name empty when there are multiple sequences copy-pasted
           selected:
             parsedSequences.length === 1 ? parsedSequences[0]?.name : '',
         };

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -110,7 +110,9 @@ export const blastFormParsedSequencesReducer = (
       : {
           ...formValues[BlastFields.name],
           userSelected: false,
-          selected: parsedSequences[0]?.name || '',
+          // Set the job name empty when there are multiple seqeunces copy-pasted
+          selected:
+            parsedSequences.length === 1 ? parsedSequences[0]?.name : '',
         };
 
   return {

--- a/src/tools/hooks/useInitialFormParameters.tsx
+++ b/src/tools/hooks/useInitialFormParameters.tsx
@@ -152,7 +152,7 @@ function useInitialFormParameters<
     return Object.freeze(formValues as FormValues<Fields>);
   }, [
     fastaLoading,
-    history.location?.state,
+    history.location,
     parametersFromHistorySearch,
     fasta,
     defaultFormValues,

--- a/src/tools/hooks/useInitialFormParameters.tsx
+++ b/src/tools/hooks/useInitialFormParameters.tsx
@@ -130,9 +130,22 @@ function useInitialFormParameters<
         selected: sequences,
       });
       const parsedSequences = sequenceProcessor(sequences);
+
+      let name = parsedSequences[0]?.name;
+      // Job name for Align is taken after the first sequence followed by number of sequences
+      if (LocationToPath[Location.Align] === history.location.pathname) {
+        name = `${parsedSequences[0]?.name} +${parsedSequences.length - 1}`;
+      }
+      // By default, job names should be after each submitted sequence for BLAST, hence do not set the name for multiple sequences.
+      if (
+        LocationToPath[Location.Blast] === history.location.pathname &&
+        parsedSequences.length > 1
+      ) {
+        name = '';
+      }
       formValues['Name' as Fields] = Object.freeze({
         fieldName: 'name',
-        selected: parsedSequences[0]?.name || '',
+        selected: name,
       });
     }
 


### PR DESCRIPTION
## Purpose
When multiple accessions are selected for BLAST or Align from the tools button, the job name is always after the first sequence. When there are multiple ones entered in the form itself, they are fine. 

## Approach
The recently introduced 'userSelected' property was changing the behaviour. It is been taken care of at the 'useInitialFormParameter' level for both BLAST and Align.

Also, for BLAST if there are more than one sequence, the job name is set to be empty and the submitted jobs take the respective name after submission.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
