### PR TITLE
Align sequence info mix

### DIFF
--- a/src/tools/align/adapters/pim.ts
+++ b/src/tools/align/adapters/pim.ts
@@ -32,7 +32,7 @@ export default (string: string): PIM => {
 
     output.push({
       name: match[1],
-      accession: extractAccession(match[1]),
+      accession: extractAccession(match[1])?.accession,
       values,
     });
   }

--- a/src/tools/align/components/results/NewickTree.tsx
+++ b/src/tools/align/components/results/NewickTree.tsx
@@ -348,7 +348,7 @@ const NewickTree: FC<NewickTreeProps> = ({
           <g className="links" />
           <g className="labels">
             {root.leaves().map(({ data: { name } }) => {
-              const accession = extractAccession(name);
+              const accession = extractAccession(name)?.accession;
               return (
                 <foreignObject className="label" key={name}>
                   <AlignLabel

--- a/src/tools/align/utils/__tests__/extractAccession.spec.ts
+++ b/src/tools/align/utils/__tests__/extractAccession.spec.ts
@@ -1,28 +1,38 @@
+import { Namespace } from '../../../../shared/types/namespaces';
 import extractAccession from '../extractAccession';
 
 describe('extractDescription', () => {
-  it('should extract valid accessions', () => {
-    expect(extractAccession('O76024')).toBe('O76024');
-    expect(extractAccession('A9WZ33')).toBe('A9WZ33');
-    expect(extractAccession('|P27272|')).toBe('P27272');
-    expect(extractAccession('sp|B7GWQ6|ACCD_ACIB3')).toBe('B7GWQ6');
-    expect(extractAccession('   A0A5B9VZG7   ')).toBe('A0A5B9VZG7');
-    expect(
-      extractAccession(
-        ' tr|A0A512FLJ5|A0A512FLJ5_9LACO Peptidase_C39_2 domain-containing'
-      )
-    ).toBe('A0A512FLJ5');
-    expect(extractAccession('c0hjw9')).toBe('C0HJW9');
-  });
+  const testCases = [
+    ['O76024', 'O76024', Namespace.uniprotkb],
+    ['A9WZ33', 'A9WZ33', Namespace.uniprotkb],
+    ['|P27272|', 'P27272', Namespace.uniprotkb],
+    ['sp|B7GWQ6|ACCD_ACIB3', 'B7GWQ6', Namespace.uniprotkb],
+    ['   A0A5B9VZG7   ', 'A0A5B9VZG7', Namespace.uniprotkb],
+    [
+      ' tr|A0A512FLJ5|A0A512FLJ5_9LACO Peptidase_C39_2 domain-containing',
+      'A0A512FLJ5',
+      Namespace.uniprotkb,
+    ],
+    ['c0hjw9', 'C0HJW9', Namespace.uniprotkb],
+    ['sp|P05067-2|A4_HUMAN', 'P05067-2', Namespace.uniprotkb],
+    ['UPI0000000001', 'UPI0000000001', Namespace.uniparc],
+    ['UniRef100_A0A023HJ61', 'UniRef100_A0A023HJ61', Namespace.uniref],
+  ];
+  test.each(testCases)(
+    'should extract valid accession %p',
+    (string, accession, namespace) => {
+      expect(extractAccession(string)).toEqual({ accession, namespace });
+    }
+  );
 
   it("shouldn't extract valid accessions within words", () => {
-    expect(extractAccession('hohohoO76024')).toBeUndefined();
-    expect(extractAccession('P27272_human')).toBeUndefined();
-    expect(extractAccession('P2727')).toBeUndefined();
+    expect(extractAccession('hohohoO76024')).toBeNull();
+    expect(extractAccession('P27272_human')).toBeNull();
+    expect(extractAccession('P2727')).toBeNull();
   });
 
   it("shouldn't extract accessions that look valid but are not", () => {
-    expect(extractAccession('076024')).toBeUndefined();
-    expect(extractAccession('X27272')).toBeUndefined();
+    expect(extractAccession('076024')).toBeNull();
+    expect(extractAccession('X27272')).toBeNull();
   });
 });

--- a/src/tools/align/utils/extractAccession.ts
+++ b/src/tools/align/utils/extractAccession.ts
@@ -1,5 +1,9 @@
-const re =
-  /(^|\W)([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})(\W|$)/i;
+import { reUniProtKBAccessionWithIsoform } from '../../../uniprotkb/utils/regexes';
+
+const re = new RegExp(
+  `(?:^|\\W)(${reUniProtKBAccessionWithIsoform.source})(?:\\W|$)`,
+  'i'
+);
 
 const extractAccession = (string?: string): string | undefined => {
   if (!string) {
@@ -7,9 +11,8 @@ const extractAccession = (string?: string): string | undefined => {
   }
   const match = string.match(re);
   // index 0: full matching string
-  // index 1: what's before the interesting bit
-  // index 2: the actual accession <--
-  return match?.[2].toUpperCase() ?? undefined;
+  // index 1: the actual accession <--
+  return match?.[1].toUpperCase() ?? undefined;
 };
 
 export default extractAccession;

--- a/src/tools/align/utils/extractAccession.ts
+++ b/src/tools/align/utils/extractAccession.ts
@@ -1,18 +1,41 @@
-import { reUniProtKBAccessionWithIsoform } from '../../../uniprotkb/utils/regexes';
+import { Namespace } from '../../../shared/types/namespaces';
+import {
+  reUniParc,
+  reUniProtKBAccessionWithIsoform,
+  reUniRefAccession,
+} from '../../../uniprotkb/utils/regexes';
 
-const re = new RegExp(
-  `(?:^|\\W)(${reUniProtKBAccessionWithIsoform.source})(?:\\W|$)`,
-  'i'
-);
+const namespaceToReAccession = [
+  {
+    namespace: Namespace.uniprotkb,
+    re: reUniProtKBAccessionWithIsoform,
+    toUpperCase: true,
+  },
+  { namespace: Namespace.uniref, re: reUniRefAccession },
+  { namespace: Namespace.uniparc, re: reUniParc, toUpperCase: true },
+].map((o) => ({
+  ...o,
+  re: new RegExp(`(?:^|\\W)(${o.re.source})(?:\\W|$)`, 'i'),
+}));
 
-const extractAccession = (string?: string): string | undefined => {
+const extractAccession = (
+  string?: string
+): { namespace: Namespace; accession: string } | null => {
   if (!string) {
-    return undefined;
+    return null;
   }
-  const match = string.match(re);
-  // index 0: full matching string
-  // index 1: the actual accession <--
-  return match?.[1].toUpperCase() ?? undefined;
+  for (const { namespace, re, toUpperCase } of namespaceToReAccession) {
+    // index 0: full matching string
+    // index 1: the actual accession <--
+    const group = string.match(re)?.[1];
+    if (group) {
+      return {
+        namespace,
+        accession: toUpperCase ? group.toUpperCase() : group,
+      };
+    }
+  }
+  return null;
 };
 
 export default extractAccession;

--- a/src/tools/align/utils/useSequenceInfo.ts
+++ b/src/tools/align/utils/useSequenceInfo.ts
@@ -11,9 +11,13 @@ import { getAccessionsURL } from '../../../shared/config/apiUrls';
 import { FeatureDatum } from '../../../uniprotkb/components/protein-data-views/UniProtKBFeaturesView';
 import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { SearchResults } from '../../../shared/types/results';
+import { Namespace } from '../../../shared/types/namespaces';
+import { UniRefAPIModel } from '../../../uniref/adapters/uniRefConverter';
+import { UniParcAPIModel } from '../../../uniparc/adapters/uniParcConverter';
 
 export type ParsedSequenceAndFeatures = SequenceObject & {
   accession: string;
+  namespace: Namespace;
   features?: FeatureDatum[];
 };
 
@@ -22,63 +26,127 @@ export type SequenceInfo = {
   data: Map<ParsedSequenceAndFeatures['accession'], ParsedSequenceAndFeatures>;
 };
 
-const hasAccession = (
-  value: SequenceObject | ParsedSequenceAndFeatures
-): value is ParsedSequenceAndFeatures =>
-  (value as ParsedSequenceAndFeatures).accession !== undefined;
+const processSequences = (rawSequences = '') => {
+  const processedSequences = [];
+  for (const processedSequence of sequenceProcessor(rawSequences)) {
+    const extracted = extractAccession(processedSequence.name);
+    if (extracted?.accession) {
+      processedSequences.push({
+        ...processedSequence,
+        ...extracted,
+      });
+    }
+  }
+  return processedSequences;
+};
 
-// TODO: handle non-UniProtKB entries too!
-// Need to separate the entries, call the 3 accessions endpoints, and merge data
-// https://www.ebi.ac.uk/panda/jira/browse/TRM-26756
+const getEndpoint = (
+  processedArray: ParsedSequenceAndFeatures[],
+  namespace: Namespace
+) =>
+  getAccessionsURL(
+    processedArray
+      .filter((p) => p.namespace === namespace)
+      .map((p) => p.accession),
+    { namespace, facets: null }
+  );
+
 const useSequenceInfo = (rawSequences?: string): SequenceInfo => {
   const processedArray: ParsedSequenceAndFeatures[] = useMemo(
-    () =>
-      sequenceProcessor(rawSequences || '')
-        .map((processed) => ({
-          ...processed,
-          accession: extractAccession(processed.name),
-        }))
-        // ensures we managed to extract an accession from header, otherwise discard
-        .filter(hasAccession),
+    () => processSequences(rawSequences),
     [rawSequences]
   );
 
-  const endpoint = getAccessionsURL(
-    processedArray.map((processed) => processed.accession),
-    { facets: null }
-  );
-  const { data, loading, error } =
-    useDataApi<SearchResults<UniProtkbAPIModel>>(endpoint);
+  const uniprotkbEndpoint = getEndpoint(processedArray, Namespace.uniprotkb);
+  const unirefEndpoint = getEndpoint(processedArray, Namespace.uniref);
+  const uniparcEndpoint = getEndpoint(processedArray, Namespace.uniparc);
+
+  const uniprotkbResults =
+    useDataApi<SearchResults<UniProtkbAPIModel>>(uniprotkbEndpoint);
+  const unirefResults =
+    useDataApi<SearchResults<UniRefAPIModel>>(unirefEndpoint);
+  const uniparcResults =
+    useDataApi<SearchResults<UniParcAPIModel>>(uniparcEndpoint);
 
   const outputData = useMemo(() => {
-    const dataPerAccession = new Map(
-      data?.results.map((object) => [object.primaryAccession, object]) ?? []
-    );
-
+    const idToSequenceAndFeatures = new Map<
+      string,
+      {
+        sequence: string;
+        features?:
+          | UniProtkbAPIModel['features']
+          | UniParcAPIModel['sequenceFeatures'];
+      }
+    >();
+    for (const result of uniprotkbResults?.data?.results || []) {
+      idToSequenceAndFeatures.set(result.primaryAccession, {
+        sequence: result.sequence.value,
+        features: result.features,
+      });
+    }
+    for (const result of unirefResults?.data?.results || []) {
+      idToSequenceAndFeatures.set(result.id, {
+        sequence: result.representativeMember.sequence.value,
+      });
+    }
+    for (const result of uniparcResults?.data?.results || []) {
+      idToSequenceAndFeatures.set(result.uniParcId, {
+        sequence: result.sequence.value,
+        // features: result.sequenceFeatures,
+      });
+    }
     const pa = processedArray
       // ensures the sequences are identical between submitted and UniProt's DB
       .filter(
         (processed) =>
           processed.sequence ===
-          dataPerAccession.get(processed.accession)?.sequence.value
+          idToSequenceAndFeatures.get(processed.accession)?.sequence
       )
       // enrich with the feature data
       .map((processed) => ({
         ...processed,
-        features: dataPerAccession.get(processed.accession)?.features,
+        features: idToSequenceAndFeatures.get(processed.accession)?.features,
       }));
     return new Map(pa.map((processed) => [processed.accession, processed]));
-  }, [data, processedArray]);
+  }, [
+    processedArray,
+    uniprotkbResults?.data?.results,
+    unirefResults?.data?.results,
+    uniparcResults?.data?.results,
+  ]);
 
   const output = useMemo(
     () => ({
       data: outputData,
-      loading: loading || !rawSequences || (endpoint && !data && !error),
+      loading:
+        !rawSequences ||
+        uniprotkbResults.loading ||
+        unirefResults.loading ||
+        uniparcResults.loading ||
+        (uniprotkbEndpoint &&
+          !uniprotkbResults.data &&
+          !uniprotkbResults.error) ||
+        (unirefEndpoint && !unirefResults.data && !unirefResults.error) ||
+        (uniparcEndpoint && !uniparcResults.data && !uniparcResults.error),
     }),
-    [outputData, loading, rawSequences, endpoint, data, error]
+    [
+      outputData,
+      rawSequences,
+      uniprotkbResults.loading,
+      uniprotkbResults.data,
+      uniprotkbResults.error,
+      unirefResults.loading,
+      unirefResults.data,
+      unirefResults.error,
+      uniparcResults.loading,
+      uniparcResults.data,
+      uniparcResults.error,
+      uniprotkbEndpoint,
+      unirefEndpoint,
+      uniparcEndpoint,
+    ]
   );
 
-  // eslint-disable-next-line consistent-return
   return output as SequenceInfo;
 };
 

--- a/src/tools/components/SequenceSearchLoader.tsx
+++ b/src/tools/components/SequenceSearchLoader.tsx
@@ -42,6 +42,11 @@ const getURLForAccessionOrID = (input: string) => {
     return null;
   }
 
+  // UniRef accession
+  if (cleanedInput.startsWith('UNIREF')) {
+    return apiUrls.entry(cleanedInput, Namespace.uniref);
+  }
+
   // UniParc accession
   if (cleanedInput.startsWith('UPI')) {
     return apiUrls.entry(cleanedInput, Namespace.uniparc);

--- a/src/uniprotkb/utils/regexes.ts
+++ b/src/uniprotkb/utils/regexes.ts
@@ -3,6 +3,10 @@
 // NOTE: modified to use a non-capturing group with "?:"
 export const reUniProtKBAccession =
   /[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](?:[A-Z][A-Z0-9]{2}[0-9]){1,2}/i;
+export const reUniProtKBAccessionWithIsoform = new RegExp(
+  `(?:${reUniProtKBAccession.source})(?:-[0-9]+)?`,
+  'i'
+);
 
 export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;

--- a/src/uniprotkb/utils/regexes.ts
+++ b/src/uniprotkb/utils/regexes.ts
@@ -7,6 +7,8 @@ export const reUniProtKBAccessionWithIsoform = new RegExp(
   `(?:${reUniProtKBAccession.source})(?:-[0-9]+)?`,
   'i'
 );
+export const reUniRefAccession = /UniRef(?:50|90|100)_[\w|-]+/i;
+export const reUniParc = /UPI[\w]{10}/i;
 
 export const reAC = new RegExp(`(?:AC ${reUniProtKBAccession.source})`, 'i');
 export const reIsoform = /\bisoform [\w-]+/i;


### PR DESCRIPTION
## Purpose
[Align sequence validation for non-UniProtKB / mixed namespaces / isoforms](https://www.ebi.ac.uk/panda/jira/browse/TRM-26756)

## Approach

- Create new id regexps: uniprotkb with isoform, uniparc and uniref and use these within existing `extractAccession` fn.
- Fetch uniprotkb, uniparc and uniref data to ensure sequence is the same

## Testing
Adapted and added `extractAccession` unit tests.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
