### PR TITLE
Different endpoint for peptide search

### DIFF
--- a/src/tools/components/APIRequest.tsx
+++ b/src/tools/components/APIRequest.tsx
@@ -35,10 +35,7 @@ const documentation = new Map<JobTypes, string>([
     JobTypes.ID_MAPPING,
     `${API_PREFIX}/docs/?urls.primaryName=idmapping#/job/submitJob`,
   ],
-  [
-    JobTypes.PEPTIDE_SEARCH,
-    'https://research.bioinformatics.udel.edu/peptidematchws/',
-  ],
+  [JobTypes.PEPTIDE_SEARCH, 'https://peptidesearch.uniprot.org/asyncrest/'],
   [
     JobTypes.ASYNC_DOWNLOAD,
     `${API_PREFIX}/docs/?urls.primaryName=asyncdownload#/job/submitJob`, // TODO: determine final URL

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -103,6 +103,7 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
         runUrl: baseURL,
         statusUrl: (jobId) => joinUrl(baseURL, 'jobs', jobId),
         resultUrl: (jobId) => joinUrl(baseURL, 'jobs', jobId),
+        detailsUrl: (jobId) => joinUrl(baseURL, 'jobs', jobId, 'parameters'),
       });
     default:
     //

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -98,8 +98,7 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
         detailsUrl: (jobId) => `${baseURL}/details/${jobId}`,
       });
     case JobTypes.PEPTIDE_SEARCH:
