### PR TITLE
Remove query string pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "protvista-variation": "3.8.10",
     "protvista-variation-adapter": "3.8.10",
     "protvista-zoom-tool": "3.8.4",
-    "query-string": "7.1.1",
     "react": "17.0.2",
     "react-beautiful-dnd": "13.1.1",
     "react-diff-viewer": "3.1.1",

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -16,7 +16,6 @@ import {
   Replay,
 } from '@sentry/react';
 import { Integrations as SentryIntegrations } from '@sentry/tracing';
-import queryString from 'query-string';
 
 import BaseLayout from '../../shared/components/layouts/BaseLayout';
 import { SingleColumnLayout } from '../../shared/components/layouts/SingleColumnLayout';
@@ -34,6 +33,7 @@ import {
   Location,
   LocationToPath,
 } from '../config/urls';
+import { stringifyUrl } from '../../shared/utils/url';
 
 import pkg from '../../../package.json';
 
@@ -302,9 +302,9 @@ const ResultsOrLanding =
       if (!params.query) {
         return (
           <Redirect
-            to={queryString.stringifyUrl({
-              url: props.location.pathname,
-              query: { ...params, query: '*' },
+            to={stringifyUrl(props.location.pathname, {
+              ...params,
+              query: '*',
             })}
           />
         );

--- a/src/contact/adapters/contactFormAdapter.ts
+++ b/src/contact/adapters/contactFormAdapter.ts
@@ -15,12 +15,13 @@ import useMessagesDispatch from '../../shared/hooks/useMessagesDispatch';
 
 import apiUrls from '../../shared/config/apiUrls';
 import { addMessage } from '../../messages/state/messagesActions';
+import { stringifyUrl } from '../../shared/utils/url';
+
 import {
   MessageFormat,
   MessageLevel,
 } from '../../messages/types/messagesTypes';
 import { Location, LocationToPath } from '../../app/config/urls';
-import { stringifyUrl } from '../../shared/utils/url';
 
 export type ContactLocationState =
   | undefined

--- a/src/contact/adapters/contactFormAdapter.ts
+++ b/src/contact/adapters/contactFormAdapter.ts
@@ -20,6 +20,7 @@ import {
   MessageLevel,
 } from '../../messages/types/messagesTypes';
 import { Location, LocationToPath } from '../../app/config/urls';
+import { stringifyUrl } from '../../shared/utils/url';
 
 export type ContactLocationState =
   | undefined
@@ -65,9 +66,7 @@ export const useFormLogic = (referrer?: string): UseFormLogicReturnType => {
   const subject = formData?.get('subject') as undefined | string;
 
   const tokenData = useDataApi<{ token: string }>(
-    subject
-      ? `${apiUrls.contact.token}?${new URLSearchParams({ key: subject })}`
-      : null
+    subject ? stringifyUrl(apiUrls.contact.token, { key: subject }) : null
   );
   const token = tokenData.data?.token;
 

--- a/src/contact/components/ContactForm.tsx
+++ b/src/contact/components/ContactForm.tsx
@@ -25,8 +25,6 @@ import {
   ContactLocationState,
 } from '../adapters/contactFormAdapter';
 
-import { parseQueryString } from '../../shared/utils/url';
-
 import { LocationToPath, Location } from '../../app/config/urls';
 
 import styles from './styles/contact-form.module.scss';
@@ -65,7 +63,9 @@ const ContactForm = () => {
 
   let subjectDefault: undefined | string;
   if (isUpdate) {
-    const { entry, entryType } = parseQueryString(search);
+    const sp = new URLSearchParams(search);
+    const entry = sp.get('entry');
+    const entryType = sp.get('entryType');
     if (entryType && entry) {
       subjectDefault = `${entryType} ${entry} entry update request`;
     } else if (entry) {

--- a/src/help/components/contextual/ContextualHelpContainer.tsx
+++ b/src/help/components/contextual/ContextualHelpContainer.tsx
@@ -22,7 +22,6 @@ import HelpLandingPage from './Landing';
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 
 import { help as helpURL } from '../../../shared/config/apiUrls';
-import { parseQueryString } from '../../../shared/utils/url';
 
 import {
   LocationToPath,
@@ -40,7 +39,8 @@ const ContextualHelpRouterContent = ({
 }) => {
   const location = useLocation();
 
-  const { query } = parseQueryString(location.search);
+  const sp = new URLSearchParams(location.search);
+  const query = sp.get('query');
   const dataObject = useDataApiWithStale<HelpSearchResponse>(
     query && helpURL.search({ query })
   );

--- a/src/help/components/contextual/SearchBar.tsx
+++ b/src/help/components/contextual/SearchBar.tsx
@@ -2,7 +2,8 @@ import { SearchInput } from 'franklin-sites';
 import { debounce } from 'lodash-es';
 import { useMemo, useEffect, useCallback, ChangeEvent, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import qs from 'query-string';
+
+import { stringifyQuery } from '../../../shared/utils/url';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
@@ -18,7 +19,7 @@ const SearchBar = ({ isLoading }: { isLoading: boolean }) => {
         // Push only the first time we get a new search, replace otherwise
         history[history.location.search ? 'replace' : 'push']({
           pathname: LocationToPath[Location.HelpResults],
-          search: qs.stringify({ query: searchValue || undefined }),
+          search: stringifyQuery({ query: searchValue || undefined }),
         });
       }, 500),
     [history]

--- a/src/help/components/entry/Entry.tsx
+++ b/src/help/components/entry/Entry.tsx
@@ -15,7 +15,6 @@ import {
   IOptions,
 } from 'sanitize-html';
 import cn from 'classnames';
-import qs from 'query-string';
 
 import HTMLHead from '../../../shared/components/HTMLHead';
 import { SingleColumnLayout } from '../../../shared/components/layouts/SingleColumnLayout';
@@ -42,6 +41,7 @@ import { LocationToPath, Location } from '../../../app/config/urls';
 
 import helper from '../../../shared/styles/helper.module.scss';
 import styles from './styles/entry.module.scss';
+import { stringifyQuery } from '../../../shared/utils/url';
 
 const internalRE = /^(https?:)?\/\/www.uniprot.org\//i;
 const sameAppURL = new RegExp(window.location.origin + BASE_URL, 'i');
@@ -231,7 +231,7 @@ const HelpEntry = ({
       <Redirect
         to={{
           pathname: LocationToPath[Location.HelpResults],
-          search: qs.stringify({
+          search: stringifyQuery({
             query: accession?.replaceAll('_', ' ') || '*',
           }),
         }}

--- a/src/help/components/entry/Entry.tsx
+++ b/src/help/components/entry/Entry.tsx
@@ -35,13 +35,13 @@ import cleanText, {
 import parseDate from '../../../shared/utils/parseDate';
 import * as logging from '../../../shared/utils/logging';
 import { sendGtagEventOutboundLinkClick } from '../../../shared/utils/gtagEvents';
+import { stringifyQuery } from '../../../shared/utils/url';
 
 import { HelpEntryResponse } from '../../adapters/helpConverter';
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import helper from '../../../shared/styles/helper.module.scss';
 import styles from './styles/entry.module.scss';
-import { stringifyQuery } from '../../../shared/utils/url';
 
 const internalRE = /^(https?:)?\/\/www.uniprot.org\//i;
 const sameAppURL = new RegExp(window.location.origin + BASE_URL, 'i');

--- a/src/help/components/landing/HelpQuickSearch.tsx
+++ b/src/help/components/landing/HelpQuickSearch.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Card, InfoList, SearchInput } from 'franklin-sites';
 import { debounce } from 'lodash-es';
-import qs from 'query-string';
 
 import CleanHighlightMarkDown from '../results/CleanHighlightMarkDown';
 
@@ -14,6 +13,7 @@ import {
   Location,
   getLocationEntryPath,
 } from '../../../app/config/urls';
+import { stringifyQuery } from '../../../shared/utils/url';
 
 import { HelpSearchResponse } from '../../adapters/helpConverter';
 
@@ -52,7 +52,7 @@ const HelpQuickSearch = () => {
 
   const allArticlesLocation = {
     pathname: LocationToPath[Location.HelpResults],
-    search: qs.stringify({ query: searchValue }),
+    search: stringifyQuery({ query: searchValue }),
   };
 
   const allArticles = dataObject.data?.results;

--- a/src/help/components/results/HelpResultFacets.tsx
+++ b/src/help/components/results/HelpResultFacets.tsx
@@ -8,12 +8,11 @@ import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 
 import { HelpSearchResponse } from '../../adapters/helpConverter';
-import { parseQueryString } from '../../../shared/utils/url';
 
 const HelpResultFacets: FC = () => {
   const { search } = useLocation();
 
-  const parsed = parseQueryString(search);
+  const parsed = Object.fromEntries(new URLSearchParams(search));
 
   const dataObject = useDataApiWithStale<HelpSearchResponse>(
     helpURL.search({
@@ -24,7 +23,8 @@ const HelpResultFacets: FC = () => {
   );
 
   const fallBackAppliedFacets = useMemo(() => {
-    const { facets } = parseQueryString(search);
+    const sp = new URLSearchParams(search);
+    const facets = sp.get('facets');
     const facetValues = facets || '';
     return {
       loading: false,

--- a/src/help/components/results/Results.tsx
+++ b/src/help/components/results/Results.tsx
@@ -21,7 +21,7 @@ import {
   help as helpURL,
   news as newsURL,
 } from '../../../shared/config/apiUrls';
-import { parseQueryString, stringifyQuery } from '../../../shared/utils/url';
+import { stringifyQuery } from '../../../shared/utils/url';
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import { HelpAPIModel, HelpUIModel } from '../../adapters/helpConverter';
@@ -53,7 +53,8 @@ const Results = ({
   inPanel,
 }: RouteChildrenProps & Props) => {
   const [searchValue, setSearchValue] = useState<string>(() => {
-    const { query } = parseQueryString(location.search);
+    const sp = new URLSearchParams(location.search);
+    const query = sp.get('query');
     if (!query || query === '*') {
       return '';
     }
@@ -61,7 +62,7 @@ const Results = ({
   });
 
   const isReleaseNotes = match?.path.includes('release-notes');
-  const parsed = parseQueryString(location.search);
+  const parsed = Object.fromEntries(new URLSearchParams(location.search));
 
   const {
     initialLoading,

--- a/src/help/components/results/Results.tsx
+++ b/src/help/components/results/Results.tsx
@@ -6,7 +6,6 @@ import {
   Loader,
   SearchInput,
 } from 'franklin-sites';
-import qs from 'query-string';
 import cn from 'classnames';
 import { debounce } from 'lodash-es';
 
@@ -22,7 +21,7 @@ import {
   help as helpURL,
   news as newsURL,
 } from '../../../shared/config/apiUrls';
-import { parseQueryString } from '../../../shared/utils/url';
+import { parseQueryString, stringifyQuery } from '../../../shared/utils/url';
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import { HelpAPIModel, HelpUIModel } from '../../adapters/helpConverter';
@@ -90,8 +89,7 @@ const Results = ({
                 ? Location.ReleaseNotesResults
                 : Location.HelpResults
             ],
-          search: qs.stringify({
-            ...parseQueryString(history.location.search),
+          search: stringifyQuery(history.location.search, {
             query: searchValue || '*',
           }),
         });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,16 +4,14 @@ import ReactDOM from 'react-dom';
 import App from './app/components/App';
 import GlobalContext from './app/contexts/Global';
 
-if (!LIVE_RELOAD) {
-  // eslint-disable-next-line no-console
-  console.info(
-    `Built with git commit ${GIT_COMMIT_HASH} ${
-      GIT_COMMIT_STATE
-        ? `with uncommitted changes:\n${GIT_COMMIT_STATE}`
-        : '(clean)'
-    }`
-  );
-}
+// eslint-disable-next-line no-console
+console.info(
+  `Built with git commit ${GIT_COMMIT_HASH} ${
+    GIT_COMMIT_STATE
+      ? `with uncommitted changes:\n${GIT_COMMIT_STATE}`
+      : '(clean)'
+  } on ${GIT_BRANCH} branch`
+);
 
 ReactDOM.render(
   <StrictMode>

--- a/src/messages/components/MessageManagerContainer.tsx
+++ b/src/messages/components/MessageManagerContainer.tsx
@@ -24,7 +24,7 @@ const MessageManager = () => {
   //  useRouteMatch.path & match.path: /uniprotkb/:id/external-links
   // The getLocationForPathname will find the location by searching over LocationToPath in app/config/urls
   const { pathname } = useLocation();
-  const currentLocation = getLocationForPathname(pathname) as Location;
+  const currentLocation = getLocationForPathname(pathname);
   const messages = useMessagesState();
   const dispatch = useMessagesDispatch();
   const { true: omitAndDeleteMessages = [], false: restActiveMessages = [] } =

--- a/src/messages/components/MessageManagerContainer.tsx
+++ b/src/messages/components/MessageManagerContainer.tsx
@@ -12,7 +12,6 @@ import { deleteMessage } from '../state/messagesActions';
 import { getLocationForPathname } from '../../shared/utils/url';
 
 import { MessageFormat } from '../types/messagesTypes';
-import { Location } from '../../app/config/urls';
 
 import styles from './styles/popup-message-hub.module.scss';
 
@@ -33,6 +32,7 @@ const MessageManager = () => {
       ({ omitAndDeleteAtLocations = [] }) =>
         !!omitAndDeleteAtLocations &&
         omitAndDeleteAtLocations.length > 0 &&
+        !!currentLocation &&
         omitAndDeleteAtLocations.includes(currentLocation)
     );
 
@@ -45,7 +45,7 @@ const MessageManager = () => {
   const filteredActiveMessages = restActiveMessages.filter(
     ({ locations }) =>
       // if no locations in the message object then show it everywhere or if locations exists only where indicated
-      !locations || locations.includes(currentLocation)
+      !locations || (!!currentLocation && locations.includes(currentLocation))
   );
 
   const {

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -13,6 +13,7 @@ import {
   sendGtagEventPanelOpen,
   sendGtagEventPanelResultsDownloadClose,
 } from '../../../shared/utils/gtagEvents';
+import { stringifyUrl } from '../../../shared/utils/url';
 
 import apiUrls, {
   createSelectedQueryString,
@@ -30,7 +31,6 @@ import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverte
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
 import { SearchResults } from '../../../shared/types/results';
 import { FileFormat } from '../../../shared/types/resultsDownload';
-import { stringifyUrl } from '../../../shared/utils/url';
 
 const DownloadComponent = lazy(
   () =>

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -30,6 +30,7 @@ import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverte
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
 import { SearchResults } from '../../../shared/types/results';
 import { FileFormat } from '../../../shared/types/resultsDownload';
+import { stringifyUrl } from '../../../shared/utils/url';
 
 const DownloadComponent = lazy(
   () =>
@@ -61,15 +62,13 @@ const ComponentsButtons = ({
 }: Props) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
-  const sp = new URLSearchParams({
-    query: `(proteome=${id}) AND (reviewed=true)`,
-    size: '0',
-  });
-
   // Note: all Eukaryotes are not eligible. Having a list of the organisms would be helpful
   const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
     superkingdom === 'eukaryota'
-      ? `${apiUrls.search(Namespace.uniprotkb)}?${sp}`
+      ? stringifyUrl(apiUrls.search(Namespace.uniprotkb), {
+          query: `(proteome=${id}) AND (reviewed=true)`,
+          size: '0',
+        })
       : null
   );
 

--- a/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, screen } from '@testing-library/react';
-import queryString from 'query-string';
 
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
@@ -37,12 +36,9 @@ describe('ComponentsButtons', () => {
         name: 'View proteins',
       });
       expect(link).toBeInTheDocument();
-      const {
-        url,
-        query: { query },
-      } = queryString.parseUrl(link.href);
-      expect(url).toMatch(/\/uniprotkb/);
-      expect(query).toMatch(expectedQuery);
+      const url = new URL(link.href);
+      expect(url.pathname).toMatch(/\/uniprotkb/);
+      expect(url.searchParams.get('query')).toMatch(expectedQuery);
     }
   );
 

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -268,7 +268,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    const search = stringifyQuery(`query=${stringify(clauses) || '*'}`);
+    const search = stringifyQuery({ query: stringify(clauses) || '*' });
     const pathname =
       searchspace === toolResults && jobId && jobResultsLocation
         ? generatePath(LocationToPath[jobResultsLocation], {

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -26,6 +26,7 @@ import { pluralise } from '../../shared/utils/utils';
 import { stringify } from '../utils/queryStringProcessor';
 import parseAndMatchQuery from '../utils/parseAndMatchQuery';
 import { rawDBToNamespace } from '../../tools/id-mapping/utils';
+import { stringifyQuery } from '../../shared/utils/url';
 
 import { addMessage } from '../../messages/state/messagesActions';
 
@@ -267,7 +268,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    const queryString = stringify(clauses) || '*';
+    const search = stringifyQuery(`query=${stringify(clauses) || '*'}`);
     const pathname =
       searchspace === toolResults && jobId && jobResultsLocation
         ? generatePath(LocationToPath[jobResultsLocation], {
@@ -277,7 +278,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
         : SearchResultsLocations[searchspace as SearchableNamespace];
     history.push({
       pathname,
-      search: `query=${queryString}`,
+      search,
     });
     onCancel();
   };

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -26,7 +26,6 @@ import { pluralise } from '../../shared/utils/utils';
 import { stringify } from '../utils/queryStringProcessor';
 import parseAndMatchQuery from '../utils/parseAndMatchQuery';
 import { rawDBToNamespace } from '../../tools/id-mapping/utils';
-import { parseQueryString } from '../../shared/utils/url';
 
 import { addMessage } from '../../messages/state/messagesActions';
 
@@ -139,7 +138,8 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
         return clauses;
       }
 
-      let query = parseQueryString(location.search, { decode: true })?.query;
+      const sp = new URLSearchParams(location.search);
+      let query = sp.get('query');
       if (query === '*') {
         // if the query is a star query, don't parse it, default to example form
         query = null;

--- a/src/query-builder/components/QueryBuilder.tsx
+++ b/src/query-builder/components/QueryBuilder.tsx
@@ -156,7 +156,7 @@ const QueryBuilder = ({ onCancel, fieldToAdd, initialSearchspace }: Props) => {
         frame().then(() => {
           dispatch(
             addMessage({
-              id: Array.isArray(query) ? query[0] : query || undefined,
+              id: query || undefined,
               content: `Found ${
                 invalidClauses.length
               } invalid query ${pluralise(

--- a/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
+++ b/src/query-builder/components/__tests__/QueryBuilder.spec.tsx
@@ -106,6 +106,8 @@ describe('QueryBuilder', () => {
 
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(rendered.history.location.pathname).toBe('/uniprotkb');
-    expect(rendered.history.location.search).toBe('?query=(gene:zen) OR eve');
+    expect(rendered.history.location.search).toBe(
+      '?query=%28gene%3Azen%29+OR+eve'
+    );
   });
 });

--- a/src/query-builder/utils/parseAndMatchQuery.ts
+++ b/src/query-builder/utils/parseAndMatchQuery.ts
@@ -25,7 +25,7 @@ export const flatten = (searchTermData: STTWithParent[]): STTWithParent[] =>
   });
 
 const parseAndMatchQuery = (
-  query: string | string[] | null | undefined,
+  query: string | null,
   searchTermsData: SearchTermType[],
   fieldToAdd?: string
 ): [valid: Clause[], invalid: Clause[]] => {
@@ -34,7 +34,7 @@ const parseAndMatchQuery = (
 
   let parsedQuery: Clause[] = [];
   if (query) {
-    parsedQuery = (Array.isArray(query) ? query : [query]).flatMap(parse);
+    parsedQuery = parse(query);
   }
   if (fieldToAdd) {
     parsedQuery = [

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -12,7 +12,7 @@ import {
   copyFailureMessage,
   copySuccessMessage,
 } from '../../../messages/state/messagesActions';
-import { getQueryString } from '../../utils/url';
+import { stringifyQuery } from '../../utils/url';
 
 import { sendGtagEventUrlCopy } from '../../utils/gtagEvents';
 
@@ -47,7 +47,7 @@ const CopyLinkWebsite = ({
     document.location.origin +
     createPath({
       ...location,
-      search: getQueryString(location.search, {
+      search: stringifyQuery(location.search, {
         fields: viewMode === 'table' ? columnNames.join(',') : null,
         view: !disableCardToggle ? viewMode : null,
       }),

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -12,6 +12,7 @@ import {
   copyFailureMessage,
   copySuccessMessage,
 } from '../../../messages/state/messagesActions';
+import { getQueryString } from '../../utils/url';
 
 import { sendGtagEventUrlCopy } from '../../utils/gtagEvents';
 
@@ -42,19 +43,15 @@ const CopyLinkWebsite = ({
   const { columnNames } = useColumnNames({ namespaceOverride });
   const { viewMode } = useViewMode(namespace, disableCardToggle);
   const location = useLocation();
-
-  const searchParams = new URLSearchParams(location.search);
-  if (viewMode === 'table') {
-    searchParams.set('fields', columnNames.join(','));
-  } else {
-    searchParams.delete('fields');
-  }
-  if (!disableCardToggle) {
-    searchParams.set('view', `${viewMode}`);
-  }
   const url =
     document.location.origin +
-    createPath({ ...location, search: searchParams.toString() });
+    createPath({
+      ...location,
+      search: getQueryString(location.search, {
+        fields: viewMode === 'table' ? columnNames.join(',') : null,
+        view: !disableCardToggle ? viewMode : null,
+      }),
+    });
 
   const handleClick = async ({ target }: MouseEvent) => {
     try {

--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -12,9 +12,9 @@ import {
   copyFailureMessage,
   copySuccessMessage,
 } from '../../../messages/state/messagesActions';
-import { stringifyQuery } from '../../utils/url';
 
 import { sendGtagEventUrlCopy } from '../../utils/gtagEvents';
+import { stringifyQuery } from '../../utils/url';
 
 import { Namespace } from '../../types/namespaces';
 

--- a/src/shared/components/action-buttons/ToolsButton.tsx
+++ b/src/shared/components/action-buttons/ToolsButton.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from 'franklin-sites';
 
+import { stringifyQuery } from '../../utils/url';
+
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import helper from '../../styles/helper.module.scss';
@@ -21,31 +23,27 @@ const ToolsButton: FC<ToolsButtonProps> = ({
   title,
   location,
   children,
-}) => {
-  const searchParams = new URLSearchParams({ ids: selectedEntries.join(',') });
-  if (sequence) {
-    searchParams.set('sequence', sequence);
-  }
-
-  return (
-    <Button
-      element={disabled ? 'button' : Link}
-      variant="tertiary"
-      title={title}
-      disabled={disabled}
-      to={
-        disabled
-          ? undefined
-          : {
-              pathname: LocationToPath[location],
-              search: searchParams.toString(),
-            }
-      }
-      className={helper['no-small']}
-    >
-      {children}
-    </Button>
-  );
-};
+}) => (
+  <Button
+    element={disabled ? 'button' : Link}
+    variant="tertiary"
+    title={title}
+    disabled={disabled}
+    to={
+      disabled
+        ? undefined
+        : {
+            pathname: LocationToPath[location],
+            search: stringifyQuery({
+              ids: selectedEntries.join(','),
+              sequence,
+            }),
+          }
+    }
+    className={helper['no-small']}
+  >
+    {children}
+  </Button>
+);
 
 export default ToolsButton;

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -11,13 +11,13 @@ import {
 } from '../../../messages/state/messagesActions';
 
 import { sendGtagEventUrlCopy } from '../../utils/gtagEvents';
+import { splitUrl, stringifyUrl } from '../../utils/url';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
 
 import { Namespace } from '../../types/namespaces';
 
 import styles from './styles/download-api-url.module.scss';
-import { splitUrl, stringifyUrl } from '../../utils/url';
 
 const reIdMapping = new RegExp(
   `/idmapping/(?:(${Namespace.uniprotkb}|${Namespace.uniparc}|${Namespace.uniref})/)?(?:results/)?stream/`

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -24,14 +24,14 @@ const reIdMapping = new RegExp(
 );
 
 export const getSearchURL = (streamURL: string, batchSize = 500) => {
-  const { base, searchParams } = splitUrl(streamURL);
+  const { base, query } = splitUrl(streamURL);
   return stringifyUrl(
     base.search(reIdMapping) >= 0
       ? base.replace(reIdMapping, (_match, namespace) =>
           namespace ? `/idmapping/${namespace}/results/` : '/idmapping/results/'
         )
       : base.replace('/stream', '/search'),
-    searchParams,
+    query,
     { size: batchSize }
   );
 };

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -1,7 +1,6 @@
 import { Button, CodeBlock, CopyIcon, LongNumber } from 'franklin-sites';
 import { useCallback } from 'react';
 import { generatePath, Link } from 'react-router-dom';
-import queryString from 'query-string';
 
 import useMessagesDispatch from '../../hooks/useMessagesDispatch';
 import useScrollIntoViewRef from '../../hooks/useScrollIntoView';
@@ -18,25 +17,23 @@ import { LocationToPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../types/namespaces';
 
 import styles from './styles/download-api-url.module.scss';
+import { splitUrl, stringifyUrl } from '../../utils/url';
 
 const reIdMapping = new RegExp(
   `/idmapping/(?:(${Namespace.uniprotkb}|${Namespace.uniparc}|${Namespace.uniref})/)?(?:results/)?stream/`
 );
 
 export const getSearchURL = (streamURL: string, batchSize = 500) => {
-  const parsed = queryString.parseUrl(streamURL);
-  let { url } = parsed;
-  if (url.search(reIdMapping) >= 0) {
-    url = url.replace(reIdMapping, (_match, namespace) =>
-      namespace ? `/idmapping/${namespace}/results/` : '/idmapping/results/'
-    );
-  } else {
-    url = url.replace('/stream', '/search');
-  }
-  return queryString.stringifyUrl({
-    url,
-    query: { ...parsed.query, size: batchSize },
-  });
+  const { base, searchParams } = splitUrl(streamURL);
+  return stringifyUrl(
+    base.search(reIdMapping) >= 0
+      ? base.replace(reIdMapping, (_match, namespace) =>
+          namespace ? `/idmapping/${namespace}/results/` : '/idmapping/results/'
+        )
+      : base.replace('/stream', '/search'),
+    searchParams,
+    { size: batchSize }
+  );
 };
 
 // NOTE: update as needed if backend limitations change!

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -6,6 +6,8 @@ import Download, { getPreviewFileFormat } from '../Download';
 
 import { IDMappingDetailsContext } from '../../../contexts/IDMappingDetails';
 
+import { stringifyQuery } from '../../../utils/url';
+
 import { FileFormat } from '../../../types/resultsDownload';
 import { Namespace } from '../../../types/namespaces';
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
@@ -14,7 +16,6 @@ import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
 import SimpleMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/SimpleMappingDetails';
 import UniProtkbMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/UniProtkbMappingDetails';
 import '../../../../uniprotkb/components/__mocks__/mockApi';
-import { stringifyQuery } from '../../../utils/url';
 
 const initialColumns = [
   UniProtKBColumn.accession,

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import queryString from 'query-string';
 
 import customRender from '../../../__test-helpers__/customRender';
 
@@ -15,6 +14,7 @@ import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
 import SimpleMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/SimpleMappingDetails';
 import UniProtkbMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/UniProtkbMappingDetails';
 import '../../../../uniprotkb/components/__mocks__/mockApi';
+import { stringifyQuery } from '../../../utils/url';
 
 const initialColumns = [
   UniProtKBColumn.accession,
@@ -159,16 +159,14 @@ describe('Download with passed query and selectedQuery props', () => {
     );
     let downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
-      expect.stringContaining(queryString.stringify({ query: `(${query})` }))
+      expect.stringContaining(stringifyQuery({ query: `(${query})` }))
     );
     fireEvent.click(
       screen.getByLabelText(`Download selected (${numberSelectedEntries})`)
     );
     downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
-      expect.stringContaining(
-        queryString.stringify({ query: `(${selectedQuery})` })
-      )
+      expect.stringContaining(stringifyQuery({ query: `(${selectedQuery})` }))
     );
   });
 });
@@ -322,7 +320,7 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
     );
     let downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
-      expect.stringContaining(queryString.stringify({ query: `(${query})` }))
+      expect.stringContaining(stringifyQuery({ query: `(${query})` }))
     );
 
     fireEvent.click(
@@ -333,7 +331,7 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
     downloadLink = screen.getByRole<HTMLAnchorElement>('link');
     expect(downloadLink.href).toEqual(
       expect.stringContaining(
-        queryString.stringify({
+        stringifyQuery({
           query: `((proteome:UP000005640) AND reviewed=true)`,
         })
       )
@@ -347,14 +345,11 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
     );
 
     downloadLink = screen.getByRole<HTMLAnchorElement>('link');
-    expect(downloadLink.href).toEqual(
-      expect.stringContaining(
-        queryString.stringify({
-          query: `((proteome:UP000005640) AND reviewed=true)`,
-          includeIsoform: true,
-        })
-      )
-    );
+    const foo = stringifyQuery({
+      query: `((proteome:UP000005640) AND reviewed=true)`,
+      includeIsoform: true,
+    });
+    expect(downloadLink.href).toEqual(expect.stringContaining(foo));
     options = screen.getAllByRole('option');
     expect(options).toHaveLength(1);
 

--- a/src/shared/components/results/AdvancedSearchSuggestion.tsx
+++ b/src/shared/components/results/AdvancedSearchSuggestion.tsx
@@ -7,6 +7,7 @@ import useDataApi from '../../hooks/useDataApi';
 import apiUrls from '../../config/apiUrls';
 import listFormat from '../../utils/listFormat';
 import { flatten } from '../../../query-builder/utils/parseAndMatchQuery';
+import { stringifyUrl } from '../../utils/url';
 
 import { Namespace } from '../../types/namespaces';
 import { LocationToPath, Location } from '../../../app/config/urls';
@@ -33,14 +34,12 @@ const AdvancedSearchSuggestion = ({
   const [termsToDisplay, setTermsToDisplay] = useState(+Infinity);
   const ref = useRef<HTMLElement>(null);
 
-  const searchParams = new URLSearchParams({
-    size: '0',
-    query,
-    showSingleTermMatchedFields: 'true',
-  });
-
   const { data } = useDataApi<MatchedFieldsResponse>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
+    stringifyUrl(apiUrls.search(Namespace.uniprotkb), {
+      size: '0',
+      query,
+      showSingleTermMatchedFields: 'true',
+    })
   );
 
   // Data to enrich the suggestions with nice labels

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -10,11 +10,7 @@ import useNS from '../../hooks/useNS';
 import useSafeState from '../../hooks/useSafeState';
 
 import fetchData from '../../utils/fetchData';
-import {
-  parseQueryString,
-  stringifyQuery,
-  stringifyUrl,
-} from '../../utils/url';
+import { stringifyQuery, stringifyUrl } from '../../utils/url';
 
 import {
   searchLocations,
@@ -123,7 +119,8 @@ const DidYouMean = ({
   const [renderContent, setRenderContent] = useSafeState(false);
   const otherNamespaceSuggestions = useRef<NamespaceSuggestions>(new Map());
 
-  const { query } = parseQueryString(location.search);
+  const sp = new URLSearchParams(location.search);
+  const query = sp.get('query');
 
   // Clear the map if new namespace or new query
   useEffect(() => {

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import queryString from 'query-string';
 import { orderBy } from 'lodash-es';
 import { Loader, Message, sequenceProcessor } from 'franklin-sites';
 import { sleep } from 'timing-functions';
@@ -11,7 +10,11 @@ import useNS from '../../hooks/useNS';
 import useSafeState from '../../hooks/useSafeState';
 
 import fetchData from '../../utils/fetchData';
-import { parseQueryString } from '../../utils/url';
+import {
+  parseQueryString,
+  stringifyQuery,
+  stringifyUrl,
+} from '../../utils/url';
 
 import {
   searchLocations,
@@ -58,7 +61,7 @@ const QuerySuggestionListItem = ({
             <Link
               to={{
                 pathname: searchLocations[namespace],
-                search: queryString.stringify({ query: cleanedQuery }),
+                search: stringifyQuery({ query: cleanedQuery }),
               }}
               key={query}
               className={styles['query-suggestion-link']}
@@ -138,10 +141,7 @@ const DidYouMean = ({
 
     const promises = otherNamespaces.map((ns) =>
       fetchData<{ results: APIModel[] }>(
-        queryString.stringifyUrl({
-          url: apiUrls.search(ns),
-          query: { query, size: 0, didyoumean: true },
-        })
+        stringifyUrl(apiUrls.search(ns), { query, size: 0, didyoumean: true })
       ).then(
         (response) => {
           const hits = +(response?.headers?.['x-total-results'] || 0);

--- a/src/shared/components/results/ExactFieldSuggestion.tsx
+++ b/src/shared/components/results/ExactFieldSuggestion.tsx
@@ -6,6 +6,7 @@ import {
 
 import useDataApi from '../../hooks/useDataApi';
 
+import { stringifyUrl } from '../../utils/url';
 import apiUrls from '../../config/apiUrls';
 
 import { Namespace } from '../../types/namespaces';
@@ -25,13 +26,11 @@ const ExactFieldSuggestion = ({
     exactMatchSearchTerms
   );
 
-  const searchParams = new URLSearchParams({
-    query: `${modifiedQuery}`,
-    size: '0',
-  });
-
   const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
+    stringifyUrl(apiUrls.search(Namespace.uniprotkb), {
+      query: modifiedQuery,
+      size: 0,
+    })
   );
 
   const hasExactSuggestion =

--- a/src/shared/components/results/OrganismSuggestion.tsx
+++ b/src/shared/components/results/OrganismSuggestion.tsx
@@ -1,6 +1,7 @@
 import { SearchTextLink } from './SearchSuggestions';
 import useDataApi from '../../hooks/useDataApi';
 
+import { stringifyUrl } from '../../utils/url';
 import apiUrls from '../../config/apiUrls';
 
 import { SearchResults } from '../../types/results';
@@ -16,13 +17,11 @@ const OrganismSuggestion = ({
   taxonID: string;
   total: number;
 }) => {
-  const searchParams = new URLSearchParams({
-    query: `organism_id:${taxonID}`,
-    size: '0',
-  });
-
   const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
+    stringifyUrl(apiUrls.search(Namespace.uniprotkb), {
+      query: `organism_id:${taxonID}`,
+      size: 0,
+    })
   );
 
   const hasOrganismSuggestion =

--- a/src/shared/components/results/ProteomeSuggestion.tsx
+++ b/src/shared/components/results/ProteomeSuggestion.tsx
@@ -5,11 +5,11 @@ import { SearchTextLink } from './SearchSuggestions';
 import useDataApi from '../../hooks/useDataApi';
 
 import apiUrls from '../../config/apiUrls';
+import { stringifyUrl } from '../../utils/url';
 
 import { SearchResults } from '../../types/results';
 import { Namespace } from '../../types/namespaces';
 import { ProteomesAPIModel } from '../../../proteomes/adapters/proteomesConverter';
-import { stringifyUrl } from '../../utils/url';
 
 const ProteomeSuggestion = ({
   query,

--- a/src/shared/components/results/ProteomeSuggestion.tsx
+++ b/src/shared/components/results/ProteomeSuggestion.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import qs from 'query-string';
 
 import { SearchTextLink } from './SearchSuggestions';
 
@@ -10,6 +9,7 @@ import apiUrls from '../../config/apiUrls';
 import { SearchResults } from '../../types/results';
 import { Namespace } from '../../types/namespaces';
 import { ProteomesAPIModel } from '../../../proteomes/adapters/proteomesConverter';
+import { stringifyUrl } from '../../utils/url';
 
 const ProteomeSuggestion = ({
   query,
@@ -21,10 +21,10 @@ const ProteomeSuggestion = ({
   const [proteomeInfo, setProteomeInfo] = useState<ProteomesAPIModel>();
 
   const { data } = useDataApi<SearchResults<ProteomesAPIModel>>(
-    `${apiUrls.search(Namespace.proteomes)}?${qs.stringify({
+    stringifyUrl(apiUrls.search(Namespace.proteomes), {
       query: `organism_id:${organismID}`,
-      fields: ['upid'],
-    })}`
+      fields: 'upid',
+    })
   );
 
   useEffect(() => {

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -1,11 +1,14 @@
 import { memo } from 'react';
 import { Facets, Facet, Loader } from 'franklin-sites';
 
+import { useLocation } from 'react-router-dom';
 import useNS from '../../hooks/useNS';
 
 import TaxonomyFacet from './TaxonomyFacet';
 import EntryTypeIcon from '../entry/EntryTypeIcon';
 import UniProtKBGroupByFacet from '../../../uniprotkb/components/results/UniProtKBGroupByFacet';
+
+import { getLocationForPathname } from '../../utils/url';
 
 import {
   mainNamespaces,
@@ -15,6 +18,7 @@ import {
 
 import { UseDataAPIWithStaleState } from '../../hooks/useDataApiWithStale';
 import { FacetObject, FacetValue } from '../../types/results';
+import { Location } from '../../../app/config/urls';
 
 import helper from '../../styles/helper.module.scss';
 import baseLayoutStyles from '../layouts/styles/base-layout.module.scss';
@@ -39,6 +43,10 @@ type Props = {
 
 const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
   const namespace = useNS(namespaceOverride);
+  const { pathname } = useLocation();
+
+  const currentLocation = getLocationForPathname(pathname);
+
   const { data, isStale, loading, progress } = dataApiObject;
 
   // TODO: show loading when a brand new search query (and not just a facet modification) is being fetched
@@ -106,7 +114,10 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
       {namespace && mainNamespaces.has(namespace) && (
         <TaxonomyFacet namespace={namespace as SearchableNamespace} />
       )}
-      {namespace === Namespace.uniprotkb && <UniProtKBGroupByFacet />}
+      {namespace === Namespace.uniprotkb &&
+        currentLocation === Location.UniProtKBResults && (
+          <UniProtKBGroupByFacet />
+        )}
       {after.map(
         (facet) =>
           facet.values && (

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -115,7 +115,7 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
         <TaxonomyFacet namespace={namespace as SearchableNamespace} />
       )}
       {namespace === Namespace.uniprotkb &&
-        currentLocation === Location.UniProtKBResults && (
+        currentLocation !== Location.UniProtKBEntry && (
           <UniProtKBGroupByFacet />
         )}
       {after.map(

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -1,14 +1,12 @@
 import { memo } from 'react';
 import { Facets, Facet, Loader } from 'franklin-sites';
 
-import { useLocation } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 import useNS from '../../hooks/useNS';
 
 import TaxonomyFacet from './TaxonomyFacet';
 import EntryTypeIcon from '../entry/EntryTypeIcon';
 import UniProtKBGroupByFacet from '../../../uniprotkb/components/results/UniProtKBGroupByFacet';
-
-import { getLocationForPathname } from '../../utils/url';
 
 import {
   mainNamespaces,
@@ -18,7 +16,7 @@ import {
 
 import { UseDataAPIWithStaleState } from '../../hooks/useDataApiWithStale';
 import { FacetObject, FacetValue } from '../../types/results';
-import { Location } from '../../../app/config/urls';
+import { Location, LocationToPath } from '../../../app/config/urls';
 
 import helper from '../../styles/helper.module.scss';
 import baseLayoutStyles from '../layouts/styles/base-layout.module.scss';
@@ -43,9 +41,9 @@ type Props = {
 
 const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
   const namespace = useNS(namespaceOverride);
-  const { pathname } = useLocation();
-
-  const currentLocation = getLocationForPathname(pathname);
+  const isUniProtKBResults = useRouteMatch(
+    LocationToPath[Location.UniProtKBResults]
+  );
 
   const { data, isStale, loading, progress } = dataApiObject;
 
@@ -114,10 +112,9 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
       {namespace && mainNamespaces.has(namespace) && (
         <TaxonomyFacet namespace={namespace as SearchableNamespace} />
       )}
-      {namespace === Namespace.uniprotkb &&
-        currentLocation !== Location.UniProtKBEntry && (
-          <UniProtKBGroupByFacet />
-        )}
+      {namespace === Namespace.uniprotkb && isUniProtKBResults && (
+        <UniProtKBGroupByFacet />
+      )}
       {after.map(
         (facet) =>
           facet.values && (

--- a/src/shared/components/results/TaxonomyFacet.tsx
+++ b/src/shared/components/results/TaxonomyFacet.tsx
@@ -32,7 +32,7 @@ const TaxonomyFacet: FC<{ namespace: SearchableNamespace }> = ({
   const { jobId } = useJobFromUrl();
 
   const parsedSearch = new URLSearchParams(search);
-  const parsedClauses = parse(parsedSearch.get('query') as string | undefined);
+  const parsedClauses = parse(parsedSearch.get('query') || '');
   const interestingClauses = parsedClauses.filter((clause) =>
     interestingTerms.test(clause.searchTerm.term)
   );

--- a/src/shared/components/results/TaxonomyFacet.tsx
+++ b/src/shared/components/results/TaxonomyFacet.tsx
@@ -1,6 +1,5 @@
 import { Suspense, useState, useCallback, FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { parse as qsParse, stringify as qsStringify } from 'query-string';
 import { Button, SlidingPanel } from 'franklin-sites';
 
 import ErrorBoundary from '../error-component/ErrorBoundary';
@@ -13,6 +12,7 @@ import {
   parse,
   stringify,
 } from '../../../query-builder/utils/queryStringProcessor';
+import { stringifyQuery } from '../../utils/url';
 
 import { SearchableNamespace } from '../../types/namespaces';
 
@@ -31,8 +31,8 @@ const TaxonomyFacet: FC<{ namespace: SearchableNamespace }> = ({
   const { search } = useLocation();
   const { jobId } = useJobFromUrl();
 
-  const parsedSearch = qsParse(search);
-  const parsedClauses = parse(parsedSearch?.query as string | undefined);
+  const parsedSearch = new URLSearchParams(search);
+  const parsedClauses = parse(parsedSearch.get('query') as string | undefined);
   const interestingClauses = parsedClauses.filter((clause) =>
     interestingTerms.test(clause.searchTerm.term)
   );
@@ -53,7 +53,7 @@ const TaxonomyFacet: FC<{ namespace: SearchableNamespace }> = ({
                 // eslint-disable-next-line uniprot-website/use-config-location
                 to={(location) => ({
                   ...location,
-                  search: qsStringify({
+                  search: stringifyQuery({
                     ...parsedSearch,
                     query: stringify(
                       // all clauses minus this active one

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -9,11 +9,11 @@ import OrganismSuggestion from './OrganismSuggestion';
 import useDataApi from '../../hooks/useDataApi';
 
 import apiUrls from '../../config/apiUrls';
+import { stringifyUrl } from '../../utils/url';
 
 import { SearchResults } from '../../types/results';
 import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../types/namespaces';
-import { stringifyUrl } from '../../utils/url';
 
 const TaxonomyLevelsSuggestion = ({
   query,

--- a/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
+++ b/src/shared/components/results/TaxonomyLevelsSuggestion.tsx
@@ -13,6 +13,7 @@ import apiUrls from '../../config/apiUrls';
 import { SearchResults } from '../../types/results';
 import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { Namespace } from '../../types/namespaces';
+import { stringifyUrl } from '../../utils/url';
 
 const TaxonomyLevelsSuggestion = ({
   query,
@@ -27,13 +28,11 @@ const TaxonomyLevelsSuggestion = ({
     taxonHierarchySearchTerms
   );
 
-  const searchParams = new URLSearchParams({
-    query: `${modifiedQuery}`,
-    size: '0',
-  });
-
   const { headers } = useDataApi<SearchResults<UniProtkbAPIModel>>(
-    `${apiUrls.search(Namespace.uniprotkb)}?${searchParams}`
+    stringifyUrl(apiUrls.search(Namespace.uniprotkb), {
+      query: `${modifiedQuery}`,
+      size: 0,
+    })
   );
 
   const hasTaxonSuggestion =

--- a/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
+++ b/src/shared/components/results/__tests__/SearchSuggestions.spec.tsx
@@ -14,7 +14,7 @@ const mock = new MockAdapter(axios);
 
 mock
   .onGet(
-    /\/uniprotkb\/search\?size=0&query=eve&showSingleTermMatchedFields=true/
+    /\/uniprotkb\/search\?query=eve&showSingleTermMatchedFields=true&size=0/
   )
   .reply(200, {
     matchedFields: [

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -23,7 +23,7 @@ import { useSmallScreen } from '../../hooks/useMatchMedia';
 import lazy from '../../utils/lazy';
 import { addMessage } from '../../../messages/state/messagesActions';
 import { rawDBToNamespace } from '../../../tools/id-mapping/utils';
-import { parseQueryString, stringifyQuery } from '../../utils/url';
+import { stringifyQuery } from '../../utils/url';
 
 import {
   Location,
@@ -276,7 +276,8 @@ const SearchContainer = ({
   // reset the text content when there is a navigation to reflect what is in the
   // URL. That includes removing the text when browsing to a non-search page.
   useEffect(() => {
-    const { query } = parseQueryString(location.search, { decode: true });
+    const sp = new URLSearchParams(location.search);
+    const query = sp.get('query');
     // Using history here because history won't change, while location will
     if (
       history.location.pathname.includes(

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -9,7 +9,6 @@ import {
   useMemo,
 } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import queryString from 'query-string';
 import { MainSearch, Button, SlidingPanel } from 'franklin-sites';
 import { SearchAction, WebSite, WithContext } from 'schema-dts';
 
@@ -24,7 +23,7 @@ import { useSmallScreen } from '../../hooks/useMatchMedia';
 import lazy from '../../utils/lazy';
 import { addMessage } from '../../../messages/state/messagesActions';
 import { rawDBToNamespace } from '../../../tools/id-mapping/utils';
-import { parseQueryString } from '../../utils/url';
+import { parseQueryString, stringifyQuery } from '../../utils/url';
 
 import {
   Location,
@@ -202,10 +201,9 @@ const SearchContainer = ({
     }
 
     // restringify the resulting search
-    const stringifiedSearch = queryString.stringify(
-      { query: rawQueryClean(searchTerm) },
-      { encode: true }
-    );
+    const stringifiedSearch = stringifyQuery({
+      query: rawQueryClean(searchTerm),
+    });
 
     // push a new location to the history containing the modified search term
     history.push({
@@ -221,8 +219,8 @@ const SearchContainer = ({
   const handleToggleQueryBuilder = useCallback(
     (reason: PanelFormCloseReason) => {
       if (displayQueryBuilder) {
-        const { query } = parseQueryString(location.search, { decode: true });
-        sendGtagEventPanelAdvancedSearchClose(reason, query);
+        const sp = new URLSearchParams(location.search);
+        sendGtagEventPanelAdvancedSearchClose(reason, sp.get('query'));
         setDisplayQueryBuilder(false);
       } else {
         sendGtagEventPanelOpen('advanced_search');

--- a/src/shared/config/__tests__/apiUrls.spec.ts
+++ b/src/shared/config/__tests__/apiUrls.spec.ts
@@ -20,7 +20,7 @@ describe('getQueryUrl', () => {
     });
     expect(queryString).toEqual(
       expect.stringContaining(
-        '/api/uniprotkb/search?facets=reviewed%2Cmodel_organism%2Cproteins_with%2Cexistence%2Cannotation_score%2Clength&query=%28cdc7%29%20AND%20%28facet1%3A%22value%201%22%29%20AND%20%28facet2%3A%22value%203%22%29'
+        '/api/uniprotkb/search?facets=reviewed%2Cmodel_organism%2Cproteins_with%2Cexistence%2Cannotation_score%2Clength&query=%28cdc7%29+AND+%28facet1%3A%22value+1%22%29+AND+%28facet2%3A%22value+3%22%29'
       )
     );
   });

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -1,7 +1,7 @@
-import queryString from 'query-string';
 import joinUrl from 'url-join';
 
 import { fromCleanMapper } from '../utils/getIdKeyForNamespace';
+import { stringifyUrl } from '../utils/url';
 import {
   getApiSortDirection,
   SortDirection,
@@ -78,47 +78,42 @@ export const apiPrefix = API_PREFIX;
 const apiUrls = {
   // uniprotkb query builder terms
   queryBuilderTerms: (namespace: Namespace) =>
-    joinUrl(apiPrefix, `/configure/${namespace}/search-fields`),
+    joinUrl(apiPrefix, `configure/${namespace}/search-fields`),
   // Annotation evidence used by query builder
   evidences: {
-    annotation: joinUrl(apiPrefix, '/configure/uniprotkb/annotation_evidences'),
+    annotation: joinUrl(apiPrefix, 'configure/uniprotkb/annotation_evidences'),
     // Go evidences used by advanced go search
     // "itemType": "goterm",
-    go: joinUrl(apiPrefix, '/configure/uniprotkb/go_evidences'),
+    go: joinUrl(apiPrefix, 'configure/uniprotkb/go_evidences'),
   },
   // Database cross references used
   allDatabases: (namespace: Namespace) =>
     joinUrl(apiPrefix, 'configure', namespace, 'allDatabases'),
   // Database cross references used by query builder
-  databaseXrefs: joinUrl(apiPrefix, '/configure/uniprotkb/databases'),
+  databaseXrefs: joinUrl(apiPrefix, 'configure/uniprotkb/databases'),
   // All result fields except supporting data reference fields
   resultsFields: (namespace: Namespace, isEntry?: boolean) =>
     joinUrl(
       apiPrefix,
-      `/configure/${namespace}/${isEntry ? 'entry-' : ''}result-fields`
+      `configure/${namespace}/${isEntry ? 'entry-' : ''}result-fields`
     ),
   // Retrieve results
   search: (namespace: Namespace = Namespace.uniprotkb) =>
-    joinUrl(apiPrefix, `/${namespace}/search`),
-  download: (namespace: Namespace) =>
-    joinUrl(apiPrefix, `/${namespace}/stream`),
+    joinUrl(apiPrefix, namespace, 'search'),
+  download: (namespace: Namespace) => joinUrl(apiPrefix, namespace, 'stream'),
   variation: 'https://www.ebi.ac.uk/proteins/api/variation', // TODO: Back end plan to add this endpoint to the k8s deployment (uniprot/beta/api). When this happens update this URL accordingly
   genecentric: (accession: string) =>
-    queryString.stringifyUrl({
-      url: joinUrl(apiPrefix, '/genecentric/search'),
-      query: { query: `accession:${accession}` },
+    stringifyUrl(joinUrl(apiPrefix, 'genecentric/search'), {
+      query: `accession:${accession}`,
     }),
-  idMappingFields: joinUrl(apiPrefix, '/configure/idmapping/fields'),
+  idMappingFields: joinUrl(apiPrefix, 'configure/idmapping/fields'),
   entry: (id: string | undefined, namespace: Namespace, columns?: Column[]) => {
     if (!id) {
       return undefined;
     }
     const url = joinUrl(apiPrefix, namespace, id);
     if (columns?.length) {
-      return queryString.stringifyUrl({
-        url,
-        query: { fields: columns.join(',') },
-      });
+      return stringifyUrl(url, { fields: columns.join(',') });
     }
     return url;
   },
@@ -130,19 +125,16 @@ const apiUrls = {
     namespace: Namespace = Namespace.uniprotkb
   ) =>
     format === FileFormat.fastaCanonicalIsoform
-      ? queryString.stringifyUrl({
-          url: apiUrls.search(namespace),
-          query: {
-            query: `accession:${accession}`,
-            includeIsoform: true,
-            format: fileFormatToUrlParameter[FileFormat.fastaCanonicalIsoform],
-          },
+      ? stringifyUrl(apiUrls.search(namespace), {
+          query: `accession:${accession}`,
+          includeIsoform: true,
+          format: fileFormatToUrlParameter[FileFormat.fastaCanonicalIsoform],
         })
       : `${apiUrls.entry(accession, namespace)}.${
           fileFormatToUrlParameter[format]
         }`,
   entryPublications: (accession: string) =>
-    joinUrl(apiPrefix, 'uniprotkb', accession, '/publications'),
+    joinUrl(apiPrefix, 'uniprotkb', accession, 'publications'),
   taxonomySuggester: 'suggester?dict=taxonomy&query=?',
   organismSuggester: 'suggester?dict=organism&query=?',
 
@@ -256,10 +248,10 @@ export const getAPIQueryParams = ({
 };
 
 export const getAPIQueryUrl = (options: ApiUrlOptions = {}) =>
-  queryString.stringifyUrl({
-    url: apiUrls.search(options.namespace || Namespace.uniprotkb),
-    query: getAPIQueryParams(options),
-  });
+  stringifyUrl(
+    apiUrls.search(options.namespace || Namespace.uniprotkb),
+    getAPIQueryParams(options)
+  );
 
 const localBlastFacets = Object.values(BlastFacet) as string[];
 const excludeLocalBlastFacets = ({ name }: SelectedFacet) =>
@@ -308,25 +300,22 @@ export const getAccessionsURL = (
     // sort to improve possible cache hit
     accs = Array.from(accessions).sort();
   }
-  return `${joinUrl(apiPrefix, `/${namespace}/${key}`)}?${queryString.stringify(
-    {
-      size,
-      [key]: accs.join(','),
-      query: [
-        query && `(${query})`,
-        createFacetsQueryString(
-          selectedFacets.filter(excludeLocalBlastFacets)
-        ) || undefined,
-      ]
-        .filter(Boolean)
-        .join(' AND '),
-      fields: (columns && columns.join(',')) || undefined,
-      facets: finalFacets?.join(',') || undefined,
-      sort:
-        sortColumn &&
-        `${sortColumn} ${getApiSortDirection(SortDirection[sortDirection])}`,
-    }
-  )}`;
+  return stringifyUrl(joinUrl(apiPrefix, namespace, key), {
+    size,
+    [key]: accs.join(','),
+    query: [
+      query && `(${query})`,
+      createFacetsQueryString(selectedFacets.filter(excludeLocalBlastFacets)) ||
+        undefined,
+    ]
+      .filter(Boolean)
+      .join(' AND '),
+    fields: (columns && columns.join(',')) || undefined,
+    facets: finalFacets?.join(',') || undefined,
+    sort:
+      sortColumn &&
+      `${sortColumn} ${getApiSortDirection(SortDirection[sortDirection])}`,
+  });
 };
 
 type GetUniProtPublicationsQueryUrl = {
@@ -341,14 +330,14 @@ export const getUniProtPublicationsQueryUrl = ({
   selectedFacets,
   size,
 }: GetUniProtPublicationsQueryUrl) =>
-  `${apiUrls.entryPublications(accession)}?${queryString.stringify({
+  stringifyUrl(apiUrls.entryPublications(accession), {
     facets: facets?.join(','),
     facetFilter:
       selectedFacets
         .map((facet) => `(${facet.name}:"${facet.value}")`)
         .join(' AND ') || undefined,
     size,
-  })}`;
+  });
 
 type Parameters = {
   query?: string;
@@ -488,7 +477,7 @@ export const getDownloadUrl = ({
     parameters.compressed = true;
   }
 
-  return queryString.stringifyUrl({ url: endpoint, query: parameters });
+  return stringifyUrl(endpoint, parameters);
 };
 
 const proteinsApiPrefix = 'https://www.ebi.ac.uk/proteins/api';
@@ -510,33 +499,30 @@ export const help = {
     queryFacets,
     facets = helpDefaultFacets,
     size,
-  }: queryString.ParsedQuery) =>
-    queryString.stringifyUrl({
-      url: joinUrl(apiPrefix, 'help/search'),
-      query: {
-        query: [
-          query || '*',
-          ...(Array.isArray(queryFacets)
-            ? queryFacets
-            : (queryFacets || '').split(',')
-          )
-            .filter(Boolean)
-            // Sort in order to improve cache hits
-            .sort()
-            .map((facet) => {
-              const [facetName, facetValue] = (facet || '').split(':');
-              return `(${facetName}:${
-                facetValue.includes(' ') ? `"${facetValue}"` : facetValue
-              })`;
-            }),
-        ]
+  }: Record<string, string[] | string | null>) =>
+    stringifyUrl(joinUrl(apiPrefix, 'help/search'), {
+      query: [
+        query || '*',
+        ...(Array.isArray(queryFacets)
+          ? queryFacets
+          : (queryFacets || '').split(',')
+        )
           .filter(Boolean)
-          .join(' AND '),
-        sort,
-        fields,
-        facets,
-        size,
-      },
+          // Sort in order to improve cache hits
+          .sort()
+          .map((facet) => {
+            const [facetName, facetValue] = (facet || '').split(':');
+            return `(${facetName}:${
+              facetValue.includes(' ') ? `"${facetValue}"` : facetValue
+            })`;
+          }),
+      ]
+        .filter(Boolean)
+        .join(' AND '),
+      sort,
+      fields,
+      facets,
+      size,
     }),
 };
 
@@ -544,12 +530,12 @@ export const help = {
 export const news = {
   accession: (accession?: string) =>
     accession && joinUrl(apiPrefix, 'release-notes', accession),
-  search: ({ query, sort }: queryString.ParsedQuery) =>
-    `${joinUrl(apiPrefix, '/release-notes/search')}?${queryString.stringify({
+  search: ({ query, sort }: Record<string, string[] | string | null>) =>
+    stringifyUrl(joinUrl(apiPrefix, 'release-notes/search'), {
       query: [query || '*'].filter(Boolean).join(' AND '),
       sort:
         sort || `release_date ${getApiSortDirection(SortDirection.descend)}`,
-    })}`,
+    }),
 };
 
 export const unisave = {
@@ -568,23 +554,18 @@ export const unisave = {
     } = { format: 'json' }
   ) =>
     accession &&
-    `${joinUrl(apiPrefix, '/unisave', accession)}?${queryString.stringify(
-      {
-        format,
-        versions: entryVersions,
-        download: download ? 'true' : undefined,
-        includeContent: includeContent ? 'true' : undefined,
-      },
-      { arrayFormat: 'comma' }
-    )}`,
+    stringifyUrl(joinUrl(apiPrefix, 'unisave', accession), {
+      format,
+      versions: entryVersions,
+      download: download ? 'true' : undefined,
+      includeContent: includeContent ? 'true' : undefined,
+    }),
   status: (accession: string) =>
-    accession && joinUrl(apiPrefix, '/unisave', accession, 'status'),
+    accession && joinUrl(apiPrefix, 'unisave', accession, 'status'),
   diff: (accession: string, version1: number, version2: number) =>
     accession &&
-    `${joinUrl(
-      apiPrefix,
-      '/unisave',
-      accession,
-      'diff'
-    )}?${queryString.stringify({ version1, version2 })}`,
+    stringifyUrl(joinUrl(apiPrefix, 'unisave', accession, 'diff'), {
+      version1,
+      version2,
+    }),
 };

--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -78,7 +78,7 @@ export const apiPrefix = API_PREFIX;
 const apiUrls = {
   // uniprotkb query builder terms
   queryBuilderTerms: (namespace: Namespace) =>
-    joinUrl(apiPrefix, `configure/${namespace}/search-fields`),
+    joinUrl(apiPrefix, 'configure', namespace, 'search-fields'),
   // Annotation evidence used by query builder
   evidences: {
     annotation: joinUrl(apiPrefix, 'configure/uniprotkb/annotation_evidences'),
@@ -95,7 +95,10 @@ const apiUrls = {
   resultsFields: (namespace: Namespace, isEntry?: boolean) =>
     joinUrl(
       apiPrefix,
-      `configure/${namespace}/${isEntry ? 'entry-' : ''}result-fields`
+      'configure',
+      namespace,
+      isEntry ? 'entry-' : '',
+      'result-fields'
     ),
   // Retrieve results
   search: (namespace: Namespace = Namespace.uniprotkb) =>

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -21,7 +21,7 @@ const ftpUrls = {
       ftpUniProt,
       `/current_release/knowledgebase/pan_proteomes/${id}.fasta.gz`
     ),
-  embeddings: joinUrl(ftpUniProt, '/current_release/knowledgebase/embeddings/'),
+  embeddings: joinUrl(ftpUniProt, 'current_release/knowledgebase/embeddings'),
 };
 
 const restFormatToFtpFormat = new Map([

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -81,11 +81,10 @@ export const getUniprotkbFtpFilenameAndUrl = (
 ) => {
   const sp = new URLSearchParams(downloadUrl);
   const query = sp.get('query');
-  const q = Array.isArray(query) ? query[0] : query;
-  if (!q) {
+  if (!query) {
     return null;
   }
-  const simplifiedQuery = simplifyQuery(q);
+  const simplifiedQuery = simplifyQuery(query);
   if (!simplifiedQuery) {
     return null;
   }

--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -1,6 +1,5 @@
 import { capitalize } from 'lodash-es';
 import joinUrl from 'url-join';
-import queryString from 'query-string';
 
 import { FileFormat } from '../types/resultsDownload';
 
@@ -80,8 +79,8 @@ export const getUniprotkbFtpFilenameAndUrl = (
   downloadUrl: string,
   format: FileFormat
 ) => {
-  const parsed = queryString.parseUrl(downloadUrl);
-  const { query } = parsed.query;
+  const sp = new URLSearchParams(downloadUrl);
+  const query = sp.get('query');
   const q = Array.isArray(query) ? query[0] : query;
   if (!q) {
     return null;

--- a/src/shared/hooks/useColumnNames.ts
+++ b/src/shared/hooks/useColumnNames.ts
@@ -6,7 +6,6 @@ import useLocalStorage from './useLocalStorage';
 import useNS from './useNS';
 
 import { Column, nsToDefaultColumns } from '../config/columns';
-import { parseQueryString } from '../utils/url';
 
 import { ColumnConfigurations } from './useColumns';
 import { Namespace } from '../types/namespaces';
@@ -35,7 +34,8 @@ const useColumnNames = ({
   displayPeptideSearchMatchColumns,
 }: UseColumnNameArgs = {}): UseColumnNameReturn => {
   const ns = useNS(namespaceOverride) || Namespace.uniprotkb;
-  const { fields: columnNamesFromUrl } = parseQueryString(useLocation().search);
+  const sp = new URLSearchParams(useLocation().search);
+  const columnNamesFromUrl = sp.get('fields');
   const [columnNamesFromStorage, setColumnNames] = useLocalStorage<Column[]>(
     `table columns for ${ns}` as const,
     nsToDefaultColumns(ns)

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import qs from 'query-string';
 
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
 
-import { parseQueryString } from '../utils/url';
+import { parseQueryString, stringifyQuery } from '../utils/url';
 import { sendGtagEventViewMode } from '../utils/gtagEvents';
 
 import { Namespace } from '../types/namespaces';
@@ -84,7 +83,7 @@ const useViewMode = (
           // eslint-disable-next-line uniprot-website/use-config-location
           {
             pathname: history.location.pathname,
-            search: qs.stringify({ ...urlParams, view: vm }),
+            search: stringifyQuery({ ...urlParams, view: vm }),
           }
         );
       } else {

--- a/src/shared/hooks/useViewMode.ts
+++ b/src/shared/hooks/useViewMode.ts
@@ -4,7 +4,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import useColumnNames from './useColumnNames';
 import useLocalStorage from './useLocalStorage';
 
-import { parseQueryString, stringifyQuery } from '../utils/url';
+import { stringifyQuery } from '../utils/url';
 import { sendGtagEventViewMode } from '../utils/gtagEvents';
 
 import { Namespace } from '../types/namespaces';
@@ -51,8 +51,9 @@ const useViewMode = (
   let invalidUrlViewMode: InvalidParamValue | undefined;
   let fromUrl = false;
 
-  const { view: viewModeFromUrl, ...urlParams } =
-    parseQueryString(locationSearch);
+  const { view: viewModeFromUrl, ...urlParams } = Object.fromEntries(
+    new URLSearchParams(locationSearch)
+  );
 
   if (disableCardToggle) {
     viewMode = 'table';

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { getLocationForPathname } from '../url';
+import { QueryStringArg, getLocationForPathname, getQueryString } from '../url';
 import { Location } from '../../../app/config/urls';
 
 describe('getLocationForPathname', () => {
@@ -24,4 +24,28 @@ describe('getLocationForPathname', () => {
       expect(getLocationForPathname(pathname)).toEqual(location)
     );
   });
+});
+
+describe('getQueryString', () => {
+  const testCases: [QueryStringArg[], string][] = [
+    [[{ a: 1 }], 'a=1'],
+    [[{ a: 1 }, { a: 2 }], 'a=2'],
+    [[{ a: 1 }, { a: undefined }], ''],
+    [
+      [
+        { a: 1, b: true },
+        { a: undefined, b: false },
+      ],
+      'b=false',
+    ],
+    [['a=1&b=true', { a: undefined, b: false }], 'b=false'],
+    [['a=1&b=true&c=2', 'a=2&b=false'], 'a=2&b=false&c=2'],
+  ];
+
+  test.each(testCases)(
+    'should %p : %p',
+    (queryStringArgs, expectedQueryString) => {
+      expect(getQueryString(...queryStringArgs)).toEqual(expectedQueryString);
+    }
+  );
 });

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -40,6 +40,9 @@ describe('stringifyQuery', () => {
     ],
     [['a=1&b=true', { a: undefined, b: false }], 'b=false'],
     [['a=1&b=true&c=2', 'a=2&b=false'], 'a=2&b=false&c=2'],
+    [[{ a: [1, 2] }, { b: undefined }], 'a=1,2'],
+    [[{ a: ['1', '2'] }, { b: undefined }], 'a=1,2'],
+    [[new URLSearchParams('a=1&b=true&c=2'), { b: false }], 'a=1&b=false&c=2'],
   ];
 
   test.each(testCases)(

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -40,8 +40,8 @@ describe('stringifyQuery', () => {
     ],
     [['a=1&b=true', { a: undefined, b: false }], 'b=false'],
     [['a=1&b=true&c=2', 'a=2&b=false'], 'a=2&b=false&c=2'],
-    [[{ a: [1, 2] }, { b: undefined }], 'a=1,2'],
-    [[{ a: ['1', '2'] }, { b: undefined }], 'a=1,2'],
+    [[{ a: [1, 2] }, { b: undefined }], 'a=1%2C2'],
+    [[{ a: ['1', '2'] }, { b: undefined }], 'a=1%2C2'],
     [[new URLSearchParams('a=1&b=true&c=2'), { b: false }], 'a=1&b=false&c=2'],
   ];
 

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -1,7 +1,13 @@
 /**
  * @jest-environment node
  */
-import { QueryStringArg, getLocationForPathname, stringifyQuery } from '../url';
+import {
+  QueryStringArg,
+  getLocationForPathname,
+  splitUrl,
+  stringifyQuery,
+  stringifyUrl,
+} from '../url';
 import { Location } from '../../../app/config/urls';
 
 describe('getLocationForPathname', () => {
@@ -51,4 +57,21 @@ describe('stringifyQuery', () => {
       expect(stringifyQuery(...queryStringArgs)).toEqual(expectedQueryString);
     }
   );
+});
+
+describe('stringifyUrl', () => {
+  it('should stringify the URL', () => {
+    expect(stringifyUrl('https://foo.com', { a: 23 })).toEqual(
+      'https://foo.com?a=23'
+    );
+  });
+});
+
+describe('splitUrl', () => {
+  it('should split the URL', () => {
+    expect(splitUrl('https://foo.com?a=23')).toEqual({
+      base: 'https://foo.com',
+      query: 'a=23',
+    });
+  });
 });

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { QueryStringArg, getLocationForPathname, getQueryString } from '../url';
+import { QueryArg, getLocationForPathname, stringifyQuery } from '../url';
 import { Location } from '../../../app/config/urls';
 
 describe('getLocationForPathname', () => {
@@ -26,8 +26,8 @@ describe('getLocationForPathname', () => {
   });
 });
 
-describe('getQueryString', () => {
-  const testCases: [QueryStringArg[], string][] = [
+describe('stringifyQuery', () => {
+  const testCases: [QueryArg[], string][] = [
     [[{ a: 1 }], 'a=1'],
     [[{ a: 1 }, { a: 2 }], 'a=2'],
     [[{ a: 1 }, { a: undefined }], ''],
@@ -45,7 +45,7 @@ describe('getQueryString', () => {
   test.each(testCases)(
     'should %p : %p',
     (queryStringArgs, expectedQueryString) => {
-      expect(getQueryString(...queryStringArgs)).toEqual(expectedQueryString);
+      expect(stringifyQuery(...queryStringArgs)).toEqual(expectedQueryString);
     }
   );
 });

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -46,7 +46,7 @@ describe('stringifyQuery', () => {
   ];
 
   test.each(testCases)(
-    'should %p : %p',
+    'should stringify %j as %p',
     (queryStringArgs, expectedQueryString) => {
       expect(stringifyQuery(...queryStringArgs)).toEqual(expectedQueryString);
     }

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -65,6 +65,11 @@ describe('stringifyUrl', () => {
       'https://foo.com?a=23'
     );
   });
+  it('should not append a ? if query string args resolves to nothing', () => {
+    expect(stringifyUrl('https://foo.com', { a: undefined })).toEqual(
+      'https://foo.com'
+    );
+  });
 });
 
 describe('splitUrl', () => {

--- a/src/shared/utils/__tests__/url.spec.ts
+++ b/src/shared/utils/__tests__/url.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { QueryArg, getLocationForPathname, stringifyQuery } from '../url';
+import { QueryStringArg, getLocationForPathname, stringifyQuery } from '../url';
 import { Location } from '../../../app/config/urls';
 
 describe('getLocationForPathname', () => {
@@ -27,7 +27,7 @@ describe('getLocationForPathname', () => {
 });
 
 describe('stringifyQuery', () => {
-  const testCases: [QueryArg[], string][] = [
+  const testCases: [QueryStringArg[], string][] = [
     [[{ a: 1 }], 'a=1'],
     [[{ a: 1 }, { a: 2 }], 'a=2'],
     [[{ a: 1 }, { a: undefined }], ''],

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -35,9 +35,8 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
       }
     }
   }
-  const sp = new URLSearchParams(combined);
-  sp.sort();
-  return sp.toString();
+  combined.sort();
+  return combined.toString();
 };
 
 export const stringifyUrl = (base: string, ...args: QueryStringArg[]) =>

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -39,8 +39,10 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
   return combined.toString();
 };
 
-export const stringifyUrl = (base: string, ...args: QueryStringArg[]) =>
-  `${base}?${stringifyQuery(...args)}`;
+export const stringifyUrl = (base: string, ...args: QueryStringArg[]) => {
+  const query = stringifyQuery(...args);
+  return query ? `${base}?${query}` : base;
+};
 
 export const splitUrl = (url: string) => {
   const [base, query] = url.split('?');

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -40,8 +40,8 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
   return sp.toString();
 };
 
-export const stringifyUrl = (url: string, ...args: QueryStringArg[]) =>
-  `${url}?${stringifyQuery(...args)}`;
+export const stringifyUrl = (base: string, ...args: QueryStringArg[]) =>
+  `${base}?${stringifyQuery(...args)}`;
 
 export const splitUrl = (url: string) => {
   const [base, query] = url.split('?');

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -44,6 +44,6 @@ export const stringifyUrl = (url: string, ...args: QueryStringArg[]) =>
   `${url}?${stringifyQuery(...args)}`;
 
 export const splitUrl = (url: string) => {
-  const [base, searchParams] = url.split('?');
-  return { base, searchParams };
+  const [base, query] = url.split('?');
+  return { base, query };
 };

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -33,9 +33,9 @@ type QueryStringParamsRecord = Record<
   string,
   string | number | boolean | undefined | null
 >;
-export type QueryStringArg = string | QueryStringParamsRecord;
+export type QueryArg = string | QueryStringParamsRecord;
 
-export const getQueryString = (...args: QueryStringArg[]) => {
+export const stringifyQuery = (...args: QueryArg[]) => {
   const combined = new URLSearchParams();
   for (const arg of args) {
     for (const [k, v] of typeof arg === 'string'
@@ -51,5 +51,5 @@ export const getQueryString = (...args: QueryStringArg[]) => {
   return new URLSearchParams(combined).toString();
 };
 
-export const getURL = (base: string, ...args: QueryStringArg[]) =>
-  `${base}?${getQueryString(...args)}`;
+export const stringifyUrl = (base: string, ...args: QueryArg[]) =>
+  `${base}?${stringifyQuery(...args)}`;

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -31,16 +31,18 @@ export const parseQueryString = (
 
 type QueryStringParamsRecord = Record<
   string,
-  string | number | boolean | undefined | null
+  string | string[] | number | number[] | boolean | undefined | null
 >;
-export type QueryStringArg = string | QueryStringParamsRecord;
+export type QueryStringArg = string | QueryStringParamsRecord | URLSearchParams;
 
 export const stringifyQuery = (...args: QueryStringArg[]) => {
   const combined = new URLSearchParams();
   for (const arg of args) {
-    for (const [k, v] of typeof arg === 'string'
-      ? new URLSearchParams(arg)
-      : Object.entries(arg)) {
+    const iter =
+      (typeof arg === 'string' && new URLSearchParams(arg)) ||
+      (arg instanceof URLSearchParams && arg) ||
+      Object.entries(arg);
+    for (const [k, v] of iter) {
       if (typeof v !== 'undefined' && v !== null) {
         combined.set(k, v.toString());
       } else if (combined.has(k)) {
@@ -48,8 +50,15 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
       }
     }
   }
-  return new URLSearchParams(combined).toString();
+  const sp = new URLSearchParams(combined);
+  sp.sort();
+  return sp.toString();
 };
 
 export const stringifyUrl = (url: string, ...args: QueryStringArg[]) =>
   `${url}?${stringifyQuery(...args)}`;
+
+export const splitUrl = (url: string) => {
+  const [base, searchParams] = url.split('?');
+  return { base, searchParams };
+};

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -33,9 +33,9 @@ type QueryStringParamsRecord = Record<
   string,
   string | number | boolean | undefined | null
 >;
-export type QueryArg = string | QueryStringParamsRecord;
+export type QueryStringArg = string | QueryStringParamsRecord;
 
-export const stringifyQuery = (...args: QueryArg[]) => {
+export const stringifyQuery = (...args: QueryStringArg[]) => {
   const combined = new URLSearchParams();
   for (const arg of args) {
     for (const [k, v] of typeof arg === 'string'
@@ -51,5 +51,5 @@ export const stringifyQuery = (...args: QueryArg[]) => {
   return new URLSearchParams(combined).toString();
 };
 
-export const stringifyUrl = (url: string, ...args: QueryArg[]) =>
+export const stringifyUrl = (url: string, ...args: QueryStringArg[]) =>
   `${url}?${stringifyQuery(...args)}`;

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -25,7 +25,7 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
     const iter =
       (typeof arg === 'string' && new URLSearchParams(arg)) ||
       (arg instanceof URLSearchParams && arg) ||
-      (typeof arg !== 'undefined' && Object.entries(arg)) ||
+      (typeof arg === 'object' && arg !== null && Object.entries(arg)) ||
       [];
     for (const [k, v] of iter) {
       if (typeof v !== 'undefined' && v !== null) {

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -1,5 +1,4 @@
 import { matchPath } from 'react-router-dom';
-import queryString from 'query-string';
 
 import { LocationToPath } from '../../app/config/urls';
 
@@ -8,25 +7,6 @@ export const getLocationForPathname = (pathname: string) => {
     matchPath(pathname, { path, exact: path === '/' })
   );
   return found?.[0];
-};
-
-/**
-Wrapper around query-string's parse function which takes the output of this and
-returns only the first value of a parameter if it is an array.
-
-@param query - The query string to parse.
-@param options - Options to pass query-string's parse 
-*/
-export const parseQueryString = (
-  query: string,
-  options?: queryString.ParseOptions
-) => {
-  const parsed = queryString.parse(query, options);
-  const parsedWithoutArrayValues: { [key: string]: string | null } = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    parsedWithoutArrayValues[key] = Array.isArray(value) ? value[0] : value;
-  }
-  return parsedWithoutArrayValues;
 };
 
 type QueryStringParamsRecord = Record<

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -1,12 +1,12 @@
 import { matchPath } from 'react-router-dom';
 
-import { LocationToPath } from '../../app/config/urls';
+import { Location, LocationToPath } from '../../app/config/urls';
 
 export const getLocationForPathname = (pathname: string) => {
   const found = Object.entries(LocationToPath).find(([, path]) =>
     matchPath(pathname, { path, exact: path === '/' })
   );
-  return found?.[0];
+  return found?.[0] as Location | undefined;
 };
 
 type QueryStringParamsRecord = Record<

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -16,12 +16,17 @@ type QueryStringParamsRecord = Record<
 export type QueryStringArg = string | QueryStringParamsRecord | URLSearchParams;
 
 export const stringifyQuery = (...args: QueryStringArg[]) => {
+  // This returns a query string by iterating over the args and creating a combined
+  // URLSearchParams instance. If a parameter key already exists it will be overwritten
+  // by the new value. If the new value is undefined or null then the parameter will
+  // be removed. Arrays will be returned as comma separated strings.
   const combined = new URLSearchParams();
   for (const arg of args) {
     const iter =
       (typeof arg === 'string' && new URLSearchParams(arg)) ||
       (arg instanceof URLSearchParams && arg) ||
-      Object.entries(arg);
+      (typeof arg !== 'undefined' && Object.entries(arg)) ||
+      [];
     for (const [k, v] of iter) {
       if (typeof v !== 'undefined' && v !== null) {
         combined.set(k, v.toString());

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -28,3 +28,25 @@ export const parseQueryString = (
   }
   return parsedWithoutArrayValues;
 };
+
+type QueryStringParamsRecord = Record<
+  string,
+  string | number | boolean | undefined | null
+>;
+export type QueryStringArg = string | QueryStringParamsRecord;
+
+export const getQueryString = (...args: QueryStringArg[]) => {
+  const combined = new URLSearchParams();
+  for (const arg of args) {
+    for (const [k, v] of typeof arg === 'string'
+      ? new URLSearchParams(arg)
+      : Object.entries(arg)) {
+      if (typeof v !== 'undefined' && v !== null) {
+        combined.set(k, v.toString());
+      } else if (combined.has(k)) {
+        combined.delete(k);
+      }
+    }
+  }
+  return new URLSearchParams(combined).toString();
+};

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -50,3 +50,6 @@ export const getQueryString = (...args: QueryStringArg[]) => {
   }
   return new URLSearchParams(combined).toString();
 };
+
+export const getURL = (base: string, ...args: QueryStringArg[]) =>
+  `${base}?${getQueryString(...args)}`;

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -23,9 +23,13 @@ export const stringifyQuery = (...args: QueryStringArg[]) => {
   const combined = new URLSearchParams();
   for (const arg of args) {
     const iter =
+      // Query string
       (typeof arg === 'string' && new URLSearchParams(arg)) ||
+      // URLSearchParams
       (arg instanceof URLSearchParams && arg) ||
+      // QueryStringParamsRecord
       (typeof arg === 'object' && arg !== null && Object.entries(arg)) ||
+      // Fallback
       [];
     for (const [k, v] of iter) {
       if (typeof v !== 'undefined' && v !== null) {

--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -51,5 +51,5 @@ export const stringifyQuery = (...args: QueryArg[]) => {
   return new URLSearchParams(combined).toString();
 };
 
-export const stringifyUrl = (base: string, ...args: QueryArg[]) =>
-  `${base}?${stringifyQuery(...args)}`;
+export const stringifyUrl = (url: string, ...args: QueryArg[]) =>
+  `${url}?${stringifyQuery(...args)}`;

--- a/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
+++ b/src/supporting-data/database/components/results/__tests__/__snapshots__/DatabaseCard.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`DatabaseCard tests should render the card component 1`] = `
               Category: 
             </strong>
             <a
-              href="/database?facets=category_exact:Sequence databases"
+              href="/database?facets=category_exact%3ASequence+databases"
             >
               Sequence databases
             </a>

--- a/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
+++ b/src/supporting-data/database/config/__tests__/__snapshots__/DatabaseColumnConfiguration.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`DatabaseColumnConfiguration component should render column "abbrev": ab
 exports[`DatabaseColumnConfiguration component should render column "category": category 1`] = `
 <DocumentFragment>
   <a
-    href="/database?facets=category_exact:Sequence databases"
+    href="/database?facets=category_exact%3ASequence+databases"
   >
     Sequence databases
   </a>

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -8,7 +8,6 @@ import {
   useImperativeHandle,
   useCallback,
 } from 'react';
-import queryString from 'query-string';
 import { SearchInput } from 'franklin-sites';
 import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
 
@@ -35,6 +34,7 @@ import {
   EntryType,
 } from '../../shared/components/entry/EntryTypeIcon';
 import { SearchResults } from '../../shared/types/results';
+import { stringifyUrl } from '../../shared/utils/url';
 
 const getURLForAccessionOrID = (input: string) => {
   const cleanedInput = input.trim().toUpperCase();
@@ -53,13 +53,11 @@ const getURLForAccessionOrID = (input: string) => {
   }
 
   // UniProtKB ID
-  const query = queryString.stringify({
+  return stringifyUrl(apiUrls.search(), {
     query: `id:${cleanedInput}`,
     fields:
       'sequence,id,reviewed,protein_name,organism_name,protein_existence,sequence_version',
   });
-
-  return `${apiUrls.search()}?${query}`;
 };
 
 // name as a NCBI ID formatted UniProt-style

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -21,6 +21,7 @@ import apiUrls from '../../shared/config/apiUrls';
 import entryToFASTAWithHeaders from '../../shared/utils/entryToFASTAWithHeaders';
 import { reUniProtKBAccession } from '../../uniprotkb/utils';
 import fetchData from '../../shared/utils/fetchData';
+import { stringifyUrl } from '../../shared/utils/url';
 import * as logging from '../../shared/utils/logging';
 
 import {
@@ -34,7 +35,6 @@ import {
   EntryType,
 } from '../../shared/components/entry/EntryTypeIcon';
 import { SearchResults } from '../../shared/types/results';
-import { stringifyUrl } from '../../shared/utils/url';
 
 const getURLForAccessionOrID = (input: string) => {
   const cleanedInput = input.trim().toUpperCase();

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -1,4 +1,3 @@
-import queryString from 'query-string';
 import deepFreeze from 'deep-freeze';
 import joinUrl from 'url-join';
 
@@ -16,6 +15,7 @@ import { JobTypes } from '../types/toolsJobTypes';
 import { Column } from '../../shared/config/columns';
 import { SortableColumn } from '../../uniprotkb/types/columnTypes';
 import { Namespace } from '../../shared/types/namespaces';
+import { stringifyUrl } from '../../shared/utils/url';
 
 type CommonResultFormats =
   | 'out' // raw output of the tool
@@ -91,10 +91,7 @@ function urlObjectCreator<T extends JobTypes>(type: T): Return<T> {
         runUrl: `${baseURL}/run`,
         statusUrl: (jobId) => joinUrl(baseURL, 'status', jobId),
         resultUrl: (redirectUrl, extra) =>
-          queryString.stringifyUrl({
-            url: redirectUrl,
-            query: getAPIQueryParams(extra),
-          }),
+          stringifyUrl(redirectUrl, getAPIQueryParams(extra)),
         detailsUrl: (jobId) => `${baseURL}/details/${jobId}`,
       });
     case JobTypes.PEPTIDE_SEARCH:

--- a/src/tools/config/urls.ts
+++ b/src/tools/config/urls.ts
@@ -7,6 +7,8 @@ import {
   getAPIQueryParams,
   getDownloadUrl,
 } from '../../shared/config/apiUrls';
+import { stringifyUrl } from '../../shared/utils/url';
+
 import {
   SelectedFacet,
   SortDirection,
@@ -15,7 +17,6 @@ import { JobTypes } from '../types/toolsJobTypes';
 import { Column } from '../../shared/config/columns';
 import { SortableColumn } from '../../uniprotkb/types/columnTypes';
 import { Namespace } from '../../shared/types/namespaces';
-import { stringifyUrl } from '../../shared/utils/url';
 
 type CommonResultFormats =
   | 'out' // raw output of the tool

--- a/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
+++ b/src/tools/hooks/__tests__/useInitialFormParameters.spec.tsx
@@ -1,11 +1,13 @@
-import queryString from 'query-string';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import getCustomRenderHook from '../../../shared/__test-helpers__/customRenderHook';
 
-import { LocationToPath, Location } from '../../../app/config/urls';
 import useInitialFormParameters from '../useInitialFormParameters';
+
+import { stringifyUrl } from '../../../shared/utils/url';
+
+import { LocationToPath, Location } from '../../../app/config/urls';
 
 import defaultAlignFormValues from '../../align/config/AlignFormData';
 import defaultPeptideSearchFormValues from '../../peptide-search/config/PeptideSearchFormData';
@@ -39,11 +41,8 @@ describe('useInitialFormParameters: Align', () => {
     const axiosMock = new MockAdapter(axios);
     axiosMock.onGet(/\/uniprotkb\/accessions/).reply(200, accessionsData);
     const { result, waitForNextUpdate } = customRenderHook(
-      queryString.stringifyUrl({
-        url: LocationToPath[Location.Blast],
-        query: {
-          ids: 'P05067[1-10]',
-        },
+      stringifyUrl(LocationToPath[Location.Blast], {
+        ids: 'P05067[1-10]',
       }),
       {
         parameters: { sequence },
@@ -67,9 +66,10 @@ describe('useInitialFormParameters: Peptide Search', () => {
     const lEQi = 'on';
     const spOnly = 'off';
     const { result } = customRenderHook(
-      queryString.stringifyUrl({
-        url: LocationToPath[Location.PeptideSearch],
-        query: { peps, lEQi, spOnly },
+      stringifyUrl(LocationToPath[Location.PeptideSearch], {
+        peps,
+        lEQi,
+        spOnly,
       })
     );
     expect(result.current.initialFormValues).toEqual({

--- a/src/uniparc/components/entry/Entry.tsx
+++ b/src/uniparc/components/entry/Entry.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useLocation, Link, Redirect } from 'react-router-dom';
-import { stringify } from 'query-string';
 import { Loader, Tabs, Tab } from 'franklin-sites';
 import cn from 'classnames';
 
@@ -31,6 +30,7 @@ import {
   UniParcXRefsColumn,
 } from '../../config/UniParcXRefsColumnConfiguration';
 import { Location, getEntryPath } from '../../../app/config/urls';
+import { stringifyUrl } from '../../../shared/utils/url';
 
 import uniParcConverter, {
   UniParcAPIModel,
@@ -67,7 +67,7 @@ const Entry = () => {
     if (!selectedFacets.length) {
       return baseURL;
     }
-    return `${baseURL}?${stringify({
+    return stringifyUrl(baseURL || '', {
       ...Object.fromEntries(
         selectedFacets.map(({ name, value }) => [name, value])
       ),
@@ -83,7 +83,7 @@ const Entry = () => {
         // Sort to have better cache hits
         .sort()
         .join(','),
-    })}`;
+    });
   }, [baseURL, search, columns]);
   const dataObject = useDataApi<UniParcAPIModel>(
     // Hack to have the backend only return the base object without xref data

--- a/src/uniparc/config/apiUrls.ts
+++ b/src/uniparc/config/apiUrls.ts
@@ -1,8 +1,8 @@
-import qs from 'query-string';
 import joinUrl from 'url-join';
 
 import { apiPrefix } from '../../shared/config/apiUrls';
 import { fileFormatToUrlParameter } from '../../shared/config/resultsDownload';
+import { stringifyUrl } from '../../shared/utils/url';
 
 import { FileFormat } from '../../shared/types/resultsDownload';
 
@@ -11,12 +11,9 @@ const apiUrls = {
     upid: string,
     options: { format?: FileFormat.tsv | FileFormat.json; size?: number } = {}
   ) =>
-    qs.stringifyUrl({
-      url: joinUrl(apiPrefix, 'uniparc', upid, 'databases'),
-      query: {
-        format: fileFormatToUrlParameter[options.format || FileFormat.json],
-        size: options.size,
-      },
+    stringifyUrl(joinUrl(apiPrefix, 'uniparc', upid, 'databases'), {
+      format: fileFormatToUrlParameter[options.format || FileFormat.json],
+      size: options.size,
     }),
 };
 

--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -1,10 +1,10 @@
 /* eslint-disable camelcase */
 import { useMemo } from 'react';
-import queryString from 'query-string';
 import { groupBy } from 'lodash-es';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 
+import { stringifyUrl } from '../../../shared/utils/url';
 import * as logging from '../../../shared/utils/logging';
 
 import { TaxonomyDatum } from '../../../supporting-data/taxonomy/adapters/taxonomyConverter';
@@ -281,11 +281,11 @@ export const useGOData = (
     return (
       slimsToIds &&
       slimsFromIds &&
-      `${SLIMMING_URL}?${queryString.stringify({
+      stringifyUrl(SLIMMING_URL, {
         slimsToIds,
         slimsFromIds,
         relations: 'is_a,part_of,occurs_in,regulates',
-      })}`
+      })
     );
   }, [goTerms, selectedSlimSet]);
 

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -3,7 +3,6 @@ import { Link, Redirect, useHistory } from 'react-router-dom';
 import { InPageNav, Loader, Tabs, Tab } from 'franklin-sites';
 import joinUrl from 'url-join';
 import cn from 'classnames';
-import qs from 'query-string';
 import { frame } from 'timing-functions';
 
 import EntrySection, {
@@ -42,6 +41,7 @@ import { hasContent } from '../../../shared/utils/utils';
 import lazy from '../../../shared/utils/lazy';
 import apiUrls from '../../../shared/config/apiUrls';
 import externalUrls from '../../../shared/config/externalUrls';
+import { stringifyQuery } from '../../../shared/utils/url';
 
 import uniProtKbConverter, {
   UniProtkbAPIModel,
@@ -398,7 +398,7 @@ const Entry = () => {
                 <ContactLink
                   to={{
                     pathname: LocationToPath[Location.ContactUpdate],
-                    search: qs.stringify({
+                    search: stringifyQuery({
                       entry: match.params.accession,
                       entryType:
                         transformedData?.entryType === EntryType.REVIEWED

--- a/src/uniprotkb/components/entry/EntryHistory.tsx
+++ b/src/uniprotkb/components/entry/EntryHistory.tsx
@@ -444,9 +444,10 @@ export const EntryHistoryList = ({ accession }: { accession: string }) => {
 };
 
 const EntryHistory = ({ accession }: { accession: string }) => {
-  const { versions: rawVersions, view: rawView } = Object.fromEntries(
-    new URLSearchParams(useLocation().search).entries()
-  );
+  const sp = new URLSearchParams(useLocation().search);
+  const rawVersions = sp.get('versions');
+  const rawView = sp.get('view');
+
   const defaultView = useMediumScreen() ? 'unified' : 'split';
 
   const title = <h2>Entry history</h2>;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/Entry.spec.tsx.snap
@@ -464,7 +464,7 @@ exports[`Entry basic should render main 1`] = `
             </a>
             <a
               class="button tertiary"
-              href="/update?entry=P21802&entryType=Reviewed%20%28Swiss-Prot%29"
+              href="/update?entry=P21802&entryType=Reviewed+%28Swiss-Prot%29"
             >
               Entry feedback
             </a>

--- a/src/uniprotkb/components/results/UniProtKBGroupBy.tsx
+++ b/src/uniprotkb/components/results/UniProtKBGroupBy.tsx
@@ -12,7 +12,6 @@ import {
   WarningTriangleIcon,
   formatLargeNumber,
 } from 'franklin-sites';
-import qs from 'query-string';
 import { sumBy } from 'lodash-es';
 
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
@@ -27,7 +26,7 @@ import externalUrls from '../../../shared/config/externalUrls';
 import { addMessage } from '../../../messages/state/messagesActions';
 import { getParamsFromURL } from '../../utils/resultsUtils';
 import { getAPIQueryParams } from '../../../shared/config/apiUrls';
-import { parseQueryString } from '../../../shared/utils/url';
+import { stringifyQuery } from '../../../shared/utils/url';
 import {
   getGroupBySuggesterUrl,
   getPercentageLabel,
@@ -170,18 +169,12 @@ type ParentNodeLinkProps = {
 
 const ParentNodeLink = ({ label, id, parent }: ParentNodeLinkProps) => (
   <Link
-    to={(location) => {
-      const sp = new URLSearchParams(location.search);
-      if (parent) {
-        sp.set('parent', parent);
-      } else {
-        sp.delete('parent');
-      }
-      return {
-        ...location,
-        search: sp.toString(),
-      };
-    }}
+    to={(location) => ({
+      ...location,
+      search: stringifyQuery(location.search, {
+        parent,
+      }),
+    })}
     title={`Set parent node to ${label}${id ? `ID:${id}` : ''}`}
   >
     {label}
@@ -555,8 +548,7 @@ const UniProtKBGroupByResults = ({ total }: UniProtKBGroupByResultsProps) => {
           // eslint-disable-next-line uniprot-website/use-config-location
           {
             pathname: history.location.pathname,
-            search: qs.stringify({
-              ...parseQueryString(locationSearch),
+            search: stringifyQuery(locationSearch, {
               parent: id,
             }),
           }

--- a/src/uniprotkb/components/results/UniProtKBGroupByFacet.tsx
+++ b/src/uniprotkb/components/results/UniProtKBGroupByFacet.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable uniprot-website/use-config-location */
 import { useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import queryString from 'query-string';
 import cn from 'classnames';
+
+import { stringifyUrl } from '../../../shared/utils/url';
+
 import { GroupBy } from '../../config/apiUrls';
 
 const groupByLabelAndParams: [string, GroupBy][] = [
@@ -18,13 +20,9 @@ const UniProtKBGroupByFacet = () => {
 
   const getTo = useMemo(
     () => (groupBy: GroupBy) =>
-      queryString.stringifyUrl({
-        url: location.pathname,
-        query: {
-          ...searchParams,
-          groupBy: searchParams.groupBy === groupBy ? undefined : groupBy,
-          parent: undefined,
-        },
+      stringifyUrl(location.pathname, searchParams, {
+        groupBy: searchParams.groupBy === groupBy ? undefined : groupBy,
+        parent: undefined,
       }),
     [location.pathname, searchParams]
   );

--- a/src/uniprotkb/components/results/__tests__/UniProtKBGroupByResults.spec.tsx
+++ b/src/uniprotkb/components/results/__tests__/UniProtKBGroupByResults.spec.tsx
@@ -17,9 +17,9 @@ let rendered: ReturnType<typeof customRender>;
 const mock = new MockAdapter(axios);
 
 mock
-  .onGet(/\/uniprotkb\/groups\/taxonomy\?query=%28%2A%29/)
+  .onGet(/\/uniprotkb\/groups\/taxonomy\?query=%28\*%29/)
   .reply(200, taxonomyRoot)
-  .onGet(/\/uniprotkb\/groups\/taxonomy\?parent=131567&query=%28%2A%29/)
+  .onGet(/\/uniprotkb\/groups\/taxonomy\?parent=131567&query=%28\*%29/)
   .reply(200, taxonomyCellularOrgranisms)
   .onGet(/\/uniprotkb\/groups\/ec/)
   .reply(200, ecNonRoot);

--- a/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBGroupByResults.spec.tsx.snap
+++ b/src/uniprotkb/components/results/__tests__/__snapshots__/UniProtKBGroupByResults.spec.tsx.snap
@@ -364,7 +364,7 @@ exports[`UniProtKBGroupByResults component with taxonomy groups should render 1`
           style="width: 20ch;"
         >
           <a
-            href="/uniprotkb?groupBy=taxonomy&query=*&parent=131567"
+            href="/uniprotkb?groupBy=taxonomy&parent=131567&query=*"
             title="Set parent node to cellular organismsID:131567"
           >
             cellular organisms
@@ -414,7 +414,7 @@ exports[`UniProtKBGroupByResults component with taxonomy groups should render 1`
           style="width: 20ch;"
         >
           <a
-            href="/uniprotkb?groupBy=taxonomy&query=*&parent=2787854"
+            href="/uniprotkb?groupBy=taxonomy&parent=2787854&query=*"
             title="Set parent node to other entriesID:2787854"
           >
             other entries
@@ -464,7 +464,7 @@ exports[`UniProtKBGroupByResults component with taxonomy groups should render 1`
           style="width: 20ch;"
         >
           <a
-            href="/uniprotkb?groupBy=taxonomy&query=*&parent=2787823"
+            href="/uniprotkb?groupBy=taxonomy&parent=2787823&query=*"
             title="Set parent node to unclassified entriesID:2787823"
           >
             unclassified entries
@@ -514,7 +514,7 @@ exports[`UniProtKBGroupByResults component with taxonomy groups should render 1`
           style="width: 20ch;"
         >
           <a
-            href="/uniprotkb?groupBy=taxonomy&query=*&parent=10239"
+            href="/uniprotkb?groupBy=taxonomy&parent=10239&query=*"
             title="Set parent node to VirusesID:10239"
           >
             Viruses

--- a/src/uniprotkb/config/apiUrls.ts
+++ b/src/uniprotkb/config/apiUrls.ts
@@ -1,16 +1,13 @@
-import queryString from 'query-string';
 import joinUrl from 'url-join';
 
 import { apiPrefix } from '../../shared/config/apiUrls';
+import { stringifyUrl } from '../../shared/utils/url';
 
 export type GroupBy = 'ec' | 'go' | 'keyword' | 'taxonomy';
 
 const apiUrls = {
   groupBy: (by: GroupBy, query: string, parent?: string) =>
-    queryString.stringifyUrl({
-      url: joinUrl(apiPrefix, 'uniprotkb/groups', by),
-      query: { query, parent },
-    }),
+    stringifyUrl(joinUrl(apiPrefix, 'uniprotkb/groups', by), { query, parent }),
 };
 
 export default apiUrls;

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -109,18 +109,15 @@ export const getLocationObjForParams = ({
   viewMode,
 }: GetLocationObjForParams = {}) => ({
   pathname,
-  search: stringifyQuery(
-    {
-      query: query || undefined,
-      facets: facetsAsString(selectedFacets),
-      sort: sortColumn,
-      dir: sortDirection,
-      activeFacet,
-      fields: columns,
-      view: viewMode,
-    },
-    { encode: false }
-  ),
+  search: stringifyQuery({
+    query: query || undefined,
+    facets: facetsAsString(selectedFacets),
+    sort: sortColumn,
+    dir: sortDirection,
+    activeFacet,
+    fields: columns,
+    view: viewMode,
+  }),
 });
 
 export const getSortableColumnToSortColumn = (

--- a/src/uniprotkb/utils/resultsUtils.ts
+++ b/src/uniprotkb/utils/resultsUtils.ts
@@ -1,5 +1,4 @@
-import qs from 'query-string';
-import { parseQueryString } from '../../shared/utils/url';
+import { stringifyQuery } from '../../shared/utils/url';
 
 import { Column } from '../../shared/config/columns';
 import { SortableColumn } from '../types/columnTypes';
@@ -58,7 +57,7 @@ export const getParamsFromURL = (
     groupBy, // Handled in UniProtKB/groupBy
     parent, // Handled in UniProtKB/groupBy
     ...restParams
-  } = parseQueryString(url);
+  } = Object.fromEntries(new URLSearchParams(url));
 
   let selectedFacets: SelectedFacet[] = [];
   if (facets && typeof facets === 'string') {
@@ -110,7 +109,7 @@ export const getLocationObjForParams = ({
   viewMode,
 }: GetLocationObjForParams = {}) => ({
   pathname,
-  search: qs.stringify(
+  search: stringifyQuery(
     {
       query: query || undefined,
       facets: facetsAsString(selectedFacets),

--- a/src/uniref/config/apiUrls.ts
+++ b/src/uniref/config/apiUrls.ts
@@ -1,9 +1,10 @@
-import qs from 'query-string';
 import joinUrl from 'url-join';
 
 import { apiPrefix } from '../../shared/config/apiUrls';
-import { FileFormat } from '../../shared/types/resultsDownload';
 import { fileFormatToUrlParameter } from '../../shared/config/resultsDownload';
+import { stringifyUrl } from '../../shared/utils/url';
+
+import { FileFormat } from '../../shared/types/resultsDownload';
 
 const apiUrls = {
   members: (
@@ -15,16 +16,13 @@ const apiUrls = {
       format?: FileFormat.json | FileFormat.list;
     } = {}
   ) =>
-    qs.stringifyUrl({
-      url: joinUrl(apiPrefix, 'uniref', id, 'members'),
-      query: {
-        size: options.size,
-        facets: options.facets?.join(',') || undefined,
-        facetFilter: options.selectedFacets?.join(' AND ') || undefined,
-        format: options.format
-          ? fileFormatToUrlParameter[options.format]
-          : undefined,
-      },
+    stringifyUrl(joinUrl(apiPrefix, 'uniref', id, 'members'), {
+      size: options.size,
+      facets: options.facets?.join(',') || undefined,
+      facetFilter: options.selectedFacets?.join(' AND ') || undefined,
+      format: options.format
+        ? fileFormatToUrlParameter[options.format]
+        : undefined,
     }),
 };
 


### PR DESCRIPTION
## Purpose
[Create url search param utility fn](https://www.ebi.ac.uk/panda/jira/browse/TRM-29979)

## Approach
- `stringifyQuery`: returns a query string by iterating over the args and creating a combined URLSearchParams instance. If a parameter key already exists it will be overwritten by the new value. If the new value is undefined or null then the parameter will be removed. Arrays will be returned as comma separated strings. This also returns the parameters in sorted order.
- `stringifyUrl`: combines a "base" url with query parameters.
- `splitUrl`: simply returns the "base" url and the query string.
- Always show the branch as I find this helpful as I have several versions of the website served locally and it can be tricky to determine which is being served at which port.
- Cleaned up a few trailing `/`s when joining urls.
- Remove `query-string` package however it's still in the yarn lock file as franklin still uses it. I will create a PR for this too.

## Testing
Updated and tested.

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
