### PR TITLE
Show the API URL content in download panel when going through the share dropdown

### DIFF
--- a/src/shared/components/action-buttons/ShareDropdown.tsx
+++ b/src/shared/components/action-buttons/ShareDropdown.tsx
@@ -17,6 +17,7 @@ import { sendGtagEventUrlCopy } from '../../utils/gtagEvents';
 import { stringifyQuery } from '../../utils/url';
 
 import { Namespace } from '../../types/namespaces';
+import { ExtraContent } from '../download/downloadReducer';
 
 const isCopySupported =
   'clipboard' in navigator && 'writeText' in navigator.clipboard;
@@ -81,10 +82,12 @@ const ShareDropdown = ({
   setDisplayDownloadPanel,
   namespaceOverride,
   disableCardToggle = false,
+  setDownloadExtraContent,
 }: {
   setDisplayDownloadPanel: Dispatch<SetStateAction<boolean>>;
   namespaceOverride?: Namespace | undefined;
   disableCardToggle?: boolean;
+  setDownloadExtraContent: Dispatch<SetStateAction<ExtraContent>>;
 }) => {
   if (!isCopySupported) {
     return null;
@@ -113,6 +116,7 @@ const ShareDropdown = ({
               setDisplayDownloadPanel(true);
               // TODO: expose way to close dropdown (in Franklin)
               clickOnDropdown(event.target as HTMLElement);
+              setDownloadExtraContent('url');
             }}
           >
             Generate URL for API

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -18,6 +18,7 @@ import {
   DownloadSelectOptions,
   downloadReducer,
   getDownloadInitialState,
+  ExtraContent,
 } from './downloadReducer';
 import {
   updateSelectedFileFormat,
@@ -77,6 +78,7 @@ export type DownloadProps<T extends JobTypes> = {
   inBasketMini?: boolean;
   jobType?: T;
   inputParamsData?: PublicServerParameters[T];
+  extraContent?: ExtraContent;
 };
 
 const Download = (props: DownloadProps<JobTypes>) => {

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -66,7 +66,7 @@ const DownloadAPIURL = ({
   isEntry,
 }: Props) => {
   const scrollRef = useScrollIntoViewRef<HTMLDivElement>();
-  const copyRef = useRef<HTMLButtonElement>();
+  const copyRef = useRef<HTMLButtonElement>(null);
   const dispatch = useMessagesDispatch();
   const handleCopyURL = useCallback(
     async (text: string) => {
@@ -161,7 +161,6 @@ const DownloadAPIURL = ({
           <CodeBlock lightMode>{ftpURL}</CodeBlock>
           <section className="button-group">
             <Button
-              ref={copyRef}
               variant="primary"
               className={styles['copy-button']}
               onClick={() => handleCopyURL(ftpURL)}
@@ -189,7 +188,6 @@ const DownloadAPIURL = ({
       <section className="button-group">
         <Button
           variant="primary"
-          ref={copyRef}
           className={styles['copy-button']}
           onClick={() => handleCopyURL(apiURL)}
           disabled={disableStream}

--- a/src/shared/components/download/DownloadAPIURL.tsx
+++ b/src/shared/components/download/DownloadAPIURL.tsx
@@ -5,7 +5,7 @@ import {
   ExternalLink,
   LongNumber,
 } from 'franklin-sites';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { generatePath, Link } from 'react-router-dom';
 import cn from 'classnames';
 
@@ -66,6 +66,7 @@ const DownloadAPIURL = ({
   isEntry,
 }: Props) => {
   const scrollRef = useScrollIntoViewRef<HTMLDivElement>();
+  const copyRef = useRef<HTMLButtonElement>();
   const dispatch = useMessagesDispatch();
   const handleCopyURL = useCallback(
     async (text: string) => {
@@ -82,6 +83,12 @@ const DownloadAPIURL = ({
     },
     [dispatch, onCopy]
   );
+
+  useEffect(() => {
+    if (copyRef.current) {
+      copyRef.current.focus();
+    }
+  }, []);
 
   const isStreamEndpoint = apiURL.includes('/stream');
   const isIdMapping = apiURL.includes('/id-mapping/');
@@ -111,6 +118,7 @@ const DownloadAPIURL = ({
             API Documentation
           </ExternalLink>
           <Button
+            ref={copyRef}
             variant="primary"
             className={styles['copy-button']}
             onClick={() => handleCopyURL(apiURL)}
@@ -153,6 +161,7 @@ const DownloadAPIURL = ({
           <CodeBlock lightMode>{ftpURL}</CodeBlock>
           <section className="button-group">
             <Button
+              ref={copyRef}
               variant="primary"
               className={styles['copy-button']}
               onClick={() => handleCopyURL(ftpURL)}
@@ -180,6 +189,7 @@ const DownloadAPIURL = ({
       <section className="button-group">
         <Button
           variant="primary"
+          ref={copyRef}
           className={styles['copy-button']}
           onClick={() => handleCopyURL(apiURL)}
           disabled={disableStream}
@@ -210,6 +220,7 @@ const DownloadAPIURL = ({
           <section className="button-group">
             <Button
               variant="primary"
+              ref={copyRef}
               className={styles['copy-button']}
               onClick={() => handleCopyURL(searchURL)}
             >

--- a/src/shared/components/download/downloadReducer.ts
+++ b/src/shared/components/download/downloadReducer.ts
@@ -45,7 +45,7 @@ export const getDownloadInitialState = ({
     selectedFileFormat: fileFormatOptions[0],
     downloadSelect: props?.selectedEntries?.length ? 'selected' : 'all', // Defaults to "download all" if no selection
     compressed: props.namespace !== Namespace.unisave,
-    extraContent: null,
+    extraContent: props.extraContent || null,
     nSelectedEntries:
       props.numberSelectedEntries || props.selectedEntries?.length || 0,
     disableForm: false,

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -96,6 +96,8 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
   inputParamsData,
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
+  const [downloadPanelExtraContent, setDownloadPanelExtraContent] =
+    useState(null);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const {
     viewMode,
@@ -218,6 +220,7 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
                 inBasketMini={inBasketMini}
                 inputParamsData={inputParamsData}
                 jobType={jobType}
+                extraContent={downloadPanelExtraContent}
               />
             </ErrorBoundary>
           </SlidingPanel>
@@ -311,6 +314,7 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
             setDisplayDownloadPanel={setDisplayDownloadPanel}
             namespaceOverride={namespaceOverride}
             disableCardToggle={disableCardToggle}
+            setDownloadExtraContent={setDownloadPanelExtraContent}
           />
         )}
         <ItemCount selected={selectedEntries.length} loaded={loadedTotal} />

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -54,6 +54,7 @@ import {
 } from '../../../messages/types/messagesTypes';
 import { JobTypes } from '../../../tools/types/toolsJobTypes';
 import { PublicServerParameters } from '../../../tools/types/toolsServerParameters';
+import { ExtraContent } from '../download/downloadReducer';
 
 import styles from './styles/results-buttons.module.scss';
 
@@ -97,7 +98,7 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const [downloadPanelExtraContent, setDownloadPanelExtraContent] =
-    useState(null);
+    useState<ExtraContent>(null);
   const namespace = useNS(namespaceOverride) || Namespace.uniprotkb;
   const {
     viewMode,


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-27441

## Approach
Added an 'extraContent' prop in download panel. It is picked up on first load if it is set to 'url'

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