-      baseURL =
-        'https://research.bioinformatics.udel.edu/peptidematchws/asyncrest';
+      baseURL = 'https://peptidesearch.uniprot.org/asyncrest';
       return deepFreeze({
         runUrl: baseURL,
         statusUrl: (jobId) => joinUrl(baseURL, 'jobs', jobId),

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -30,7 +30,7 @@ import { truncateTaxonLabel } from '../../utils';
 
 import { JobTypes } from '../../types/toolsJobTypes';
 import { FormParameters } from '../types/peptideSearchFormParameters';
-import { PepS, LEQi, SpOnly } from '../types/peptideSearchServerParameters';
+import { peps, lEQi, spOnly } from '../types/peptideSearchServerParameters';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 import defaultFormValues, {
@@ -166,11 +166,11 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
     // transformation of FormParameters into ServerParameters happens in the
     // tools middleware
     const parameters: FormParameters = {
-      peps: formValues[PeptideSearchFields.peps].selected as PepS,
+      peps: formValues[PeptideSearchFields.peps].selected as peps,
       taxIds: formValues[PeptideSearchFields.taxIds]
         .selected as SelectedTaxon[],
-      lEQi: formValues[PeptideSearchFields.lEQi].selected as LEQi,
-      spOnly: formValues[PeptideSearchFields.spOnly].selected as SpOnly,
+      lEQi: formValues[PeptideSearchFields.lEQi].selected as lEQi,
+      spOnly: formValues[PeptideSearchFields.spOnly].selected as spOnly,
     };
 
     // navigate to the dashboard, not immediately, to give the impression that

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -25,6 +25,7 @@ import NoResultsPage from '../../../../shared/components/error-pages/NoResultsPa
 import ErrorHandler from '../../../../shared/components/error-pages/ErrorHandler';
 
 import toolsURLs from '../../../config/urls';
+import { apiPrefix } from '../../../../shared/config/apiUrls';
 import {
   Namespace,
   namespaceAndToolsLabels,
@@ -41,14 +42,13 @@ import { SearchResults } from '../../../../shared/types/results';
 import { PeptideSearchResults } from '../../types/peptideSearchResults';
 import { JobTypes } from '../../../types/toolsJobTypes';
 import { FormParameters } from '../../types/peptideSearchFormParameters';
-
-import helper from '../../../../shared/styles/helper.module.scss';
-import sidebarStyles from '../../../../shared/components/layouts/styles/sidebar-layout.module.scss';
 import {
   TaxonomyAPIModel,
   TaxonomyDatum,
 } from '../../../../supporting-data/taxonomy/adapters/taxonomyConverter';
-import { apiPrefix, getAPIQueryUrl } from '../../../../shared/config/apiUrls';
+
+import helper from '../../../../shared/styles/helper.module.scss';
+import sidebarStyles from '../../../../shared/components/layouts/styles/sidebar-layout.module.scss';
 
 const jobType = JobTypes.PEPTIDE_SEARCH;
 const urls = toolsURLs(jobType);
@@ -188,8 +188,8 @@ const PeptideSearchResult = () => {
   const facetTotal = facetHeaders?.['x-total-results'];
 
   const converter = useMemo(() => {
-    const peps = jobInputParameters.peps;
-    return peps ? partialRight(peptideSearchConverter, peps) : undefined;
+    const pepSeq = jobInputParameters.peps;
+    return pepSeq ? partialRight(peptideSearchConverter, pepSeq) : undefined;
   }, [jobInputParameters.peps]);
 
   const resultsDataObject = usePaginatedAccessions(accessions, converter);

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, lazy, Suspense } from 'react';
+import { useMemo, lazy, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Loader,
@@ -14,7 +14,6 @@ import useDataApi from '../../../../shared/hooks/useDataApi';
 import useDataApiWithStale from '../../../../shared/hooks/useDataApiWithStale';
 import useNSQuery from '../../../../shared/hooks/useNSQuery';
 import useMarkJobAsSeen from '../../../hooks/useMarkJobAsSeen';
-import useToolsState from '../../../../shared/hooks/useToolsState';
 import useMatchWithRedirect from '../../../../shared/hooks/useMatchWithRedirect';
 import usePaginatedAccessions from '../../../../shared/hooks/usePaginatedAccessions';
 
@@ -41,12 +40,15 @@ import { UniProtkbAPIModel } from '../../../../uniprotkb/adapters/uniProtkbConve
 import { SearchResults } from '../../../../shared/types/results';
 import { PeptideSearchResults } from '../../types/peptideSearchResults';
 import { JobTypes } from '../../../types/toolsJobTypes';
-import { Status } from '../../../types/toolsStatuses';
-import { FinishedJob } from '../../../types/toolsJob';
-import { ToolsState } from '../../../state/toolsInitialState';
+import { FormParameters } from '../../types/peptideSearchFormParameters';
 
 import helper from '../../../../shared/styles/helper.module.scss';
 import sidebarStyles from '../../../../shared/components/layouts/styles/sidebar-layout.module.scss';
+import {
+  TaxonomyAPIModel,
+  TaxonomyDatum,
+} from '../../../../supporting-data/taxonomy/adapters/taxonomyConverter';
+import { apiPrefix, getAPIQueryUrl } from '../../../../shared/config/apiUrls';
 
 const jobType = JobTypes.PEPTIDE_SEARCH;
 const urls = toolsURLs(jobType);
@@ -85,21 +87,21 @@ type Params = {
   subPage?: TabLocation;
 };
 
+enum ServerJobParameters {
+  QueryPetides = 'QueryPetides',
+  TaxonIds = 'TaxonIds',
+  lEqi = 'lEqi',
+  swissProtOnly = 'swissProtOnly',
+}
+
 export const MAX_PEPTIDE_FACETS_OR_DOWNLOAD = 1_000;
 
-const PeptideSearchResult = ({
-  toolsState,
-}: {
-  toolsState: NonNullable<ToolsState>;
-}) => {
+const PeptideSearchResult = () => {
   const match = useMatchWithRedirect<Params>(
     Location.PeptideSearchResult,
     TabLocation
   );
 
-  const jobSubmission = useRef<FinishedJob<JobTypes.PEPTIDE_SEARCH> | null>(
-    null
-  );
   const jobID = match?.params.id || '';
   const {
     data: jobResultData,
@@ -110,18 +112,55 @@ const PeptideSearchResult = ({
     headers: { accept: 'text/plain' },
   });
 
-  // Get the job mission from local tools state. Save this in a reference as
-  // the job may change with useMarkJobAsSeen but we don't want to have to
-  // recreate the converter which will cause usePagination to duplicate rows
-  if (!jobSubmission.current) {
-    jobSubmission.current =
-      Object.values(toolsState).find(
-        (
-          jobSubmission
-        ): jobSubmission is FinishedJob<JobTypes.PEPTIDE_SEARCH> =>
-          jobSubmission.status === Status.FINISHED &&
-          jobSubmission?.remoteID === jobID
-      ) || null;
+  const { data: jobParameters } = useDataApi<PeptideSearchResults>(
+    urls.detailsUrl?.(jobID),
+    {
+      headers: { accept: 'text/plain' },
+    }
+  );
+
+  const jobInputParameters: FormParameters = {
+    peps: '',
+    lEQi: 'off',
+    spOnly: 'off',
+  };
+  let taxonIds = '';
+  jobParameters?.split(/\n/)?.forEach((keyValuePair) => {
+    const [key, value] = keyValuePair.split(':');
+    switch (key) {
+      case ServerJobParameters.QueryPetides:
+        jobInputParameters.peps = value;
+        break;
+      case ServerJobParameters.TaxonIds:
+        if (value) {
+          taxonIds = value;
+        }
+        break;
+      case ServerJobParameters.lEqi:
+        jobInputParameters.lEQi = value === 'Y' ? 'on' : 'off';
+        break;
+      case ServerJobParameters.swissProtOnly:
+        jobInputParameters.spOnly = value === 'Y' ? 'on' : 'off';
+        break;
+      default:
+    }
+  });
+
+  const { data: taxonomyData, loading: taxonomyLoading } = useDataApi<
+    SearchResults<TaxonomyAPIModel>
+  >(
+    taxonIds
+      ? `${apiPrefix}/${Namespace.taxonomy}/taxonIds/${taxonIds}?fields=scientific_name`
+      : undefined
+  );
+
+  if (!taxonomyLoading && taxonomyData) {
+    jobInputParameters.taxIds = taxonomyData?.results?.map(
+      (taxon: TaxonomyDatum) => ({
+        id: taxon.taxonId.toString(),
+        label: `${taxon.scientificName} [${taxon.taxonId}]`,
+      })
+    );
   }
 
   const accessions = useMemo(
@@ -149,12 +188,10 @@ const PeptideSearchResult = ({
   const facetTotal = facetHeaders?.['x-total-results'];
 
   const converter = useMemo(() => {
-    const peps = jobSubmission.current?.parameters.peps;
+    const peps = jobInputParameters.peps;
     return peps ? partialRight(peptideSearchConverter, peps) : undefined;
-  }, [jobSubmission]);
+  }, [jobInputParameters.peps]);
 
-  // TODO: if the user didn't submit this jobSubmission there is no way to get the initial sequence. In the
-  // future the API may provide this information in which case we would want to fetch and show
   const resultsDataObject = usePaginatedAccessions(accessions, converter);
 
   const {
@@ -277,7 +314,6 @@ const PeptideSearchResult = ({
               total={total}
               resultsDataObject={resultsDataObject}
               accessions={accessions}
-              jobSubmission={jobSubmission}
             />
           </Suspense>
         </Tab>
@@ -295,7 +331,7 @@ const PeptideSearchResult = ({
           <Suspense fallback={<Loader />}>
             <InputParameters
               id={match.params.id}
-              inputParamsData={jobSubmission.current?.parameters}
+              inputParamsData={jobInputParameters}
               jobType={jobType}
             />
           </Suspense>
@@ -312,7 +348,7 @@ const PeptideSearchResult = ({
           <Suspense fallback={<Loader />}>
             <APIRequest
               jobType={jobType}
-              inputParamsData={jobSubmission.current?.parameters}
+              inputParamsData={jobInputParameters}
             />
           </Suspense>
         </Tab>
@@ -321,13 +357,4 @@ const PeptideSearchResult = ({
   );
 };
 
-const PeptideSearchResultWithToolsState = () => {
-  const toolsState = useToolsState();
-  return toolsState === null ? (
-    <Loader />
-  ) : (
-    <PeptideSearchResult toolsState={toolsState} />
-  );
-};
-
-export default PeptideSearchResultWithToolsState;
+export default PeptideSearchResult;

--- a/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
@@ -1,12 +1,9 @@
-import { MutableRefObject } from 'react';
 import ResultsButtons from '../../../../shared/components/results/ResultsButtons';
 import ResultsData from '../../../../shared/components/results/ResultsData';
 
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 
 import { APIModel } from '../../../../shared/types/apiModel';
-import { FinishedJob } from '../../../types/toolsJob';
-import { JobTypes } from '../../../types/toolsJobTypes';
 
 type PeptideSearchResultTableProps = {
   total?: number;
@@ -20,14 +17,12 @@ type PeptideSearchResultTableProps = {
     failedIds?: string[] | undefined;
   };
   accessions?: string[];
-  jobSubmission: MutableRefObject<FinishedJob<JobTypes.PEPTIDE_SEARCH> | null>;
 };
 
 const PeptideSearchResultTable = ({
   total,
   resultsDataObject,
   accessions,
-  jobSubmission,
 }: PeptideSearchResultTableProps) => {
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
@@ -44,8 +39,7 @@ const PeptideSearchResultTable = ({
         resultsDataObject={resultsDataObject}
         setSelectedItemFromEvent={setSelectedItemFromEvent}
         setSelectedEntries={setSelectedEntries}
-        // TODO: change logic when peptide search API is able to return submitted jobSubmission information
-        displayPeptideSearchMatchColumns={Boolean(jobSubmission.current)}
+        displayPeptideSearchMatchColumns={true}
       />
     </>
   );

--- a/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
@@ -39,7 +39,7 @@ const PeptideSearchResultTable = ({
         resultsDataObject={resultsDataObject}
         setSelectedItemFromEvent={setSelectedItemFromEvent}
         setSelectedEntries={setSelectedEntries}
-        displayPeptideSearchMatchColumns={true}
+        displayPeptideSearchMatchColumns
       />
     </>
   );

--- a/src/tools/peptide-search/components/results/__tests__/PeptideSearchResult.spec.tsx
+++ b/src/tools/peptide-search/components/results/__tests__/PeptideSearchResult.spec.tsx
@@ -34,8 +34,21 @@ const mockJob: FinishedJob<JobTypes.PEPTIDE_SEARCH> = {
 
 const mockRequests = new MockAdapter(axios);
 mockRequests
-  .onGet(new RegExp(`/peptidematchws/asyncrest/jobs/${mockJob.remoteID}$`))
+  .onGet(
+    new RegExp(`/peptidesearch.uniprot.org/asyncrest/jobs/${mockJob.remoteID}$`)
+  )
   .reply(200, 'P35575,O43826');
+
+mockRequests
+  .onGet(
+    new RegExp(
+      `/peptidesearch.uniprot.org/asyncrest/jobs/${mockJob.remoteID}/parameters$`
+    )
+  )
+  .reply(
+    200,
+    'QueryPetides:AAQGYGYYRTVIFSAMFGGYSLYYFNRKTFSF\nIQSTHYLQVNYQDSQDWFILVSVIADLRNAFYVLFPIWFHLQEAVGI\nTaxonIds:\nlEqi:Y\nswissProtOnly:Y'
+  );
 
 mockRequests
   .onGet(/uniprotkb\/accessions/)

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -189,6 +189,17 @@ exports[`PeptideSearchResult should render with the correct number of results in
                 </th>
                 <th
                   class=""
+                >
+                  <span
+                    aria-expanded="false"
+                  >
+                    <span>
+                      Match
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class=""
                 />
                 <th
                   class=""
@@ -283,6 +294,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                     </a>
                   </span>
                 </td>
+                <td />
                 <td>
                   <span
                     class="entry-title__status icon--reviewed"
@@ -357,6 +369,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
                     </a>
                   </span>
                 </td>
+                <td />
                 <td>
                   <span
                     class="entry-title__status icon--reviewed"

--- a/src/tools/peptide-search/types/peptideSearchFormParameters.ts
+++ b/src/tools/peptide-search/types/peptideSearchFormParameters.ts
@@ -1,9 +1,9 @@
-import { PepS, LEQi, SpOnly } from './peptideSearchServerParameters';
+import { peps, lEQi, spOnly } from './peptideSearchServerParameters';
 import { SelectedTaxon } from '../../types/toolsFormData';
 
 export type FormParameters = {
-  peps: PepS;
+  peps: peps;
   taxIds?: SelectedTaxon[];
-  lEQi: LEQi;
-  spOnly: SpOnly;
+  lEQi: lEQi;
+  spOnly: spOnly;
 };

--- a/src/tools/peptide-search/types/peptideSearchServerParameters.ts
+++ b/src/tools/peptide-search/types/peptideSearchServerParameters.ts
@@ -1,19 +1,19 @@
 /* Parameters of a peptide search job as required by the server */
 // http://peptidesearch.uniprot.org/
 
-export type PepS = string;
+export type peps = string;
 
-export type TaxIds = string;
+export type taxIds = string;
 
-export type LEQi = 'on' | 'off';
+export type lEQi = 'on' | 'off';
 
-export type SpOnly = 'on' | 'off';
+export type spOnly = 'on' | 'off';
 
 export type ServerParameters = {
-  peps: PepS;
-  taxIds?: TaxIds;
-  lEQi: LEQi;
-  spOnly: SpOnly;
+  peps: peps;
+  taxIds?: taxIds;
+  lEQi: lEQi;
+  spOnly: spOnly;
 };
 
 // same, because no email was provided before

--- a/src/tools/utils/index.tsx
+++ b/src/tools/utils/index.tsx
@@ -49,7 +49,6 @@ export const getRemoteIDFromResponse = async (
       break;
     case JobTypes.PEPTIDE_SEARCH:
       // This gets the job info from the "location" header
-      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers - Needs to be done at the server side for accessing the location in the header
       remoteID =
         response.headers.get('Location')?.match(peptideSearchJobPattern)?.groups
           ?.jobID || null;

--- a/src/tools/utils/index.tsx
+++ b/src/tools/utils/index.tsx
@@ -49,6 +49,7 @@ export const getRemoteIDFromResponse = async (
       break;
     case JobTypes.PEPTIDE_SEARCH:
       // This gets the job info from the "location" header
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers - Needs to be done at the server side for accessing the location in the header
       remoteID =
         response.headers.get('Location')?.match(peptideSearchJobPattern)?.groups
           ?.jobID || null;


### PR DESCRIPTION
## Purpose
Use the other endpoint for Peptide search jobs. It also provides the job parameters which enables to view the inputs of a remote job.

## Approach
Replace the URL and update the server parameters.
Pass the input parameters obtained where necessary instead of accessing tools state
## Testing
Test updated
## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
