### PR TITLE
set max-width: 200ch on non-search result pages

### DIFF
--- a/src/help/components/results/Results.tsx
+++ b/src/help/components/results/Results.tsx
@@ -169,6 +169,7 @@ const Results = ({
           <HelpResultFacets />
         </>
       }
+      noOverflow
     >
       {/* TODO: check and change this title when implementing Help */}
       <HTMLHead

--- a/src/shared/components/layouts/styles/sidebar-layout.module.scss
+++ b/src/shared/components/layouts/styles/sidebar-layout.module.scss
@@ -13,7 +13,6 @@
     --sidebar-size: 30ch;
   }
 
-  max-width: 100%;
   min-height: calc(100vh - var(--top-header-margin));
   display: grid;
   align-items: start;
@@ -24,6 +23,10 @@
 
   &.no-overflow {
     grid-template-columns: 3rem calc(var(--sidebar-size) - 3rem) minmax(0, 1fr);
+
+    // setting max-width for all pages other than search results
+    max-width: 200ch;
+    margin: auto;
   }
 
   & > .sidebar {

--- a/src/shared/components/layouts/styles/sidebar-layout.module.scss
+++ b/src/shared/components/layouts/styles/sidebar-layout.module.scss
@@ -13,6 +13,7 @@
     --sidebar-size: 30ch;
   }
 
+  max-width: 100%;
   min-height: calc(100vh - var(--top-header-margin));
   display: grid;
   align-items: start;


### PR DESCRIPTION
## Purpose
Uniprot website currently is displayed full-width, which raises readability issues in desktop/large monitor environments. 
This fix sets a max-width on the content which improves the readability of pages.

## Approach
Max-width of 200 ch set for all pages minus search results. 

## Testing
Tested on:
- homepage
- entry pages
- search results page
- help pages, help search result pages
- blast/align/idmapping pages and results pages

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
