### PR TITLE
Link to new release statistics

### DIFF
--- a/src/shared/components/error-pages/ResourceNotFoundPage.tsx
+++ b/src/shared/components/error-pages/ResourceNotFoundPage.tsx
@@ -58,7 +58,7 @@ const redirectMap = new Map<RedirectEntry[0], RedirectEntry[1]>([
   // release notes
   [/^\/(news|release-note)(?<rest>\/.*)?$/i, `/release-notes$<rest>`],
   // other
-  [/^\/statistics?$/i, `/help/release-statistics`],
+  [/^\/statistics?$/i, `/uniprotkb/statistics`],
   [/^\/downloads?$/i, `/help/downloads`],
 ]);
 

--- a/src/shared/components/layouts/ReleaseInfo.tsx
+++ b/src/shared/components/layouts/ReleaseInfo.tsx
@@ -3,7 +3,11 @@ import cn from 'classnames';
 
 import useUniProtDataVersion from '../../hooks/useUniProtDataVersion';
 
-import { getLocationEntryPath, Location } from '../../../app/config/urls';
+import {
+  getLocationEntryPath,
+  Location,
+  LocationToPath,
+} from '../../../app/config/urls';
 
 import helper from '../../styles/helper.module.scss';
 import blurLoading from '../../styles/blur-loading.module.scss';
@@ -43,9 +47,7 @@ const ReleaseInfo = () => {
         )}
       </span>
       {' | '}
-      <Link to={getLocationEntryPath(Location.HelpEntry, 'release-statistics')}>
-        Statistics
-      </Link>
+      <Link to={LocationToPath[Location.UniProtKBStatistics]}>Statistics</Link>
     </span>
   );
 };

--- a/src/shared/components/layouts/UniProtFooter.tsx
+++ b/src/shared/components/layouts/UniProtFooter.tsx
@@ -7,11 +7,7 @@ import ExternalLink from '../ExternalLink';
 import ReleaseInfo from './ReleaseInfo';
 import Contact from './Contact';
 
-import {
-  getLocationEntryPath,
-  Location,
-  LocationToPath,
-} from '../../../app/config/urls';
+import { Location, LocationToPath } from '../../../app/config/urls';
 
 import helper from '../../styles/helper.module.scss';
 import footer from './styles/footer.module.scss';

--- a/src/shared/components/layouts/UniProtFooter.tsx
+++ b/src/shared/components/layouts/UniProtFooter.tsx
@@ -293,9 +293,7 @@ const FooterShortcuts = () => (
           </Link>
         </li>
         <li>
-          <Link
-            to={getLocationEntryPath(Location.HelpEntry, 'release-statistics')}
-          >
+          <Link to={LocationToPath[Location.UniProtKBStatistics]}>
             Statistics
           </Link>
         </li>

--- a/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
+++ b/src/shared/components/layouts/__tests__/__snapshots__/UniProtFooter.spec.tsx.snap
@@ -92,7 +92,7 @@ exports[`HomePage component should render 1`] = `
           </span>
            | 
           <a
-            href="/help/release-statistics"
+            href="/uniprotkb/statistics"
           >
             Statistics
           </a>
@@ -330,7 +330,7 @@ exports[`HomePage component should render 1`] = `
             </li>
             <li>
               <a
-                href="/help/release-statistics"
+                href="/uniprotkb/statistics"
               >
                 Statistics
               </a>

--- a/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
+++ b/src/tools/peptide-search/components/results/__tests__/__snapshots__/PeptideSearchResult.spec.tsx.snap
@@ -540,7 +540,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
           </span>
            | 
           <a
-            href="/help/release-statistics"
+            href="/uniprotkb/statistics"
           >
             Statistics
           </a>
@@ -778,7 +778,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
             </li>
             <li>
               <a
-                href="/help/release-statistics"
+                href="/uniprotkb/statistics"
               >
                 Statistics
               </a>
@@ -1506,7 +1506,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
           </span>
            | 
           <a
-            href="/help/release-statistics"
+            href="/uniprotkb/statistics"
           >
             Statistics
           </a>
@@ -1744,7 +1744,7 @@ exports[`PeptideSearchResult should render with the correct number of results in
             </li>
             <li>
               <a
-                href="/help/release-statistics"
+                href="/uniprotkb/statistics"
               >
                 Statistics
               </a>

--- a/src/uniprotkb/components/landing-page/LandingPage.tsx
+++ b/src/uniprotkb/components/landing-page/LandingPage.tsx
@@ -205,14 +205,7 @@ const LandingPage = () => {
                 </span>
               </p>
               <p>
-                <Link
-                  // TODO: link to statistics page when we have it
-                  to={getLocationEntryPath(
-                    Location.HelpEntry,
-                    'release-statistics'
-                  )}
-                  // to={LocationToPath[Location.UniProtKBStatistics]}
-                >
+                <Link to={LocationToPath[Location.UniProtKBStatistics]}>
                   Explore the {release?.releaseNumber} release »
                 </Link>
               </p>

--- a/src/uniprotkb/components/statistics/StatisticsPage.tsx
+++ b/src/uniprotkb/components/statistics/StatisticsPage.tsx
@@ -39,7 +39,11 @@ import {
   getNumberReleaseEntries,
 } from './utils';
 
-import { LocationToPath, Location } from '../../../app/config/urls';
+import {
+  LocationToPath,
+  Location,
+  getLocationEntryPath,
+} from '../../../app/config/urls';
 
 import sidebarStyles from '../../../shared/components/layouts/styles/sidebar-layout.module.scss';
 import styles from './styles/statistics-page.module.scss';
@@ -562,6 +566,14 @@ const StatisticsPage = () => {
             </time>
           </strong>
           .
+        </p>
+        <p>
+          <Link
+            to={getLocationEntryPath(Location.HelpEntry, 'release-statistics')}
+          >
+            Previous release statistics are available from the UniProt FTP
+            server.
+          </Link>
         </p>
         <IntroductionEntriesTable
           reviewedData={reviewedData.AUDIT}

--- a/src/uniprotkb/components/statistics/StatisticsPage.tsx
+++ b/src/uniprotkb/components/statistics/StatisticsPage.tsx
@@ -546,10 +546,7 @@ const StatisticsPage = () => {
       className={styles['statistics-page']}
       noOverflow
     >
-      <HTMLHead title={['UniProtKB', 'Statistics']}>
-        {/* Remove when this page is finished */}
-        <meta name="robots" content="noindex" />
-      </HTMLHead>
+      <HTMLHead title={['UniProtKB', 'Statistics']} />
       <h1>UniProtKB statistics</h1>
       <Card id="introduction">
         <h2>Introduction</h2>


### PR DESCRIPTION
## Purpose

[Make the statistics page public](https://www.ebi.ac.uk/panda/jira/browse/TRM-30365):

- [x] Remove the no robot meta tag
- [x] Link to it from website header and footer (replacing current link to help page)
- [x] Add link to https://www.uniprot.org/help/release-statistics from somewhere up in the statistics page
- [x] Add link to the statistics page in the "current release" part of the https://www.uniprot.org/help/release-statistics help page (replacing current links to the static pages). [PR](https://github.com/ebi-uniprot/uniprot-manual/pull/26)
- [x] Add link to the statistics page in the UniProtKB landing page (replacing current "Explore..." link to the static pages)