### PR TITLE
Embl links update

### DIFF
--- a/src/uniprotkb/components/protein-data-views/EMBLView.tsx
+++ b/src/uniprotkb/components/protein-data-views/EMBLView.tsx
@@ -52,6 +52,7 @@ export type ProtvistaPDB = {
 
 const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
   const data = processData(xrefs);
+
   const databaseInfoMaps = useDatabaseInfoMaps();
 
   if (!databaseInfoMaps) {
@@ -117,64 +118,75 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
         {data.map(
           (d) =>
             d &&
-            d.proteinId &&
-            d.sequenceId && (
+            (d.proteinId || d.sequenceId) && (
               <tr key={`${d.sequenceId}-${d.proteinId}-${d.moleculeType}`}>
                 <td>
-                  {d.sequenceId}
-                  {' ('}
-                  <ExternalLink
-                    url={processUrlTemplate(emblDnaLink, {
-                      ProteinId: d.sequenceId,
-                    })}
-                  >
-                    EMBL
-                  </ExternalLink>
-                  {' | '}
-                  <ExternalLink
-                    url={processUrlTemplate(genBankDnaLink, {
-                      ProteinId: d.sequenceId,
-                    })}
-                  >
-                    GenBank
-                  </ExternalLink>
-                  {' | '}
-                  <ExternalLink
-                    url={processUrlTemplate(ddbjDnaLink, {
-                      ProteinId: d.sequenceId,
-                    })}
-                  >
-                    DDBJ
-                  </ExternalLink>
-                  )
+                  {d.sequenceId ? (
+                    <>
+                      {d.sequenceId}
+                      {' ('}
+                      <ExternalLink
+                        url={processUrlTemplate(emblDnaLink, {
+                          ProteinId: d.sequenceId,
+                        })}
+                      >
+                        EMBL
+                      </ExternalLink>
+                      {' | '}
+                      <ExternalLink
+                        url={processUrlTemplate(genBankDnaLink, {
+                          ProteinId: d.sequenceId,
+                        })}
+                      >
+                        GenBank
+                      </ExternalLink>
+                      {' | '}
+                      <ExternalLink
+                        url={processUrlTemplate(ddbjDnaLink, {
+                          ProteinId: d.sequenceId,
+                        })}
+                      >
+                        DDBJ
+                      </ExternalLink>
+                      )
+                    </>
+                  ) : (
+                    '-'
+                  )}
                 </td>
                 <td>
-                  {d.proteinId}
-                  {' ('}
-                  <ExternalLink
-                    url={processUrlTemplate(emblProteinLink, {
-                      id: d.proteinId,
-                    })}
-                  >
-                    EMBL
-                  </ExternalLink>
-                  {' | '}
-                  <ExternalLink
-                    url={processUrlTemplate(genBankProteinLink, {
-                      id: d.proteinId,
-                    })}
-                  >
-                    GenBank
-                  </ExternalLink>
-                  {' | '}
-                  <ExternalLink
-                    url={processUrlTemplate(ddbjProteinLink, {
-                      id: d.proteinId,
-                    })}
-                  >
-                    DDBJ
-                  </ExternalLink>
-                  )
+                  {d.proteinId ? (
+                    <>
+                      {d.proteinId}
+                      {' ('}
+                      <ExternalLink
+                        url={processUrlTemplate(emblProteinLink, {
+                          id: d.proteinId,
+                        })}
+                      >
+                        EMBL
+                      </ExternalLink>
+                      {' | '}
+                      <ExternalLink
+                        url={processUrlTemplate(genBankProteinLink, {
+                          id: d.proteinId,
+                        })}
+                      >
+                        GenBank
+                      </ExternalLink>
+                      {' | '}
+                      <ExternalLink
+                        url={processUrlTemplate(ddbjProteinLink, {
+                          id: d.proteinId,
+                        })}
+                      >
+                        DDBJ
+                      </ExternalLink>
+                      )
+                    </>
+                  ) : (
+                    '-'
+                  )}
                 </td>
                 <td translate="yes">
                   {d.moleculeType.replace(/translation/i, '')}

--- a/src/uniprotkb/components/protein-data-views/EMBLView.tsx
+++ b/src/uniprotkb/components/protein-data-views/EMBLView.tsx
@@ -11,6 +11,8 @@ import * as logging from '../../../shared/utils/logging';
 import { Xref } from '../../../shared/types/apiModel';
 import { PropertyKey } from '../../types/modelTypes';
 
+import styles from './styles/embl-view.module.scss';
+
 const EMBLXrefProperties: Record<string, string> = {
   Genomic_DNA: 'Genomic DNA Translation',
   Genomic_RNA: 'Genomic RNA Translation',
@@ -105,11 +107,11 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
   }
 
   const table = (
-    <table>
+    <table className={styles['embl-view']}>
       <thead>
         <tr>
-          <th>Sequence</th>
-          <th>Protein</th>
+          <th>Nucleotide Sequence</th>
+          <th>Protein Sequence</th>
           <th>Molecule Type</th>
           <th>Status</th>
         </tr>
@@ -124,7 +126,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                   {d.sequenceId ? (
                     <>
                       {d.sequenceId}
-                      {' ('}
+                      <br />
                       <ExternalLink
                         url={processUrlTemplate(emblDnaLink, {
                           ProteinId: d.sequenceId,
@@ -132,7 +134,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         EMBL
                       </ExternalLink>
-                      {' | '}
                       <ExternalLink
                         url={processUrlTemplate(genBankDnaLink, {
                           ProteinId: d.sequenceId,
@@ -140,7 +141,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         GenBank
                       </ExternalLink>
-                      {' | '}
                       <ExternalLink
                         url={processUrlTemplate(ddbjDnaLink, {
                           ProteinId: d.sequenceId,
@@ -148,7 +148,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         DDBJ
                       </ExternalLink>
-                      )
                     </>
                   ) : (
                     '-'
@@ -158,7 +157,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                   {d.proteinId ? (
                     <>
                       {d.proteinId}
-                      {' ('}
+                      <br />
                       <ExternalLink
                         url={processUrlTemplate(emblProteinLink, {
                           id: d.proteinId,
@@ -166,7 +165,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         EMBL
                       </ExternalLink>
-                      {' | '}
                       <ExternalLink
                         url={processUrlTemplate(genBankProteinLink, {
                           id: d.proteinId,
@@ -174,7 +172,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         GenBank
                       </ExternalLink>
-                      {' | '}
                       <ExternalLink
                         url={processUrlTemplate(ddbjProteinLink, {
                           id: d.proteinId,
@@ -182,7 +179,6 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         DDBJ
                       </ExternalLink>
-                      )
                     </>
                   ) : (
                     '-'

--- a/src/uniprotkb/components/protein-data-views/EMBLView.tsx
+++ b/src/uniprotkb/components/protein-data-views/EMBLView.tsx
@@ -185,7 +185,9 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                   )}
                 </td>
                 <td translate="yes">
-                  {d.moleculeType.replace(/translation/i, '')}
+                  {d.moleculeType
+                    ? d.moleculeType.replace(/translation/i, '')
+                    : '-'}
                 </td>
                 <td translate="yes">{d.status}</td>
               </tr>

--- a/src/uniprotkb/components/protein-data-views/EMBLView.tsx
+++ b/src/uniprotkb/components/protein-data-views/EMBLView.tsx
@@ -11,8 +11,6 @@ import * as logging from '../../../shared/utils/logging';
 import { Xref } from '../../../shared/types/apiModel';
 import { PropertyKey } from '../../types/modelTypes';
 
-import styles from './styles/embl-view.module.scss';
-
 const EMBLXrefProperties: Record<string, string> = {
   Genomic_DNA: 'Genomic DNA Translation',
   Genomic_RNA: 'Genomic RNA Translation',
@@ -107,7 +105,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
   }
 
   const table = (
-    <table className={styles['embl-view']}>
+    <table>
       <thead>
         <tr>
           <th>Nucleotide Sequence</th>
@@ -134,6 +132,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         EMBL
                       </ExternalLink>
+                      {'· '}
                       <ExternalLink
                         url={processUrlTemplate(genBankDnaLink, {
                           ProteinId: d.sequenceId,
@@ -141,6 +140,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         GenBank
                       </ExternalLink>
+                      {'· '}
                       <ExternalLink
                         url={processUrlTemplate(ddbjDnaLink, {
                           ProteinId: d.sequenceId,
@@ -165,6 +165,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         EMBL
                       </ExternalLink>
+                      {'· '}
                       <ExternalLink
                         url={processUrlTemplate(genBankProteinLink, {
                           id: d.proteinId,
@@ -172,6 +173,7 @@ const EMBLView = ({ xrefs }: { xrefs: Xref[] }) => {
                       >
                         GenBank
                       </ExternalLink>
+                      {'· '}
                       <ExternalLink
                         url={processUrlTemplate(ddbjProteinLink, {
                           id: d.proteinId,

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
@@ -11,9 +11,7 @@ exports[`XRefView should render section 1`] = `
     <protvista-datatable
       filter-scroll="true"
     >
-      <table
-        class="embl-view"
-      >
+      <table>
         <thead>
           <tr>
             <th>
@@ -49,6 +47,7 @@ exports[`XRefView should render section 1`] = `
                   width="12.5"
                 />
               </a>
+              · 
               <a
                 class="external-link"
                 href="https://www.ncbi.nlm.nih.gov/nuccore/1234"
@@ -61,6 +60,7 @@ exports[`XRefView should render section 1`] = `
                   width="12.5"
                 />
               </a>
+              · 
               <a
                 class="external-link"
                 href="http://getentry.ddbj.nig.ac.jp/getentry/na/1234"

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/XrefView.spec.tsx.snap
@@ -11,14 +11,16 @@ exports[`XRefView should render section 1`] = `
     <protvista-datatable
       filter-scroll="true"
     >
-      <table>
+      <table
+        class="embl-view"
+      >
         <thead>
           <tr>
             <th>
-              Sequence
+              Nucleotide Sequence
             </th>
             <th>
-              Protein
+              Protein Sequence
             </th>
             <th>
               Molecule Type
@@ -30,7 +32,61 @@ exports[`XRefView should render section 1`] = `
         </thead>
         <tbody
           translate="no"
-        />
+        >
+          <tr>
+            <td>
+              1234
+              <br />
+              <a
+                class="external-link"
+                href="https://www.ebi.ac.uk/ena/data/view/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                EMBL
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+              <a
+                class="external-link"
+                href="https://www.ncbi.nlm.nih.gov/nuccore/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                GenBank
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+              <a
+                class="external-link"
+                href="http://getentry.ddbj.nig.ac.jp/getentry/na/1234"
+                rel="noopener"
+                target="_blank"
+              >
+                DDBJ
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+            </td>
+            <td>
+              -
+            </td>
+            <td
+              translate="yes"
+            >
+              -
+            </td>
+            <td
+              translate="yes"
+            />
+          </tr>
+        </tbody>
       </table>
     </protvista-datatable>
     <button

--- a/src/uniprotkb/components/protein-data-views/styles/embl-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/embl-view.module.scss
@@ -1,0 +1,5 @@
+table.embl-view {
+  :global(.external-link) {
+    margin-right: 0.33rem;
+  }
+}

--- a/src/uniprotkb/components/protein-data-views/styles/embl-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/embl-view.module.scss
@@ -1,5 +1,0 @@
-table.embl-view {
-  :global(.external-link) {
-    margin-right: 0.33rem;
-  }
-}

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -678,7 +678,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.rhea, {
                     >
                       UniProtKB <SearchIcon width="1.333ch" />
                     </Link>
-                    {' | '}
+                    {'| '}
                     <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
                       Rhea
                     </ExternalLink>
@@ -1490,7 +1490,7 @@ const getXrefColumn = (databaseName: string) => {
                       <ExternalLink url={externalUrls.dbSNP(dbSNPRef.id)}>
                         dbSNP
                       </ExternalLink>
-                      {' | '}
+                      {'| '}
                       <ExternalLink
                         url={externalUrls.EnsemblVariation(dbSNPRef.id)}
                       >

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -1893,7 +1893,7 @@ exports[`UniProtKBColumnConfiguration component should render column "rhea": rhe
             width="1.333ch"
           />
         </a>
-         | 
+        | 
         <a
           class="external-link"
           href="https://www.rhea-db.org/rhea/12345"
@@ -2078,7 +2078,7 @@ exports[`UniProtKBColumnConfiguration component should render column "xref_dbsnp
           width="12.5"
         />
       </a>
-       | 
+      | 
       <a
         class="external-link"
         href="http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=db id"


### PR DESCRIPTION
## Purpose
[Sequence Protein Molecule Type Status: No data displayed for NOT_ANNOTATED_CDS](https://www.ebi.ac.uk/panda/jira/browse/TRM-27954)

## Example

http://localhost:8080/uniprotkb/A0A0B4J2F0/external-links


## Approach

- Include situations where protein or nucleotide sequence is not available and display a `-` for this missing data.
- Use `·` to copy 3D xref table link separator style
- Update column headers per jira comments
- Noticed the `|` separator was a little unsymmetrical in the catalytic activity sections so updated the spacing

## Testing
Updated

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
