### PR TITLE
Fragment fix

### DIFF
--- a/src/uniprotkb/adapters/sequenceConverter.ts
+++ b/src/uniprotkb/adapters/sequenceConverter.ts
@@ -115,7 +115,8 @@ export const convertSequence = (
     sequenceData.flag = data.proteinDescription.flag;
 
     sequenceData.status = fragmentFlags.has(data.proteinDescription.flag)
-      ? data.proteinDescription.flag
+      ? // Split to not include precursor flag which is handled in sequenceData.processing below
+        data.proteinDescription.flag.split(',')[0]
       : 'Complete';
 
     sequenceData.processing = precursorFlags.has(data.proteinDescription.flag)

--- a/src/uniprotkb/adapters/sequenceConverter.ts
+++ b/src/uniprotkb/adapters/sequenceConverter.ts
@@ -111,18 +111,20 @@ export const convertSequence = (
   }
 
   // Deal with flags
-  if (data.proteinDescription && data.proteinDescription.flag) {
-    sequenceData.flag = data.proteinDescription.flag;
+  sequenceData.flag = data.proteinDescription?.flag;
 
-    sequenceData.status = fragmentFlags.has(data.proteinDescription.flag)
-      ? // Split to not include precursor flag which is handled in sequenceData.processing below
+  sequenceData.status =
+    data.proteinDescription?.flag &&
+    fragmentFlags.has(data.proteinDescription.flag)
+      ? // Split to exclude precursor flag which is handled in sequenceData.processing below
         data.proteinDescription.flag.split(',')[0]
       : 'Complete';
 
-    sequenceData.processing = precursorFlags.has(data.proteinDescription.flag)
+  sequenceData.processing =
+    data.proteinDescription?.flag &&
+    precursorFlags.has(data.proteinDescription.flag)
       ? 'The displayed sequence is further processed into a mature form.'
       : undefined;
-  }
 
   // Add the last update
   if (data.entryAudit) {

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -465,7 +465,8 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.fragment, {
   render: (data) => {
     const { flag } = data[EntrySection.Sequence];
     const isFragment = flag && fragmentFlags.has(flag);
-    return isFragment && flag;
+    // Split to not include precursor flag
+    return isFragment && flag.split(',')[0];
   },
 });
 

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -465,7 +465,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.fragment, {
   render: (data) => {
     const { flag } = data[EntrySection.Sequence];
     const isFragment = flag && fragmentFlags.has(flag);
-    // Split to not include precursor flag
+    // Split to exclude precursor flag
     return isFragment && flag.split(',')[0];
   },
 });


### PR DESCRIPTION
## Purpose
It has been [highlighted](https://www.ebi.ac.uk/panda/jira/browse/TRM-30606) that fragments are incorrectly showing precursor information.

## Approach
As we are guaranteed the string format by the API just use a `split(',')[0]` to remove precursor if present for both search results and the entry page.

## Testing
Manually looked at the provided examples from the [jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-30606)

| Localhost                                      | SIB                                          | Combination               | 
| ---------------------------------------------- | -------------------------------------------- | ------------------------- |
| http://localhost:8080/uniprot/P14431#sequences | http://sp.sib.swiss/uniprot/P14431#sequences | fragment, precursor       |
| http://localhost:8080/uniprot/P01895#sequences | http://sp.sib.swiss/uniprot/P01895#sequences | fragment, no precursor    |
| http://localhost:8080/uniprot/Q86UE6#sequences | http://sp.sib.swiss/uniprot/Q86UE6#sequences | no fragment, precursor    |
| http://localhost:8080/uniprot/P43341#sequences | http://sp.sib.swiss/uniprot/P43341#sequences | no fragment, no precursor |
| http://localhost:8080/uniprot/A0JP26#sequences | http://sp.sib.swiss/uniprot/A0JP26#sequences | no fragment, no precursor |


And search results: http://localhost:8080/uniprotkb?fields=accession%2Creviewed%2Cid%2Cprotein_name%2Cgene_names%2Cfragment&query=accession%3AP14431+OR+accession%3AP01895+OR+accession%3AQ86UE6+OR+accession%3AP43341&view=table


## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
