### PR TITLE
Per entry average

### DIFF
--- a/src/shared/config/apiUrls.ts
+++ b/src/shared/config/apiUrls.ts
@@ -79,18 +79,9 @@ const apiUrls = {
   // uniprotkb query builder terms
   queryBuilderTerms: (namespace: Namespace) =>
     joinUrl(apiPrefix, 'configure', namespace, 'search-fields'),
-  // Annotation evidence used by query builder
-  evidences: {
-    annotation: joinUrl(apiPrefix, 'configure/uniprotkb/annotation_evidences'),
-    // Go evidences used by advanced go search
-    // "itemType": "goterm",
-    go: joinUrl(apiPrefix, 'configure/uniprotkb/go_evidences'),
-  },
   // Database cross references used
   allDatabases: (namespace: Namespace) =>
     joinUrl(apiPrefix, 'configure', namespace, 'allDatabases'),
-  // Database cross references used by query builder
-  databaseXrefs: joinUrl(apiPrefix, 'configure/uniprotkb/databases'),
   // All result fields except supporting data reference fields
   resultsFields: (namespace: Namespace, isEntry?: boolean) =>
     joinUrl(

--- a/src/uniprotkb/components/statistics/AbstractSectionTable.tsx
+++ b/src/uniprotkb/components/statistics/AbstractSectionTable.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import { ReactNode } from 'react';
+import cn from 'classnames';
 
 import CountLinkOrNothing from './CountLinkOrNothing';
 import { ReviewedLabel, UnreviewedLabel } from './UniProtKBLabels';
@@ -61,8 +62,8 @@ const AbstractSectionTable = ({
           </tr>
         )}
         <tr>
-          <td>
-            {!excludeUniProtKB && '⮑'} <ReviewedLabel />
+          <td className={cn({ [styles.indent]: !excludeUniProtKB })}>
+            <ReviewedLabel />
           </td>
           {tableData.map(({ data, query, accessor = 'entryCount' }, index) => (
             <td key={index} className={styles.end}>
@@ -83,8 +84,8 @@ const AbstractSectionTable = ({
           ))}
         </tr>
         <tr>
-          <td>
-            {!excludeUniProtKB && '⮑'} <UnreviewedLabel />
+          <td className={cn({ [styles.indent]: !excludeUniProtKB })}>
+            <UnreviewedLabel />
           </td>
           {tableData.map(({ data, query, accessor = 'entryCount' }, index) => (
             <td key={index} className={styles.end}>

--- a/src/uniprotkb/components/statistics/ReviewedUnreviewedStatsTable.tsx
+++ b/src/uniprotkb/components/statistics/ReviewedUnreviewedStatsTable.tsx
@@ -12,6 +12,8 @@ type Props = {
   title?: string;
   countLabel?: string;
   nameLabel?: string;
+  reviewedNumberReleaseEntries: number;
+  unreviewedNumberReleaseEntries: number;
 };
 
 const ReviewedUnreviewedStatsTable = ({
@@ -23,21 +25,27 @@ const ReviewedUnreviewedStatsTable = ({
   nameLabel,
   reviewedCaption,
   unreviewedCaption,
+  reviewedNumberReleaseEntries,
+  unreviewedNumberReleaseEntries,
 }: Props) => (
   <ReviewedUnreviewedTabs title={title || reviewedData[categoryName].label}>
     <StatsTable
       key="reviewed"
+      dataset="reviewed"
       category={reviewedData[categoryName]}
       countLabel={countLabel}
       nameLabel={nameLabel}
       caption={reviewedCaption}
+      numberReleaseEntries={reviewedNumberReleaseEntries}
     />
     <StatsTable
       key="unreviewed"
+      dataset="unreviewed"
       category={unreviewedData[categoryName]}
       countLabel={countLabel}
       nameLabel={nameLabel}
       caption={unreviewedCaption}
+      numberReleaseEntries={unreviewedNumberReleaseEntries}
     />
   </ReviewedUnreviewedTabs>
 );

--- a/src/uniprotkb/components/statistics/StatisticsPage.tsx
+++ b/src/uniprotkb/components/statistics/StatisticsPage.tsx
@@ -36,6 +36,7 @@ import {
   getUniqueAuthorString,
   merge,
   mergeToMap,
+  getNumberReleaseEntries,
 } from './utils';
 
 import { LocationToPath, Location } from '../../../app/config/urls';
@@ -530,6 +531,10 @@ const StatisticsPage = () => {
     unreviewedStats.data.results.map((stat) => [stat.categoryName, stat])
   ) as CategoryToStatistics;
 
+  const reviewedNumberReleaseEntries = getNumberReleaseEntries(reviewedData);
+  const unreviewedNumberReleaseEntries =
+    getNumberReleaseEntries(unreviewedData);
+
   return (
     <SidebarLayout
       sidebar={
@@ -603,6 +608,8 @@ const StatisticsPage = () => {
           unreviewedData={unreviewedData}
           title="Most represented species"
           nameLabel="Species"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
         <FrequencyTable
           reviewedData={reviewedData.ORGANISM_FREQUENCY}
@@ -660,6 +667,8 @@ const StatisticsPage = () => {
           unreviewedData={unreviewedData}
           countLabel="Citations"
           nameLabel="Journal"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
       </Card>
       <Card id="statistics-for-some-line-type">
@@ -676,6 +685,8 @@ const StatisticsPage = () => {
           reviewedCaption={getUniqueAuthorString(reviewedData)}
           unreviewedCaption={getUniqueAuthorString(unreviewedData)}
           nameLabel="Publication type"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
         <ReviewedUnreviewedStatsTable
           categoryName="FEATURES"
@@ -683,6 +694,8 @@ const StatisticsPage = () => {
           reviewedData={reviewedData}
           unreviewedData={unreviewedData}
           nameLabel="Feature"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
         <ReviewedUnreviewedStatsTable
           categoryName="COMMENTS"
@@ -690,6 +703,8 @@ const StatisticsPage = () => {
           reviewedData={reviewedData}
           unreviewedData={unreviewedData}
           nameLabel="Comment"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
         <ReviewedUnreviewedStatsTable
           categoryName="CROSS_REFERENCE"
@@ -697,6 +712,8 @@ const StatisticsPage = () => {
           reviewedData={reviewedData}
           unreviewedData={unreviewedData}
           nameLabel="Cross reference"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
       </Card>
       <Card id="amino-acid-composition">
@@ -714,11 +731,13 @@ const StatisticsPage = () => {
             </div>
             <StatsTable
               key="reviewed"
+              dataset="reviewed"
               category={setAminoAcidsTotalCount(
                 reviewedData.SEQUENCE_AMINO_ACID
               )}
               nameLabel="Amino acid"
               alwaysExpand
+              numberReleaseEntries={reviewedNumberReleaseEntries}
             />
           </div>
           <div className={styles['side-by-side']}>
@@ -734,12 +753,14 @@ const StatisticsPage = () => {
               </LazyComponent>
             </div>
             <StatsTable
-              key="reviewed"
+              key="unreviewed"
+              dataset="unreviewed"
               category={setAminoAcidsTotalCount(
                 unreviewedData.SEQUENCE_AMINO_ACID
               )}
               nameLabel="Amino acid"
               alwaysExpand
+              numberReleaseEntries={unreviewedNumberReleaseEntries}
             />
           </div>
         </ReviewedUnreviewedTabs>
@@ -752,6 +773,8 @@ const StatisticsPage = () => {
           reviewedData={getEncodedLocations(reviewedData)}
           unreviewedData={getEncodedLocations(unreviewedData)}
           nameLabel="Encoded location"
+          reviewedNumberReleaseEntries={reviewedNumberReleaseEntries}
+          unreviewedNumberReleaseEntries={unreviewedNumberReleaseEntries}
         />
         <ReviewedSequenceCorrections data={reviewedData} />
       </Card>

--- a/src/uniprotkb/components/statistics/StatsTable.tsx
+++ b/src/uniprotkb/components/statistics/StatsTable.tsx
@@ -94,10 +94,8 @@ const StatsTable = ({
             {hasPercent && hasOnlyEntryCounts && <th>Percent</th>}
             {!hasOnlyEntryCounts && (
               <th>
-                {countLabel || nameLabel
-                  ? `${countLabel || nameLabel} per `
-                  : 'Per'}{' '}
-                {dataset}-entry average
+                Average {countLabel?.toLowerCase() || 'count'} per {dataset}{' '}
+                entry
               </th>
             )}
             {hasDescription && <th>Description</th>}

--- a/src/uniprotkb/components/statistics/StatsTable.tsx
+++ b/src/uniprotkb/components/statistics/StatsTable.tsx
@@ -33,6 +33,8 @@ type StatsTableProps = {
   nameLabel?: string;
   countLabel?: string;
   caption?: string;
+  numberReleaseEntries: number;
+  dataset: 'reviewed' | 'unreviewed';
 };
 
 const StatsTable = ({
@@ -41,6 +43,8 @@ const StatsTable = ({
   nameLabel,
   countLabel,
   caption,
+  numberReleaseEntries,
+  dataset,
 }: StatsTableProps) => {
   const [expand, setExpand] = useState(alwaysExpand);
   const tableRef = useRef<HTMLTableElement>(null);
@@ -88,7 +92,14 @@ const StatsTable = ({
               </th>
             )}
             {hasPercent && hasOnlyEntryCounts && <th>Percent</th>}
-            {/* {!hasOnlyEntryCounts && <th>Per-entry average</th>} */}
+            {!hasOnlyEntryCounts && (
+              <th>
+                {countLabel || nameLabel
+                  ? `${countLabel || nameLabel} per `
+                  : 'Per'}{' '}
+                {dataset}-entry average
+              </th>
+            )}
             {hasDescription && <th>Description</th>}
           </tr>
         </thead>
@@ -126,12 +137,11 @@ const StatsTable = ({
                   </td>
                 )}
                 {/* Per-entry average */}
-                {/* WRONG: This needs to be divided by number of entries in data release */}
-                {/* {!hasOnlyEntryCounts && (
-                <td className={styles.end}>
-                  {(row.count / row.entryCount).toFixed(2)}
-                </td>
-              )} */}
+                {!hasOnlyEntryCounts && (
+                  <td className={styles.end}>
+                    {(row.count / numberReleaseEntries).toFixed(2)}
+                  </td>
+                )}
                 {/* Description */}
                 {hasDescription && <td>{row.description}</td>}
               </tr>

--- a/src/uniprotkb/components/statistics/styles/statistics-page.module.scss
+++ b/src/uniprotkb/components/statistics/styles/statistics-page.module.scss
@@ -37,6 +37,10 @@
     padding: $global-padding * 0.25 $global-padding * 0.5;
     border: 1px solid $colour-sea-blue;
     border-collapse: collapse;
+
+    &.indent {
+      padding-inline-start: 1.5 * $global-padding;
+    }
   }
 
   :global(.tabs) {

--- a/src/uniprotkb/components/statistics/styles/uniprotkb-labels.module.scss
+++ b/src/uniprotkb/components/statistics/styles/uniprotkb-labels.module.scss
@@ -1,9 +1,12 @@
 @import 'franklin-sites/src/styles/colours';
 
+$reviewed-tweak: 0.125em;
+
 .unreviewed-icon {
   color: $colour-unreviewed;
 }
 
 .reviewed-icon {
   color: $colour-reviewed;
+  margin-inline: -$reviewed-tweak $reviewed-tweak;
 }

--- a/src/uniprotkb/components/statistics/utils.ts
+++ b/src/uniprotkb/components/statistics/utils.ts
@@ -115,3 +115,6 @@ export const setAminoAcidsTotalCount = (data: StatisticsCategory) => ({
   ...data,
   totalCount: sumBy(data.items, 'count'),
 });
+
+export const getNumberReleaseEntries = (data: CategoryToStatistics) =>
+  data.AUDIT.items.find(({ name }) => name === 'ENTRY')?.entryCount || 0;


### PR DESCRIPTION
## Purpose

- [Statistics: add average per entry column](https://www.ebi.ac.uk/panda/jira/browse/TRM-30348)
- Remove ⮑ indent instead; fix un/reviewed icon spacing.
- Unrelatedly, remove obsolete api urls.

## Approach

- Pass the number of entries for each of reviewed and unreviewed
- To make it clear to the user what the average is referring to state in the header the entry type.

## Testing
None

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
