### PR TITLE
Advanced search suggestions

### DIFF
--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -324,6 +324,7 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
     expect(downloadLink.href).toEqual(
       expect.stringContaining(queryString.stringify({ query: `(${query})` }))
     );
+
     fireEvent.click(
       screen.getByLabelText(
         `Download only reviewed (Swiss-Prot) canonical proteins (20,408)`
@@ -337,5 +338,24 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
         })
       )
     );
+
+    let options = screen.getAllByRole('option');
+    expect(options).toHaveLength(6);
+
+    fireEvent.click(
+      screen.getByLabelText(`Include reviewed (Swiss-Prot) isoforms`)
+    );
+
+    downloadLink = screen.getByRole<HTMLAnchorElement>('link');
+    expect(downloadLink.href).toEqual(
+      expect.stringContaining(
+        queryString.stringify({
+          query: `((proteome:UP000005640) AND reviewed=true)`,
+          includeIsoform: true,
+        })
+      )
+    );
+    options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
   });
 });

--- a/src/shared/components/results/AdvancedSearchSuggestion.tsx
+++ b/src/shared/components/results/AdvancedSearchSuggestion.tsx
@@ -113,7 +113,7 @@ const AdvancedSearchSuggestion = ({
   }
 
   /*  If the single matched field's number of hits is equal to the existing total that is displayed, do not suggest.
-      Ideally we need to fetch results of the relevant suggestion to compare with the current result set
+      As the results will be a subset of the overall search anyway, comparing by number of hits is enough in this use case.
   */
   if (termsToDisplay === 1 && searchTerms[0].hits === total) {
     return null;

--- a/src/shared/components/results/AdvancedSearchSuggestion.tsx
+++ b/src/shared/components/results/AdvancedSearchSuggestion.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useLayoutEffect, useMemo, useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { EllipsisReveal } from 'franklin-sites';
-import qs from 'query-string';
 
 import useDataApi from '../../hooks/useDataApi';
 
@@ -34,12 +33,14 @@ const AdvancedSearchSuggestion = ({
   const [termsToDisplay, setTermsToDisplay] = useState(+Infinity);
   const ref = useRef<HTMLElement>(null);
 
+  const searchParams = new URLSearchParams({
+    size: '0',
+    query: `${query}`,
+    showSingleTermMatchedFields: 'true',
+  });
+
   const { data } = useDataApi<MatchedFieldsResponse>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
-      size: 0,
-      query,
-      showSingleTermMatchedFields: true,
-    })}`
+    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
   // Data to enrich the suggestions with nice labels

--- a/src/shared/components/results/AdvancedSearchSuggestion.tsx
+++ b/src/shared/components/results/AdvancedSearchSuggestion.tsx
@@ -35,7 +35,7 @@ const AdvancedSearchSuggestion = ({
 
   const searchParams = new URLSearchParams({
     size: '0',
-    query: `${query}`,
+    query,
     showSingleTermMatchedFields: 'true',
   });
 

--- a/src/shared/components/results/AdvancedSearchSuggestion.tsx
+++ b/src/shared/components/results/AdvancedSearchSuggestion.tsx
@@ -23,7 +23,13 @@ type MatchedFieldsResponse = {
 
 const finalBrackets = / \[[A-Z]+\]$/;
 
-const AdvancedSearchSuggestion = ({ query }: { query: string }) => {
+const AdvancedSearchSuggestion = ({
+  query,
+  total,
+}: {
+  query: string;
+  total: number;
+}) => {
   const [linesToDisplay, setLinesToDisplay] = useState(1);
   const [termsToDisplay, setTermsToDisplay] = useState(+Infinity);
   const ref = useRef<HTMLElement>(null);
@@ -103,6 +109,13 @@ const AdvancedSearchSuggestion = ({ query }: { query: string }) => {
   }, [searchTerms, linesToDisplay, termsToDisplay]);
 
   if (!searchTerms?.length) {
+    return null;
+  }
+
+  /*  If the single matched field's number of hits is equal to the existing total that is displayed, do not suggest.
+      Ideally we need to fetch results of the relevant suggestion to compare with the current result set
+  */
+  if (termsToDisplay === 1 && searchTerms[0].hits === total) {
     return null;
   }
 

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -48,7 +48,7 @@ const ExactFieldSuggestion = ({
         setDataAvailable(true);
       }
     }
-  }, [data]);
+  }, [data, results, total]);
 
   if (dataAvailable && query !== modifiedQuery) {
     return (

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -34,11 +34,11 @@ const ExactFieldSuggestion = ({
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  const isDataAvailable =
+  const hasExactSuggestion =
     headers?.['x-total-results'] &&
     Number(headers?.['x-total-results']) !== total;
 
-  if (isDataAvailable && query !== modifiedQuery) {
+  if (hasExactSuggestion && query !== modifiedQuery) {
     return (
       <small>
         {' '}

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -18,7 +18,7 @@ import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverte
 const ExactFieldSuggestion = ({
   query,
   total,
-  results,
+  results: existingResults,
 }: {
   query: string;
   total: number;
@@ -31,16 +31,16 @@ const ExactFieldSuggestion = ({
     exactMatchSearchTerms
   );
 
-  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+  const { data: newData } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
       query: modifiedQuery,
     })}`
   );
 
   useEffect(() => {
-    if (data?.results.length && data.results.length !== total) {
-      const differentResultSet = data.results.filter((r) =>
-        results.some(
+    if (newData?.results.length && newData.results.length !== total) {
+      const differentResultSet = newData.results.filter((r) =>
+        existingResults.some(
           (existing) => existing.primaryAccession !== r.primaryAccession
         )
       );
@@ -48,7 +48,7 @@ const ExactFieldSuggestion = ({
         setDataAvailable(true);
       }
     }
-  }, [data, results, total]);
+  }, [newData, existingResults, total]);
 
   if (dataAvailable && query !== modifiedQuery) {
     return (

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import {
   exactMatchSearchTerms,
   modifyQueryWithSuggestions,
@@ -21,7 +19,6 @@ const ExactFieldSuggestion = ({
   query: string;
   total: number;
 }) => {
-  const [dataAvailable, setDataAvailable] = useState(false);
   const { modifiedQuery, searchValue } = modifyQueryWithSuggestions(
     query,
     'exact',
@@ -30,19 +27,18 @@ const ExactFieldSuggestion = ({
 
   const searchParams = new URLSearchParams({
     query: `${modifiedQuery}`,
+    size: '0',
   });
 
-  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+  const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  useEffect(() => {
-    if (data?.results.length && data.results.length !== total) {
-      setDataAvailable(true);
-    }
-  }, [data, total]);
+  const isDataAvailable =
+    headers?.['x-total-results'] &&
+    Number(headers?.['x-total-results']) !== total;
 
-  if (dataAvailable && query !== modifiedQuery) {
+  if (isDataAvailable && query !== modifiedQuery) {
     return (
       <small>
         {' '}

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import qs from 'query-string';
 
 import {
   exactMatchSearchTerms,
@@ -29,10 +28,12 @@ const ExactFieldSuggestion = ({
     exactMatchSearchTerms
   );
 
+  const searchParams = new URLSearchParams({
+    query: `${modifiedQuery}`,
+  });
+
   const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
-      query: modifiedQuery,
-    })}`
+    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
   useEffect(() => {

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -15,7 +15,15 @@ import { Namespace } from '../../types/namespaces';
 import { SearchResults } from '../../types/results';
 import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 
-const ExactFieldSuggestion = ({ query }: { query: string }) => {
+const ExactFieldSuggestion = ({
+  query,
+  total,
+  results,
+}: {
+  query: string;
+  total: number;
+  results: UniProtkbAPIModel[];
+}) => {
   const [dataAvailable, setDataAvailable] = useState(false);
   const { modifiedQuery, searchValue } = modifyQueryWithSuggestions(
     query,
@@ -30,8 +38,15 @@ const ExactFieldSuggestion = ({ query }: { query: string }) => {
   );
 
   useEffect(() => {
-    if (data?.results.length) {
-      setDataAvailable(true);
+    if (data?.results.length && data.results.length !== total) {
+      const differentResultSet = data.results.filter((r) =>
+        results.some(
+          (existing) => existing.primaryAccession !== r.primaryAccession
+        )
+      );
+      if (differentResultSet.length) {
+        setDataAvailable(true);
+      }
     }
   }, [data]);
 

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -18,11 +18,9 @@ import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverte
 const ExactFieldSuggestion = ({
   query,
   total,
-  results: existingResults,
 }: {
   query: string;
   total: number;
-  results: UniProtkbAPIModel[];
 }) => {
   const [dataAvailable, setDataAvailable] = useState(false);
   const { modifiedQuery, searchValue } = modifyQueryWithSuggestions(
@@ -31,24 +29,17 @@ const ExactFieldSuggestion = ({
     exactMatchSearchTerms
   );
 
-  const { data: newData } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
       query: modifiedQuery,
     })}`
   );
 
   useEffect(() => {
-    if (newData?.results.length && newData.results.length !== total) {
-      const differentResultSet = newData.results.filter((r) =>
-        existingResults.some(
-          (existing) => existing.primaryAccession !== r.primaryAccession
-        )
-      );
-      if (differentResultSet.length) {
-        setDataAvailable(true);
-      }
+    if (data?.results.length && data.results.length !== total) {
+      setDataAvailable(true);
     }
-  }, [newData, existingResults, total]);
+  }, [data, total]);
 
   if (dataAvailable && query !== modifiedQuery) {
     return (

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -28,12 +28,10 @@ const OrganismSuggestion = ({
   );
 
   useEffect(() => {
-    console.log(data?.results.length);
-    console.log(total);
     if (data?.results.length && data?.results.length !== total) {
       setOrganismExists(true);
     }
-  }, [data]);
+  }, [data, total]);
 
   if (organismExists && !query.includes('proteome')) {
     return (

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -13,9 +13,11 @@ import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverte
 const OrganismSuggestion = ({
   query,
   taxonID,
+  total,
 }: {
   query: string;
   taxonID: string;
+  total: number;
 }) => {
   const [organismExists, setOrganismExists] = useState(false);
 
@@ -26,7 +28,9 @@ const OrganismSuggestion = ({
   );
 
   useEffect(() => {
-    if (data?.results.length) {
+    console.log(data?.results.length);
+    console.log(total);
+    if (data?.results.length && data?.results.length !== total) {
       setOrganismExists(true);
     }
   }, [data]);

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -25,11 +25,11 @@ const OrganismSuggestion = ({
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  const isValidSuggestion =
+  const hasOrganismSuggestion =
     headers?.['x-total-results'] &&
     Number(headers?.['x-total-results']) !== total;
 
-  if (isValidSuggestion && !query.includes('proteome')) {
+  if (hasOrganismSuggestion && !query.includes('proteome')) {
     return (
       <>
         {' '}

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import qs from 'query-string';
 
 import { SearchTextLink } from './SearchSuggestions';
 import useDataApi from '../../hooks/useDataApi';
@@ -21,10 +20,12 @@ const OrganismSuggestion = ({
 }) => {
   const [organismExists, setOrganismExists] = useState(false);
 
+  const searchParams = new URLSearchParams({
+    query: `organism_id:${taxonID}`,
+  });
+
   const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
-      query: `organism_id:${taxonID}`,
-    })}`
+    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
   useEffect(() => {

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import { SearchTextLink } from './SearchSuggestions';
 import useDataApi from '../../hooks/useDataApi';
 
@@ -18,23 +16,20 @@ const OrganismSuggestion = ({
   taxonID: string;
   total: number;
 }) => {
-  const [organismExists, setOrganismExists] = useState(false);
-
   const searchParams = new URLSearchParams({
     query: `organism_id:${taxonID}`,
+    size: '0',
   });
 
-  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+  const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  useEffect(() => {
-    if (data?.results.length && data?.results.length !== total) {
-      setOrganismExists(true);
-    }
-  }, [data, total]);
+  const isValidSuggestion =
+    headers?.['x-total-results'] &&
+    Number(headers?.['x-total-results']) !== total;
 
-  if (organismExists && !query.includes('proteome')) {
+  if (isValidSuggestion && !query.includes('proteome')) {
     return (
       <>
         {' '}

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -133,6 +133,7 @@ const Results = () => {
               query={params.query}
               namespace={ns}
               total={total}
+              loadedResults={resultsDataObject.allResults}
             />
           )}
         </ErrorBoundary>

--- a/src/shared/components/results/Results.tsx
+++ b/src/shared/components/results/Results.tsx
@@ -133,7 +133,6 @@ const Results = () => {
               query={params.query}
               namespace={ns}
               total={total}
-              loadedResults={resultsDataObject.allResults}
             />
           )}
         </ErrorBoundary>

--- a/src/shared/components/results/SearchSuggestions.tsx
+++ b/src/shared/components/results/SearchSuggestions.tsx
@@ -11,6 +11,8 @@ import {
 
 import { Namespace } from '../../types/namespaces';
 import { Clause } from '../../../query-builder/types/searchTypes';
+import { APIModel } from '../../types/apiModel';
+import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 
 const simpleQuery = /^[a-zA-Z0-9]+$/;
 
@@ -72,10 +74,12 @@ const SearchSuggestions = ({
   query,
   namespace,
   total,
+  loadedResults,
 }: {
   query?: string;
   namespace?: Namespace;
   total?: number;
+  loadedResults: APIModel[];
 }) => {
   // We try to not have a request if not needed, under these conditions:
   const validQueryWithContent = // Only when there are results
@@ -88,16 +92,22 @@ const SearchSuggestions = ({
 
   if (validQueryWithContent) {
     if (simpleQuery.test(query)) {
-      return <AdvancedSearchSuggestion query={query} />;
+      return <AdvancedSearchSuggestion query={query} total={total} />;
     }
     if (
       hasMatchingQuery(exactMatchSearchTerms, query) &&
       !query.includes('exact')
     ) {
-      return <ExactFieldSuggestion query={query} />;
+      return (
+        <ExactFieldSuggestion
+          query={query}
+          total={total}
+          results={loadedResults as UniProtkbAPIModel[]}
+        />
+      );
     }
     if (hasMatchingQuery(taxonHierarchySearchTerms, query)) {
-      return <TaxonomyLevelsSuggestion query={query} />;
+      return <TaxonomyLevelsSuggestion query={query} total={total} />;
     }
     // Add more suggestions in the future here
   }

--- a/src/shared/components/results/SearchSuggestions.tsx
+++ b/src/shared/components/results/SearchSuggestions.tsx
@@ -11,8 +11,6 @@ import {
 
 import { Namespace } from '../../types/namespaces';
 import { Clause } from '../../../query-builder/types/searchTypes';
-import { APIModel } from '../../types/apiModel';
-import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 
 const simpleQuery = /^[a-zA-Z0-9]+$/;
 
@@ -74,12 +72,10 @@ const SearchSuggestions = ({
   query,
   namespace,
   total,
-  loadedResults,
 }: {
   query?: string;
   namespace?: Namespace;
   total?: number;
-  loadedResults?: APIModel[];
 }) => {
   // We try to not have a request if not needed, under these conditions:
   const validQueryWithContent = // Only when there are results
@@ -98,13 +94,7 @@ const SearchSuggestions = ({
       hasMatchingQuery(exactMatchSearchTerms, query) &&
       !query.includes('exact')
     ) {
-      return (
-        <ExactFieldSuggestion
-          query={query}
-          total={total}
-          results={loadedResults as UniProtkbAPIModel[]}
-        />
-      );
+      return <ExactFieldSuggestion query={query} total={total} />;
     }
     if (hasMatchingQuery(taxonHierarchySearchTerms, query)) {
       return <TaxonomyLevelsSuggestion query={query} total={total} />;

--- a/src/shared/components/results/SearchSuggestions.tsx
+++ b/src/shared/components/results/SearchSuggestions.tsx
@@ -79,7 +79,7 @@ const SearchSuggestions = ({
   query?: string;
   namespace?: Namespace;
   total?: number;
-  loadedResults: APIModel[];
+  loadedResults?: APIModel[];
 }) => {
   // We try to not have a request if not needed, under these conditions:
   const validQueryWithContent = // Only when there are results

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import qs from 'query-string';
 
 import ProteomeSuggestion from './ProteomeSuggestion';
 import {
@@ -31,10 +30,12 @@ const TaxonomyLevelsSuggestion = ({
     taxonHierarchySearchTerms
   );
 
+  const searchParams = new URLSearchParams({
+    query: `${modifiedQuery}`,
+  });
+
   const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
-      query: modifiedQuery,
-    })}`
+    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
   useEffect(() => {

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -36,7 +36,7 @@ const TaxonomyLevelsSuggestion = ({
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  const showTaxonSuggestion =
+  const hasTaxonSuggestion =
     headers?.['x-total-results'] &&
     Number(headers?.['x-total-results']) !== total;
 
@@ -46,7 +46,7 @@ const TaxonomyLevelsSuggestion = ({
       <small>
         {searchByOrganism && !query.includes('proteome') ? (
           <>
-            {showTaxonSuggestion ? (
+            {hasTaxonSuggestion ? (
               <>
                 {' '}
                 or expand search to &quot;<b>{searchValue}</b>&quot; to{' '}

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -41,7 +41,7 @@ const TaxonomyLevelsSuggestion = ({
     if (data?.results.length && data?.results.length !== total) {
       setShowTaxonSuggestion(true);
     }
-  }, [data]);
+  }, [data, total]);
 
   if (query !== modifiedQuery && searchValue) {
     const searchByOrganism = query.includes('organism');

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from 'react';
-
 import ProteomeSuggestion from './ProteomeSuggestion';
 import {
   modifyQueryWithSuggestions,
@@ -23,7 +21,6 @@ const TaxonomyLevelsSuggestion = ({
   query: string;
   total: number;
 }) => {
-  const [showTaxonSuggestion, setShowTaxonSuggestion] = useState(false);
   const { modifiedQuery, searchValue } = modifyQueryWithSuggestions(
     query,
     'taxon',
@@ -32,17 +29,16 @@ const TaxonomyLevelsSuggestion = ({
 
   const searchParams = new URLSearchParams({
     query: `${modifiedQuery}`,
+    size: '0',
   });
 
-  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+  const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
   );
 
-  useEffect(() => {
-    if (data?.results.length && data?.results.length !== total) {
-      setShowTaxonSuggestion(true);
-    }
-  }, [data, total]);
+  const showTaxonSuggestion =
+    headers?.['x-total-results'] &&
+    Number(headers?.['x-total-results']) !== total;
 
   if (query !== modifiedQuery && searchValue) {
     const searchByOrganism = query.includes('organism');

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -1,3 +1,6 @@
+import { useState, useEffect } from 'react';
+import qs from 'query-string';
+
 import ProteomeSuggestion from './ProteomeSuggestion';
 import {
   modifyQueryWithSuggestions,
@@ -6,12 +9,39 @@ import {
 } from './SearchSuggestions';
 import OrganismSuggestion from './OrganismSuggestion';
 
-const TaxonomyLevelsSuggestion = ({ query }: { query: string }) => {
+import useDataApi from '../../hooks/useDataApi';
+
+import apiUrls from '../../config/apiUrls';
+
+import { SearchResults } from '../../types/results';
+import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
+import { Namespace } from '../../types/namespaces';
+
+const TaxonomyLevelsSuggestion = ({
+  query,
+  total,
+}: {
+  query: string;
+  total: number;
+}) => {
+  const [showTaxonSuggestion, setShowTaxonSuggestion] = useState(false);
   const { modifiedQuery, searchValue } = modifyQueryWithSuggestions(
     query,
     'taxon',
     taxonHierarchySearchTerms
   );
+
+  const { data } = useDataApi<SearchResults<UniProtkbAPIModel>>(
+    `${apiUrls.search(Namespace.uniprotkb)}?${qs.stringify({
+      query: modifiedQuery,
+    })}`
+  );
+
+  useEffect(() => {
+    if (data?.results.length && data?.results.length !== total) {
+      setShowTaxonSuggestion(true);
+    }
+  }, [data]);
 
   if (query !== modifiedQuery && searchValue) {
     const searchByOrganism = query.includes('organism');
@@ -19,16 +49,26 @@ const TaxonomyLevelsSuggestion = ({ query }: { query: string }) => {
       <small>
         {searchByOrganism && !query.includes('proteome') ? (
           <>
-            {' '}
-            or expand search to &quot;<b>{searchValue}</b>&quot; to{' '}
-            <SearchTextLink
-              query={modifiedQuery}
-              text="include lower taxonomic ranks"
-            />
+            {showTaxonSuggestion ? (
+              <>
+                {' '}
+                or expand search to &quot;<b>{searchValue}</b>&quot; to{' '}
+                <SearchTextLink
+                  query={modifiedQuery}
+                  text="include lower taxonomic ranks"
+                />
+              </>
+            ) : (
+              ''
+            )}
             <ProteomeSuggestion query={query} organismID={searchValue} />
           </>
         ) : (
-          <OrganismSuggestion query={modifiedQuery} taxonID={searchValue} />
+          <OrganismSuggestion
+            query={modifiedQuery}
+            taxonID={searchValue}
+            total={total}
+          />
         )}
       </small>
     );

--- a/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
+++ b/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
@@ -14,7 +14,7 @@ const mock = new MockAdapter(axios);
 
 mock
   .onGet(
-    /\/uniprotkb\/search\?query=eve&showSingleTermMatchedFields=true&size=0/
+    /\/uniprotkb\/search\?size=0&query=eve&showSingleTermMatchedFields=true/
   )
   .reply(200, {
     matchedFields: [

--- a/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
+++ b/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
@@ -57,6 +57,18 @@ mock.onGet(/\/uniprotkb\/search\?query=organism_id%3A9606/).reply(200, {
   ],
 });
 
+mock.onGet(/\/uniprotkb\/search\?query=%28taxonomy_id%3A9606%29/).reply(200, {
+  results: [
+    {
+      organism: {
+        scientificName: 'Homo sapiens',
+        commonName: 'Human',
+        taxonId: 9606,
+      },
+    },
+  ],
+});
+
 mock.onGet(/\/uniprotkb\/search\?organism_id%3A2/).reply(200, {
   results: [],
 });

--- a/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
+++ b/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
@@ -32,42 +32,33 @@ mock
   .onGet(/\/configure\/uniprotkb\/search-fields/)
   .reply(200, configureSearchTerms);
 
-mock.onGet(/\/uniprotkb\/search\?query=%28gene_exact%3Aapp%29/).reply(200, {
-  results: [
-    {
-      entryType: 'UniProtKB reviewed (Swiss-Prot)',
-      primaryAccession: 'P05067',
-    },
-  ],
-});
+mock.onGet(/\/uniprotkb\/search\?query=%28gene_exact%3Aapp%29&size=0/).reply(
+  200,
+  {
+    results: [],
+  },
+  { 'x-total-results': 1704 }
+);
 
 mock.onGet(/\/uniprotkb\/search\?query=%28gene_exact%3Aerv%29/).reply(200, {
   results: [],
 });
 
-mock.onGet(/\/uniprotkb\/search\?query=organism_id%3A9606/).reply(200, {
-  results: [
-    {
-      organism: {
-        scientificName: 'Homo sapiens',
-        commonName: 'Human',
-        taxonId: 9606,
-      },
-    },
-  ],
-});
+mock.onGet(/\/uniprotkb\/search\?query=organism_id%3A9606&size=0/).reply(
+  200,
+  {
+    results: [],
+  },
+  { 'x-total-results': 207892 }
+);
 
-mock.onGet(/\/uniprotkb\/search\?query=%28taxonomy_id%3A9606%29/).reply(200, {
-  results: [
-    {
-      organism: {
-        scientificName: 'Homo sapiens',
-        commonName: 'Human',
-        taxonId: 9606,
-      },
-    },
-  ],
-});
+mock.onGet(/\/uniprotkb\/search\?query=%28taxonomy_id%3A9606%29&size=0/).reply(
+  200,
+  {
+    results: [],
+  },
+  { 'x-total-results': 207981 }
+);
 
 mock.onGet(/\/uniprotkb\/search\?organism_id%3A2/).reply(200, {
   results: [],
@@ -145,7 +136,7 @@ describe('SearchSuggestions', () => {
       <SearchSuggestions
         query="gene:app"
         namespace={Namespace.uniprotkb}
-        total={100}
+        total={5405}
       />
     );
 
@@ -174,7 +165,7 @@ describe('SearchSuggestions', () => {
       <SearchSuggestions
         query="taxonomy_id:9606"
         namespace={Namespace.uniprotkb}
-        total={100}
+        total={207981}
       />
     );
 
@@ -202,7 +193,7 @@ describe('SearchSuggestions', () => {
       <SearchSuggestions
         query="organism_id:9606"
         namespace={Namespace.uniprotkb}
-        total={100}
+        total={207892}
       />
     );
 


### PR DESCRIPTION
## Purpose
There should be no suggestions of queries which
- return 0 hits
- return the same hits as the original question.

As the search results of a suggestion are subsets of the whole search, comparing the number of hits is enough.

 e.g. https://www.uniprot.org/uniprotkb?query=BSU06210 don't
suggest to restrict to gene name.

https://www.uniprot.org/uniprotkb?query=gene%3Acyk3%20AND%20organism_id%3A284812
don't suggest exact match as it is the same result

## Approach
Exact match, taxonomy and matching fields suggestion takes into account the number of results to decide. if it is different to the total number of hits that are currently shown in the results page, the suggestion is shown

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
