### PR TITLE
2023 09 datatable expand button

### DIFF
--- a/src/shared/components/views/DatatableWithToggle.tsx
+++ b/src/shared/components/views/DatatableWithToggle.tsx
@@ -22,7 +22,7 @@ const DatatableWithToggle = ({ children }: { children: ReactNode }) => {
   const tableRef = useRef<HTMLElement>(null);
   const firstRenderRef = useRef(true);
 
-  const params = useParams<{ accession: string }>();
+  const params = useParams<{ accession?: string }>();
 
   const datatableElement = useCustomElement(
     /* istanbul ignore next */
@@ -45,7 +45,7 @@ const DatatableWithToggle = ({ children }: { children: ReactNode }) => {
         });
       }
       sendGtagEventFeatureDataTableViewClick(
-        params.accession,
+        params.accession || '',
         expandTable ? 'expanded' : 'collapsed'
       );
     }

--- a/src/shared/components/views/__tests__/DatatableWithToggle.spec.tsx
+++ b/src/shared/components/views/__tests__/DatatableWithToggle.spec.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import customRender from '../../../__test-helpers__/customRender';
+
+import DatatableWithToggle from '../DatatableWithToggle';
+
+describe('DatatableWithToggle component', () => {
+  it('should render with a working toggle button', async () => {
+    const { asFragment } = customRender(
+      <DatatableWithToggle>
+        <table />
+      </DatatableWithToggle>
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const button = screen.getByRole('button', { name: /Expand/ });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(
+      await screen.findByRole('button', { name: /Collapse/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/views/__tests__/SimpleView.spec.tsx
+++ b/src/shared/components/views/__tests__/SimpleView.spec.tsx
@@ -5,11 +5,11 @@ import customRender from '../../../__test-helpers__/customRender';
 import SimpleView from '../SimpleView';
 
 describe('SimpleView component', () => {
-  test('should render', () => {
+  it('should render', () => {
     const { asFragment } = render(<SimpleView termValue="blah" />);
     expect(asFragment()).toMatchSnapshot();
   });
-  test('should render with link', () => {
+  it('should render with link', () => {
     const { asFragment } = customRender(
       <SimpleView termValue="blah" linkTo="linkto" />
     );

--- a/src/shared/components/views/__tests__/__snapshots__/DatatableWithToggle.spec.tsx.snap
+++ b/src/shared/components/views/__tests__/__snapshots__/DatatableWithToggle.spec.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatatableWithToggle component should render with a working toggle button 1`] = `
+<DocumentFragment>
+  <div
+    class="datatable-with-toggle"
+  >
+    <protvista-datatable
+      filter-scroll="true"
+    >
+      <table />
+    </protvista-datatable>
+    <button
+      class="button primary toggle-button"
+      type="button"
+    >
+      Expand table
+    </button>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Purpose
Only show the expand button for datatable when there is something to expand to. [TRM-28963](https://www.ebi.ac.uk/panda/jira/browse/TRM-28963)

## Approach
Detect scroll within the Nightingale datatable container and if there is no scroll hide the expand button.
Do the check anytime the content changes (data loaded, class changed when hiding/showing rows) with a MutationObserver.

## Testing
Manual testing as MutationObserver is tricky to test in Jest/jsdom. Better coverage by adding a test about the button itself.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
