### PR TITLE
Rich text dbsnp

### DIFF
--- a/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
+++ b/src/uniprotkb/components/protein-data-views/DiseaseInvolvementView.tsx
@@ -6,6 +6,7 @@ import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 import { XRef } from './XRefView';
 import DatatableWithToggle from '../../../shared/components/views/DatatableWithToggle';
 import ExternalLink from '../../../shared/components/ExternalLink';
+import { RichText } from './FreeTextView';
 
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 
@@ -95,17 +96,6 @@ export const DiseaseVariants = ({
           }
 
           let { description } = variant;
-          let rsIDs: string[] | undefined = [];
-
-          const dbSNPRegEx = /dbsnp:rs\d*/gi;
-          if (description && dbSNPRegEx.test(description)) {
-            const matches = description.match(dbSNPRegEx);
-            rsIDs = matches?.map((match) => {
-              const [, rsId] = match.split(/dbsnp:/i);
-              return rsId;
-            });
-            [description] = description.split(dbSNPRegEx).filter(Boolean);
-          }
 
           if (variant.location.sequence) {
             description = `In isoform ${variant.location.sequence}; ${description}`;
@@ -136,12 +126,7 @@ export const DiseaseVariants = ({
                   {protvarVariantLink(variant, accession)}
                 </td>
                 <td>
-                  {description}
-                  {rsIDs?.map((rsID) => (
-                    <ExternalLink url={externalUrls.dbSNP(rsID)} key={rsID}>
-                      dbSNP:{rsID}
-                    </ExternalLink>
-                  ))}
+                  <RichText>{description}</RichText>
                   {variant.evidences && (
                     <UniProtKBEvidenceTag evidences={variant.evidences} />
                   )}

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -1,6 +1,7 @@
 import { Fragment, FC, ReactNode } from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 
+import { ExternalLink } from 'franklin-sites';
 import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 import SimilarityView from './SimilarityView';
 
@@ -9,6 +10,7 @@ import {
   getEntryPathFor,
   allEntryPages,
 } from '../../../app/config/urls';
+import externalUrls from '../../../shared/config/externalUrls';
 import {
   reAC,
   reIsoform,
@@ -18,6 +20,7 @@ import {
   reUniProtKBAccession,
   reSubscript,
   reSuperscript,
+  reDbSnp,
 } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
@@ -91,6 +94,15 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
               {/* eslint-disable-next-line uniprot-website/use-config-location */}
               <Link to={{ hash: `Isoform_${isoform}` }}>{isoform}</Link>
             </Fragment>
+          );
+        }
+        const dbSnpMatch = part.match(reDbSnp);
+        if (dbSnpMatch?.groups) {
+          const { rsid } = dbSnpMatch.groups;
+          return (
+            <ExternalLink url={externalUrls.dbSNP(rsid)} key={rsid}>
+              {`dbSNP:${rsid}`}
+            </ExternalLink>
           );
         }
       }

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -19,8 +19,8 @@ import {
   reUniProtKBAccession,
   reSubscript,
   reSuperscript,
-  reDbSnp,
   getNeedsTextProcessingParts,
+  reDbSnpID,
 } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
@@ -96,7 +96,7 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
             </Fragment>
           );
         }
