### PR TITLE
Add 'Resubmit' to ID mapping and Peptide search job results page

### DIFF
--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -26,6 +26,7 @@ import ShareDropdown from '../action-buttons/ShareDropdown';
 import ItemCount from '../ItemCount';
 import ErrorBoundary from '../error-component/ErrorBoundary';
 import FirstTimeSelection from './FirstTimeSelection';
+import { ResubmitButton } from '../../../tools/components/ResultButtons';
 
 import useNS from '../../hooks/useNS';
 import useViewMode, { ViewMode } from '../../hooks/useViewMode';
@@ -52,6 +53,8 @@ import {
   MessageLevel,
 } from '../../../messages/types/messagesTypes';
 import { FileFormat } from '../../types/resultsDownload';
+import { JobTypes } from '../../../tools/types/toolsJobTypes';
+import { PublicServerParameters } from '../../../tools/types/toolsServerParameters';
 
 import styles from './styles/results-buttons.module.scss';
 
@@ -60,7 +63,7 @@ const DownloadComponent = lazy(
   () => import(/* webpackChunkName: "download" */ '../download/Download')
 );
 
-type ResultsButtonsProps = {
+type ResultsButtonsProps<T extends JobTypes> = {
   selectedEntries: string[];
   setSelectedEntries?: Dispatch<SetStateAction<string[]>>;
   total: number;
@@ -75,9 +78,11 @@ type ResultsButtonsProps = {
   subsetsMap?: Map<string, string>;
   supportedFormats?: FileFormat[];
   excludeColumns?: boolean;
+  jobType?: T;
+  inputParamsData?: PublicServerParameters[T];
 };
 
-const ResultsButtons: FC<ResultsButtonsProps> = ({
+const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
   selectedEntries,
   setSelectedEntries,
   total,
@@ -92,6 +97,8 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
   subsetsMap,
   supportedFormats,
   excludeColumns = false,
+  jobType,
+  inputParamsData,
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
@@ -294,6 +301,9 @@ const ResultsButtons: FC<ResultsButtonsProps> = ({
           (viewMode === 'table' || disableCardToggle) && (
             <CustomiseButton namespace={namespace} />
           )}
+        {jobType && !inBasket && (
+          <ResubmitButton jobType={jobType} inputParamsData={inputParamsData} />
+        )}
         {!notCustomisable && !inBasket && (
           <ShareDropdown
             setDisplayDownloadPanel={setDisplayDownloadPanel}

--- a/src/tools/adapters/parameters.ts
+++ b/src/tools/adapters/parameters.ts
@@ -218,11 +218,16 @@ export function serverParametersToFormParameters<T extends JobTypes>(
         const { from, to, ids, taxId } =
           serverParameters as PublicServerParameters[JobTypes.ID_MAPPING];
 
+        const taxon: SelectedTaxon = {
+          id: taxId?.toString() || '',
+          label: taxId ? taxonMapping.get(taxId.toString()) || '' : '',
+        };
+
         formParameters = {
           from,
           to,
           ids: ids.split(','),
-          taxId, // TODO: check
+          taxId: taxon,
         } as FormParameters[T];
       }
       break;

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -55,9 +55,17 @@ export const ResubmitButton = ({
       'taxId' in inputParamsData
     ) {
       const taxonRequests = [
-        ...(inputParamsData.taxids || '').split(','),
-        ...(inputParamsData.negative_taxids || '').split(','),
-        ...(inputParamsData.taxId || '').split(','),
+        ...(
+          (inputParamsData as PublicServerParameters[JobTypes.BLAST]).taxids ||
+          ''
+        ).split(','),
+        ...(
+          (inputParamsData as PublicServerParameters[JobTypes.BLAST])
+            .negative_taxids || ''
+        ).split(','),
+        (
+          inputParamsData as PublicServerParameters[JobTypes.ID_MAPPING]
+        ).taxId?.toString() || '',
       ].map((id) => {
         const idCleaned = id.trim();
         if (!idCleaned) {

--- a/src/tools/components/ResultButtons.tsx
+++ b/src/tools/components/ResultButtons.tsx
@@ -49,10 +49,15 @@ export const ResubmitButton = ({
     setDisabled(true);
 
     const taxonMapping = new Map();
-    if ('taxids' in inputParamsData || 'negative_taxids' in inputParamsData) {
+    if (
+      'taxids' in inputParamsData ||
+      'negative_taxids' in inputParamsData ||
+      'taxId' in inputParamsData
+    ) {
       const taxonRequests = [
         ...(inputParamsData.taxids || '').split(','),
         ...(inputParamsData.negative_taxids || '').split(','),
+        ...(inputParamsData.taxId || '').split(','),
       ].map((id) => {
         const idCleaned = id.trim();
         if (!idCleaned) {

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -310,6 +310,7 @@ const IDMappingForm = ({ initialFormValues, formConfigData }: Props) => {
                     }
                   }
                   dispatch(updateSelected(IDMappingFields.toDb, nextToDb));
+                  dispatch(updateInputTextIDs(textIDs)); // Update the name based on the DB selection
                 }}
                 label={fromDbInfo.displayName}
                 defaultActiveNodes={[

--- a/src/tools/id-mapping/components/results/IDMappingResult.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResult.tsx
@@ -49,6 +49,7 @@ import { MessageLevel } from '../../../../messages/types/messagesTypes';
 
 import styles from './styles/id-mapping-result.module.scss';
 import sidebarStyles from '../../../../shared/components/layouts/styles/sidebar-layout.module.scss';
+import { ServerParameters } from '../../types/idMappingServerParameters';
 
 const jobType = JobTypes.ID_MAPPING;
 const urls = toolsURLs(jobType);
@@ -335,6 +336,7 @@ const IDMappingResult = () => {
               resultsDataObject={resultsDataObject}
               detailsData={detailsData}
               notCustomisable={notCustomisable}
+              inputParamsData={detailsData as ServerParameters}
             />
           </Suspense>
         </Tab>

--- a/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
+++ b/src/tools/id-mapping/components/results/IDMappingResultTable.tsx
@@ -14,12 +14,15 @@ import splitAndTidyText from '../../../../shared/utils/splitAndTidyText';
 import { Namespace } from '../../../../shared/types/namespaces';
 import { PaginatedResults } from '../../../../shared/hooks/usePagination';
 import { MappingDetails } from '../../types/idMappingSearchResults';
+import { JobTypes } from '../../../types/toolsJobTypes';
+import { PublicServerParameters } from '../../types/idMappingServerParameters';
 
 type IDMappingResultTableProps = {
   namespaceOverride: Namespace;
   resultsDataObject: PaginatedResults;
   detailsData?: MappingDetails;
   notCustomisable?: boolean;
+  inputParamsData: PublicServerParameters;
 };
 
 const IDMappingResultTable = ({
@@ -27,6 +30,7 @@ const IDMappingResultTable = ({
   resultsDataObject,
   detailsData,
   notCustomisable = false,
+  inputParamsData,
 }: IDMappingResultTableProps) => {
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
@@ -55,6 +59,8 @@ const IDMappingResultTable = ({
         }
         excludeColumns={namespaceOverride === Namespace.idmapping}
         supportedFormats={supportedFormats}
+        jobType={JobTypes.ID_MAPPING}
+        inputParamsData={inputParamsData}
       />
       {inputIDs && (
         <HeroContainer>

--- a/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResult.tsx
@@ -314,6 +314,7 @@ const PeptideSearchResult = () => {
               total={total}
               resultsDataObject={resultsDataObject}
               accessions={accessions}
+              inputParamsData={jobInputParameters}
             />
           </Suspense>
         </Tab>

--- a/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
+++ b/src/tools/peptide-search/components/results/PeptideSearchResultTable.tsx
@@ -4,6 +4,8 @@ import ResultsData from '../../../../shared/components/results/ResultsData';
 import useItemSelect from '../../../../shared/hooks/useItemSelect';
 
 import { APIModel } from '../../../../shared/types/apiModel';
+import { JobTypes } from '../../../types/toolsJobTypes';
+import { FormParameters } from '../../types/peptideSearchFormParameters';
 
 type PeptideSearchResultTableProps = {
   total?: number;
@@ -17,12 +19,14 @@ type PeptideSearchResultTableProps = {
     failedIds?: string[] | undefined;
   };
   accessions?: string[];
+  inputParamsData: FormParameters;
 };
 
 const PeptideSearchResultTable = ({
   total,
   resultsDataObject,
   accessions,
+  inputParamsData,
 }: PeptideSearchResultTableProps) => {
   const [selectedEntries, setSelectedItemFromEvent, setSelectedEntries] =
     useItemSelect();
@@ -34,6 +38,8 @@ const PeptideSearchResultTable = ({
         loadedTotal={resultsDataObject.allResults.length}
         selectedEntries={selectedEntries}
         accessions={accessions}
+        jobType={JobTypes.PEPTIDE_SEARCH}
+        inputParamsData={inputParamsData}
       />
       <ResultsData
         resultsDataObject={resultsDataObject}

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -154,6 +154,13 @@ exports[`PeptideSearchResult should render with the correct number of results in
               <test-file-stub />
               Customize columns
             </button>
+            <button
+              class="button tertiary"
+              type="button"
+            >
+              <test-file-stub />
+              Resubmit
+            </button>
           </div>
           <table
             class="results-data data-table"
@@ -1095,6 +1102,13 @@ exports[`PeptideSearchResult should render with the correct number of results in
             >
               <test-file-stub />
               Customize columns
+            </button>
+            <button
+              class="button tertiary"
+              type="button"
+            >
+              <test-file-stub />
+              Resubmit
             </button>
           </div>
           <table


### PR DESCRIPTION
## Purpose

- Add Resubmit feature to the overview pages of ID mapping and Peptide search to be consistent with Align and Blast
- Fix default name in ID mapping form to reflect the source and target DB selection.

## Approach
Add 'ResubmitButton' to ResultsButton making use of the input details that we get now in Peptide search endpoint.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
