### PR TITLE
More feature tab downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "global": {
         "lines": 80,
         "statements": 80,
-        "functions": 78.12,
+        "functions": 78,
         "branches": 68
       }
     },

--- a/src/shared/components/download/DownloadPreview.tsx
+++ b/src/shared/components/download/DownloadPreview.tsx
@@ -14,21 +14,30 @@ import styles from './styles/download-preview.module.scss';
 type Props = {
   previewUrl?: string;
   previewFileFormat?: FileFormat;
+  acceptHeaderOverride?: string;
 };
 
-const DownloadPreview = ({ previewUrl, previewFileFormat }: Props) => {
+const DownloadPreview = ({
+  previewUrl,
+  previewFileFormat,
+  acceptHeaderOverride,
+}: Props) => {
   const scrollRef = useScrollIntoViewRef<HTMLDivElement>();
   const options = useMemo(() => {
     if (!previewFileFormat) {
       return undefined;
     }
     const headers: Record<string, string> = {};
-    const accept = fileFormatToContentType[previewFileFormat];
-    if (accept) {
-      headers.Accept = accept;
+    if (acceptHeaderOverride) {
+      headers.Accept = acceptHeaderOverride;
+    } else {
+      const accept = fileFormatToContentType[previewFileFormat];
+      if (accept) {
+        headers.Accept = accept;
+      }
     }
     return { headers };
-  }, [previewFileFormat]);
+  }, [acceptHeaderOverride, previewFileFormat]);
 
   const { data, loading } = useDataApi<JsonObject | string>(
     previewUrl,

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -431,8 +431,8 @@ const EntryDownload = ({
       : undefined;
 
   if (alphaFoldUrls) {
-    availableDatasets.push(Dataset.alphaFoldConfidence);
     availableDatasets.push(Dataset.alphaFoldCoordinates);
+    availableDatasets.push(Dataset.alphaFoldConfidence);
   }
 
   if (!entryFeatures.loading && entryFeatures.data) {

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -298,6 +298,7 @@ export type EntryDownloadProps = {
   columns?: Column[];
   dataset?: Dataset;
   featureTypes?: string[];
+  sequence?: string;
 };
 
 const EntryDownload = ({
@@ -307,6 +308,7 @@ const EntryDownload = ({
   columns,
   dataset,
   featureTypes,
+  sequence,
 }: EntryDownloadProps) => {
   const match = useRouteMatch<{ namespace: Namespace; accession: string }>(
     allEntryPages
@@ -422,7 +424,11 @@ const EntryDownload = ({
       : ''
   );
 
-  const alphaFoldUrls = getAlphaFoldUrls(alphaFoldPrediction?.data);
+  const alphaFoldUrls =
+    // As there can be a build mismatch only use AlphaFold predictions if the sequence is the same as the entry's
+    sequence && sequence === alphaFoldPrediction?.data?.[0].uniprotSequence
+      ? getAlphaFoldUrls(alphaFoldPrediction?.data)
+      : undefined;
 
   if (alphaFoldUrls) {
     availableDatasets.push(Dataset.alphaFoldConfidence);

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -79,6 +79,7 @@ const alphaFoldCoordinatesFormats = [
   FileFormat.pdb,
 ];
 const alphaFoldConfidenceFormats = [FileFormat.json];
+const alphaMissenseAnnotationsFormats = [FileFormat.csv];
 
 // once it is OK to expose peff format, uncomment the following
 // const proteinsAPIVariationFormats = [
@@ -99,6 +100,7 @@ export enum Dataset {
   interProRepresentativeDomains = 'InterPro Representative Domains',
   alphaFoldConfidence = 'AlphaFold Confidence',
   alphaFoldCoordinates = 'AlphaFold Coordinates',
+  alphaMissenseAnnotations = 'AlphaMissense Annotations',
 }
 
 const uniprotKBEntryDatasets = {
@@ -113,6 +115,7 @@ const uniprotKBEntryDatasets = {
     Dataset.interProRepresentativeDomains,
     Dataset.alphaFoldConfidence,
     Dataset.alphaFoldCoordinates,
+    Dataset.alphaMissenseAnnotations,
   ],
 };
 
@@ -140,10 +143,9 @@ type AlphafoldPayloadEntry = {
 
 type AlphafoldPayload = AlphafoldPayloadEntry[];
 
-// TODO: add amAnnotationsUrl
 type AlphaFoldUrls = Pick<
   AlphafoldPayloadEntry,
-  'cifUrl' | 'bcifUrl' | 'pdbUrl'
+  'cifUrl' | 'bcifUrl' | 'pdbUrl' | 'amAnnotationsUrl'
 > & { confidenceUrl?: string };
 
 const maxPaginationDownload = 500;
@@ -158,7 +160,12 @@ const getAlphaFoldUrls = (
   if (!first) {
     return undefined;
   }
-  const alphaFoldUrls = pick(first, ['cifUrl', 'bcifUrl', 'pdbUrl']);
+  const alphaFoldUrls = pick(first, [
+    'cifUrl',
+    'bcifUrl',
+    'pdbUrl',
+    'amAnnotationsUrl',
+  ]);
   if (Object.values(alphaFoldUrls).some((url) => !url)) {
     return undefined;
   }
@@ -248,6 +255,8 @@ const getEntryDownloadUrl = (
     }
     case Dataset.alphaFoldConfidence:
       return alphaFoldUrls?.confidenceUrl || '';
+    case Dataset.alphaMissenseAnnotations:
+      return alphaFoldUrls?.amAnnotationsUrl || '';
     default:
       return '';
   }
@@ -433,6 +442,7 @@ const EntryDownload = ({
   if (alphaFoldUrls) {
     availableDatasets.push(Dataset.alphaFoldCoordinates);
     availableDatasets.push(Dataset.alphaFoldConfidence);
+    availableDatasets.push(Dataset.alphaMissenseAnnotations);
   }
 
   if (!entryFeatures.loading && entryFeatures.data) {
@@ -515,6 +525,9 @@ const EntryDownload = ({
         break;
       case Dataset.alphaFoldCoordinates:
         setFileFormats(alphaFoldCoordinatesFormats);
+        break;
+      case Dataset.alphaMissenseAnnotations:
+        setFileFormats(alphaMissenseAnnotationsFormats);
         break;
       default:
         break;

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -13,6 +13,7 @@ import useDataApi from '../../hooks/useDataApi';
 import apiUrls from '../../config/apiUrls/apiUrls';
 import uniparcApiUrls from '../../../uniparc/config/apiUrls';
 import unirefApiUrls from '../../../uniref/config/apiUrls';
+import externalUrls from '../../config/externalUrls';
 import {
   allEntryPages,
   getLocationEntryPathFor,
@@ -87,6 +88,7 @@ export enum Dataset {
   proteomics = 'Proteomics',
   proteomicsPtm = 'Proteomics-PTM',
   antigen = 'Antigen',
+  interProRepresentativeDomains = 'interProRepresentativeDomains',
 }
 
 const uniprotKBEntryDatasets = {
@@ -98,6 +100,7 @@ const uniprotKBEntryDatasets = {
     Dataset.proteomics,
     Dataset.proteomicsPtm,
     Dataset.antigen,
+    Dataset.interProRepresentativeDomains,
   ],
 };
 
@@ -163,6 +166,11 @@ const getEntryDownloadUrl = (
       return apiUrls.proteinsApi.mutagenesis(accession, fileFormat);
     case Dataset.antigen:
       return apiUrls.proteinsApi.antigen(accession, fileFormat);
+    case Dataset.interProRepresentativeDomains:
+      return fileFormat === FileFormat.tsv || fileFormat === FileFormat.json
+        ? externalUrls.InterProRepresentativeDomains(accession, fileFormat)
+        : '';
+
     default:
       return '';
   }

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -72,6 +72,8 @@ const proteinsAPICommonFormats = [
   FileFormat.gff,
 ];
 
+const interProRepresentativeDomainsFormats = [FileFormat.json, FileFormat.tsv];
+
 // once it is OK to expose peff format, uncomment the following
 // const proteinsAPIVariationFormats = [
 //   ...proteinsAPICommonFormats,
@@ -88,7 +90,7 @@ export enum Dataset {
   proteomics = 'Proteomics',
   proteomicsPtm = 'Proteomics-PTM',
   antigen = 'Antigen',
-  interProRepresentativeDomains = 'interProRepresentativeDomains',
+  interProRepresentativeDomains = 'InterPro Representative Domains',
 }
 
 const uniprotKBEntryDatasets = {
@@ -287,42 +289,50 @@ const EntryDownload = ({
 
   const proteinsApiVariation = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.variation(accession))
+      ? apiUrls.proteinsApi.variation(accession)
       : '',
     { method: 'HEAD' }
   );
 
   const proteinsApiProteomics = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.proteomics(accession))
+      ? apiUrls.proteinsApi.proteomics(accession)
       : '',
     { method: 'HEAD' }
   );
 
   const proteinsApiPTMs = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.proteomicsPtm(accession))
+      ? apiUrls.proteinsApi.proteomicsPtm(accession)
       : '',
     { method: 'HEAD' }
   );
 
   const proteinsApiMutagenesis = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.mutagenesis(accession))
+      ? apiUrls.proteinsApi.mutagenesis(accession)
       : '',
     { method: 'HEAD' }
   );
 
   const proteinsApiAntigen = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.antigen(accession))
+      ? apiUrls.proteinsApi.antigen(accession)
       : '',
     { method: 'HEAD' }
   );
 
   const proteinsApiCoordinates = useDataApi(
     namespace === Namespace.uniprotkb && accession
-      ? joinUrl(apiUrls.proteinsApi.coordinates(accession))
+      ? apiUrls.proteinsApi.coordinates(accession)
+      : '',
+    { method: 'HEAD' }
+  );
+
+  const interProRepresentativeDomains = useDataApi(
+    (namespace === Namespace.uniprotkb || namespace === Namespace.uniparc) &&
+      accession
+      ? externalUrls.InterProRepresentativeDomains(accession)
       : '',
     { method: 'HEAD' }
   );
@@ -363,6 +373,12 @@ const EntryDownload = ({
   ) {
     availableDatasets.push(Dataset.coordinates);
   }
+  if (
+    !interProRepresentativeDomains.loading &&
+    interProRepresentativeDomains.status === 200
+  ) {
+    availableDatasets.push(Dataset.interProRepresentativeDomains);
+  }
 
   useEffect(() => {
     if (data) {
@@ -392,6 +408,9 @@ const EntryDownload = ({
       case Dataset.antigen:
       case Dataset.mutagenesis:
         setFileFormats(proteinsAPICommonFormats);
+        break;
+      case Dataset.interProRepresentativeDomains:
+        setFileFormats(interProRepresentativeDomainsFormats);
         break;
       default:
         break;
@@ -642,6 +661,7 @@ const EntryDownload = ({
 
       {(selectedFormat === FileFormat.tsv ||
         selectedFormat === FileFormat.excel) &&
+        selectedDataset !== Dataset.interProRepresentativeDomains &&
         downloadColumns && (
           <>
             <legend>Customize columns</legend>

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -160,17 +160,13 @@ const getAlphaFoldUrls = (
   if (!first) {
     return undefined;
   }
-  const alphaFoldUrls = pick(first, [
-    'cifUrl',
-    'bcifUrl',
-    'pdbUrl',
-    'amAnnotationsUrl',
-  ]);
+  const alphaFoldUrls = pick(first, ['cifUrl', 'bcifUrl', 'pdbUrl']);
   if (Object.values(alphaFoldUrls).some((url) => !url)) {
     return undefined;
   }
   return {
     ...alphaFoldUrls,
+    amAnnotationsUrl: first.amAnnotationsUrl,
     confidenceUrl: alphaFoldUrls.cifUrl
       .replace('-model', '-confidence')
       .replace('.cif', '.json'),
@@ -442,7 +438,9 @@ const EntryDownload = ({
   if (alphaFoldUrls) {
     availableDatasets.push(Dataset.alphaFoldCoordinates);
     availableDatasets.push(Dataset.alphaFoldConfidence);
-    availableDatasets.push(Dataset.alphaMissenseAnnotations);
+    if (alphaFoldUrls.amAnnotationsUrl) {
+      availableDatasets.push(Dataset.alphaMissenseAnnotations);
+    }
   }
 
   if (!entryFeatures.loading && entryFeatures.data) {

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { Button, ExternalLink, LongNumber } from 'franklin-sites';
 import cn from 'classnames';
-import joinUrl from 'url-join';
 
 import DownloadPreview from '../download/DownloadPreview';
 import DownloadAPIURL from '../download/DownloadAPIURL';
@@ -565,6 +564,11 @@ const EntryDownload = ({
       <DownloadPreview
         previewUrl={previewUrl}
         previewFileFormat={previewFileFormat}
+        acceptHeaderOverride={
+          selectedDataset === Dataset.interProRepresentativeDomains
+            ? '*/*'
+            : undefined
+        }
       />
     );
   } else if (extraContent === 'url') {

--- a/src/shared/components/entry/EntryDownloadPanel.tsx
+++ b/src/shared/components/entry/EntryDownloadPanel.tsx
@@ -13,6 +13,7 @@ type EntryDownloadPanelProps = {
   columns?: Column[];
   dataset?: Dataset;
   featureTypes?: string[];
+  sequence?: string;
 };
 const EntryDownloadPanel = ({
   handleToggle,
@@ -21,6 +22,7 @@ const EntryDownloadPanel = ({
   columns,
   dataset,
   featureTypes,
+  sequence,
 }: EntryDownloadPanelProps) => (
   <Suspense fallback={null}>
     <SlidingPanel title="Download" position="left" onClose={handleToggle}>
@@ -32,6 +34,7 @@ const EntryDownloadPanel = ({
           columns={columns}
           dataset={dataset}
           featureTypes={featureTypes}
+          sequence={sequence}
         />
       </ErrorBoundary>
     </SlidingPanel>

--- a/src/shared/components/views/FeaturesView.tsx
+++ b/src/shared/components/views/FeaturesView.tsx
@@ -103,7 +103,7 @@ const FeaturesView = <T extends GenericFeature>({
               <Fragment key={featureType}>
                 {i > 0 && ', '}
                 {featureType === 'Other' ? (
-                  featureType.toLowerCase()
+                  'other'
                 ) : (
                   <span data-article-id={FeatureTypeHelpMappings[featureType]}>
                     {featureType.toLowerCase()}

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -5,6 +5,8 @@ import { FileFormat } from '../types/resultsDownload';
 
 const IntActBase = '//www.ebi.ac.uk/intact/';
 const externalUrls = {
+  AlphaFoldPrediction: (id: string) =>
+    `https://alphafold.ebi.ac.uk/api/prediction/${id}`,
   QuickGOAnnotations: (id: string | number) =>
     `//www.ebi.ac.uk/QuickGO/annotations?geneProductId=${id}`,
   NCBI: (id: string | number) =>

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -1,4 +1,7 @@
 import joinUrl from 'url-join';
+import { fileFormatToUrlParameter } from './resultsDownload';
+import { stringifyUrl } from '../utils/url';
+import { FileFormat } from '../types/resultsDownload';
 
 const IntActBase = '//www.ebi.ac.uk/intact/';
 const externalUrls = {
@@ -28,6 +31,18 @@ const externalUrls = {
     `https://www.ebi.ac.uk/interpro/entry/InterPro/${id}/`,
   InterProSearch: (searchTerm: string | number) =>
     `https://www.ebi.ac.uk/interpro/search/text/${searchTerm}`,
+  InterProRepresentativeDomains: (
+    id: string,
+    format: FileFormat.json | FileFormat.tsv
+  ) =>
+    stringifyUrl(
+      `https://www.ebi.ac.uk/interpro/api/entry/all/protein/uniprot/${id}`,
+      {
+        type: 'domain',
+        page_size: 100,
+        format: fileFormatToUrlParameter[format],
+      }
+    ),
   // variation
   UniProt: (id: string | number) =>
     `https://web.expasy.org/variant_pages/${id}.html`,

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -33,7 +33,7 @@ const externalUrls = {
     `https://www.ebi.ac.uk/interpro/search/text/${searchTerm}`,
   InterProRepresentativeDomains: (
     id: string,
-    format: FileFormat.json | FileFormat.tsv
+    format: FileFormat.json | FileFormat.tsv = FileFormat.json
   ) =>
     stringifyUrl(
       `https://www.ebi.ac.uk/interpro/api/entry/all/protein/uniprot/${id}`,

--- a/src/shared/config/resultsDownload.ts
+++ b/src/shared/config/resultsDownload.ts
@@ -39,6 +39,9 @@ export const fileFormatToContentType: Record<FileFormat, ContentType> = {
   [FileFormat.obo]: ContentType.obo,
   [FileFormat.embeddings]: ContentType.embeddings,
   [FileFormat.peff]: ContentType.peff,
+  [FileFormat.mmCIF]: ContentType.mmCIF,
+  [FileFormat.binaryCif]: ContentType.binaryCIF,
+  [FileFormat.pdb]: ContentType.pdb,
 };
 
 export const fileFormatToUrlParameter: Record<FileFormat, string> = {
@@ -61,6 +64,9 @@ export const fileFormatToUrlParameter: Record<FileFormat, string> = {
   [FileFormat.obo]: 'obo',
   [FileFormat.embeddings]: 'h5',
   [FileFormat.peff]: 'peff',
+  [FileFormat.binaryCif]: 'bcif', // Not actually needed but added for completeness
+  [FileFormat.mmCIF]: 'cif', // Not actually needed but added for completeness
+  [FileFormat.pdb]: 'pdb', // Not actually needed but added for completeness
 };
 
 export const fileFormatsWithColumns = new Set([

--- a/src/shared/config/resultsDownload.ts
+++ b/src/shared/config/resultsDownload.ts
@@ -42,6 +42,7 @@ export const fileFormatToContentType: Record<FileFormat, ContentType> = {
   [FileFormat.mmCIF]: ContentType.mmCIF,
   [FileFormat.binaryCif]: ContentType.binaryCIF,
   [FileFormat.pdb]: ContentType.pdb,
+  [FileFormat.csv]: ContentType.csv,
 };
 
 export const fileFormatToUrlParameter: Record<FileFormat, string> = {
@@ -67,6 +68,7 @@ export const fileFormatToUrlParameter: Record<FileFormat, string> = {
   [FileFormat.binaryCif]: 'bcif', // Not actually needed but added for completeness
   [FileFormat.mmCIF]: 'cif', // Not actually needed but added for completeness
   [FileFormat.pdb]: 'pdb', // Not actually needed but added for completeness
+  [FileFormat.csv]: 'csv', // Not actually needed but added for completeness
 };
 
 export const fileFormatsWithColumns = new Set([

--- a/src/shared/types/resultsDownload.ts
+++ b/src/shared/types/resultsDownload.ts
@@ -11,6 +11,8 @@ export enum ContentType {
   obo = 'text/plain; format=obo',
   embeddings = 'application/x-hdf5',
   peff = 'text/x-peff',
+  pdb = 'chemical/x-pdb',
+  mmCIF = 'chemical/x-mmcif',
 }
 
 export enum FileFormat {
@@ -33,4 +35,7 @@ export enum FileFormat {
   obo = 'OBO',
   embeddings = 'Embeddings',
   peff = 'PEFF',
+  pdb = 'PDB', // AlphaFold coordinates
+  mmCIF = 'mmCIF', // AlphaFold coordinates
+  binaryCif = 'BinaryCIF', // AlphaFold coordinates
 }

--- a/src/shared/types/resultsDownload.ts
+++ b/src/shared/types/resultsDownload.ts
@@ -13,6 +13,7 @@ export enum ContentType {
   peff = 'text/x-peff',
   pdb = 'chemical/x-pdb',
   mmCIF = 'chemical/x-mmcif',
+  binaryCIF = 'application/octet-stream; charset=binary',
 }
 
 export enum FileFormat {

--- a/src/shared/types/resultsDownload.ts
+++ b/src/shared/types/resultsDownload.ts
@@ -14,6 +14,7 @@ export enum ContentType {
   pdb = 'chemical/x-pdb',
   mmCIF = 'chemical/x-mmcif',
   binaryCIF = 'application/octet-stream; charset=binary',
+  csv = 'text/csv',
 }
 
 export enum FileFormat {
@@ -39,4 +40,5 @@ export enum FileFormat {
   pdb = 'PDB', // AlphaFold coordinates
   mmCIF = 'mmCIF', // AlphaFold coordinates
   binaryCif = 'BinaryCIF', // AlphaFold coordinates
+  csv = 'CSV', // AlphaMissense annotations
 }

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -471,6 +471,7 @@ const Entry = () => {
                 <EntryDownloadPanel
                   handleToggle={handleToggleDownload}
                   isoformsAvailable={Boolean(listOfIsoformAccessions.length)}
+                  sequence={data.sequence.value}
                 />
               )}
               <div className="button-group">

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -612,6 +612,7 @@ const Entry = () => {
                 <FeatureViewerTab
                   accession={accession}
                   importedVariants={importedVariants}
+                  sequence={data.sequence.value}
                 />
               </ErrorBoundary>
             </Suspense>

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -568,6 +568,7 @@ const Entry = () => {
                 importedVariants={importedVariants}
                 primaryAccession={accession}
                 title="Variants"
+                sequence={data.sequence.value}
               />
             </ErrorBoundary>
           </Suspense>

--- a/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
@@ -22,9 +22,11 @@ import tabsStyles from './styles/tabs-styles.module.scss';
 const FeatureViewer = ({
   accession,
   importedVariants,
+  sequence,
 }: {
   accession: string;
   importedVariants: number | 'loading';
+  sequence: string;
 }) => {
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   // just to make sure not to render protvista-uniprot if we won't get any data
@@ -65,6 +67,7 @@ const FeatureViewer = ({
         <EntryDownloadPanel
           handleToggle={handleToggleDownload}
           dataset={Dataset.features}
+          sequence={sequence}
         />
       )}
       {data?.features && (

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -127,12 +127,14 @@ type VariationViewProps = {
   importedVariants: number | 'loading';
   primaryAccession: string;
   title?: string;
+  sequence?: string;
 };
 
 const VariationViewer = ({
   importedVariants,
   primaryAccession,
   title,
+  sequence,
 }: VariationViewProps) => {
   const isSmallScreen = useSmallScreen();
   const searchParams = new URLSearchParams(useLocation().search);
@@ -214,7 +216,6 @@ const VariationViewer = ({
 
   const handleToggleDownload = () =>
     setDisplayDownloadPanel(!displayDownloadPanel);
-
   if (!shouldRender) {
     return (
       <div className="wider-tab-content hotjar-margin">
@@ -223,6 +224,7 @@ const VariationViewer = ({
           <EntryDownloadPanel
             handleToggle={handleToggleDownload}
             dataset={Dataset.variation}
+            sequence={sequence}
           />
         )}
         <EntryDownloadButton handleToggle={handleToggleDownload} />
@@ -591,6 +593,7 @@ const VariationViewer = ({
         <EntryDownloadPanel
           handleToggle={handleToggleDownload}
           dataset={Dataset.variation}
+          sequence={sequence}
         />
       )}
       <EntryDownloadButton handleToggle={handleToggleDownload} />


### PR DESCRIPTION
## Purpose
[Add more download sources for the feature viewer download panel](https://www.ebi.ac.uk/panda/jira/browse/TRM-31104)

## Approach
- Show interpro representative domains if present
- Download alphafold from prediction endpoint eg https://alphafold.ebi.ac.uk/api/prediction/P05067
- Grab the urls from the json
- Modify the cif url to get confidence url
- Pass uniprot sequence to entry download to compare to alphafold's and if different don't offer downloads
- Display alphafold files in both main, variant viewer and feature viewer tab (as we do with the other additional file formats)

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
