### PR TITLE
ProtVar links in Variation table

### DIFF
--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -52,6 +52,7 @@ const externalUrls: Record<string, (id: string | number) => string> = {
   dbSNP: (id) => `https://www.ncbi.nlm.nih.gov/snp/${id}`,
   Ensembl: (id) =>
     `http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${id}`,
+  ProtVar: (id) => `https://www.ebi.ac.uk/ProtVar/query?search=${id}`,
   // citations
   DOI: (id) => `https://dx.doi.org/${id}`,
   PubMed: (id) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -43,7 +43,13 @@ export const uniprotVariantLink = (variant: FeatureDatum) =>
     <em>missing</em>
   );
 
-export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
+export const DiseaseVariants = ({
+  variants,
+  accession,
+}: {
+  variants: FeatureDatum[];
+  accession: string;
+}) => {
   const table = (
     <table>
       <thead>
@@ -52,6 +58,7 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
           <th>Position(s)</th>
           <th>Change</th>
           <th>Description</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -95,6 +102,22 @@ export const DiseaseVariants = ({ variants }: { variants: FeatureDatum[] }) => {
                   {variant.evidences && (
                     <UniProtKBEvidenceTag evidences={variant.evidences} />
                   )}
+                </td>
+                <td>
+                  {variant.alternativeSequence?.originalSequence?.length ===
+                    1 &&
+                    variant.alternativeSequence?.alternativeSequences
+                      ?.length === 1 &&
+                    variant.alternativeSequence?.alternativeSequences[0]
+                      .length === 1 && (
+                      <ExternalLink
+                        url={externalUrls.ProtVar(
+                          `${accession} ${variant.alternativeSequence.originalSequence}${variant.location.start.value}${variant.alternativeSequence?.alternativeSequences[0]}`
+                        )}
+                      >
+                        ProtVar
+                      </ExternalLink>
+                    )}
                 </td>
               </tr>
             </Fragment>
@@ -226,7 +249,7 @@ export const DiseaseInvolvementEntry = ({
       {diseaseVariants && diseaseVariants.length ? (
         <>
           <h5>Natural variants in {disease?.acronym}</h5>
-          <DiseaseVariants variants={diseaseVariants} />
+          <DiseaseVariants variants={diseaseVariants} accession={accession} />
         </>
       ) : null}
     </>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -58,7 +58,7 @@ export const DiseaseVariants = ({
           <th>Position(s)</th>
           <th>Change</th>
           <th>Description</th>
-          <th></th>
+          <th aria-label="protvar-link" />
         </tr>
       </thead>
       <tbody>

--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -29,19 +29,46 @@ const sortByLocation = (a: FeatureDatum, b: FeatureDatum) => {
   return aStart - bStart;
 };
 
-export const uniprotVariantLink = (variant: FeatureDatum) =>
-  variant.alternativeSequence?.originalSequence ||
-  variant.alternativeSequence?.alternativeSequences?.[0] ? (
-    <ExternalLink url={externalUrls.UniProt(variant.featureId || '')} noIcon>
-      {variant.alternativeSequence?.originalSequence || <em>missing</em>}
-      {'>'}
-      {variant.alternativeSequence?.alternativeSequences?.[0] || (
-        <em>missing</em>
-      )}
-    </ExternalLink>
-  ) : (
-    <em>missing</em>
-  );
+export const protvarVariantLink = (
+  variant: FeatureDatum,
+  accession: string
+) => {
+  let variantEl;
+  if (
+    variant.alternativeSequence?.originalSequence?.length === 1 &&
+    variant.alternativeSequence?.alternativeSequences?.[0].length === 1
+  ) {
+    variantEl = (
+      <ExternalLink
+        url={externalUrls.ProtVar(
+          `${accession} ${variant.alternativeSequence?.originalSequence}${variant.location.start.value}${variant.alternativeSequence?.alternativeSequences?.[0]}`
+        )}
+        title="View in ProtVar"
+        noIcon
+      >
+        {variant.alternativeSequence?.originalSequence}
+        {'>'}
+        {variant.alternativeSequence?.alternativeSequences?.[0]}
+      </ExternalLink>
+    );
+  } else if (
+    !variant.alternativeSequence?.originalSequence &&
+    !variant.alternativeSequence?.alternativeSequences?.[0]
+  ) {
+    variantEl = <em>missing</em>;
+  } else {
+    variantEl = (
+      <>
+        {variant.alternativeSequence?.originalSequence || <em>missing</em>}
+        {'>'}
+        {variant.alternativeSequence?.alternativeSequences?.[0] || (
+          <em>missing</em>
+        )}
+      </>
+    );
+  }
+  return variantEl;
+};
 
 export const DiseaseVariants = ({
   variants,
@@ -58,7 +85,6 @@ export const DiseaseVariants = ({
           <th>Position(s)</th>
           <th>Change</th>
           <th>Description</th>
-          <th aria-label="protvar-link" />
         </tr>
       </thead>
       <tbody>
@@ -89,9 +115,26 @@ export const DiseaseVariants = ({
             // eslint-disable-next-line react/no-array-index-key
             <Fragment key={i}>
               <tr>
-                <td>{variant.featureId}</td>
+                <td>
+                  {variant.alternativeSequence?.originalSequence?.length ===
+                    1 &&
+                  variant.alternativeSequence?.alternativeSequences?.[0]
+                    .length === 1 ? (
+                    <ExternalLink
+                      url={externalUrls.UniProt(variant.featureId || '')}
+                      title="View in Expasy"
+                      noIcon
+                    >
+                      {variant.featureId}
+                    </ExternalLink>
+                  ) : (
+                    variant.featureId
+                  )}
+                </td>
                 <td>{position}</td>
-                <td className={styles.change}>{uniprotVariantLink(variant)}</td>
+                <td className={styles.change}>
+                  {protvarVariantLink(variant, accession)}
+                </td>
                 <td>
                   {description}
                   {rsIDs?.map((rsID) => (
@@ -102,22 +145,6 @@ export const DiseaseVariants = ({
                   {variant.evidences && (
                     <UniProtKBEvidenceTag evidences={variant.evidences} />
                   )}
-                </td>
-                <td>
-                  {variant.alternativeSequence?.originalSequence?.length ===
-                    1 &&
-                    variant.alternativeSequence?.alternativeSequences
-                      ?.length === 1 &&
-                    variant.alternativeSequence?.alternativeSequences[0]
-                      .length === 1 && (
-                      <ExternalLink
-                        url={externalUrls.ProtVar(
-                          `${accession} ${variant.alternativeSequence.originalSequence}${variant.location.start.value}${variant.alternativeSequence?.alternativeSequences[0]}`
-                        )}
-                      >
-                        ProtVar
-                      </ExternalLink>
-                    )}
                 </td>
               </tr>
             </Fragment>

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -235,7 +235,6 @@ const VariationView = ({
             significance
           </th>
           <th>Provenance</th>
-          <th aria-label="protvar-link" />
         </tr>
       </thead>
       <tbody>
@@ -281,16 +280,29 @@ const VariationView = ({
                 </td>
                 <td>{position}</td>
                 <td className={styles.change}>
-                  {variantFeature.wildType ||
-                  variantFeature.alternativeSequence ? (
+                  {variantFeature.consequenceType !== ConsequenceType.Empty &&
+                  variantFeature.wildType.length === 1 &&
+                  variantFeature.alternativeSequence?.length === 1 ? (
+                    <ExternalLink
+                      url={externalUrls.ProtVar(
+                        `${primaryAccession} ${variantFeature.wildType}${variantFeature.start}${variantFeature.alternativeSequence}`
+                      )}
+                      title="View in ProtVar"
+                      noIcon
+                    >
+                      {variantFeature.wildType}
+                      {'>'}
+                      {variantFeature.alternativeSequence}
+                    </ExternalLink>
+                  ) : (
                     <>
                       {variantFeature.wildType || <em>missing</em>}
                       {'>'}
                       {variantFeature.alternativeSequence || <em>missing</em>}
                     </>
-                  ) : (
-                    <em>missing</em>
                   )}
+                  {!variantFeature.wildType &&
+                    !variantFeature.alternativeSequence && <em>missing</em>}
                 </td>
                 <td>
                   {variantFeature.descriptions?.length ? (
@@ -353,19 +365,6 @@ const VariationView = ({
                         </span>
                       </Fragment>
                     ))}
-                </td>
-                <td>
-                  {variantFeature.consequenceType !== ConsequenceType.Empty &&
-                    variantFeature.wildType.length === 1 &&
-                    variantFeature.alternativeSequence?.length === 1 && (
-                      <ExternalLink
-                        url={externalUrls.ProtVar(
-                          `${primaryAccession} ${variantFeature.wildType}${variantFeature.start}${variantFeature.alternativeSequence}`
-                        )}
-                      >
-                        ProtVar
-                      </ExternalLink>
-                    )}
                 </td>
               </tr>
               <tr

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -5,10 +5,7 @@ import { groupBy, intersection, union } from 'lodash-es';
 import cn from 'classnames';
 import { PartialDeep, SetRequired } from 'type-fest';
 
-import {
-  ConsequenceType,
-  ProteinsAPIVariation,
-} from 'protvista-variation-adapter/dist/es/variants';
+import { ProteinsAPIVariation } from 'protvista-variation-adapter/dist/es/variants';
 import { transformData, TransformedVariant } from 'protvista-variation-adapter';
 
 import ExternalLink from '../../../shared/components/ExternalLink';
@@ -280,7 +277,7 @@ const VariationView = ({
                 </td>
                 <td>{position}</td>
                 <td className={styles.change}>
-                  {variantFeature.consequenceType !== ConsequenceType.Empty &&
+                  {variantFeature.consequenceType !== '-' &&
                   variantFeature.wildType.length === 1 &&
                   variantFeature.alternativeSequence?.length === 1 ? (
                     <ExternalLink

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -231,6 +231,7 @@ const VariationView = ({
             significance
           </th>
           <th>Provenance</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -348,6 +349,14 @@ const VariationView = ({
                         </span>
                       </Fragment>
                     ))}
+                </td>
+                {/* TODO: Add more conditions to check for SNP validity */}
+                <td>
+                  <ExternalLink
+                    url={`https://www.ebi.ac.uk/ProtVar/query?accession=${primaryAccession}&protein_position=${variantFeature.start}&reference_AA=${variantFeature.wildType}&variant_AA=${variantFeature.alternativeSequence}`}
+                  >
+                    ProtVar
+                  </ExternalLink>
                 </td>
               </tr>
               <tr

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -235,7 +235,7 @@ const VariationView = ({
             significance
           </th>
           <th>Provenance</th>
-          <th></th>
+          <th aria-label="protvar-link" />
         </tr>
       </thead>
       <tbody>

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -17,11 +17,11 @@ import useCustomElement from '../../../shared/hooks/useCustomElement';
 import { useSmallScreen } from '../../../shared/hooks/useMatchMedia';
 
 import apiUrls from '../../../shared/config/apiUrls';
+import externalUrls from '../../../shared/config/externalUrls';
 
 import { Evidence } from '../../types/modelTypes';
 
 import styles from './styles/variation-view.module.scss';
-import externalUrls from '../../../shared/config/externalUrls';
 
 const VisualVariationView = lazy(
   () =>

--- a/src/uniprotkb/components/protein-data-views/VariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VariationView.tsx
@@ -5,7 +5,10 @@ import { groupBy, intersection, union } from 'lodash-es';
 import cn from 'classnames';
 import { PartialDeep, SetRequired } from 'type-fest';
 
-import { ProteinsAPIVariation } from 'protvista-variation-adapter/dist/es/variants';
+import {
+  ConsequenceType,
+  ProteinsAPIVariation,
+} from 'protvista-variation-adapter/dist/es/variants';
 import { transformData, TransformedVariant } from 'protvista-variation-adapter';
 
 import ExternalLink from '../../../shared/components/ExternalLink';
@@ -21,6 +24,7 @@ import apiUrls from '../../../shared/config/apiUrls';
 import { Evidence } from '../../types/modelTypes';
 
 import styles from './styles/variation-view.module.scss';
+import externalUrls from '../../../shared/config/externalUrls';
 
 const VisualVariationView = lazy(
   () =>
@@ -350,13 +354,18 @@ const VariationView = ({
                       </Fragment>
                     ))}
                 </td>
-                {/* TODO: Add more conditions to check for SNP validity */}
                 <td>
-                  <ExternalLink
-                    url={`https://www.ebi.ac.uk/ProtVar/query?accession=${primaryAccession}&protein_position=${variantFeature.start}&reference_AA=${variantFeature.wildType}&variant_AA=${variantFeature.alternativeSequence}`}
-                  >
-                    ProtVar
-                  </ExternalLink>
+                  {variantFeature.consequenceType !== ConsequenceType.Empty &&
+                    variantFeature.wildType.length === 1 &&
+                    variantFeature.alternativeSequence?.length === 1 && (
+                      <ExternalLink
+                        url={externalUrls.ProtVar(
+                          `${primaryAccession} ${variantFeature.wildType}${variantFeature.start}${variantFeature.alternativeSequence}`
+                        )}
+                      >
+                        ProtVar
+                      </ExternalLink>
+                    )}
                 </td>
               </tr>
               <tr

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
@@ -123,7 +123,15 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
         <tbody>
           <tr>
             <td>
-              VAR_019255
+              <a
+                class="external-link"
+                href="https://web.expasy.org/variant_pages/VAR_019255.html"
+                rel="noopener"
+                target="_blank"
+                title="View in Expasy"
+              >
+                VAR_019255
+              </a>
             </td>
             <td>
               23
@@ -133,9 +141,10 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
             >
               <a
                 class="external-link"
-                href="https://web.expasy.org/variant_pages/VAR_019255.html"
+                href="https://www.ebi.ac.uk/ProtVar/query?search=P05067 Q23P"
                 rel="noopener"
                 target="_blank"
+                title="View in ProtVar"
               >
                 Q&gt;P
               </a>
@@ -158,7 +167,15 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
           </tr>
           <tr>
             <td>
-              VAR_019256
+              <a
+                class="external-link"
+                href="https://web.expasy.org/variant_pages/VAR_019256.html"
+                rel="noopener"
+                target="_blank"
+                title="View in Expasy"
+              >
+                VAR_019256
+              </a>
             </td>
             <td>
               99
@@ -168,9 +185,10 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
             >
               <a
                 class="external-link"
-                href="https://web.expasy.org/variant_pages/VAR_019256.html"
+                href="https://www.ebi.ac.uk/ProtVar/query?search=P05067 I99V"
                 rel="noopener"
                 target="_blank"
+                title="View in ProtVar"
               >
                 I&gt;V
               </a>

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/VariationView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/VariationView.spec.tsx.snap
@@ -134,7 +134,15 @@ exports[`VariationView component renders on data 1`] = `
               <td
                 class="change"
               >
-                L&gt;A
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P05067 L10A"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  L&gt;A
+                </a>
               </td>
               <td />
               <td />

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -69,7 +69,7 @@ import {
 import { KeywordList } from '../components/protein-data-views/KeywordView';
 // import { DatabaseList } from '../components/protein-data-views/XRefView';
 import DiseaseInvolvementView, {
-  uniprotVariantLink,
+  protvarVariantLink,
 } from '../components/protein-data-views/DiseaseInvolvementView';
 import CatalyticActivityView, {
   getRheaId,
@@ -1432,7 +1432,7 @@ const getXrefColumn = (databaseName: string) => {
               <div key={featureId}>
                 {dbSNPRef?.id && (
                   <>
-                    {uniprotVariantLink(feature)}
+                    {protvarVariantLink(feature, data.primaryAccession)}
                     <span className={helper['no-wrap']}>
                       {` ${dbSNPRef.id}`}
                       {' ( '}

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -2039,14 +2039,7 @@ exports[`UniProtKBColumnConfiguration component should render column "xref_ctd":
 exports[`UniProtKBColumnConfiguration component should render column "xref_dbsnp": xref_dbsnp 1`] = `
 <DocumentFragment>
   <div>
-    <a
-      class="external-link"
-      href="https://web.expasy.org/variant_pages/id value CHAIN.html"
-      rel="noopener"
-      target="_blank"
-    >
-      original value&gt;alternative value
-    </a>
+    original value&gt;alternative value
     <span
       class="no-wrap"
     >


### PR DESCRIPTION
## Purpose
Add ProtVar links in entry and variant-viewer tab
## Approach
Link the variant change to ProtVar and VAR ids to Expasy. This also changes the link from Expasy to ProtVar in the dbSNP column of results page.
## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
