### PR TITLE
Show groupBy and taxonomy facets only in search results of UniProtKB

### DIFF
--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { Facets, Facet, Loader } from 'franklin-sites';
 
-import { useRouteMatch } from 'react-router-dom';
+import { useParams, useRouteMatch } from 'react-router-dom';
 import useNS from '../../hooks/useNS';
 
 import TaxonomyFacet from './TaxonomyFacet';
@@ -41,9 +41,10 @@ type Props = {
 
 const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
   const namespace = useNS(namespaceOverride);
-  const isUniProtKBResults = useRouteMatch(
+  const uniprotKBResultsRoute = useRouteMatch(
     LocationToPath[Location.UniProtKBResults]
   );
+  const { subPage } = useParams<{ subPage: string }>();
 
   const { data, isStale, loading, progress } = dataApiObject;
 
@@ -109,10 +110,12 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
             />
           )
       )}
-      {namespace && mainNamespaces.has(namespace) && (
-        <TaxonomyFacet namespace={namespace as SearchableNamespace} />
-      )}
-      {namespace === Namespace.uniprotkb && isUniProtKBResults && (
+      {namespace &&
+        mainNamespaces.has(namespace) &&
+        subPage !== 'publications' && (
+          <TaxonomyFacet namespace={namespace as SearchableNamespace} />
+        )}
+      {namespace === Namespace.uniprotkb && uniprotKBResultsRoute?.isExact && (
         <UniProtKBGroupByFacet />
       )}
       {after.map(


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-30785

## Approach
Using the isExact property of UseRouteMatch to check if the URL is the same.
For taxonomy facet showing up in Publications, 'subPage' is checked.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
