### PR TITLE
Fix download for redundant and excluded proteomes

### DIFF
--- a/src/proteomes/components/entry/Components.tsx
+++ b/src/proteomes/components/entry/Components.tsx
@@ -32,12 +32,18 @@ const getIdKey = ({ name }: Component) => name;
 
 type ComponentsProps = Pick<
   ProteomesAPIModel,
-  'components' | 'id' | 'proteomeType' | 'taxonomy' | 'proteomeStatistics'
+  | 'components'
+  | 'id'
+  | 'proteinCount'
+  | 'proteomeType'
+  | 'taxonomy'
+  | 'proteomeStatistics'
 >;
 
 const Components = ({
   components,
   id,
+  proteinCount,
   proteomeType,
   taxonomy,
   proteomeStatistics,
@@ -148,6 +154,7 @@ const Components = ({
         components={components}
         selectedEntries={selectedEntries}
         id={id}
+        proteinCount={proteinCount}
         proteomeType={proteomeType}
         proteomeStatistics={proteomeStatistics}
       />

--- a/src/proteomes/components/entry/Components.tsx
+++ b/src/proteomes/components/entry/Components.tsx
@@ -112,15 +112,9 @@ const Components = ({
           if (!proteinCount) {
             return 0;
           }
-          if (
-            // Excluded not supported at the moment, need to wait for TRM-28011
-            proteomeType === 'Excluded'
-          ) {
-            return <LongNumber>{proteinCount}</LongNumber>;
-          }
-          // const shouldPointToUniParc =
-          //   proteomeType === 'Excluded' || proteomeType === 'Redundant proteome';
-          const shouldPointToUniParc = proteomeType === 'Redundant proteome';
+          const shouldPointToUniParc =
+            proteomeType === 'Redundant proteome' ||
+            proteomeType === 'Excluded';
           return (
             <Link
               to={{
@@ -162,10 +156,7 @@ const Components = ({
         density="compact"
         columns={columns}
         data={components}
-        onSelectionChange={
-          // Excluded not supported at the moment, need to wait for TRM-28011
-          proteomeType === 'Excluded' ? undefined : setSelectedItemFromEvent
-        }
+        onSelectionChange={setSelectedItemFromEvent}
         fixedLayout
       />
     </Card>

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -32,7 +32,7 @@ const ComponentsDownloadComponent = lazy(
 
 type Props = Pick<
   ProteomesAPIModel,
-  'id' | 'components' | 'proteomeType' | 'proteomeStatistics'
+  'id' | 'proteinCount' | 'components' | 'proteomeType' | 'proteomeStatistics'
 > & {
   selectedEntries: string[];
 };
@@ -41,6 +41,7 @@ const fetchOptions = { method: 'HEAD' };
 
 const ComponentsButtons = ({
   id,
+  proteinCount,
   components,
   selectedEntries,
   proteomeType,
@@ -116,6 +117,7 @@ const ComponentsButtons = ({
                 query={allQuery}
                 selectedEntries={selectedEntries}
                 selectedQuery={selectedQuery}
+                totalNumberResults={proteinCount}
                 numberSelectedEntries={numberSelectedProteins}
                 onClose={handleToggleDownload}
                 proteomeStatistics={proteomeStatistics}

--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -23,9 +23,7 @@ import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import { LocationToPath, Location } from '../../../app/config/urls';
 import { Namespace } from '../../../shared/types/namespaces';
 import { ProteomesAPIModel } from '../../adapters/proteomesConverter';
-import { UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { UniProtKBColumn } from '../../../uniprotkb/types/columnTypes';
-import { SearchResults } from '../../../shared/types/results';
 
 const ComponentsDownloadComponent = lazy(
   () =>
@@ -63,11 +61,10 @@ const ComponentsButtons = ({
     },
     []
   );
+  const isUniparcSearch =
+    proteomeType === 'Redundant proteome' || proteomeType === 'Excluded';
 
-  const allQuery = `(${
-    // Excluded not supported at the moment, need to wait for TRM-28011
-    proteomeType === 'Redundant proteome' ? 'upid' : 'proteome'
-  }:${id})`;
+  const allQuery = `(${isUniparcSearch ? 'upid' : 'proteome'}:${id})`;
   const selectedQuery = useMemo(
     () =>
       `${allQuery}${
@@ -82,14 +79,17 @@ const ComponentsButtons = ({
     [allQuery, components?.length, selectedEntries]
   );
 
-  const { headers: selectedHeaders } = useDataApi<
-    SearchResults<UniProtkbAPIModel>
-  >(
+  const { headers: selectedHeaders } = useDataApi(
     displayDownloadPanel && selectedEntries.length
-      ? stringifyUrl(apiUrls.search.searchPrefix(Namespace.uniprotkb), {
-          query: selectedQuery,
-          size: '0',
-        })
+      ? stringifyUrl(
+          apiUrls.search.searchPrefix(
+            isUniparcSearch ? Namespace.uniparc : Namespace.uniprotkb
+          ),
+          {
+            query: selectedQuery,
+            size: '0',
+          }
+        )
       : null,
     fetchOptions
   );
@@ -98,8 +98,7 @@ const ComponentsButtons = ({
     selectedHeaders?.['x-total-results'] || 0
   );
 
-  // Excluded not supported at the moment, need to wait for TRM-28011
-  if (!components?.length || proteomeType === 'Excluded') {
+  if (!components?.length) {
     return null;
   }
 
@@ -119,8 +118,8 @@ const ComponentsButtons = ({
                 selectedQuery={selectedQuery}
                 numberSelectedEntries={numberSelectedProteins}
                 onClose={handleToggleDownload}
-                proteomeType={proteomeType}
                 proteomeStatistics={proteomeStatistics}
+                isUniparcSearch={isUniparcSearch}
               />
             </ErrorBoundary>
           </SlidingPanel>
@@ -141,7 +140,7 @@ const ComponentsButtons = ({
           to={{
             pathname:
               LocationToPath[
-                proteomeType === 'Redundant proteome'
+                isUniparcSearch
                   ? Location.UniParcResults
                   : Location.UniProtKBResults
               ],

--- a/src/proteomes/components/entry/ComponentsDownload.tsx
+++ b/src/proteomes/components/entry/ComponentsDownload.tsx
@@ -34,6 +34,7 @@ type DownloadProps = {
   query: string;
   selectedEntries?: string[];
   selectedQuery: string;
+  totalNumberResults: number;
   numberSelectedEntries: number;
   onClose: (
     panelCloseReason: DownloadPanelFormCloseReason,
@@ -51,16 +52,13 @@ const ComponentsDownload = ({
   query,
   selectedQuery,
   selectedEntries = [],
+  totalNumberResults,
   numberSelectedEntries,
   onClose,
   proteomeStatistics,
   isUniparcSearch,
 }: DownloadProps) => {
   const namespace = isUniparcSearch ? Namespace.uniparc : Namespace.uniprotkb;
-
-  const totalNumberResults =
-    proteomeStatistics.reviewedProteinCount +
-    proteomeStatistics.unreviewedProteinCount;
 
   const { columnNames } = useColumnNames({ namespaceOverride: namespace });
 
@@ -198,13 +196,12 @@ const ComponentsDownload = ({
           onChange={handleDownloadAllChange}
           disabled={nSelectedEntries === 0}
         />
-        Download selected{' '}
+        Download selected{' ('}
+        <LongNumber>{nSelectedEntries}</LongNumber>
         {!isUniparcSearch && (
-          <>
-            <LongNumber>{nSelectedEntries}</LongNumber>
-            {includeIsoform && nSelectedEntries ? ' + isoforms' : ''}
-          </>
+          <>{includeIsoform && nSelectedEntries ? ' + isoforms' : ''}</>
         )}
+        )
       </label>
       {isUniparcSearch ? (
         <label htmlFor="data-selection-all">
@@ -216,7 +213,7 @@ const ComponentsDownload = ({
             checked={downloadSelect === 'all'}
             onChange={handleDownloadAllChange}
           />
-          Download all
+          Download all (<LongNumber>{totalNumberResults}</LongNumber>)
         </label>
       ) : (
         <>

--- a/src/proteomes/components/entry/__tests__/Components.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/Components.spec.tsx
@@ -13,6 +13,7 @@ describe('Components view', () => {
       <Components
         components={data.components}
         id={data.id}
+        proteinCount={data.proteinCount}
         proteomeType={data.proteomeType}
         taxonomy={data.taxonomy}
         proteomeStatistics={data.proteomeStatistics}

--- a/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsButtons.spec.tsx
@@ -28,6 +28,7 @@ describe('ComponentsButtons', () => {
           components={components as Component[]}
           selectedEntries={selectedComponents}
           proteomeType="Reference and representative proteome"
+          proteinCount={100}
           proteomeStatistics={{
             reviewedProteinCount: 50,
             unreviewedProteinCount: 50,
@@ -50,6 +51,7 @@ describe('ComponentsButtons', () => {
         id="id"
         selectedEntries={[]}
         proteomeType="Reference and representative proteome"
+        proteinCount={100}
         proteomeStatistics={{
           reviewedProteinCount: 50,
           unreviewedProteinCount: 50,
@@ -66,6 +68,7 @@ describe('ComponentsButtons', () => {
         selectedEntries={[]}
         components={getComponents(10) as Component[]}
         proteomeType="Reference and representative proteome"
+        proteinCount={100}
         proteomeStatistics={{
           reviewedProteinCount: 50,
           unreviewedProteinCount: 50,

--- a/src/proteomes/components/entry/__tests__/ComponentsDownload.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsDownload.spec.tsx
@@ -29,10 +29,10 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
         query={query}
         onClose={onCloseMock}
         proteomeStatistics={proteomeStatistics}
-        proteomeType="Reference and representative proteome"
         numberSelectedEntries={0}
         // selectedEntries={[]}
         selectedQuery="(proteome:UP000005640)"
+        isUniparcSearch={false}
       />,
       {
         route: '/proteomes/UP000005640',
@@ -79,5 +79,36 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
     fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.change(formatSelect, { target: { value: FileFormat.tsv } });
     expect(await screen.findByText('Customize columns')).toBeInTheDocument();
+  });
+});
+
+describe('Download proteins for a redundant proteome', () => {
+  it('should point to uniparc search', async () => {
+    const onCloseMock = jest.fn();
+    const query = '(proteome:UP000006503)';
+    const proteomeStatistics = {
+      reviewedProteinCount: 0,
+      unreviewedProteinCount: 0,
+      isoformProteinCount: 0,
+    };
+
+    customRender(
+      <ComponentsDownload
+        query={query}
+        onClose={onCloseMock}
+        proteomeStatistics={proteomeStatistics}
+        numberSelectedEntries={0}
+        selectedQuery="(proteome:UP000006503)"
+        isUniparcSearch
+      />,
+      {
+        route: '/proteomes/UP000006503',
+      }
+    );
+    const downloadLink = screen.getByRole<HTMLAnchorElement>('link');
+    expect(downloadLink.href).toContain('uniparc');
+    expect(downloadLink.href).toEqual(
+      expect.stringContaining(stringifyQuery({ query: `(${query})` }))
+    );
   });
 });

--- a/src/proteomes/components/entry/__tests__/ComponentsDownload.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/ComponentsDownload.spec.tsx
@@ -29,6 +29,7 @@ describe('Download reviewed proteins for a proteome entry that is an Eukaryote',
         query={query}
         onClose={onCloseMock}
         proteomeStatistics={proteomeStatistics}
+        totalNumberResults={82485}
         numberSelectedEntries={0}
         // selectedEntries={[]}
         selectedQuery="(proteome:UP000005640)"
@@ -97,6 +98,7 @@ describe('Download proteins for a redundant proteome', () => {
         query={query}
         onClose={onCloseMock}
         proteomeStatistics={proteomeStatistics}
+        totalNumberResults={5841}
         numberSelectedEntries={0}
         selectedQuery="(proteome:UP000006503)"
         isUniparcSearch

--- a/src/proteomes/config/ProteomesColumnConfiguration.tsx
+++ b/src/proteomes/config/ProteomesColumnConfiguration.tsx
@@ -181,12 +181,7 @@ ProteomesColumnConfiguration.set(ProteomesColumn.proteinCount, {
           search: `query=${shouldPointToUniParc ? 'upid' : 'proteome'}:${id}`,
         }}
       >
-        {/* Excluded not supported at the moment, need to wait for TRM-28011 */}
-        {proteomeType === 'Excluded' ? (
-          'Browse UniParc entries'
-        ) : (
-          <LongNumber>{proteinCount}</LongNumber>
-        )}
+        <LongNumber>{proteinCount}</LongNumber>
       </Link>
     );
   },

--- a/src/proteomes/config/ProteomesEntryConfig.tsx
+++ b/src/proteomes/config/ProteomesEntryConfig.tsx
@@ -20,6 +20,7 @@ const ProteomesEntryConfig: {
     sectionContent: ({
       components,
       id,
+      proteinCount,
       proteomeType,
       taxonomy,
       proteomeStatistics,
@@ -27,6 +28,7 @@ const ProteomesEntryConfig: {
       <Components
         components={components}
         id={id}
+        proteinCount={proteinCount}
         proteomeType={proteomeType}
         taxonomy={taxonomy}
         proteomeStatistics={proteomeStatistics}


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-31017

## Approach
Use Uniparc search for both redundant and excluded proteomes.
Since there is a mismatch in the counts returned in the data (JIRA linked), it is decided to not show the numbers in the download panel until it is fixed.

## Testing
Added a test

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
