### PR TITLE
Proteome download

### DIFF
--- a/src/proteomes/components/entry/Components.tsx
+++ b/src/proteomes/components/entry/Components.tsx
@@ -22,8 +22,11 @@ const genomeAccessionDB = 'GenomeAccession' as const;
 const getIdKey = ({ name }: Component) => name;
 
 export const Components: FC<
-  Pick<ProteomesAPIModel, 'components' | 'id' | 'proteinCount' | 'proteomeType'>
-> = ({ components, id, proteinCount, proteomeType }) => {
+  Pick<
+    ProteomesAPIModel,
+    'components' | 'id' | 'proteinCount' | 'proteomeType' | 'superkingdom'
+  >
+> = ({ components, id, proteinCount, proteomeType, superkingdom }) => {
   const [selectedEntries, setSelectedItemFromEvent] = useItemSelect();
 
   const columns = useMemo<
@@ -128,6 +131,7 @@ export const Components: FC<
         proteinCount={proteinCount}
         id={id}
         proteomeType={proteomeType}
+        superkingdom={superkingdom}
       />
       <DataTable
         getIdKey={getIdKey}

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -63,13 +63,15 @@ const ComponentsButtons = ({
 }: Props) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
+  const sp = new URLSearchParams({
+    query: `(proteome=${id}) AND (reviewed=true)`,
+    size: '0',
+  });
+
   // Note: all Eukaryotes are not eligible. Having a list of the organisms would be helpful
   const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     superkingdom === 'eukaryota'
-      ? `${apiUrls.search(Namespace.uniprotkb)}?${queryString.stringify({
-          query: `(proteome=${id}) AND (reviewed=true)`,
-          size: 0,
-        })}`
+      ? `${apiUrls.search(Namespace.uniprotkb)}?${sp}`
       : null
   );
 

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -127,7 +127,7 @@ const ComponentsButtons = ({
                 selectedQuery={selectedQuery}
                 numberSelectedEntries={numberSelectedProteins}
                 totalNumberResults={proteinCount}
-                reviewedNumberResults={reviewedProteinsCount}
+                filteredNumberResults={reviewedProteinsCount}
                 onClose={handleToggleDownload}
                 namespace={
                   // Excluded not supported at the moment, need to wait for TRM-28011

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -1,7 +1,6 @@
 import { useState, Suspense, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, DownloadIcon, SlidingPanel } from 'franklin-sites';
-import queryString from 'query-string';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 

--- a/src/proteomes/components/entry/Overview.tsx
+++ b/src/proteomes/components/entry/Overview.tsx
@@ -60,7 +60,7 @@ export const Overview = ({ data }: { data: ProteomesUIModel }) => {
       {
         title: (
           <span data-article-id="proteome_terminology#protein-count">
-            Protein count
+            Number of entries
           </span>
         ),
         content: renderColumnContent(ProteomesColumn.proteinCount),

--- a/src/proteomes/components/entry/__tests__/Components.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/Components.spec.tsx
@@ -15,6 +15,7 @@ describe('Components view', () => {
         id={data.id}
         proteinCount={data.proteinCount}
         proteomeType={data.proteomeType}
+        superkingdom={data.superkingdom}
       />
     );
     expect(asFragment()).toMatchSnapshot();

--- a/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
@@ -30,6 +30,7 @@ describe('ComponentsButtons', () => {
           selectedEntries={selectedComponents}
           proteinCount={100}
           proteomeType="Reference and representative proteome"
+          superkingdom="superkingdom"
         />
       );
       const link = screen.getByRole<HTMLAnchorElement>('link', {
@@ -52,6 +53,7 @@ describe('ComponentsButtons', () => {
         proteinCount={100}
         selectedEntries={[]}
         proteomeType="Reference and representative proteome"
+        superkingdom="superkingdom"
       />
     );
     expect(container).toBeEmptyDOMElement();
@@ -65,6 +67,7 @@ describe('ComponentsButtons', () => {
         selectedEntries={[]}
         components={getComponents(10) as Component[]}
         proteomeType="Reference and representative proteome"
+        superkingdom="superkingdom"
       />
     );
     const downloadButton = screen.getByRole('button', { name: 'Download' });

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`EntryMain view should render 1`] = `
                 <span
                   data-article-id="proteome_terminology#protein-count"
                 >
-                  Protein count
+                  Number of entries
                 </span>
               </div>
               <div

--- a/src/proteomes/config/ProteomesEntryConfig.tsx
+++ b/src/proteomes/config/ProteomesEntryConfig.tsx
@@ -16,12 +16,19 @@ const ProteomesEntryConfig: {
   },
   {
     id: EntrySection.Components,
-    sectionContent: ({ components, id, proteinCount, proteomeType }) => (
+    sectionContent: ({
+      components,
+      id,
+      proteinCount,
+      proteomeType,
+      superkingdom,
+    }) => (
       <Components
         components={components}
         id={id}
         proteinCount={proteinCount}
         proteomeType={proteomeType}
+        superkingdom={superkingdom}
       />
     ),
   },

--- a/src/proteomes/config/download.ts
+++ b/src/proteomes/config/download.ts
@@ -1,11 +1,11 @@
 import { FileFormat } from '../../shared/types/resultsDownload';
 
 export const fileFormatsResultsDownload = [
+  FileFormat.fasta,
   FileFormat.tsv,
   FileFormat.excel,
   FileFormat.json,
   FileFormat.xml,
-  FileFormat.rdfXml,
   FileFormat.list,
 ];
 
@@ -18,3 +18,8 @@ export const fileFormatEntryDownload = [
 ];
 
 export const fileFormatsResultsDownloadForRedundant = [FileFormat.fasta];
+
+export const fileFormatsResultsDownloadForIsoformSequence = [
+  FileFormat.fasta,
+  FileFormat.json,
+];

--- a/src/proteomes/config/download.ts
+++ b/src/proteomes/config/download.ts
@@ -18,8 +18,3 @@ export const fileFormatEntryDownload = [
 ];
 
 export const fileFormatsResultsDownloadForRedundant = [FileFormat.fasta];
-
-export const fileFormatsResultsDownloadForIsoformSequence = [
-  FileFormat.fasta,
-  FileFormat.json,
-];

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -58,6 +58,7 @@ type DownloadProps = {
   selectedQuery?: string;
   totalNumberResults: number;
   numberSelectedEntries?: number;
+  reviewedNumberResults?: number;
   namespace: Namespace;
   onClose: (
     panelCloseReason: DownloadPanelFormCloseReason,
@@ -78,6 +79,7 @@ const Download: FC<DownloadProps> = ({
   selectedQuery,
   selectedEntries = [],
   totalNumberResults,
+  reviewedNumberResults,
   numberSelectedEntries,
   onClose,
   namespace,
@@ -300,8 +302,27 @@ const Download: FC<DownloadProps> = ({
           onChange={handleDownloadAllChange}
           disabled={redirectToIDMapping}
         />
-        Download all (<LongNumber>{totalNumberResults}</LongNumber>)
+        Download all{' '}
+        {reviewedNumberResults
+          ? 'reviewed (Swiss-Prot) adnd unreviewed (TrEMBL)'
+          : ''}{' '}
+        (<LongNumber>{totalNumberResults}</LongNumber>)
       </label>
+      {reviewedNumberResults && (
+        <label htmlFor="data-selection-reviewed">
+          <input
+            id="data-selection-reviewed"
+            type="radio"
+            name="data-selection"
+            value="false"
+            checked={!downloadAll}
+            onChange={handleDownloadAllChange}
+            disabled={redirectToIDMapping}
+          />
+          Download reviewed only (
+          <LongNumber>{reviewedNumberResults}</LongNumber>)
+        </label>
+      )}
       <fieldset>
         <label>
           Format

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,4 +1,4 @@
-import { useState, FC, ChangeEvent, useEffect } from 'react';
+import { useState, FC, ChangeEvent } from 'react';
 import { generatePath, Link, useLocation } from 'react-router-dom';
 import { Button, DownloadIcon, LongNumber, Message } from 'franklin-sites';
 import cn from 'classnames';
@@ -25,7 +25,6 @@ import {
 } from '../../config/resultsDownload';
 import defaultFormValues from '../../../tools/async-download/config/asyncDownloadFormData';
 import { getUniprotkbFtpFilenameAndUrl } from '../../config/ftpUrls';
-
 import { Location, LocationToPath } from '../../../app/config/urls';
 
 import { FileFormat } from '../../types/resultsDownload';

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -1,4 +1,4 @@
-import { useState, FC, ChangeEvent, useEffect } from 'react';
+import { useState, FC, ChangeEvent } from 'react';
 import { generatePath, Link, useLocation } from 'react-router-dom';
 import { Button, DownloadIcon, LongNumber, Message } from 'franklin-sites';
 import cn from 'classnames';

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -34,10 +34,10 @@ import {
   DownloadMethod,
   DownloadPanelFormCloseReason,
 } from '../../utils/gtagEvents';
+import { IsoformStatistics } from '../../../proteomes/components/entry/ComponentsButtons';
 
 import sticky from '../../styles/sticky.module.scss';
 import styles from './styles/download.module.scss';
-import { IsoformStatistics } from '../../../proteomes/components/entry/ComponentsButtons';
 
 const DOWNLOAD_SIZE_LIMIT_EMBEDDINGS = 1_000_000 as const;
 

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -58,7 +58,7 @@ type DownloadProps = {
   selectedQuery?: string;
   totalNumberResults: number;
   numberSelectedEntries?: number;
-  reviewedNumberResults?: number;
+  filteredNumberResults?: number;
   namespace: Namespace;
   onClose: (
     panelCloseReason: DownloadPanelFormCloseReason,
@@ -81,7 +81,7 @@ const Download: FC<DownloadProps> = ({
   selectedQuery,
   selectedEntries = [],
   totalNumberResults,
-  reviewedNumberResults,
+  filteredNumberResults,
   numberSelectedEntries,
   onClose,
   namespace,
@@ -186,7 +186,7 @@ const Download: FC<DownloadProps> = ({
       downloadCount = totalNumberResults;
       break;
     case 'filtered':
-      downloadCount = reviewedNumberResults || 0;
+      downloadCount = filteredNumberResults || 0;
       break;
     case 'selected':
       downloadCount = nSelectedEntries;
@@ -323,12 +323,12 @@ const Download: FC<DownloadProps> = ({
           disabled={redirectToIDMapping}
         />
         Download all{' '}
-        {reviewedNumberResults
+        {filteredNumberResults
           ? 'reviewed (Swiss-Prot) adnd unreviewed (TrEMBL)'
           : ''}{' '}
         (<LongNumber>{totalNumberResults}</LongNumber>)
       </label>
-      {reviewedNumberResults && (
+      {filteredNumberResults && (
         <label htmlFor="data-selection-reviewed">
           <input
             id="data-selection-reviewed"
@@ -340,7 +340,7 @@ const Download: FC<DownloadProps> = ({
             disabled={redirectToIDMapping}
           />
           Download reviewed only (
-          <LongNumber>{reviewedNumberResults}</LongNumber>)
+          <LongNumber>{filteredNumberResults}</LongNumber>)
         </label>
       )}
       <fieldset>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -74,7 +74,7 @@ type DownloadProps = {
 
 type ExtraContent = 'url' | 'generate' | 'preview' | 'ftp';
 
-type DownloadCategories = 'all' | 'selected' | 'filtered';
+type DownloadSelectOptions = 'all' | 'selected' | 'filtered';
 
 const Download: FC<DownloadProps> = ({
   query,
@@ -100,7 +100,7 @@ const Download: FC<DownloadProps> = ({
 
   const [selectedColumns, setSelectedColumns] = useState<Column[]>(columnNames);
   // Defaults to "download all" if no selection
-  const [downloadAll, setDownloadAll] = useState<DownloadCategories>(
+  const [downloadSelect, setDownloadSelect] = useState<DownloadSelectOptions>(
     selectedEntries.length ? 'selected' : 'all'
   );
   const [fileFormat, setFileFormat] = useState(fileFormats[0]);
@@ -117,11 +117,11 @@ const Download: FC<DownloadProps> = ({
   // This logic is needed specifically for the proteomes components
   let urlQuery: string;
   let urlSelected: string[];
-  if (downloadAll === 'all') {
+  if (downloadSelect === 'all') {
     // If query prop provided use this otherwise fallback to query from URL
     urlQuery = query || queryFromUrl;
     urlSelected = [];
-  } else if (downloadAll === 'filtered') {
+  } else if (downloadSelect === 'filtered') {
     urlQuery = `${query || queryFromUrl} AND reviewed=true`;
     urlSelected = [];
   } else {
@@ -180,7 +180,7 @@ const Download: FC<DownloadProps> = ({
 
   const nSelectedEntries = numberSelectedEntries || selectedEntries.length;
   let downloadCount;
-  switch (downloadAll) {
+  switch (downloadSelect) {
     case 'all':
       downloadCount = totalNumberResults;
       break;
@@ -211,7 +211,7 @@ const Download: FC<DownloadProps> = ({
   const previewUrl = previewOptions && getDownloadUrl(previewOptions);
 
   const handleDownloadAllChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setDownloadAll(e.target.name as DownloadCategories);
+    setDownloadSelect(e.target.name as DownloadSelectOptions);
   };
 
   const handleCompressedChange = (e: ChangeEvent<HTMLInputElement>) =>
@@ -305,7 +305,7 @@ const Download: FC<DownloadProps> = ({
           type="radio"
           name="selected"
           value="false"
-          checked={downloadAll === 'selected'}
+          checked={downloadSelect === 'selected'}
           onChange={handleDownloadAllChange}
           disabled={nSelectedEntries === 0 || redirectToIDMapping}
         />
@@ -317,7 +317,7 @@ const Download: FC<DownloadProps> = ({
           type="radio"
           name="all"
           value="true"
-          checked={downloadAll === 'all'}
+          checked={downloadSelect === 'all'}
           onChange={handleDownloadAllChange}
           disabled={redirectToIDMapping}
         />
@@ -334,7 +334,7 @@ const Download: FC<DownloadProps> = ({
             type="radio"
             name="filtered"
             value="false"
-            checked={downloadAll === 'filtered'}
+            checked={downloadSelect === 'filtered'}
             onChange={handleDownloadAllChange}
             disabled={redirectToIDMapping}
           />

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -358,7 +358,7 @@ const Download: FC<DownloadProps> = ({
             Download only reviewed (Swiss-Prot) canonical proteins (
             {/* <LongNumber>{includeIsoform ? isoformStats?.reviewedWithIsoforms : isoformStats?.reviewed}</LongNumber>) */}
             <LongNumber>{isoformStats?.reviewed || 0}</LongNumber>
-            {includeIsoform ? '+ isoforms' : ''})
+            {includeIsoform ? ' + isoforms' : ''})
           </label>
           <label className={styles['isoform-option']}>
             <input
@@ -387,7 +387,7 @@ const Download: FC<DownloadProps> = ({
           : ''}{' '}
         {/* (<LongNumber>{showReviewedOption ? isoformStats?.allWithIsoforms : totalNumberResults}</LongNumber>) */}
         (<LongNumber>{totalNumberResults}</LongNumber>{' '}
-        {showReviewedOption ? '+ isoforms' : ''})
+        {showReviewedOption ? ' + isoforms' : ''})
       </label>
       <fieldset>
         <label>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -26,10 +26,7 @@ import {
 import defaultFormValues from '../../../tools/async-download/config/asyncDownloadFormData';
 import { getUniprotkbFtpFilenameAndUrl } from '../../config/ftpUrls';
 import { Location, LocationToPath } from '../../../app/config/urls';
-import {
-  fileFormatsResultsDownload as fileFormatsProteomeResultsDownload,
-  fileFormatsResultsDownloadForIsoformSequence,
-} from '../../../proteomes/config/download';
+import { fileFormatsResultsDownload as fileFormatsProteomeResultsDownload } from '../../../proteomes/config/download';
 
 import { FileFormat } from '../../types/resultsDownload';
 import { Namespace } from '../../types/namespaces';
@@ -189,20 +186,19 @@ const Download: FC<DownloadProps> = ({
   switch (downloadSelect) {
     case 'all':
       downloadCount = totalNumberResults;
-      if (showReviewedOption && fileFormat === FileFormat.fasta) {
+      if (showReviewedOption) {
         // downloadCount = isoformStats?.allWithIsoforms;
         downloadOptions.fileFormat = FileFormat.fastaCanonicalIsoform;
-        fileFormats = fileFormatsResultsDownloadForIsoformSequence;
+        fileFormats = [FileFormat.fasta];
       }
       break;
     case 'reviewed':
       // Once we have the counts, we should update the downloadCount accordingly
       downloadCount = isoformStats?.reviewed || 0;
-      // TODO Need to check if JSON is still necessary
       if (includeIsoform) {
         // downloadCount = isoformStats?.reviewedWithIsoforms || 0;
         downloadOptions.fileFormat = FileFormat.fastaCanonicalIsoform;
-        fileFormats = fileFormatsResultsDownloadForIsoformSequence;
+        fileFormats = [FileFormat.fasta];
       } else {
         // downloadCount = isoformStats?.reviewed || 0;
         downloadOptions.fileFormat = FileFormat.fastaCanonical;
@@ -244,7 +240,7 @@ const Download: FC<DownloadProps> = ({
 
   const handleIsoformSelect = (e: ChangeEvent<HTMLInputElement>) => {
     if (e?.target.checked) {
-      fileFormats = fileFormatsResultsDownloadForIsoformSequence;
+      fileFormats = [FileFormat.fasta];
       setIncludeIsoform(true);
     } else {
       fileFormats = fileFormatsProteomeResultsDownload;

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -108,10 +108,6 @@ const Download: FC<DownloadProps> = ({
   const [extraContent, setExtraContent] = useState<null | ExtraContent>(null);
   const { jobResultsLocation, jobResultsNamespace } = useJobFromUrl();
 
-  // useEffect(() => {
-  //   setDownloadAll('filtered');
-  // }, [reviewedNumberResults])
-
   const [
     { query: queryFromUrl, selectedFacets = [], sortColumn, sortDirection },
   ] = getParamsFromURL(queryParamFromUrl);
@@ -124,6 +120,9 @@ const Download: FC<DownloadProps> = ({
   if (downloadAll === 'all') {
     // If query prop provided use this otherwise fallback to query from URL
     urlQuery = query || queryFromUrl;
+    urlSelected = [];
+  } else if (downloadAll === 'filtered') {
+    urlQuery = `${query || queryFromUrl} AND reviewed=true`;
     urlSelected = [];
   } else {
     // Download selected

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -292,21 +292,26 @@ describe('Download with ID mapping results', () => {
   });
 });
 
-describe('Download reviewed proteins for a proteome entry', () => {
+describe('Download reviewed proteins for a proteome entry assuming it is an Eukaryote', () => {
   it('should check the filteredNumberResults and add the additional select options', async () => {
     const namespace = Namespace.uniprotkb;
     const onCloseMock = jest.fn();
     const query = '(proteome:UP000000625)';
     const totalNumberResults = 4403;
-    const filteredNumberResults = 4401;
+    const isoformStats = {
+      allWithIsoforms: undefined,
+      reviewed: 4401,
+      reviewedWithIsoforms: undefined,
+    };
 
     customRender(
       <Download
         query={query}
         totalNumberResults={totalNumberResults}
-        filteredNumberResults={filteredNumberResults}
         onClose={onCloseMock}
         namespace={namespace}
+        showReviewedOption
+        isoformStats={isoformStats}
       />,
       {
         route: '/proteomes/UP000000625',
@@ -319,7 +324,11 @@ describe('Download reviewed proteins for a proteome entry', () => {
     expect(downloadLink.href).toEqual(
       expect.stringContaining(queryString.stringify({ query: `(${query})` }))
     );
-    fireEvent.click(screen.getByLabelText(`Download reviewed only (4,401)`));
+    fireEvent.click(
+      screen.getByLabelText(
+        `Download only reviewed (Swiss-Prot) canonical proteins (4,401)`
+      )
+    );
     downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
       expect.stringContaining(

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -292,15 +292,15 @@ describe('Download with ID mapping results', () => {
   });
 });
 
-describe('Download reviewed proteins for a proteome entry assuming it is an Eukaryote', () => {
+describe('Download reviewed proteins for a proteome entry that is an Eukaryote', () => {
   it('should check the filteredNumberResults and add the additional select options', async () => {
     const namespace = Namespace.uniprotkb;
     const onCloseMock = jest.fn();
-    const query = '(proteome:UP000000625)';
-    const totalNumberResults = 4403;
+    const query = '(proteome:UP000005640)';
+    const totalNumberResults = 82678;
     const isoformStats = {
       allWithIsoforms: undefined,
-      reviewed: 4401,
+      reviewed: 20408,
       reviewedWithIsoforms: undefined,
     };
 
@@ -314,7 +314,7 @@ describe('Download reviewed proteins for a proteome entry assuming it is an Euka
         isoformStats={isoformStats}
       />,
       {
-        route: '/proteomes/UP000000625',
+        route: '/proteomes/UP000005640',
         initialLocalStorage: {
           'table columns for uniprotkb': initialColumns,
         },
@@ -326,14 +326,14 @@ describe('Download reviewed proteins for a proteome entry assuming it is an Euka
     );
     fireEvent.click(
       screen.getByLabelText(
-        `Download only reviewed (Swiss-Prot) canonical proteins (4,401)`
+        `Download only reviewed (Swiss-Prot) canonical proteins (20,408)`
       )
     );
     downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
       expect.stringContaining(
         queryString.stringify({
-          query: `((proteome:UP000000625) AND reviewed=true)`,
+          query: `((proteome:UP000005640) AND reviewed=true)`,
         })
       )
     );

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -291,3 +291,42 @@ describe('Download with ID mapping results', () => {
     expect(await screen.findByText('Customize columns')).toBeInTheDocument();
   });
 });
+
+describe('Download reviewed proteins for a proteome entry', () => {
+  it('should check the filteredNumberResults and add the additional select options', async () => {
+    const namespace = Namespace.uniprotkb;
+    const onCloseMock = jest.fn();
+    const query = '(proteome:UP000000625)';
+    const totalNumberResults = 4403;
+    const filteredNumberResults = 4401;
+
+    customRender(
+      <Download
+        query={query}
+        totalNumberResults={totalNumberResults}
+        filteredNumberResults={filteredNumberResults}
+        onClose={onCloseMock}
+        namespace={namespace}
+      />,
+      {
+        route: '/proteomes/UP000000625',
+        initialLocalStorage: {
+          'table columns for uniprotkb': initialColumns,
+        },
+      }
+    );
+    let downloadLink = screen.getByRole<HTMLAnchorElement>('link');
+    expect(downloadLink.href).toEqual(
+      expect.stringContaining(queryString.stringify({ query: `(${query})` }))
+    );
+    fireEvent.click(screen.getByLabelText(`Download reviewed only (4,401)`));
+    downloadLink = screen.getByRole<HTMLAnchorElement>('link');
+    expect(downloadLink.href).toEqual(
+      expect.stringContaining(
+        queryString.stringify({
+          query: `((proteome:UP000000625) AND reviewed=true)`,
+        })
+      )
+    );
+  });
+});

--- a/src/shared/components/download/styles/download.module.scss
+++ b/src/shared/components/download/styles/download.module.scss
@@ -22,3 +22,7 @@
     vertical-align: middle;
   }
 }
+
+.isoform-option {
+  margin-left: 10rem;
+}


### PR DESCRIPTION
## Purpose
Add an option to download only reviewed proteins (with isoforms) for organisms that are Eukaryote
## Approach
Changed the existing downloadAll from boolean to a union of 'all, selected, reviewed'
Pass a 'showReviewedOption' flag to include in the download along with isoform statistics.

## Testing
Created an additional test case
## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
