### PR TITLE
Set a threshold for variant and feature viewer

### DIFF
--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -604,7 +604,10 @@ const Entry = () => {
                     searchableNamespaceLabels[Namespace.uniprotkb],
                   ]}
                 />
-                <FeatureViewerTab accession={accession} />
+                <FeatureViewerTab
+                  accession={accession}
+                  importedVariants={importedVariants}
+                />
               </ErrorBoundary>
             </Suspense>
           )}

--- a/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
+++ b/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
@@ -6,3 +6,8 @@
   padding: 1rem;
   font-size: 0.8rem;
 }
+
+.too-many {
+  max-inline-size: 50ch;
+  margin-inline: auto;
+}

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -226,7 +226,7 @@ const VariationViewer = ({
           />
         )}
         <EntryDownloadButton handleToggle={handleToggleDownload} />
-        <div className={styles['too-many']}>
+        <div className={tabsStyles['too-many']}>
           <Message>
             Due to the large number (<LongNumber>{importedVariants}</LongNumber>
             ) of variations for this entry, the variant viewer will not be

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -8,13 +8,8 @@ import {
   ReactNode,
   Suspense,
 } from 'react';
-import {
-  Button,
-  EllipsisReveal,
-  Loader,
-  LongNumber,
-  Message,
-} from 'franklin-sites';
+import { Link, useLocation } from 'react-router-dom';
+import { EllipsisReveal, Loader, LongNumber, Message } from 'franklin-sites';
 import { groupBy, intersection, union } from 'lodash-es';
 import cn from 'classnames';
 import { PartialDeep, SetRequired } from 'type-fest';
@@ -36,8 +31,11 @@ import { useSmallScreen } from '../../../../../shared/hooks/useMatchMedia';
 import apiUrls from '../../../../../shared/config/apiUrls/apiUrls';
 import externalUrls from '../../../../../shared/config/externalUrls';
 import { sortByLocation } from '../../../../utils';
+import { getEntryPath } from '../../../../../app/config/urls';
 
 import { Evidence } from '../../../../types/modelTypes';
+import { Namespace } from '../../../../../shared/types/namespaces';
+import { TabLocation } from '../../../../types/entry';
 import { Dataset } from '../../../../../shared/components/entry/EntryDownload';
 
 import styles from './styles/variation-viewer.module.scss';
@@ -52,7 +50,7 @@ const VisualVariationView = lazy(
 );
 
 // hardcoded threshold
-const VARIANT_COUNT_LIMIT = 2_000;
+export const VARIANT_COUNT_LIMIT = 2_000;
 
 type ProteinsAPIEvidence = SetRequired<
   PartialDeep<Exclude<TransformedVariant['evidences'], undefined>[number]>,
@@ -137,14 +135,15 @@ const VariationViewer = ({
   title,
 }: VariationViewProps) => {
   const isSmallScreen = useSmallScreen();
+  const searchParams = new URLSearchParams(useLocation().search);
+  const loadAllVariants = searchParams.get('loadVariants');
 
-  const [forcedRender, setForceRender] = useState(false);
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
   const shouldRender =
     (importedVariants !== 'loading' &&
       importedVariants <= VARIANT_COUNT_LIMIT) ||
-    forcedRender;
+    loadAllVariants;
 
   const { loading, data, progress, error, status } =
     useDataApi<ProteinsAPIVariation>(
@@ -233,10 +232,23 @@ const VariationViewer = ({
             ) of variations for this entry, the variant viewer will not be
             loaded automatically for performance reasons.
           </Message>
-          <Button onClick={() => setForceRender(true)}>
+          <Link
+            className="button primary"
+            to={{
+              pathname: getEntryPath(
+                Namespace.uniprotkb,
+                primaryAccession,
+                TabLocation.VariantViewer
+              ),
+              search: new URLSearchParams({
+                loadVariants: 'true',
+              }).toString(),
+            }}
+            target="variants"
+          >
             Click to load the <LongNumber>{importedVariants}</LongNumber>{' '}
             variations
-          </Button>
+          </Link>
         </div>
       </div>
     );

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -52,7 +52,7 @@ const VisualVariationView = lazy(
 );
 
 // hardcoded threshold
-const VARIANT_COUNT_LIMIT = 5_000;
+const VARIANT_COUNT_LIMIT = 2_000;
 
 type ProteinsAPIEvidence = SetRequired<
   PartialDeep<Exclude<TransformedVariant['evidences'], undefined>[number]>,
@@ -229,9 +229,9 @@ const VariationViewer = ({
         <EntryDownloadButton handleToggle={handleToggleDownload} />
         <div className={styles['too-many']}>
           <Message>
-            As there are <LongNumber>{importedVariants}</LongNumber> variations,
-            the variant viewer has not automatically been loaded for performance
-            reasons.
+            Due to the large number (<LongNumber>{importedVariants}</LongNumber>
+            ) of variations for this entry, the variant viewer will not be
+            loaded automatically for performance reasons.
           </Message>
           <Button onClick={() => setForceRender(true)}>
             Click to load the <LongNumber>{importedVariants}</LongNumber>{' '}

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/VariationViewer.spec.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/VariationViewer.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import customRender from '../../../../../../shared/__test-helpers__/customRender';
 
@@ -18,7 +18,7 @@ jest.mock('../../../../protein-data-views/VisualVariationView', () => ({
 describe('VariationViewer component', () => {
   it('renders on loading', () => {
     (useDataApi as jest.Mock).mockReturnValue({ loading: true });
-    const { asFragment } = render(
+    const { asFragment } = customRender(
       <VariationViewer importedVariants={0} primaryAccession="P05067" />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -30,7 +30,7 @@ describe('VariationViewer component', () => {
       error: new Error('some error'),
       status: 500,
     });
-    const { asFragment } = render(
+    const { asFragment } = customRender(
       <VariationViewer importedVariants={0} primaryAccession="P05067" />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe('VariationViewer component', () => {
       loading: false,
       status: 404,
     });
-    const { asFragment } = render(
+    const { asFragment } = customRender(
       <VariationViewer importedVariants={0} primaryAccession="P05067" />
     );
     expect(asFragment()).toMatchSnapshot();

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/styles/variation-viewer.module.scss
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/styles/variation-viewer.module.scss
@@ -2,8 +2,3 @@
   max-inline-size: 10ch;
   word-wrap: break-word;
 }
-
-.too-many {
-  max-inline-size: 50ch;
-  margin-inline: auto;
-}


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-30952
https://www.ebi.ac.uk/panda/jira/browse/TRM-30953

## Approach
Pass the imported variant count to feature viewer too for deciding whether to load or redirect to new tab to view all of them.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
