### PR TITLE
Feature tab zoom buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "global": {
         "lines": 80,
         "statements": 80,
-        "functions": 79,
+        "functions": 78.99,
         "branches": 68
       }
     },

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -612,6 +612,7 @@ const Entry = () => {
                 <FeatureViewerTab
                   accession={accession}
                   importedVariants={importedVariants}
+                  sequenceLength={data.sequence.length}
                 />
               </ErrorBoundary>
             </Suspense>

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/ProteinProcessingSection.spec.tsx.snap
@@ -47,6 +47,7 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
             length="10"
           >
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-in"
             >
@@ -55,6 +56,7 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
               />
             </span>
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-out"
             >
@@ -63,6 +65,7 @@ exports[`ProteinProcessingSection should render when PTMeXchange is available 1`
               />
             </span>
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-in-seq"
             >
@@ -390,6 +393,7 @@ exports[`ProteinProcessingSection should render when no PTMeXchange is available
             length="772"
           >
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-in"
             >
@@ -398,6 +402,7 @@ exports[`ProteinProcessingSection should render when no PTMeXchange is available
               />
             </span>
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-out"
             >
@@ -406,6 +411,7 @@ exports[`ProteinProcessingSection should render when no PTMeXchange is available
               />
             </span>
             <span
+              aria-hidden="true"
               class="nightingale-button-content"
               slot="zoom-in-seq"
             >

--- a/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
@@ -115,16 +115,18 @@ const FeatureViewer = ({
         />
       )}
       {data?.features && (
-        <EntryDownloadButton handleToggle={handleToggleDownload} />
+        <>
+          {shouldRender && (
+            <NightingaleZoomTool length={sequenceLength} onZoom={handleZoom} />
+          )}
+          <EntryDownloadButton handleToggle={handleToggleDownload} />
+        </>
       )}
       {shouldRender ? (
-        <>
-          <NightingaleZoomTool length={sequenceLength} onZoom={handleZoom} />
-          <protvistaElement.name
-            accession={accession}
-            ref={protvistaUniprotRef}
-          />
-        </>
+        <protvistaElement.name
+          accession={accession}
+          ref={protvistaUniprotRef}
+        />
       ) : (
         <div className={tabsStyles['too-many']}>
           <Message>

--- a/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
@@ -4,7 +4,9 @@ import { Loader, Message } from 'franklin-sites';
 
 import EntryDownloadPanel from '../../../../shared/components/entry/EntryDownloadPanel';
 import EntryDownloadButton from '../../../../shared/components/entry/EntryDownloadButton';
-import NightingaleZoomTool from '../../protein-data-views/NightingaleZoomTool';
+import NightingaleZoomTool, {
+  ZoomOperations,
+} from '../../protein-data-views/NightingaleZoomTool';
 
 import useDataApi from '../../../../shared/hooks/useDataApi';
 import useCustomElement from '../../../../shared/hooks/useCustomElement';
@@ -49,7 +51,7 @@ const FeatureViewer = ({
   );
 
   const handleZoom = useCallback(
-    (operation) => {
+    (operation: ZoomOperations) => {
       if (!protvistaElement.defined || !protvistaUniprotRef.current) {
         return;
       }

--- a/src/uniprotkb/components/protein-data-views/NightingaleZoomTool.tsx
+++ b/src/uniprotkb/components/protein-data-views/NightingaleZoomTool.tsx
@@ -3,10 +3,18 @@ import useCustomElement from '../../../shared/hooks/useCustomElement';
 
 import './styles/nightingale-zoom-tool.scss';
 
+export type ZoomOperations = 'zoom-in' | 'zoom-out' | 'zoom-in-seq';
+
 // Icons and icon size TBD once designed.
 export const iconSize = 19;
 
-const NightingaleZoomTool = ({ length }: { length: number }) => {
+const NightingaleZoomTool = ({
+  length,
+  onZoom,
+}: {
+  length: number;
+  onZoom?: (x: ZoomOperations) => void;
+}) => {
   const protvistaZoomToolElement = useCustomElement(
     /* istanbul ignore next */
     () =>
@@ -18,13 +26,28 @@ const NightingaleZoomTool = ({ length }: { length: number }) => {
 
   return (
     <protvistaZoomToolElement.name length={length}>
-      <span slot="zoom-in" className="nightingale-button-content">
+      <span
+        slot="zoom-in"
+        className="nightingale-button-content"
+        onClick={() => onZoom?.('zoom-in')}
+        aria-hidden="true"
+      >
         <ZoomIn height={iconSize} />
       </span>
-      <span slot="zoom-out" className="nightingale-button-content">
+      <span
+        slot="zoom-out"
+        className="nightingale-button-content"
+        onClick={() => onZoom?.('zoom-out')}
+        aria-hidden="true"
+      >
         <ZoomOut height={iconSize} />
       </span>
-      <span slot="zoom-in-seq" className="nightingale-button-content">
+      <span
+        slot="zoom-in-seq"
+        className="nightingale-button-content"
+        onClick={() => onZoom?.('zoom-in-seq')}
+        aria-hidden="true"
+      >
         <ZoomToSequence height={iconSize} />
       </span>
     </protvistaZoomToolElement.name>


### PR DESCRIPTION
## Purpose
[Add in zoom in/out buttons on feature viewer](https://www.ebi.ac.uk/panda/jira/browse/TRM-30967)

## Approach

- Replicate logic seen in protvista's ProtvistaZoomTool
- Interact with protvista-manager by getting/setting `displaystart` and `displayend`

## Testing
None

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