-        const dbSnpMatch = part.match(reDbSnp);
+        const dbSnpMatch = part.match(reDbSnpID);
         if (dbSnpMatch?.groups) {
           const { rsid } = dbSnpMatch.groups;
           return (

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -97,12 +97,10 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
         if (dbSnpMatch?.groups) {
           const { rsid } = dbSnpMatch.groups;
           return (
-            <>
+            <Fragment key={rsid}>
               dbSNP:
-              <ExternalLink url={externalUrls.dbSNP(rsid)} key={rsid}>
-                {rsid}
-              </ExternalLink>
-            </>
+              <ExternalLink url={externalUrls.dbSNP(rsid)}>{rsid}</ExternalLink>
+            </Fragment>
           );
         }
       }

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -14,13 +14,13 @@ import externalUrls from '../../../shared/config/externalUrls';
 import {
   reAC,
   reIsoform,
-  needTextProcessingRE,
   rePubMedID,
   rePubMed,
   reUniProtKBAccession,
   reSubscript,
   reSuperscript,
   reDbSnp,
+  getNeedsTextProcessingParts,
 } from '../../utils';
 
 import { Namespace } from '../../../shared/types/namespaces';
@@ -52,7 +52,7 @@ type RichTextProps = {
 
 export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
   <>
-    {children?.split(needTextProcessingRE).map((part, index, mappedArr) => {
+    {getNeedsTextProcessingParts(children)?.map((part, index, mappedArr) => {
       // Capturing group will allow split to conserve that bit in the split parts
       // NOTE: rePubMed and reAC should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
       // it is not supported in Safari yet. It's OK, we just get more chunks when splitting

--- a/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
+++ b/src/uniprotkb/components/protein-data-views/FreeTextView.tsx
@@ -97,9 +97,12 @@ export const RichText = ({ children, addPeriod, noLink }: RichTextProps) => (
         if (dbSnpMatch?.groups) {
           const { rsid } = dbSnpMatch.groups;
           return (
-            <ExternalLink url={externalUrls.dbSNP(rsid)} key={rsid}>
-              {`dbSNP:${rsid}`}
-            </ExternalLink>
+            <>
+              dbSNP:
+              <ExternalLink url={externalUrls.dbSNP(rsid)} key={rsid}>
+                {rsid}
+              </ExternalLink>
+            </>
           );
         }
       }

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -75,7 +75,7 @@ describe('RichText component', () => {
     ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
   });
 
-  it('should render two dbSNP links', () => {
+  it.skip('should render two dbSNP links', () => {
     render(
       <RichText>
         in AD1; increased amyloid-beta protein 42/40 ratio; dbSNP:rs63750973;

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -75,7 +75,7 @@ describe('RichText component', () => {
     ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
   });
 
-  it.skip('should render two dbSNP links', () => {
+  it('should render two dbSNP links', () => {
     render(
       <RichText>
         in AD1; increased amyloid-beta protein 42/40 ratio; dbSNP:rs63750973;

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -1,7 +1,7 @@
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
-import FreeTextView from '../FreeTextView';
+import FreeTextView, { RichText } from '../FreeTextView';
 
 import freeTextUIData from './__mocks__/freeTextUIData';
 
@@ -52,5 +52,26 @@ describe('FreeText component', () => {
     it('should render pubmed and AC links', () => {
       expect(screen.queryAllByRole('link')).toHaveLength(3);
     });
+  });
+});
+
+describe('RichText component', () => {
+  it('should render superscript', () => {
+    const { container } = render(
+      <RichText>Required for Cu(2+) reduction</RichText>
+    );
+    const superscript = container.querySelector('sup');
+    expect(superscript).toHaveTextContent('2+');
+  });
+
+  it('should render dbSNP link', () => {
+    render(
+      <RichText>
+        in AD1; increased amyloid-beta protein 42/40 ratio; dbSNP:rs63750973
+      </RichText>
+    );
+    expect(
+      screen.getByRole('link', { name: 'dbSNP:rs63750973' })
+    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
   });
 });

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -74,4 +74,21 @@ describe('RichText component', () => {
       screen.getByRole('link', { name: 'dbSNP:rs63750973' })
     ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
   });
+
+  it('should render two dbSNP links', () => {
+    render(
+      <RichText>
+        in AD1; increased amyloid-beta protein 42/40 ratio; dbSNP:rs63750973;
+        dbSNP:rs12345678
+      </RichText>
+    );
+    expect(
+      screen.getByRole('link', { name: 'dbSNP:rs63750973' })
+    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
+    expect(
+      screen.getByRole('link', { name: 'dbSNP:rs12345678' })
+    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs12345678');
+  });
+
+  // 	in AD1; dbSNP:rs63750643
 });

--- a/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/FreeTextView.spec.tsx
@@ -70,9 +70,10 @@ describe('RichText component', () => {
         in AD1; increased amyloid-beta protein 42/40 ratio; dbSNP:rs63750973
       </RichText>
     );
-    expect(
-      screen.getByRole('link', { name: 'dbSNP:rs63750973' })
-    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
+    expect(screen.getByRole('link', { name: 'rs63750973' })).toHaveAttribute(
+      'href',
+      'https://www.ncbi.nlm.nih.gov/snp/rs63750973'
+    );
   });
 
   it('should render two dbSNP links', () => {
@@ -82,12 +83,14 @@ describe('RichText component', () => {
         dbSNP:rs12345678
       </RichText>
     );
-    expect(
-      screen.getByRole('link', { name: 'dbSNP:rs63750973' })
-    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs63750973');
-    expect(
-      screen.getByRole('link', { name: 'dbSNP:rs12345678' })
-    ).toHaveAttribute('href', 'https://www.ncbi.nlm.nih.gov/snp/rs12345678');
+    expect(screen.getByRole('link', { name: 'rs63750973' })).toHaveAttribute(
+      'href',
+      'https://www.ncbi.nlm.nih.gov/snp/rs63750973'
+    );
+    expect(screen.getByRole('link', { name: 'rs12345678' })).toHaveAttribute(
+      'href',
+      'https://www.ncbi.nlm.nih.gov/snp/rs12345678'
+    );
   });
 
   // 	in AD1; dbSNP:rs63750643

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/DiseaseInvolvementView.spec.tsx.snap
@@ -150,14 +150,14 @@ exports[`DiseaseInvolvement should render DiseaseInvolvement 1`] = `
               </a>
             </td>
             <td>
-              in AD; supposed to be rendered with the disease; Italian type; 
+              in AD; supposed to be rendered with the disease; Italian type; dbSNP:
               <a
                 class="external-link"
                 href="https://www.ncbi.nlm.nih.gov/snp/rs63750579"
                 rel="noopener"
                 target="_blank"
               >
-                dbSNP:rs63750579
+                rs63750579
                 <test-file-stub
                   data-testid="external-link-icon"
                   width="12.5"

--- a/src/uniprotkb/utils/__tests__/index.spec.ts
+++ b/src/uniprotkb/utils/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import { getNeedsTextProcessingParts } from '..';
+import { getTextProcessingParts } from '..';
 
 const testCases: [string, string[]][] = [
   [
@@ -41,6 +41,6 @@ const testCases: [string, string[]][] = [
 
 describe('getNeedsTextProcessingParts', () => {
   test.each(testCases)('should return the parts for text', (text, parts) => {
-    expect(getNeedsTextProcessingParts(text)).toEqual(parts);
+    expect(getTextProcessingParts(text)).toEqual(parts);
   });
 });

--- a/src/uniprotkb/utils/__tests__/index.spec.ts
+++ b/src/uniprotkb/utils/__tests__/index.spec.ts
@@ -40,7 +40,7 @@ const testCases: [string, string[]][] = [
 ];
 
 describe('getNeedsTextProcessingParts', () => {
-  test.each(testCases)('foo', (text, parts) => {
+  test.each(testCases)('should return the parts for text', (text, parts) => {
     expect(getNeedsTextProcessingParts(text)).toEqual(parts);
   });
 });

--- a/src/uniprotkb/utils/__tests__/index.spec.ts
+++ b/src/uniprotkb/utils/__tests__/index.spec.ts
@@ -1,0 +1,46 @@
+import { getNeedsTextProcessingParts } from '..';
+
+const testCases: [string, string[]][] = [
+  [
+    'Proteolytically processed under normal cellular conditions. Cleavage either by alpha-secretase, beta-secretase or theta-secretase leads to generation and extracellular release of soluble APP peptides, S-APP-alpha and S-APP-beta, and the retention of corresponding membrane-anchored C-terminal fragments, C80, C83 and C99. Subsequent processing of C80 and C83 by gamma-secretase yields P3 peptides. This is the major secretory pathway and is non-amyloidogenic. Alternatively, presenilin/nicastrin-mediated gamma-secretase processing of C99 releases the amyloid-beta proteins, amyloid-beta protein 40 and amyloid-beta protein 42, major components of amyloid plaques, and the cytotoxic C-terminal fragments, gamma-CTF(50), gamma-CTF(57) and gamma-CTF(59). PSEN1 cleavage is more efficient with C83 than with C99 as substrate (in vitro) (PubMed:30630874). Amyloid-beta protein 40 and Amyloid-beta protein 42 are cleaved by ACE (PubMed:11604391, PubMed:16154999). Many other minor amyloid-beta peptides, amyloid-beta 1-X peptides, are found in cerebral spinal fluid (CSF) including the amyloid-beta X-15 peptides, produced from the cleavage by alpha-secretase and all terminating at Gln-686',
+    [
+      'Proteolytically processed under normal cellular conditions. Cleavage either by alpha-secretase, beta-secretase or theta-secretase leads to generation and extracellular release of soluble APP peptides, S-APP-alpha and S-APP-beta, and the retention of corresponding membrane-anchored C-terminal fragments, C80, C83 and C99. Subsequent processing of C80 and C83 by gamma-secretase yields P3 peptides. This is the major secretory pathway and is non-amyloidogenic. Alternatively, presenilin/nicastrin-mediated gamma-secretase processing of C99 releases the amyloid-beta proteins, amyloid-beta protein 40 and amyloid-beta protein 42, major components of amyloid plaques, and the cytotoxic C-terminal fragments, gamma-CTF',
+      '(50)',
+      ', gamma-CTF',
+      '(57)',
+      ' and gamma-CTF',
+      '(59)',
+      '. PSEN1 cleavage is more efficient with C83 than with C99 as substrate (in vitro) (',
+      'PubMed:30630874',
+      '). Amyloid-beta protein 40 and Amyloid-beta protein 42 are cleaved by ACE (',
+      'PubMed:11604391',
+      ', ',
+      'PubMed:16154999',
+      '). Many other minor amyloid-beta peptides, amyloid-beta 1-X peptides, are found in cerebral spinal fluid (CSF) including the amyloid-beta X-15 peptides, produced from the cleavage by alpha-secretase and all terminating at Gln-686',
+    ],
+  ],
+  [
+    'in isoform APP695, isoform L-APP696, isoform L-APP677 and isoform APP714',
+    [
+      'in ',
+      'isoform APP695',
+      ', ',
+      'isoform L-APP696',
+      ', ',
+      'isoform L-APP677',
+      ' and ',
+      'isoform APP714',
+      '',
+    ],
+  ],
+  [
+    'in CAA-APP; Italian type; dbSNP:rs63750921',
+    ['in CAA-APP; Italian type; ', 'dbSNP:rs63750921', ''],
+  ],
+];
+
+describe('getNeedsTextProcessingParts', () => {
+  test.each(testCases)('foo', (text, parts) => {
+    expect(getNeedsTextProcessingParts(text)).toEqual(parts);
+  });
+});

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -93,7 +93,5 @@ const needTextProcessingRE = new RegExp(
   'i'
 );
 
-export const getNeedsTextProcessingParts = (s?: string) => {
-  const foo = s?.split(needTextProcessingRE);
-  return foo;
-};
+export const getNeedsTextProcessingParts = (s?: string) =>
+  s?.split(needTextProcessingRE);

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -83,17 +83,17 @@ export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;
 export const rePubMedID = /\d{7,8}/;
 export const rePubMed = new RegExp(`(?:pubmed:${rePubMedID.source})`, 'i');
-export const reDbSnp = /dbSNP:(?<rsid>\d+)/;
+export const reDbSnpID = /dbSNP:(?<rsid>rs\d+)/;
+export const reDbSnp = /dbSNP:rs\d+/;
 export const reSubscript = /\(\d+\)/;
 export const reSuperscript = /\(\d?[+-]\)|\(-\d\)/;
 
 const needTextProcessingRE = new RegExp(
-  `(${rePubMed.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source}|${reDbSnp})`,
+  `(${rePubMed.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source}|${reDbSnp.source})`,
   'i'
 );
 
 export const getNeedsTextProcessingParts = (s?: string) => {
   const foo = s?.split(needTextProcessingRE);
-  console.log(foo);
   return foo;
 };

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -83,6 +83,7 @@ export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;
 export const rePubMedID = /\d{7,8}/;
 export const rePubMed = new RegExp(`(?:pubmed:${rePubMedID.source})`, 'i');
+export const reDbSnp = /dbSNP:(?<rsid>\w+)/;
 export const reSubscript = /\(\d+\)/;
 export const reSuperscript = /\(\d?[+-]\)|\(-\d\)/;
 

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -83,11 +83,17 @@ export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;
 export const rePubMedID = /\d{7,8}/;
 export const rePubMed = new RegExp(`(?:pubmed:${rePubMedID.source})`, 'i');
-export const reDbSnp = /dbSNP:(?<rsid>\w+)/;
+export const reDbSnp = /dbSNP:(?<rsid>\d+)/;
 export const reSubscript = /\(\d+\)/;
 export const reSuperscript = /\(\d?[+-]\)|\(-\d\)/;
 
-export const needTextProcessingRE = new RegExp(
-  `(${rePubMed.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source})`,
+const needTextProcessingRE = new RegExp(
+  `(${rePubMed.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source}|${reDbSnp})`,
   'i'
 );
+
+export const getNeedsTextProcessingParts = (s?: string) => {
+  const foo = s?.split(needTextProcessingRE);
+  console.log(foo);
+  return foo;
+};

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -81,17 +81,35 @@ export const reUniProtKBAccession =
 
 export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;
-export const rePubMedID = /\d{7,8}/;
-export const rePubMed = new RegExp(`(?:pubmed:${rePubMedID.source})`, 'i');
-export const reDbSnpID = /dbSNP:(?<rsid>rs\d+)/;
-export const reDbSnp = /dbSNP:rs\d+/;
+const rePubMedID = /\d{7,8}/;
+export const rePubMedCapture = new RegExp(
+  `pubmed:(?<pmid>${rePubMedID.source})`,
+  'i'
+);
+export const rePubMedNonCapture = new RegExp(
+  `(?:pubmed:${rePubMedID.source})`,
+  'i'
+);
+const reDbSnpID = /rs\d+/;
+export const reDbSnpCapture = new RegExp(
+  `dbSNP:(?<rsid>${reDbSnpID.source})`,
+  'i'
+);
+export const reDbSnpNonCapture = new RegExp(
+  `(?:dbSNP:${reDbSnpID.source})`,
+  'i'
+);
 export const reSubscript = /\(\d+\)/;
 export const reSuperscript = /\(\d?[+-]\)|\(-\d\)/;
 
-const needTextProcessingRE = new RegExp(
-  `(${rePubMed.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source}|${reDbSnp.source})`,
+const reNeedsTextProcessing = new RegExp(
+  `(${rePubMedNonCapture.source}|${reAC.source}|${reIsoform.source}|By similarity|${reSubscript.source}|${reSuperscript.source}|${reDbSnpNonCapture.source})`,
   'i'
 );
 
-export const getNeedsTextProcessingParts = (s?: string) =>
-  s?.split(needTextProcessingRE);
+export const getTextProcessingParts = (s?: string) =>
+  // Capturing group will allow split to conserve that bit in the split parts
+  // NOTE: rePubMed and reAC should be using a lookbehind eg `/(?<=pubmed:)(\d{7,8})/i` but
+  // it is not supported in Safari yet. It's OK, we just get more chunks when splitting.
+  // For now don't use capture groups in reNeedsTextProcessing
+  s?.split(reNeedsTextProcessing);

--- a/src/uniprotkb/utils/index.ts
+++ b/src/uniprotkb/utils/index.ts
@@ -87,7 +87,7 @@ export const rePubMedCapture = new RegExp(
   'i'
 );
 export const rePubMedNonCapture = new RegExp(
-  `(?:pubmed:${rePubMedID.source})`,
+  `pubmed:${rePubMedID.source}`,
   'i'
 );
 const reDbSnpID = /rs\d+/;
@@ -95,10 +95,7 @@ export const reDbSnpCapture = new RegExp(
   `dbSNP:(?<rsid>${reDbSnpID.source})`,
   'i'
 );
-export const reDbSnpNonCapture = new RegExp(
-  `(?:dbSNP:${reDbSnpID.source})`,
-  'i'
-);
+export const reDbSnpNonCapture = new RegExp(`dbSNP:${reDbSnpID.source}`, 'i');
 export const reSubscript = /\(\d+\)/;
 export const reSuperscript = /\(\d?[+-]\)|\(-\d\)/;
 


### PR DESCRIPTION
## Purpose
[Improve RichText component to parse variant description texts (parse dbsnp links)](https://www.ebi.ac.uk/panda/jira/browse/TRM-29431)


## Approach

- Add dbsnp regexp
- Extract `getTextProcessingParts` create tests as I was messing things up but couldn't figure out why
- Made explicit capture and non-capture groups to avoid multiple regex matches

## Testing
Updated and added

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
