### PR TITLE
Tools resubmit from dashboard

### DIFF
--- a/src/tools/align/components/AlignForm.tsx
+++ b/src/tools/align/components/AlignForm.tsx
@@ -5,6 +5,7 @@ import {
   FC,
   useReducer,
   useCallback,
+  useEffect,
 } from 'react';
 import {
   SequenceSubmission,
@@ -113,8 +114,13 @@ const AlignForm = ({ initialFormValues }: Props) => {
   const [{ parsedSequences, formValues, sending, submitDisabled }, dispatch] =
     useReducer(
       getAlignFormDataReducer(defaultFormValues),
-      getAlignFormInitialState(initialFormValues)
+      initialFormValues,
+      getAlignFormInitialState
     );
+
+  useEffect(() => {
+    dispatch(resetFormState(initialFormValues));
+  }, [initialFormValues]);
 
   // form event handlers
   const handleReset = (event: FormEvent) => {

--- a/src/tools/align/state/__tests__/alignFormReducer.spec.ts
+++ b/src/tools/align/state/__tests__/alignFormReducer.spec.ts
@@ -1,0 +1,34 @@
+import {
+  AlignFormAction,
+  getAlignFormDataReducer,
+  getAlignFormInitialState,
+} from '../alignFormReducer';
+import * as actions from '../alignFormActions';
+import defaultFormValues, { AlignFields } from '../../config/AlignFormData';
+
+describe('alignFormReducer', () => {
+  it('should reset with new form values when provided', () => {
+    const reducer = getAlignFormDataReducer(defaultFormValues);
+    const initialState = getAlignFormInitialState(defaultFormValues);
+    let action: AlignFormAction = {
+      type: actions.RESET,
+      payload: {
+        ...initialState.formValues,
+        [AlignFields.name]: {
+          fieldName: 'name',
+          selected: 'foo',
+        },
+      },
+    };
+    let state = reducer(initialState, action);
+    expect(state.formValues.Name.selected).toEqual(
+      action.payload?.Name.selected
+    );
+    action = {
+      type: actions.RESET,
+      payload: undefined,
+    };
+    state = reducer(state, action);
+    expect(state).toEqual(initialState);
+  });
+});

--- a/src/tools/align/state/__tests__/alignFormReducer.spec.ts
+++ b/src/tools/align/state/__tests__/alignFormReducer.spec.ts
@@ -7,7 +7,7 @@ import * as actions from '../alignFormActions';
 import defaultFormValues, { AlignFields } from '../../config/AlignFormData';
 
 describe('alignFormReducer', () => {
-  it('should reset with new form values when provided', () => {
+  it('should reset with new form values when provided then reset to default if not provided', () => {
     const reducer = getAlignFormDataReducer(defaultFormValues);
     const initialState = getAlignFormInitialState(defaultFormValues);
     let action: AlignFormAction = {

--- a/src/tools/align/state/alignFormActions.ts
+++ b/src/tools/align/state/alignFormActions.ts
@@ -1,7 +1,11 @@
 import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
 import { action } from 'typesafe-actions';
 
-import { AlignFormValue, AlignFields } from '../config/AlignFormData';
+import {
+  AlignFormValue,
+  AlignFields,
+  AlignFormValues,
+} from '../config/AlignFormData';
 
 export const UPDATE_SELECTED = 'UPDATE_SELECTED';
 export const UPDATE_PARSED_SEQUENCES = 'UPDATE_PARSED_SEQUENCES';
@@ -18,4 +22,5 @@ export const updateParsedSequences = (parsedSequences: SequenceObject[]) =>
 
 export const updateSending = () => action(UPDATE_SENDING);
 
-export const resetFormState = () => action(RESET);
+export const resetFormState = (formValues?: Readonly<AlignFormValues>) =>
+  action(RESET, formValues);

--- a/src/tools/align/state/alignFormReducer.ts
+++ b/src/tools/align/state/alignFormReducer.ts
@@ -159,7 +159,7 @@ export const getAlignFormDataReducer =
           sending: true,
         };
       case alignFormActions.RESET:
-        return getAlignFormInitialState(defaultFormValues);
+        return getAlignFormInitialState(action.payload || defaultFormValues);
       default:
         return state;
     }

--- a/src/tools/blast/components/BlastForm.tsx
+++ b/src/tools/blast/components/BlastForm.tsx
@@ -1,4 +1,11 @@
-import { FC, FormEvent, MouseEvent, useRef, useReducer } from 'react';
+import {
+  FC,
+  FormEvent,
+  MouseEvent,
+  useRef,
+  useReducer,
+  useEffect,
+} from 'react';
 import {
   Chip,
   SequenceSubmission,
@@ -124,8 +131,13 @@ const BlastForm = ({ initialFormValues }: Props) => {
   const [{ parsedSequences, formValues, sending, submitDisabled }, dispatch] =
     useReducer(
       getBlastFormDataReducer(defaultFormValues),
-      getBlastFormInitialState(initialFormValues)
+      initialFormValues,
+      getBlastFormInitialState
     );
+
+  useEffect(() => {
+    dispatch(resetFormState(initialFormValues));
+  }, [initialFormValues]);
 
   // actual form fields
   const excludeTaxonField = excludeTaxonForDB(

--- a/src/tools/blast/state/__test__/blastFormReducer.spec.ts
+++ b/src/tools/blast/state/__test__/blastFormReducer.spec.ts
@@ -1,0 +1,34 @@
+import {
+  BlastFormAction,
+  getBlastFormDataReducer,
+  getBlastFormInitialState,
+} from '../blastFormReducer';
+import * as actions from '../blastFormActions';
+import defaultFormValues, { BlastFields } from '../../config/BlastFormData';
+
+describe('blastFormReducer', () => {
+  it('should reset with new form values when provided', () => {
+    const reducer = getBlastFormDataReducer(defaultFormValues);
+    const initialState = getBlastFormInitialState(defaultFormValues);
+    let action: BlastFormAction = {
+      type: actions.RESET,
+      payload: {
+        ...initialState.formValues,
+        [BlastFields.name]: {
+          fieldName: 'name',
+          selected: 'foo',
+        },
+      },
+    };
+    let state = reducer(initialState, action);
+    expect(state.formValues.Name.selected).toEqual(
+      action.payload?.Name.selected
+    );
+    action = {
+      type: actions.RESET,
+      payload: undefined,
+    };
+    state = reducer(state, action);
+    expect(state).toEqual(initialState);
+  });
+});

--- a/src/tools/blast/state/blastFormActions.ts
+++ b/src/tools/blast/state/blastFormActions.ts
@@ -1,6 +1,10 @@
 import { SequenceObject } from 'franklin-sites/dist/types/sequence-utils/sequence-processor';
 import { action } from 'typesafe-actions';
-import { BlastFields, BlastFormValue } from '../config/BlastFormData';
+import {
+  BlastFields,
+  BlastFormValue,
+  BlastFormValues,
+} from '../config/BlastFormData';
 
 export const UPDATE_SELECTED = 'UPDATE_SELECTED';
 export const UPDATE_PARSED_SEQUENCES = 'UPDATE_PARSED_SEQUENCES';
@@ -17,4 +21,5 @@ export const updateParsedSequences = (parsedSequences: SequenceObject[]) =>
 
 export const updateSending = () => action(UPDATE_SENDING);
 
-export const resetFormState = () => action(RESET);
+export const resetFormState = (formValues?: Readonly<BlastFormValues>) =>
+  action(RESET, formValues);

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -10,7 +10,7 @@ import { BLAST_LIMIT } from '../../../shared/config/limits';
 
 import { BlastFormValues, BlastFields } from '../config/BlastFormData';
 
-type BlastFormState = {
+export type BlastFormState = {
   formValues: BlastFormValues;
   parsedSequences: SequenceObject[];
   submitDisabled: boolean;

--- a/src/tools/blast/state/blastFormReducer.ts
+++ b/src/tools/blast/state/blastFormReducer.ts
@@ -164,7 +164,7 @@ export const getBlastFormDataReducer =
           sending: true,
         };
       case blastFormActions.RESET:
-        return getBlastFormInitialState(defaultFormValues);
+        return getBlastFormInitialState(action.payload || defaultFormValues);
       default:
         return state;
     }

--- a/src/tools/id-mapping/components/IDMappingForm.tsx
+++ b/src/tools/id-mapping/components/IDMappingForm.tsx
@@ -1,4 +1,4 @@
-import { useRef, FormEvent, useMemo, useReducer } from 'react';
+import { useRef, FormEvent, useMemo, useReducer, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
   PageIntro,
@@ -101,8 +101,13 @@ const IDMappingForm = ({ initialFormValues, formConfigData }: Props) => {
   const [{ formValues, textIDs, sending, submitDisabled }, dispatch] =
     useReducer(
       getIDMappingFormDataReducer(defaultFormValues),
-      getIDMappingFormInitialState(initialFormValues)
+      initialFormValues,
+      getIDMappingFormInitialState
     );
+
+  useEffect(() => {
+    dispatch(resetFormState(initialFormValues));
+  }, [initialFormValues]);
 
   const [dbNameToDbInfo, ruleIdToRuleInfo]: [
     DbNameToDbInfo | undefined | null,

--- a/src/tools/id-mapping/state/__tests__/idMappingFormReducer.spec.ts
+++ b/src/tools/id-mapping/state/__tests__/idMappingFormReducer.spec.ts
@@ -1,0 +1,36 @@
+import {
+  IDMappingFormAction,
+  getIDMappingFormDataReducer,
+  getIDMappingFormInitialState,
+} from '../idMappingFormReducer';
+import * as actions from '../idMappingFormActions';
+import defaultFormValues, {
+  IDMappingFields,
+} from '../../config/idMappingFormData';
+
+describe('idmappingFormReducer', () => {
+  it('should reset with new form values when provided then reset to default if not provided', () => {
+    const reducer = getIDMappingFormDataReducer(defaultFormValues);
+    const initialState = getIDMappingFormInitialState(defaultFormValues);
+    let action: IDMappingFormAction = {
+      type: actions.RESET,
+      payload: {
+        ...initialState.formValues,
+        [IDMappingFields.name]: {
+          fieldName: 'name',
+          selected: 'foo',
+        },
+      },
+    };
+    let state = reducer(initialState, action);
+    expect(state.formValues.Name.selected).toEqual(
+      action.payload?.Name.selected
+    );
+    action = {
+      type: actions.RESET,
+      payload: undefined,
+    };
+    state = reducer(state, action);
+    expect(state).toEqual(initialState);
+  });
+});

--- a/src/tools/id-mapping/state/idMappingFormActions.ts
+++ b/src/tools/id-mapping/state/idMappingFormActions.ts
@@ -2,6 +2,7 @@ import { action } from 'typesafe-actions';
 
 import {
   IDMappingFormValue,
+  IDMappingFormValues,
   IDMappingFields,
 } from '../config/idMappingFormData';
 
@@ -20,4 +21,5 @@ export const updateInputTextIDs = (textIDs: string) =>
 
 export const updateSending = () => action(UPDATE_SENDING);
 
-export const resetFormState = () => action(RESET);
+export const resetFormState = (formValues?: Readonly<IDMappingFormValues>) =>
+  action(RESET, formValues);

--- a/src/tools/id-mapping/state/idMappingFormReducer.ts
+++ b/src/tools/id-mapping/state/idMappingFormReducer.ts
@@ -166,7 +166,9 @@ export const getIDMappingFormDataReducer =
           sending: true,
         };
       case idMappingFormActions.RESET:
-        return getIDMappingFormInitialState(defaultFormValues);
+        return getIDMappingFormInitialState(
+          action.payload || defaultFormValues
+        );
       default:
         return state;
     }

--- a/src/tools/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/tools/peptide-search/components/PeptideSearchForm.tsx
@@ -1,4 +1,11 @@
-import { FC, FormEvent, MouseEvent, useRef, useReducer } from 'react';
+import {
+  FC,
+  FormEvent,
+  MouseEvent,
+  useRef,
+  useReducer,
+  useEffect,
+} from 'react';
 import { useHistory } from 'react-router-dom';
 import { Chip, PageIntro, SpinnerIcon } from 'franklin-sites';
 import { sleep } from 'timing-functions';
@@ -108,8 +115,13 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
   const [{ parsedSequences, formValues, sending, submitDisabled }, dispatch] =
     useReducer(
       getPeptideSearchFormDataReducer(defaultFormValues),
-      getPeptideSearchFormInitialState(initialFormValues)
+      initialFormValues,
+      getPeptideSearchFormInitialState
     );
+
+  useEffect(() => {
+    dispatch(resetFormState(initialFormValues));
+  }, [initialFormValues]);
 
   // taxon field handlers
   const updateTaxonFormValue = (path: string, id?: string) => {

--- a/src/tools/peptide-search/state/__tests__/peptideSearchFormReducer.spec.ts
+++ b/src/tools/peptide-search/state/__tests__/peptideSearchFormReducer.spec.ts
@@ -1,20 +1,22 @@
 import {
-  BlastFormAction,
-  getBlastFormDataReducer,
-  getBlastFormInitialState,
-} from '../blastFormReducer';
-import * as actions from '../blastFormActions';
-import defaultFormValues, { BlastFields } from '../../config/BlastFormData';
+  PeptideSearchFormAction,
+  getPeptideSearchFormDataReducer,
+  getPeptideSearchFormInitialState,
+} from '../peptideSearchFormReducer';
+import * as actions from '../peptideSearchFormActions';
+import defaultFormValues, {
+  PeptideSearchFields,
+} from '../../config/PeptideSearchFormData';
 
-describe('blastFormReducer', () => {
+describe('peptidesearchFormReducer', () => {
   it('should reset with new form values when provided then reset to default if not provided', () => {
-    const reducer = getBlastFormDataReducer(defaultFormValues);
-    const initialState = getBlastFormInitialState(defaultFormValues);
-    let action: BlastFormAction = {
+    const reducer = getPeptideSearchFormDataReducer(defaultFormValues);
+    const initialState = getPeptideSearchFormInitialState(defaultFormValues);
+    let action: PeptideSearchFormAction = {
       type: actions.RESET,
       payload: {
         ...initialState.formValues,
-        [BlastFields.name]: {
+        [PeptideSearchFields.name]: {
           fieldName: 'name',
           selected: 'foo',
         },

--- a/src/tools/peptide-search/state/peptideSearchFormActions.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormActions.ts
@@ -3,6 +3,7 @@ import { action } from 'typesafe-actions';
 import {
   PeptideSearchFields,
   PeptideSearchFormValue,
+  PeptideSearchFormValues,
 } from '../config/PeptideSearchFormData';
 
 export const UPDATE_SELECTED = 'UPDATE_SELECTED';
@@ -20,4 +21,6 @@ export const updatePeptideSequences = (peps: string) =>
 
 export const updateSending = () => action(UPDATE_SENDING);
 
-export const resetFormState = () => action(RESET);
+export const resetFormState = (
+  formValues?: Readonly<PeptideSearchFormValues>
+) => action(RESET, formValues);

--- a/src/tools/peptide-search/state/peptideSearchFormReducer.ts
+++ b/src/tools/peptide-search/state/peptideSearchFormReducer.ts
@@ -167,7 +167,9 @@ export const getPeptideSearchFormDataReducer =
           sending: true,
         };
       case peptideSearchFormActions.RESET:
-        return getPeptideSearchFormInitialState(defaultFormValues);
+        return getPeptideSearchFormInitialState(
+          action.payload || defaultFormValues
+        );
       default:
         return state;
     }


### PR DESCRIPTION
## Purpose
[Fix resubmitting job when already in the corresponding job submission form](https://www.ebi.ac.uk/panda/jira/browse/TRM-30603)

## Approach
`useReducer` doesn't recreate the state if a new initial state is provided so use a `useEffect` hook to do this for us.

## Testing
Add new unit tests.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
