### PR TITLE
Covid redirect warning

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -21,7 +21,7 @@ import BaseLayout from '../../shared/components/layouts/BaseLayout';
 import { SingleColumnLayout } from '../../shared/components/layouts/SingleColumnLayout';
 import ErrorBoundary from '../../shared/components/error-component/ErrorBoundary';
 import GDPR from '../../shared/components/gdpr/GDPR';
-import DeploymentWarning from './DeploymentWarning';
+import DevDeploymentWarning from './DevDeploymentWarning';
 
 import history from '../../shared/utils/browserHistory';
 
@@ -331,7 +331,7 @@ const App = () => {
           content="UniProt is the world’s leading high-quality, comprehensive and freely accessible resource of protein sequence and functional information."
         />
       </Helmet>
-      <DeploymentWarning />
+      <DevDeploymentWarning />
       <BaseLayout>
         <Suspense fallback={<Loader />}>
           <Switch>

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -22,6 +22,7 @@ import { SingleColumnLayout } from '../../shared/components/layouts/SingleColumn
 import ErrorBoundary from '../../shared/components/error-component/ErrorBoundary';
 import GDPR from '../../shared/components/gdpr/GDPR';
 import DevDeploymentWarning from './DevDeploymentWarning';
+import Covid19RedirectWarning from './Covid19RedirectWarning';
 
 import history from '../../shared/utils/browserHistory';
 
@@ -332,6 +333,7 @@ const App = () => {
         />
       </Helmet>
       <DevDeploymentWarning />
+      <Covid19RedirectWarning />
       <BaseLayout>
         <Suspense fallback={<Loader />}>
           <Switch>

--- a/src/app/components/Covid19RedirectWarning.tsx
+++ b/src/app/components/Covid19RedirectWarning.tsx
@@ -1,0 +1,28 @@
+import { Message } from 'franklin-sites';
+import { useState } from 'react';
+
+import style from './styles/warning-message.module.scss';
+
+const reFromCovidPortal = /fromCovid19Portal=true/i;
+
+const Covid19DeploymentWarning = () => {
+  const [dismissed, setDismissed] = useState(false);
+  return (
+    <>
+      {!window.location.search.match(reFromCovidPortal) &&
+      !LIVE_RELOAD &&
+      !dismissed ? (
+        <Message
+          className={style['warning-message']}
+          level="warning"
+          onDismiss={() => setDismissed(true)}
+        >
+          You have been redirected from the COVID-19 Portal which has been shut
+          down.
+        </Message>
+      ) : null}
+    </>
+  );
+};
+
+export default Covid19DeploymentWarning;

--- a/src/app/components/Covid19RedirectWarning.tsx
+++ b/src/app/components/Covid19RedirectWarning.tsx
@@ -17,8 +17,8 @@ const Covid19DeploymentWarning = () => {
           level="warning"
           onDismiss={() => setDismissed(true)}
         >
-          You have been redirected from the COVID-19 Portal which has been shut
-          down.
+          You have been redirected from the COVID-19 portal which is now
+          obsolete as all entries have been fully integrated into UniProtKB.
         </Message>
       ) : null}
     </>

--- a/src/app/components/Covid19RedirectWarning.tsx
+++ b/src/app/components/Covid19RedirectWarning.tsx
@@ -3,13 +3,13 @@ import { useState } from 'react';
 
 import style from './styles/warning-message.module.scss';
 
-const reFromCovidPortal = /fromCovid19Portal=true/i;
+const reFromCovid19Portal = /fromCovid19Portal=true/;
 
 const Covid19DeploymentWarning = () => {
   const [dismissed, setDismissed] = useState(false);
   return (
     <>
-      {!window.location.search.match(reFromCovidPortal) &&
+      {window.location.search.match(reFromCovid19Portal) &&
       !LIVE_RELOAD &&
       !dismissed ? (
         <Message

--- a/src/app/components/DevDeploymentWarning.tsx
+++ b/src/app/components/DevDeploymentWarning.tsx
@@ -1,7 +1,7 @@
 import { Message } from 'franklin-sites';
 import { useState } from 'react';
 
-import style from './styles/dev-deployment-warning.module.scss';
+import style from './styles/warning-message.module.scss';
 
 const reUniProtOrg = /^https?:\/\/www\.uniprot\.org/;
 
@@ -13,7 +13,7 @@ const DevDeploymentWarning = () => {
       !LIVE_RELOAD &&
       !dismissed ? (
         <Message
-          className={style['dev-deployment-warning']}
+          className={style['warning-message']}
           level="warning"
           onDismiss={() => setDismissed(true)}
         >

--- a/src/app/components/DevDeploymentWarning.tsx
+++ b/src/app/components/DevDeploymentWarning.tsx
@@ -1,11 +1,11 @@
 import { Message } from 'franklin-sites';
 import { useState } from 'react';
 
-import style from './styles/deployment-warning.module.scss';
+import style from './styles/dev-deployment-warning.module.scss';
 
 const reUniProtOrg = /^https?:\/\/www\.uniprot\.org/;
 
-const DeploymentWarning = () => {
+const DevDeploymentWarning = () => {
   const [dismissed, setDismissed] = useState(false);
   return (
     <>
@@ -13,7 +13,7 @@ const DeploymentWarning = () => {
       !LIVE_RELOAD &&
       !dismissed ? (
         <Message
-          className={style['deployment-warning']}
+          className={style['dev-deployment-warning']}
           level="warning"
           onDismiss={() => setDismissed(true)}
         >
@@ -26,4 +26,4 @@ const DeploymentWarning = () => {
   );
 };
 
-export default DeploymentWarning;
+export default DevDeploymentWarning;

--- a/src/app/components/styles/dev-deployment-warning.module.scss
+++ b/src/app/components/styles/dev-deployment-warning.module.scss
@@ -1,4 +1,4 @@
-.deployment-warning {
+.dev-deployment-warning {
   width: 100%;
   margin-bottom: 0;
 }

--- a/src/app/components/styles/warning-message.module.scss
+++ b/src/app/components/styles/warning-message.module.scss
@@ -1,4 +1,4 @@
-.dev-deployment-warning {
+.warning-message {
   width: 100%;
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Purpose
COVID-19 portal is being shut down so alert users if they have been redirected.

Corresponds to this [traffic-manager MR](https://gitlab.ebi.ac.uk/wp/wp-traffic-manager/-/merge_requests/1175).

## Approach

- Check `window.location.search` for `fromCovid19Portal=true` and if present show a dismissible message.
- Renamed the existing deployment warning for clarity.

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
