### PR TITLE
Async download friction

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -41,7 +41,6 @@ import {
   getIsAsyncDownload,
   getRedirectToIDMapping,
   getExtraContent,
-  hasColumns,
   getIsEmbeddings,
   getPreviewCount,
   isAsyncDownloadIdMapping,

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -58,6 +58,7 @@ import { PublicServerParameters } from '../../../tools/types/toolsServerParamete
 
 import sticky from '../../styles/sticky.module.scss';
 import styles from './styles/download.module.scss';
+import helper from '../../styles/helper.module.scss';
 
 export type DownloadProps<T extends JobTypes> = {
   query?: string;
@@ -348,7 +349,9 @@ const Download = (props: DownloadProps<JobTypes>) => {
         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <a
           href={isAsyncDownload || ftpFilenameAndUrl ? undefined : downloadUrl}
-          className={cn('button', 'primary')}
+          className={cn('button', 'primary', {
+            [helper.disabled]: state.disableForm,
+          })}
           title={
             isAsyncDownload
               ? 'Download with a File Generation job'
@@ -365,7 +368,6 @@ const Download = (props: DownloadProps<JobTypes>) => {
               onClose('download', 'sync');
             }
           }}
-          // disabled={state.disableForm}
         >
           Download
         </a>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -45,6 +45,7 @@ import {
   getIsEmbeddings,
   getPreviewCount,
   isAsyncDownloadIdMapping,
+  showColumnSelect,
 } from './downloadUtils';
 
 import { FileFormat } from '../../types/resultsDownload';
@@ -307,7 +308,7 @@ const Download = (props: DownloadProps<JobTypes>) => {
         </Message>
       )}
 
-      {hasColumns(state, props, job) && (
+      {showColumnSelect(state, props, job) && (
         <>
           <legend>Customize columns</legend>
           <ColumnSelect

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -16,6 +16,7 @@ import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
 import SimpleMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/SimpleMappingDetails';
 import UniProtkbMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/UniProtkbMappingDetails';
 import '../../../../uniprotkb/components/__mocks__/mockApi';
+import { DOWNLOAD_SIZE_LIMIT } from '../DownloadAPIURL';
 
 const initialColumns = [
   UniProtKBColumn.accession,
@@ -278,5 +279,43 @@ describe('Download with ID mapping results', () => {
       expect.stringContaining('/idmapping/uniprotkb/results/stream/id2')
     );
     expect(await screen.findByText('Customize columns')).toBeInTheDocument();
+  });
+});
+
+describe('Download with file generation job', () => {
+  it('should show file generation form then confirmation with form elements disabled', async () => {
+    Element.prototype.scrollIntoView = jest.fn();
+    const onCloseMock = jest.fn();
+    customRender(
+      <Download
+        totalNumberResults={DOWNLOAD_SIZE_LIMIT + 1}
+        onClose={onCloseMock}
+        namespace={Namespace.uniprotkb}
+      />,
+      {
+        route: '/uniprotkb?query=*',
+        initialLocalStorage: {
+          'table columns for uniprotkb': initialColumns,
+        },
+      }
+    );
+    fireEvent.change(screen.getByTestId('file-format-select'), {
+      target: { value: FileFormat.tsv },
+    });
+    fireEvent.click(
+      screen.getByTitle<HTMLAnchorElement>(
+        'Download with a File Generation job'
+      )
+    );
+    expect(
+      await screen.findByText(/File Generation Needed/)
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Submit'));
+    expect(
+      await screen.findByText(/Review your file generation request/)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('file-format-select')).toBeDisabled();
+    expect(screen.queryByRole('radio', { name: 'compressed' })).toBeDisabled();
+    expect(screen.queryByText('Customize columns')).not.toBeInTheDocument();
   });
 });

--- a/src/shared/components/download/__tests__/Download.spec.tsx
+++ b/src/shared/components/download/__tests__/Download.spec.tsx
@@ -8,6 +8,8 @@ import { IDMappingDetailsContext } from '../../../contexts/IDMappingDetails';
 
 import { stringifyQuery } from '../../../utils/url';
 
+import { DOWNLOAD_SIZE_LIMIT } from '../DownloadAPIURL';
+
 import { FileFormat } from '../../../types/resultsDownload';
 import { Namespace } from '../../../types/namespaces';
 import { UniProtKBColumn } from '../../../../uniprotkb/types/columnTypes';
@@ -16,7 +18,6 @@ import mockFasta from '../../../../uniprotkb/components/__mocks__/fasta.json';
 import SimpleMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/SimpleMappingDetails';
 import UniProtkbMappingDetails from '../../../../tools/id-mapping/components/results/__mocks__/UniProtkbMappingDetails';
 import '../../../../uniprotkb/components/__mocks__/mockApi';
-import { DOWNLOAD_SIZE_LIMIT } from '../DownloadAPIURL';
 
 const initialColumns = [
   UniProtKBColumn.accession,

--- a/src/shared/components/download/__tests__/downloadUtils.spec.ts
+++ b/src/shared/components/download/__tests__/downloadUtils.spec.ts
@@ -93,6 +93,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaCanonical,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -162,6 +163,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaCanonical,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -236,6 +238,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaCanonical,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -329,6 +332,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaCanonical,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -426,6 +430,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.tsvIdMappingFromTo,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -506,6 +511,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.tsvIdMappingFromTo,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -593,6 +599,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.tsvIdMappingFromTo,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -664,6 +671,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaCanonical,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -736,6 +744,7 @@ describe('Download Utils', () => {
       downloadSelect: 'all',
       extraContent: null,
       compressed: true,
+      disableForm: false,
       nSelectedEntries: 0,
     });
     // Manually set state
@@ -807,6 +816,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.text,
       downloadSelect: 'all',
       compressed: false,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });
@@ -891,6 +901,7 @@ describe('Download Utils', () => {
       selectedFileFormat: FileFormat.fastaSubsequence,
       downloadSelect: 'all',
       compressed: true,
+      disableForm: false,
       extraContent: null,
       nSelectedEntries: 0,
     });

--- a/src/shared/components/download/downloadActions.ts
+++ b/src/shared/components/download/downloadActions.ts
@@ -10,6 +10,7 @@ export const UPDATE_SELECTED_FILE_FORMAT =
 export const UPDATE_DOWNLOAD_SELECT = 'UPDATE_DOWNLOAD_SELECT' as const;
 export const UPDATE_COMPRESSED = 'UPDATE_COMPRESSED' as const;
 export const UPDATE_EXTRA_CONTENT = 'UPDATE_EXTRA_CONTENT' as const;
+export const UPDATE_DISABLE_FORM = 'UPDATE_DISABLE_FORM' as const;
 
 export const updateSelectedColumns = (columns: Column[]) =>
   action(UPDATE_SELECTED_COLUMNS, { columns });
@@ -25,3 +26,6 @@ export const updateCompressed = (compressed: boolean) =>
 
 export const updateExtraContent = (extraContent: ExtraContent) =>
   action(UPDATE_EXTRA_CONTENT, { extraContent });
+
+export const updateDisableForm = (disableForm: boolean) =>
+  action(UPDATE_DISABLE_FORM, { disableForm });

--- a/src/shared/components/download/downloadReducer.ts
+++ b/src/shared/components/download/downloadReducer.ts
@@ -26,6 +26,7 @@ export type DownloadState = {
   compressed: boolean;
   extraContent: ExtraContent;
   nSelectedEntries: number;
+  disableForm: boolean;
 };
 
 export const getDownloadInitialState = ({
@@ -47,6 +48,7 @@ export const getDownloadInitialState = ({
     extraContent: null,
     nSelectedEntries:
       props.numberSelectedEntries || props.selectedEntries?.length || 0,
+    disableForm: false,
   };
 };
 
@@ -71,6 +73,8 @@ export function downloadReducer(
       return { ...state, compressed: action.payload.compressed };
     case downloadActions.UPDATE_EXTRA_CONTENT:
       return { ...state, extraContent: action.payload.extraContent };
+    case downloadActions.UPDATE_DISABLE_FORM:
+      return { ...state, disableForm: action.payload.disableForm };
     default:
       return state;
   }

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -119,8 +119,13 @@ export const hasColumns = (
   fileFormatsWithColumns.has(state.selectedFileFormat) &&
   (props.namespace !== Namespace.idmapping ||
     isAsyncDownloadIdMapping(state, props, job)) &&
-  props.namespace !== Namespace.unisave &&
-  !state.disableForm;
+  props.namespace !== Namespace.unisave;
+
+export const showColumnSelect = (
+  state: DownloadState,
+  props: DownloadProps<JobTypes>,
+  job: JobFromUrl
+) => hasColumns(state, props, job) && !state.disableForm;
 
 export const getDownloadOptions = (
   state: DownloadState,

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -119,7 +119,8 @@ export const hasColumns = (
   fileFormatsWithColumns.has(state.selectedFileFormat) &&
   (props.namespace !== Namespace.idmapping ||
     isAsyncDownloadIdMapping(state, props, job)) &&
-  props.namespace !== Namespace.unisave;
+  props.namespace !== Namespace.unisave &&
+  !state.disableForm;
 
 export const getDownloadOptions = (
   state: DownloadState,

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -101,10 +101,12 @@ const AsyncDownloadConfirmation = ({
       title: 'File format',
       content: <CodeBlock lightMode>{jobParameters.fileFormat}</CodeBlock>,
     },
-    {
+    !!jobParameters.columns?.length && {
       title: 'Columns',
       content: (
-        <CodeBlock lightMode>{jobParameters.columns?.join(', ')}</CodeBlock>
+        <CodeBlock lightMode className={styles.codeblock}>
+          {jobParameters.columns?.join(', ')}
+        </CodeBlock>
       ),
     },
   ].filter(Boolean);

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -8,6 +8,7 @@ import {
 } from 'franklin-sites';
 import { keyBy } from 'lodash-es';
 
+import { InfoListItem } from 'franklin-sites/dist/types/components/info-list';
 import useNSQuery from '../../../shared/hooks/useNSQuery';
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 
@@ -67,53 +68,51 @@ const AsyncDownloadConfirmation = ({
     return <Loader />;
   }
 
-  const infoData = [
+  const infoData: (InfoListItem | false)[] = [
     {
       title: 'File generation job name',
-      content: <CodeBlock lightMode>{jobName}</CodeBlock>,
+      content: jobName,
     },
     {
       title: 'Data source',
-      content: <CodeBlock lightMode>{jobParameters.namespace}</CodeBlock>,
+      content: jobParameters.namespace,
     },
-    {
+    !!jobParameters.query && {
       title: 'Query',
-      content: <CodeBlock lightMode>{jobParameters.query}</CodeBlock>,
+      content: jobParameters.query,
     },
-    jobParameters.selectedFacets &&
-      data?.facets && {
+    !!jobParameters.selectedFacets &&
+      !!data?.facets && {
         title: 'Selected facets',
-        content: (
-          <CodeBlock lightMode>
-            {getFacetString(data.facets, jobParameters.selectedFacets)}
-          </CodeBlock>
-        ),
+        content: getFacetString(data.facets, jobParameters.selectedFacets),
       },
     {
       title: 'Number of entries',
-      content: (
-        <CodeBlock lightMode>
-          <LongNumber>{count}</LongNumber>
-        </CodeBlock>
-      ),
+      content: <LongNumber>{count}</LongNumber>,
     },
     {
       title: 'File format',
-      content: <CodeBlock lightMode>{jobParameters.fileFormat}</CodeBlock>,
+      content: jobParameters.fileFormat,
     },
     !!jobParameters.columns?.length && {
       title: 'Columns',
-      content: (
-        <CodeBlock lightMode>{jobParameters.columns?.join(', ')}</CodeBlock>
-      ),
+      content: jobParameters.columns?.join(', ') || '',
     },
-  ].filter(Boolean);
+  ];
   return (
     <Card
       header={<h4>Review your file generation request</h4>}
       className={styles['confirm-async-download']}
     >
-      <InfoList infoData={infoData} className={styles['info-list']} />
+      <InfoList
+        infoData={infoData
+          .filter((d): d is InfoListItem => !!d)
+          .map(({ title, content }) => ({
+            title,
+            content: <CodeBlock lightMode>{content}</CodeBlock>,
+          }))}
+        className={styles['info-list']}
+      />
       <section className="tools-form-section tools-form-section--right button-group tools-form-section__buttons">
         <Button variant="secondary" onClick={onCancel}>
           Cancel

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -1,4 +1,11 @@
-import { CodeBlock, InfoList, Loader, LongNumber } from 'franklin-sites';
+import {
+  Button,
+  Card,
+  CodeBlock,
+  InfoList,
+  Loader,
+  LongNumber,
+} from 'franklin-sites';
 import { keyBy } from 'lodash-es';
 
 import useNSQuery from '../../../shared/hooks/useNSQuery';
@@ -10,6 +17,7 @@ import { FacetObject, SearchResults } from '../../../shared/types/results';
 import { SelectedFacet } from '../../../uniprotkb/types/resultsTypes';
 
 import styles from './styles/async-download-confirmation.module.scss';
+import '../../styles/ToolsForm.scss';
 
 type Props = {
   jobParameters: FormParameters;
@@ -90,7 +98,28 @@ const AsyncDownloadConfirmation = ({
       content: <CodeBlock lightMode>{jobParameters.fileFormat}</CodeBlock>,
     },
   ].filter(Boolean);
-  return <InfoList infoData={infoData} className={styles['info-data']} />;
+  return (
+    <Card
+      header={<h4>Review your file generation request</h4>}
+      className={styles['confirm-async-download']}
+    >
+      <InfoList infoData={infoData} className={styles['info-list']} />
+      <section className="tools-form-section tools-form-section--right button-group tools-form-section__buttons">
+        <Button variant="secondary" onClick={() => console.log('cancel')}>
+          Cancel
+        </Button>
+        <Button
+          className="button primary"
+          type="submit"
+          onClick={() => {
+            console.log('submit');
+          }}
+        >
+          Submit
+        </Button>
+      </section>
+    </Card>
+  );
 };
 
 export default AsyncDownloadConfirmation;

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -104,9 +104,7 @@ const AsyncDownloadConfirmation = ({
     !!jobParameters.columns?.length && {
       title: 'Columns',
       content: (
-        <CodeBlock lightMode className={styles.codeblock}>
-          {jobParameters.columns?.join(', ')}
-        </CodeBlock>
+        <CodeBlock lightMode>{jobParameters.columns?.join(', ')}</CodeBlock>
       ),
     },
   ].filter(Boolean);

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -1,18 +1,50 @@
-import { CodeBlock, InfoList } from 'franklin-sites';
+import { CodeBlock, InfoList, LongNumber } from 'franklin-sites';
 
-import { AsyncDownloadFormValues } from '../config/asyncDownloadFormData';
+import { FormParameters } from '../types/asyncDownloadFormParameters';
+
+import styles from './styles/async-download-confirmation.module.scss';
 
 type Props = {
-  formValues: AsyncDownloadFormValues;
+  jobParameters: FormParameters;
+  jobName: string;
 };
 
-const AsyncDownloadConfirmation = ({ formValues }: Props) => (
-  <InfoList
-    infoData={Object.entries(formValues).map(([k, v]) => ({
-      title: k,
-      content: <CodeBlock lightMode>{JSON.stringify(v)}</CodeBlock>,
-    }))}
-  />
-);
+const AsyncDownloadConfirmation = ({ jobParameters, jobName }: Props) => {
+  const infoData = [
+    {
+      title: 'File generation job name',
+      content: <CodeBlock lightMode>{jobName}</CodeBlock>,
+    },
+    {
+      title: 'Data source',
+      content: <CodeBlock lightMode>{jobParameters.namespace}</CodeBlock>,
+    },
+    {
+      title: 'Query',
+      content: <CodeBlock lightMode>{jobParameters.query}</CodeBlock>,
+    },
+    !!jobParameters.selectedFacets?.length && {
+      title: 'Selected facets',
+      content: (
+        <CodeBlock lightMode>
+          {JSON.stringify(jobParameters.selectedFacets)}
+        </CodeBlock>
+      ),
+    },
+    {
+      title: 'Number of entries',
+      content: (
+        <CodeBlock lightMode>
+          <LongNumber>2323232323</LongNumber>
+        </CodeBlock>
+      ),
+    },
+    {
+      title: 'File format',
+      content: <CodeBlock lightMode>{jobParameters.fileFormat}</CodeBlock>,
+    },
+  ].filter(Boolean);
+  return <InfoList infoData={infoData} className={styles['info-data']} />;
+};
 
 export default AsyncDownloadConfirmation;

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -1,12 +1,18 @@
+import { CodeBlock, InfoList } from 'franklin-sites';
+
 import { AsyncDownloadFormValues } from '../config/asyncDownloadFormData';
 
 type Props = {
   formValues: AsyncDownloadFormValues;
 };
 
-const AsyncDownloadConfirmation = ({ formValues }: Props) => {
-  console.log(formValues);
-  return <>{JSON.stringify(formValues)}</>;
-};
+const AsyncDownloadConfirmation = ({ formValues }: Props) => (
+  <InfoList
+    infoData={Object.entries(formValues).map(([k, v]) => ({
+      title: k,
+      content: <CodeBlock lightMode>{JSON.stringify(v)}</CodeBlock>,
+    }))}
+  />
+);
 
 export default AsyncDownloadConfirmation;

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -19,12 +19,6 @@ import { SelectedFacet } from '../../../uniprotkb/types/resultsTypes';
 import styles from './styles/async-download-confirmation.module.scss';
 import '../../styles/ToolsForm.scss';
 
-type Props = {
-  jobParameters: FormParameters;
-  jobName: string;
-  count: number;
-};
-
 export const getFacetString = (
   facetData: FacetObject<string>[],
   selectedFacets: SelectedFacet[]
@@ -41,10 +35,20 @@ export const getFacetString = (
     .join(', ');
 };
 
+type Props = {
+  jobParameters: FormParameters;
+  jobName: string;
+  count: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
 const AsyncDownloadConfirmation = ({
   jobParameters,
   jobName,
   count,
+  onCancel,
+  onConfirm,
 }: Props) => {
   // Query for facets
   const initialApiFacetUrl = useNSQuery(
@@ -97,6 +101,12 @@ const AsyncDownloadConfirmation = ({
       title: 'File format',
       content: <CodeBlock lightMode>{jobParameters.fileFormat}</CodeBlock>,
     },
+    {
+      title: 'Columns',
+      content: (
+        <CodeBlock lightMode>{jobParameters.columns?.join(', ')}</CodeBlock>
+      ),
+    },
   ].filter(Boolean);
   return (
     <Card
@@ -105,16 +115,10 @@ const AsyncDownloadConfirmation = ({
     >
       <InfoList infoData={infoData} className={styles['info-list']} />
       <section className="tools-form-section tools-form-section--right button-group tools-form-section__buttons">
-        <Button variant="secondary" onClick={() => console.log('cancel')}>
+        <Button variant="secondary" onClick={onCancel}>
           Cancel
         </Button>
-        <Button
-          className="button primary"
-          type="submit"
-          onClick={() => {
-            console.log('submit');
-          }}
-        >
+        <Button className="button primary" type="submit" onClick={onConfirm}>
           Submit
         </Button>
       </section>

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -7,9 +7,14 @@ import styles from './styles/async-download-confirmation.module.scss';
 type Props = {
   jobParameters: FormParameters;
   jobName: string;
+  count: number;
 };
 
-const AsyncDownloadConfirmation = ({ jobParameters, jobName }: Props) => {
+const AsyncDownloadConfirmation = ({
+  jobParameters,
+  jobName,
+  count,
+}: Props) => {
   const infoData = [
     {
       title: 'File generation job name',
@@ -35,7 +40,7 @@ const AsyncDownloadConfirmation = ({ jobParameters, jobName }: Props) => {
       title: 'Number of entries',
       content: (
         <CodeBlock lightMode>
-          <LongNumber>2323232323</LongNumber>
+          <LongNumber>{count}</LongNumber>
         </CodeBlock>
       ),
     },

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -1,3 +1,4 @@
+import { keyBy } from 'lodash-es';
 import {
   Button,
   Card,
@@ -6,9 +7,8 @@ import {
   Loader,
   LongNumber,
 } from 'franklin-sites';
-import { keyBy } from 'lodash-es';
-
 import { InfoListItem } from 'franklin-sites/dist/types/components/info-list';
+
 import useNSQuery from '../../../shared/hooks/useNSQuery';
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
 
@@ -51,7 +51,8 @@ const AsyncDownloadConfirmation = ({
   onCancel,
   onConfirm,
 }: Props) => {
-  // Query for facets
+  // Query for facets in order to create a nice, human readable display
+  // of what the user has selected
   const initialApiFacetUrl = useNSQuery(
     jobParameters.selectedFacets?.length
       ? {

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -1,0 +1,12 @@
+import { AsyncDownloadFormValues } from '../config/asyncDownloadFormData';
+
+type Props = {
+  formValues: AsyncDownloadFormValues;
+};
+
+const AsyncDownloadConfirmation = ({ formValues }: Props) => {
+  console.log(formValues);
+  return <>{JSON.stringify(formValues)}</>;
+};
+
+export default AsyncDownloadConfirmation;

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -83,7 +83,7 @@ const AsyncDownloadConfirmation = ({
       content: jobParameters.query,
     },
     !!jobParameters.selectedFacets &&
-      !!data?.facets && {
+      !!data?.facets?.length && {
         title: 'Selected facets',
         content: getFacetString(data.facets, jobParameters.selectedFacets),
       },

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -97,7 +97,7 @@ const AsyncDownloadConfirmation = ({
     },
     !!jobParameters.columns?.length && {
       title: 'Columns',
-      content: jobParameters.columns?.join(', ') || '',
+      content: jobParameters.columns.join(', ') || '',
     },
   ];
   return (

--- a/src/tools/async-download/components/AsyncDownloadForm.tsx
+++ b/src/tools/async-download/components/AsyncDownloadForm.tsx
@@ -3,6 +3,8 @@ import { useHistory } from 'react-router-dom';
 import { LongNumber, Message, SpinnerIcon, Chip } from 'franklin-sites';
 import { sleep } from 'timing-functions';
 
+import AsyncDownloadConfirmation from './AsyncDownloadConfirmation';
+
 import { useReducedMotion } from '../../../shared/hooks/useMatchMedia';
 import useToolsDispatch from '../../../shared/hooks/useToolsDispatch';
 import useScrollIntoViewRef from '../../../shared/hooks/useScrollIntoView';
@@ -20,6 +22,7 @@ import {
   updateSelected,
   updateSending,
   updateDownloadUrlOptions,
+  updateConfirmation,
 } from '../state/asyncDownloadFormActions';
 import initialFormValues, {
   AsyncDownloadFields,
@@ -82,15 +85,17 @@ const AsyncDownloadForm = ({
     }
   }
 
-  const [{ formValues, sending, submitDisabled }, dispatch] = useReducer(
-    asyncDownloadFormDataReducer,
-    { initialFormValues, downloadUrlOptions, count, jobTitle },
-    getAsyncDownloadFormInitialState
-  );
+  const [{ formValues, sending, submitDisabled, showConfirmation }, dispatch] =
+    useReducer(
+      asyncDownloadFormDataReducer,
+      { initialFormValues, downloadUrlOptions, count, jobTitle },
+      getAsyncDownloadFormInitialState
+    );
 
   useEffect(() => {
     dispatch(updateDownloadUrlOptions(downloadUrlOptions));
   }, [downloadUrlOptions]);
+
   const submitAsyncDownloadJob = useCallback(
     (event: FormEvent | MouseEvent) => {
       event.preventDefault();
@@ -136,9 +141,13 @@ const AsyncDownloadForm = ({
     ]
   );
 
+  if (showConfirmation) {
+    return <AsyncDownloadConfirmation formValues={formValues} />;
+  }
+
   return (
     <form
-      onSubmit={submitAsyncDownloadJob}
+      onSubmit={() => dispatch(updateConfirmation(true))}
       aria-label="Async download job submission form"
       ref={scrollRef}
     >
@@ -230,7 +239,7 @@ const AsyncDownloadForm = ({
               className="button primary"
               type="submit"
               disabled={submitDisabled}
-              onClick={submitAsyncDownloadJob}
+              onClick={() => dispatch(updateConfirmation(true))}
             >
               Submit
             </button>

--- a/src/tools/async-download/components/AsyncDownloadForm.tsx
+++ b/src/tools/async-download/components/AsyncDownloadForm.tsx
@@ -157,6 +157,7 @@ const AsyncDownloadForm = ({
           jobId
         )}
         jobName={formValues[AsyncDownloadFields.name].selected}
+        count={count}
       />
     );
   }

--- a/src/tools/async-download/components/AsyncDownloadForm.tsx
+++ b/src/tools/async-download/components/AsyncDownloadForm.tsx
@@ -37,8 +37,23 @@ import { JobTypes } from '../../types/toolsJobTypes';
 import { Namespace } from '../../../shared/types/namespaces';
 import { Status } from '../../types/toolsStatuses';
 import { PublicServerParameters } from '../../types/toolsServerParameters';
+import { FormParameters } from '../types/asyncDownloadFormParameters';
 
 import '../../styles/ToolsForm.scss';
+
+const getJobParameters = (
+  downloadUrlOptions: DownloadUrlOptions,
+  isIdMappingResult: boolean,
+  jobId?: string
+): FormParameters => ({
+  ...downloadUrlOptions,
+  compressed: false,
+  download: false,
+  namespace: isIdMappingResult
+    ? Namespace.idmapping
+    : downloadUrlOptions.namespace,
+  jobId: isIdMappingResult ? jobId : undefined,
+});
 
 type Props<T extends JobTypes> = {
   downloadUrlOptions: DownloadUrlOptions;
@@ -62,7 +77,7 @@ const AsyncDownloadForm = ({
   const { jobId } = useJobFromUrl();
   const tools = useToolsState();
 
-  const isIdMappingResult = jobType === JobTypes.ID_MAPPING && jobId;
+  const isIdMappingResult = Boolean(jobType === JobTypes.ID_MAPPING && jobId);
 
   let jobTitle = '';
   if (isIdMappingResult) {
@@ -113,15 +128,7 @@ const AsyncDownloadForm = ({
         // side-effect of createJob) cannot mount immediately before navigating away.
         dispatchTools(
           createJob(
-            {
-              ...downloadUrlOptions,
-              compressed: false,
-              download: false,
-              namespace: isIdMappingResult
-                ? Namespace.idmapping
-                : downloadUrlOptions.namespace,
-              jobId: isIdMappingResult ? jobId : undefined,
-            },
+            getJobParameters(downloadUrlOptions, isIdMappingResult, jobId),
             JobTypes.ASYNC_DOWNLOAD,
             formValues[AsyncDownloadFields.name].selected
           )
@@ -142,7 +149,16 @@ const AsyncDownloadForm = ({
   );
 
   if (showConfirmation) {
-    return <AsyncDownloadConfirmation formValues={formValues} />;
+    return (
+      <AsyncDownloadConfirmation
+        jobParameters={getJobParameters(
+          downloadUrlOptions,
+          isIdMappingResult,
+          jobId
+        )}
+        jobName={formValues[AsyncDownloadFields.name].selected}
+      />
+    );
   }
 
   return (

--- a/src/tools/async-download/components/AsyncDownloadForm.tsx
+++ b/src/tools/async-download/components/AsyncDownloadForm.tsx
@@ -80,7 +80,6 @@ const AsyncDownloadForm = ({
   const tools = useToolsState();
 
   const isIdMappingResult = Boolean(jobType === JobTypes.ID_MAPPING && jobId);
-
   let jobTitle = '';
   if (isIdMappingResult) {
     // If the user submitted the job, use the name they provided
@@ -117,9 +116,14 @@ const AsyncDownloadForm = ({
     onDisableForm(showConfirmation);
   }, [onDisableForm, showConfirmation]);
 
+  const onFormSubmit = useCallback((event: FormEvent | MouseEvent) => {
+    event.preventDefault();
+    dispatch(updateConfirmation(true));
+  }, []);
+
   const submitAsyncDownloadJob = useCallback(
-    (event: FormEvent | MouseEvent) => {
-      event.preventDefault();
+    (event?: FormEvent | MouseEvent) => {
+      event?.preventDefault();
       dispatch(updateSending());
 
       // navigate to the dashboard, but not immediately, to give the impression that
@@ -164,13 +168,15 @@ const AsyncDownloadForm = ({
         )}
         jobName={formValues[AsyncDownloadFields.name].selected}
         count={count}
+        onCancel={() => dispatch(updateConfirmation(false))}
+        onConfirm={() => submitAsyncDownloadJob()}
       />
     );
   }
 
   return (
     <form
-      onSubmit={() => dispatch(updateConfirmation(true))}
+      onSubmit={onFormSubmit}
       aria-label="Async download job submission form"
       ref={scrollRef}
     >
@@ -262,7 +268,7 @@ const AsyncDownloadForm = ({
               className="button primary"
               type="submit"
               disabled={submitDisabled}
-              onClick={() => dispatch(updateConfirmation(true))}
+              onClick={onFormSubmit}
             >
               Submit
             </button>

--- a/src/tools/async-download/components/AsyncDownloadForm.tsx
+++ b/src/tools/async-download/components/AsyncDownloadForm.tsx
@@ -59,6 +59,7 @@ type Props<T extends JobTypes> = {
   downloadUrlOptions: DownloadUrlOptions;
   count: number;
   onClose: () => void;
+  onDisableForm: (disableForm: boolean) => void;
   jobType?: T;
   inputParamsData?: PublicServerParameters[T];
 };
@@ -67,6 +68,7 @@ const AsyncDownloadForm = ({
   downloadUrlOptions,
   count,
   onClose,
+  onDisableForm,
   jobType,
   inputParamsData,
 }: Props<JobTypes>) => {
@@ -110,6 +112,10 @@ const AsyncDownloadForm = ({
   useEffect(() => {
     dispatch(updateDownloadUrlOptions(downloadUrlOptions));
   }, [downloadUrlOptions]);
+
+  useEffect(() => {
+    onDisableForm(showConfirmation);
+  }, [onDisableForm, showConfirmation]);
 
   const submitAsyncDownloadJob = useCallback(
     (event: FormEvent | MouseEvent) => {

--- a/src/tools/async-download/components/__tests__/AsyncDownloadConfirmation.spec.ts
+++ b/src/tools/async-download/components/__tests__/AsyncDownloadConfirmation.spec.ts
@@ -1,0 +1,19 @@
+import { getFacetString } from '../AsyncDownloadConfirmation';
+
+import { FacetObject } from '../../../../shared/types/results';
+
+import mockResults from '../../../../uniprotkb/components/__mocks__/results';
+
+describe('getFacetString', () => {
+  it('should create facet string', () => {
+    expect(
+      getFacetString(mockResults.facets as Array<FacetObject>, [
+        { name: 'proteins_with', value: '2' },
+        { name: 'existence', value: '3' },
+        { name: 'reviewed', value: 'false' },
+      ])
+    ).toEqual(
+      'Proteins with: Active site, Protein existence: Homology, Status: Unreviewed (TrEMBL)'
+    );
+  });
+});

--- a/src/tools/async-download/components/__tests__/AsyncDownloadForm.tsx.spec.tsx
+++ b/src/tools/async-download/components/__tests__/AsyncDownloadForm.tsx.spec.tsx
@@ -20,6 +20,7 @@ describe('AsyncDownloadForm', () => {
         }}
         jobType={JobTypes.ID_MAPPING}
         onClose={jest.fn()}
+        onDisableForm={jest.fn()}
       />,
       {
         route:

--- a/src/tools/async-download/components/styles/async-download-confirmation.module.scss
+++ b/src/tools/async-download/components/styles/async-download-confirmation.module.scss
@@ -8,4 +8,8 @@
   :global(.decorated-list-item__title) {
     flex-basis: 20vw;
   }
+
+  :global(.codeblock) {
+    white-space: normal;
+  }
 }

--- a/src/tools/async-download/components/styles/async-download-confirmation.module.scss
+++ b/src/tools/async-download/components/styles/async-download-confirmation.module.scss
@@ -1,0 +1,7 @@
+.info-data {
+  display: inline-block;
+
+  :global(.decorated-list-item__title) {
+    flex-basis: 20vw;
+  }
+}

--- a/src/tools/async-download/components/styles/async-download-confirmation.module.scss
+++ b/src/tools/async-download/components/styles/async-download-confirmation.module.scss
@@ -6,7 +6,7 @@
   }
 
   :global(.decorated-list-item__title) {
-    flex-basis: 20vw;
+    flex-basis: 25%;
   }
 
   :global(.codeblock) {

--- a/src/tools/async-download/components/styles/async-download-confirmation.module.scss
+++ b/src/tools/async-download/components/styles/async-download-confirmation.module.scss
@@ -1,5 +1,9 @@
-.info-data {
+.confirm-async-download {
   display: inline-block;
+
+  .info-list {
+    margin-top: 1rem;
+  }
 
   :global(.decorated-list-item__title) {
     flex-basis: 20vw;

--- a/src/tools/async-download/state/__tests__/asyncDownloadFormReducer.spec.ts
+++ b/src/tools/async-download/state/__tests__/asyncDownloadFormReducer.spec.ts
@@ -33,6 +33,7 @@ describe('Async download form reducer', () => {
     jobTitle: 'bar',
     submitDisabled: false,
     sending: false,
+    showConfirmation: false,
   };
   it('should update url download options with compressed false; set submitDisabled to true; use jobTitle', () => {
     const action = {

--- a/src/tools/async-download/state/asyncDownloadFormActions.ts
+++ b/src/tools/async-download/state/asyncDownloadFormActions.ts
@@ -11,6 +11,7 @@ export const UPDATE_DOWNLOAD_URL_OPTIONS =
 export const UPDATE_COUNT = 'UPDATE_COUNT' as const;
 export const UPDATE_SENDING = 'UPDATE_SENDING' as const;
 export const RESET = 'RESET' as const;
+export const UPDATE_CONFIRMATION = 'UPDATE_CONFIRMATION' as const;
 
 export const updateSelected = (
   id: AsyncDownloadFields,
@@ -27,3 +28,6 @@ export const updateDownloadUrlOptions = (
 export const updateSending = () => action(UPDATE_SENDING);
 
 export const resetFormState = () => action(RESET);
+
+export const updateConfirmation = (show: boolean) =>
+  action(UPDATE_CONFIRMATION, { show });

--- a/src/tools/async-download/state/asyncDownloadFormReducer.ts
+++ b/src/tools/async-download/state/asyncDownloadFormReducer.ts
@@ -16,6 +16,7 @@ export type AsyncDownloadFormState = {
   jobTitle?: string;
   submitDisabled: boolean;
   sending: boolean;
+  showConfirmation: boolean;
 };
 
 export type AsyncDownloadFormAction = ActionType<
@@ -63,6 +64,7 @@ export const getAsyncDownloadFormInitialState = ({
   submitDisabled:
     isExcel(downloadUrlOptions) || isUncompressed(downloadUrlOptions),
   sending: false,
+  showConfirmation: false,
 });
 
 export const asyncDownloadFormUpdateUrlOptionsReducer = (
@@ -131,6 +133,11 @@ export const asyncDownloadFormDataReducer = (
         ...state,
         submitDisabled: true,
         sending: true,
+      };
+    case asyncDownloadFormActions.UPDATE_CONFIRMATION:
+      return {
+        ...state,
+        showConfirmation: action.payload.show,
       };
     default:
       return state;


### PR DESCRIPTION
## Purpose
[Create a confirmation form when submitting a download async form to create friction.](https://www.ebi.ac.uk/panda/jira/browse/TRM-29508)

## Approach
Create a new view which is triggered from the async download form

## Testing
Created and updated.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
