### PR TITLE
Add proteome property to Unirule's rule set

### DIFF
--- a/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
+++ b/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
@@ -228,6 +228,30 @@ const conditionsToInfoData = (
         key,
       };
     }
+    // Proteome property
+    if (condition.type === 'proteome property') {
+      return {
+        title: 'proteome property',
+        content: condition.conditionValues?.map(({ value }) => {
+          if (!value) {
+            return null;
+          }
+          return (
+            <Fragment key={value}>
+              {condition.isNegative && (
+                <>
+                  <span className={cn(styles.statement, styles.negation)}>
+                    not
+                  </span>{' '}
+                </>
+              )}
+              {value}
+            </Fragment>
+          );
+        }),
+        key,
+      };
+    }
     // Signature match
     if (condition.type?.endsWith('id') || condition.type?.endsWith('hits')) {
       const signatureDB: string = condition.type.replace(/ (id|hits)$/, '');
@@ -247,6 +271,7 @@ const conditionsToInfoData = (
           } ${pluralise('hit', condition.range.end.value)}`;
         }
       }
+
       return {
         // NOTE: don't pluralise, the values are "OR"-separated
         title: `${signatureDB}${


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-30816

## Approach
Add property property. Documentation reference (from Vishal): https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=UniProt&title=UniRule+tool+-+user+manual

I tried to find more help in the manual to link but there is nothing on proteome property.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
