### PR TITLE
FASTA subsequence download in Basket

### DIFF
--- a/src/basket/BasketFullView.tsx
+++ b/src/basket/BasketFullView.tsx
@@ -94,10 +94,10 @@ const BasketFullView = () => {
   }
 
   let total: undefined | number = accessions.length;
-  if (facetTotal !== undefined) {
+  if (facetTotal !== undefined && !subsetsMap) {
     total = +facetTotal;
   }
-  if (resultsDataTotal !== undefined) {
+  if (resultsDataTotal !== undefined && !subsetsMap) {
     total = +resultsDataTotal;
   }
 

--- a/src/basket/BasketMiniView.tsx
+++ b/src/basket/BasketMiniView.tsx
@@ -160,7 +160,6 @@ const BasketMiniViewTab = ({
         subsetsMap={subsetsMap}
         inBasket
         inBasketMini
-        notCustomisable
       />
       <ResultsData
         resultsDataObject={resultsDataObject}

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -241,7 +241,7 @@ const Download = (props: DownloadProps<JobTypes>) => {
   }
 
   const { totalCount: totalCountForCustomisableSet, selectedCount } =
-    getCountForCustomisableSet(state, props, totalNumberResults);
+    getCountForCustomisableSet(state, props);
 
   return (
     <>

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -48,6 +48,7 @@ import {
   isAsyncDownloadIdMapping,
   showColumnSelect,
   filterFullXrefColumns,
+  getAccessionFromSubSequenceMap,
 } from './downloadUtils';
 
 import { MAX_PEPTIDE_FACETS_OR_DOWNLOAD } from '../../config/limits';
@@ -78,6 +79,7 @@ export type DownloadProps<T extends JobTypes> = {
     downloadMethod?: DownloadMethod
   ) => void;
   accessions?: string[];
+  accessionSubSequenceMap?: Map<string, string>;
   base?: string;
   notCustomisable?: boolean;
   inBasketMini?: boolean;
@@ -238,6 +240,23 @@ const Download = (props: DownloadProps<JobTypes>) => {
       break;
   }
 
+  let total = totalNumberResults;
+  let selectedCount = state.nSelectedEntries;
+  if (props.accessionSubSequenceMap) {
+    if (state.selectedFileFormat !== FileFormat.fastaCanonical) {
+      total = getAccessionFromSubSequenceMap(
+        props.accessions,
+        props.accessionSubSequenceMap
+      ).length;
+      selectedCount = props.selectedEntries?.length
+        ? getAccessionFromSubSequenceMap(
+            props.selectedEntries,
+            props.accessionSubSequenceMap
+          ).length
+        : 0;
+    }
+  }
+
   return (
     <>
       {notCustomisable ? (
@@ -260,8 +279,7 @@ const Download = (props: DownloadProps<JobTypes>) => {
                 state.disableForm
               }
             />
-            Download selected (<LongNumber>{state.nSelectedEntries}</LongNumber>
-            )
+            Download selected (<LongNumber>{selectedCount}</LongNumber>)
           </label>
           <label htmlFor="data-selection-true">
             <input
@@ -273,7 +291,7 @@ const Download = (props: DownloadProps<JobTypes>) => {
               onChange={handleDownloadAllChange}
               disabled={redirectToIDMapping || state.disableForm}
             />
-            Download all (<LongNumber>{totalNumberResults}</LongNumber>)
+            Download all (<LongNumber>{total}</LongNumber>)
           </label>
         </>
       )}

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -48,7 +48,7 @@ import {
   isAsyncDownloadIdMapping,
   showColumnSelect,
   filterFullXrefColumns,
-  getAccessionFromSubSequenceMap,
+  getCountForCustomisableSet,
 } from './downloadUtils';
 
 import { MAX_PEPTIDE_FACETS_OR_DOWNLOAD } from '../../config/limits';
@@ -240,22 +240,8 @@ const Download = (props: DownloadProps<JobTypes>) => {
       break;
   }
 
-  let total = totalNumberResults;
-  let selectedCount = state.nSelectedEntries;
-  if (props.accessionSubSequenceMap) {
-    if (state.selectedFileFormat !== FileFormat.fastaCanonical) {
-      total = getAccessionFromSubSequenceMap(
-        props.accessions,
-        props.accessionSubSequenceMap
-      ).length;
-      selectedCount = props.selectedEntries?.length
-        ? getAccessionFromSubSequenceMap(
-            props.selectedEntries,
-            props.accessionSubSequenceMap
-          ).length
-        : 0;
-    }
-  }
+  const { totalCount: totalCountForCustomisableSet, selectedCount } =
+    getCountForCustomisableSet(state, props, totalNumberResults);
 
   return (
     <>
@@ -291,7 +277,8 @@ const Download = (props: DownloadProps<JobTypes>) => {
               onChange={handleDownloadAllChange}
               disabled={redirectToIDMapping || state.disableForm}
             />
-            Download all (<LongNumber>{total}</LongNumber>)
+            Download all (
+            <LongNumber>{totalCountForCustomisableSet}</LongNumber>)
           </label>
         </>
       )}

--- a/src/shared/components/download/__tests__/downloadUtils.spec.ts
+++ b/src/shared/components/download/__tests__/downloadUtils.spec.ts
@@ -1000,13 +1000,13 @@ describe('Download Utils', () => {
       nSelectedEntries: 2,
       fullXref: false,
     });
-    expect(getCountForCustomisableSet(state, props, 3)).toEqual({
+    expect(getCountForCustomisableSet(state, props)).toEqual({
       totalCount: 3,
       selectedCount: 2,
     });
     // Manually set state
     state.selectedFileFormat = FileFormat.fastaCanonicalIsoform;
-    expect(getCountForCustomisableSet(state, props, 3)).toEqual({
+    expect(getCountForCustomisableSet(state, props)).toEqual({
       totalCount: 2,
       selectedCount: 1,
     });

--- a/src/shared/components/download/__tests__/downloadUtils.spec.ts
+++ b/src/shared/components/download/__tests__/downloadUtils.spec.ts
@@ -18,6 +18,7 @@ import {
   getRedirectToIDMapping,
   hasColumns,
   isSubsequenceFrom,
+  getCountForCustomisableSet,
 } from '../downloadUtils';
 
 import { defaultColumns } from '../../../../uniprotkb/config/UniProtKBColumnConfiguration';
@@ -958,6 +959,7 @@ describe('Download Utils', () => {
   test('Entries with subsequence download from basket', () => {
     const props: DownloadProps<JobTypes> = {
       selectedEntries: ['P05067[96-110]', 'P05067'],
+      accessions: ['P05067[96-110]', 'P05067', 'A0JP26[1-581]'],
       totalNumberResults: 3,
       namespace: Namespace.uniprotkb,
       notCustomisable: false,
@@ -998,8 +1000,16 @@ describe('Download Utils', () => {
       nSelectedEntries: 2,
       fullXref: false,
     });
+    expect(getCountForCustomisableSet(state, props, 3)).toEqual({
+      totalCount: 3,
+      selectedCount: 2,
+    });
     // Manually set state
     state.selectedFileFormat = FileFormat.fastaCanonicalIsoform;
+    expect(getCountForCustomisableSet(state, props, 3)).toEqual({
+      totalCount: 2,
+      selectedCount: 1,
+    });
     expect(getDownloadCount(state, props)).toEqual(1);
     expect(getDownloadOptions(state, props, location, job)).toEqual({
       base: undefined,
@@ -1007,7 +1017,7 @@ describe('Download Utils', () => {
       fileFormat: FileFormat.fastaCanonicalIsoform,
       namespace: Namespace.uniprotkb,
       selected: ['P05067'],
-      accessions: [],
+      accessions: ['P05067', 'A0JP26'],
       selectedIdField: 'accession',
     });
     expect(getPreviewCount(state, props, location, job)).toEqual(1);

--- a/src/shared/components/download/__tests__/downloadUtils.spec.ts
+++ b/src/shared/components/download/__tests__/downloadUtils.spec.ts
@@ -954,4 +954,62 @@ describe('Download Utils', () => {
     expect(getExtraContent(state, props, location, job)).toEqual(null);
     expect(getRedirectToIDMapping(state, props, job)).toEqual(false);
   });
+
+  test('Entries with subsequence download from basket', () => {
+    const props: DownloadProps<JobTypes> = {
+      selectedEntries: ['P05067[96-110]', 'P05067'],
+      totalNumberResults: 3,
+      namespace: Namespace.uniprotkb,
+      notCustomisable: false,
+      inBasketMini: true,
+      accessionSubSequenceMap: new Map([
+        ['P05067[96-110]', 'P05067'],
+        ['P05067', 'P05067'],
+        ['A0JP26[1-581]', 'A0JP26'],
+      ]),
+      onClose: jest.fn(),
+    };
+    const location: HistoryLocation = {
+      pathname: '/uniprotkb/P05067/entry',
+      search: '',
+      hash: '',
+      key: '',
+      state: undefined,
+    };
+    const job: JobFromUrl = {
+      jobId: undefined,
+      jobResultsLocation: undefined,
+      jobResultsNamespace: undefined,
+    };
+    const state = getDownloadInitialState({
+      props,
+      job,
+      selectedColumns: defaultColumns,
+    });
+
+    expect(state).toEqual({
+      selectedColumns: defaultColumns,
+      fileFormatOptions: normalFileFormatOptions,
+      selectedFileFormat: FileFormat.fastaCanonical,
+      downloadSelect: 'selected',
+      compressed: true,
+      disableForm: false,
+      extraContent: null,
+      nSelectedEntries: 2,
+      fullXref: false,
+    });
+    // Manually set state
+    state.selectedFileFormat = FileFormat.fastaCanonicalIsoform;
+    expect(getDownloadCount(state, props)).toEqual(1);
+    expect(getDownloadOptions(state, props, location, job)).toEqual({
+      base: undefined,
+      compressed: true,
+      fileFormat: FileFormat.fastaCanonicalIsoform,
+      namespace: Namespace.uniprotkb,
+      selected: ['P05067'],
+      accessions: [],
+      selectedIdField: 'accession',
+    });
+    expect(getPreviewCount(state, props, location, job)).toEqual(1);
+  });
 });

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -98,10 +98,9 @@ export const getPreviewFileFormat = (
 
 export const getCountForCustomisableSet = (
   state: DownloadState,
-  props: DownloadProps<JobTypes>,
-  totalNumberResults: number
+  props: DownloadProps<JobTypes>
 ) => {
-  let totalCount = totalNumberResults;
+  let totalCount = props.totalNumberResults;
   let selectedCount = state.nSelectedEntries;
   if (props.accessionSubSequenceMap) {
     // Basket view

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -100,6 +100,7 @@ export const getDownloadCount = (
   state: DownloadState,
   props: DownloadProps<JobTypes>
 ) => {
+  // Handle subsequences present in the basket
   if (props.accessionSubSequenceMap) {
     if (state.selectedFileFormat === FileFormat.fastaCanonical) {
       return state.downloadSelect === 'all'
@@ -111,6 +112,7 @@ export const getDownloadCount = (
       props.accessionSubSequenceMap
     ).length;
   }
+
   return state.downloadSelect === 'all'
     ? props.totalNumberResults
     : state.nSelectedEntries || 0;
@@ -186,7 +188,7 @@ export const getDownloadOptions = (
   const [urlParams] = getParamsFromURL(location.search);
   const hasSubSequence =
     props.accessionSubSequenceMap &&
-    state.selectedFileFormat === FileFormat.fastaCanonical;
+    state.selectedFileFormat !== FileFormat.fastaCanonical;
   // If query prop provided use this otherwise fallback to query from URL
   const query =
     state.downloadSelect === 'all'
@@ -223,16 +225,16 @@ export const getDownloadOptions = (
     fileFormat: state.selectedFileFormat,
     compressed: state.compressed,
     selected: hasSubSequence
-      ? selected
-      : getAccessionFromSubSequenceMap(selected, props.accessionSubSequenceMap),
+      ? getAccessionFromSubSequenceMap(selected, props.accessionSubSequenceMap)
+      : selected,
     selectedIdField,
     namespace: props.namespace,
     accessions: hasSubSequence
-      ? props.accessions
-      : getAccessionFromSubSequenceMap(
+      ? getAccessionFromSubSequenceMap(
           props.accessions,
           props.accessionSubSequenceMap
-        ),
+        )
+      : props.accessions,
     base: downloadBase,
   };
 

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -100,7 +100,7 @@ export const getDownloadCount = (
   state: DownloadState,
   props: DownloadProps<JobTypes>
 ) => {
-  // Handle subsequences present in the basket
+  // Count will vary if there is subsequence in the basket
   if (props.accessionSubSequenceMap) {
     if (state.selectedFileFormat === FileFormat.fastaCanonical) {
       return state.downloadSelect === 'all'
@@ -186,9 +186,12 @@ export const getDownloadOptions = (
   job: JobFromUrl
 ) => {
   const [urlParams] = getParamsFromURL(location.search);
-  const hasSubSequence =
+
+  // Subsequence map is passed from the basket alone and subsequences are considered only in file format FASTA(Canonical)
+  const subSequenceCompatible =
     props.accessionSubSequenceMap &&
     state.selectedFileFormat !== FileFormat.fastaCanonical;
+
   // If query prop provided use this otherwise fallback to query from URL
   const query =
     state.downloadSelect === 'all'
@@ -224,12 +227,12 @@ export const getDownloadOptions = (
   const downloadOptions: DownloadUrlOptions = {
     fileFormat: state.selectedFileFormat,
     compressed: state.compressed,
-    selected: hasSubSequence
+    selected: subSequenceCompatible
       ? getAccessionFromSubSequenceMap(selected, props.accessionSubSequenceMap)
       : selected,
     selectedIdField,
     namespace: props.namespace,
-    accessions: hasSubSequence
+    accessions: subSequenceCompatible
       ? getAccessionFromSubSequenceMap(
           props.accessions,
           props.accessionSubSequenceMap

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -96,6 +96,34 @@ export const getPreviewFileFormat = (
   return state.selectedFileFormat;
 };
 
+export const getCountForCustomisableSet = (
+  state: DownloadState,
+  props: DownloadProps<JobTypes>,
+  totalNumberResults: number
+) => {
+  let totalCount = totalNumberResults;
+  let selectedCount = state.nSelectedEntries;
+  if (props.accessionSubSequenceMap) {
+    // Basket view
+    if (state.selectedFileFormat !== FileFormat.fastaCanonical) {
+      totalCount = getAccessionFromSubSequenceMap(
+        props.accessions,
+        props.accessionSubSequenceMap
+      ).length;
+      selectedCount = props.selectedEntries?.length
+        ? getAccessionFromSubSequenceMap(
+            props.selectedEntries,
+            props.accessionSubSequenceMap
+          ).length
+        : 0;
+    }
+  }
+  return {
+    totalCount,
+    selectedCount,
+  };
+};
+
 export const getDownloadCount = (
   state: DownloadState,
   props: DownloadProps<JobTypes>

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -197,7 +197,7 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
           <SlidingPanel
             title="Download"
             // Meaning, in basket mini view, slide from the right
-            position={notCustomisable && inBasket ? 'right' : 'left'}
+            position={inBasketMini ? 'right' : 'left'}
             onClose={handleToggleDownload}
           >
             <ErrorBoundary>

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -190,11 +190,6 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
 
   const isMain = mainNamespaces.has(namespace);
 
-  // Download expect accessions without modifications (applicable in Basket views)
-  const selectedAccWithoutSubset = subsetsMap
-    ? Array.from(new Set(selectedEntries.map((e) => subsetsMap.get(e) || e)))
-    : selectedEntries;
-
   return (
     <>
       {displayDownloadPanel && (
@@ -207,12 +202,9 @@ const ResultsButtons: FC<ResultsButtonsProps<JobTypes>> = ({
           >
             <ErrorBoundary>
               <DownloadComponent
-                selectedEntries={selectedAccWithoutSubset}
-                accessions={
-                  subsetsMap
-                    ? Array.from(new Set(subsetsMap?.values()))
-                    : accessions
-                } // Passing all accessions without modifications to Download
+                selectedEntries={selectedEntries}
+                accessions={accessions}
+                accessionSubSequenceMap={subsetsMap}
                 totalNumberResults={total}
                 onClose={handleToggleDownload}
                 namespace={namespace}


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-30836

## Approach
If 'SubsequencetoAccessionMap' is present, the accessions are either taken with or without subsequence depending on the selected file format.

The download/preview count and the number of entries in the basket page are all in sync now. 
Removed `notCustomisable` from BasketMiniView and used the 'inBasketMini' to determine the position of sliding panel in BasketMiniView. This also fixes the count of `selected` and `all` when downloaded from basketMiniView instead of fixed total number which is wrong.

## Testing
Added a test for subsequence download from basket

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
