### PR TITLE
improve contact form

### DIFF
--- a/src/contact/adapters/__tests__/__snapshots__/contactFormAdapter.spec.tsx.snap
+++ b/src/contact/adapters/__tests__/__snapshots__/contactFormAdapter.spec.tsx.snap
@@ -4,11 +4,11 @@ exports[`Test contact form adapter should parse the inputs and generate a generi
 {
   "email": "pat@pencaster.co.uk",
   "message": "I would like this entry to be updated
+--------------- prefilled context details ---------------
 
-Name: Postman Pat
-Referred from: http://localhost/uniprotkb/P05067
-Browser: Browser and OS info
-Git commit: #git_commit_id",
+
+
+Name: Postman Pat",
   "requiredForRobots": "",
   "subject": "[uuw] General enquiry",
   "token": "random_token",

--- a/src/contact/adapters/contactFormAdapter.ts
+++ b/src/contact/adapters/contactFormAdapter.ts
@@ -41,15 +41,13 @@ export const modifyFormData = (formData: FormData, token: string) => {
     }`
   );
   output.set('requiredForRobots', formData.get('requiredForRobots') || '');
-  output.set(
-    'message',
-    `${formData.get('message')}\r\n\r\nName: ${formData.get(
-      'name'
-    )}\r\nReferred from: ${globalThis.location.origin}${formData.get(
-      'referrer'
-    )}\r\nBrowser: ${navigator.userAgent}\r\nGit commit: ${GIT_COMMIT_HASH}` ||
-      ''
-  );
+  const message = `${formData.get('message') || ''}
+--------------- prefilled context details ---------------
+
+${formData.get('context') || ''}
+
+Name: ${formData.get('name')}`;
+  output.set('message', message);
   return output;
 };
 

--- a/src/contact/components/__tests__/ContactForm.spec.tsx
+++ b/src/contact/components/__tests__/ContactForm.spec.tsx
@@ -16,7 +16,13 @@ const handleSubmit = jest.fn();
 const handleChange = jest.fn();
 
 describe('ContactForm', () => {
-  beforeEach(async () => {
+  beforeAll(() => {
+    jest
+      .spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue('mocked user agent');
+  });
+
+  beforeEach(() => {
     handleSubmit.mockClear();
     (useFormLogic as jest.Mock<UseFormLogicReturnType>).mockReturnValue({
       sending: false,

--- a/src/contact/components/__tests__/__snapshots__/ContactForm.spec.tsx.snap
+++ b/src/contact/components/__tests__/__snapshots__/ContactForm.spec.tsx.snap
@@ -222,7 +222,7 @@ exports[`ContactForm should be disabled when submitting 1`] = `
           readonly=""
         >
           Referred from: http://localhost
-User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+User browser: mocked user agent
 Website version: #git_commit_id
         </textarea>
       </span>
@@ -483,7 +483,7 @@ exports[`ContactForm should render for feedback contact form 1`] = `
           readonly=""
         >
           Referred from: http://localhost
-User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+User browser: mocked user agent
 Website version: #git_commit_id
         </textarea>
       </span>
@@ -783,7 +783,7 @@ exports[`ContactForm should render for generic contact form 1`] = `
           readonly=""
         >
           Referred from: http://localhost
-User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+User browser: mocked user agent
 Website version: #git_commit_id
         </textarea>
       </span>

--- a/src/contact/components/__tests__/__snapshots__/ContactForm.spec.tsx.snap
+++ b/src/contact/components/__tests__/__snapshots__/ContactForm.spec.tsx.snap
@@ -207,6 +207,26 @@ exports[`ContactForm should be disabled when submitting 1`] = `
         />
       </span>
       <label
+        class="label label-wide"
+        for="prefilled-1"
+      >
+        Additional information (sent with your message to help our helpdesk help you):
+      </label>
+      <span
+        class="input input__message"
+      >
+        <textarea
+          data-hj-allow="true"
+          id="context-1"
+          name="context"
+          readonly=""
+        >
+          Referred from: http://localhost
+User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+Website version: #git_commit_id
+        </textarea>
+      </span>
+      <label
         class="privacy"
       >
         <input
@@ -233,12 +253,6 @@ exports[`ContactForm should be disabled when submitting 1`] = `
         name="requiredForRobots"
         tabindex="-1"
         type="text"
-      />
-      <input
-        hidden=""
-        name="referrer"
-        readonly=""
-        value=""
       />
       <button
         class="button primary disabled"
@@ -454,6 +468,26 @@ exports[`ContactForm should render for feedback contact form 1`] = `
         />
       </span>
       <label
+        class="label label-wide"
+        for="prefilled-1"
+      >
+        Additional information (sent with your message to help our helpdesk help you):
+      </label>
+      <span
+        class="input input__message"
+      >
+        <textarea
+          data-hj-allow="true"
+          id="context-1"
+          name="context"
+          readonly=""
+        >
+          Referred from: http://localhost
+User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+Website version: #git_commit_id
+        </textarea>
+      </span>
+      <label
         class="privacy"
       >
         <input
@@ -480,12 +514,6 @@ exports[`ContactForm should render for feedback contact form 1`] = `
         name="requiredForRobots"
         tabindex="-1"
         type="text"
-      />
-      <input
-        hidden=""
-        name="referrer"
-        readonly=""
-        value=""
       />
       <button
         class="button primary"
@@ -740,6 +768,26 @@ exports[`ContactForm should render for generic contact form 1`] = `
         />
       </span>
       <label
+        class="label label-wide"
+        for="prefilled-1"
+      >
+        Additional information (sent with your message to help our helpdesk help you):
+      </label>
+      <span
+        class="input input__message"
+      >
+        <textarea
+          data-hj-allow="true"
+          id="context-1"
+          name="context"
+          readonly=""
+        >
+          Referred from: http://localhost
+User browser: Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3
+Website version: #git_commit_id
+        </textarea>
+      </span>
+      <label
         class="privacy"
       >
         <input
@@ -766,12 +814,6 @@ exports[`ContactForm should render for generic contact form 1`] = `
         name="requiredForRobots"
         tabindex="-1"
         type="text"
-      />
-      <input
-        hidden=""
-        name="referrer"
-        readonly=""
-        value=""
       />
       <button
         class="button primary"

--- a/src/contact/components/styles/contact-form.module.scss
+++ b/src/contact/components/styles/contact-form.module.scss
@@ -19,9 +19,11 @@
     grid-template-areas:
       'label-name    input-name'
       'label-email   input-email'
-      'label-subject input-'
+      'label-subject input-subject'
       'label-message .'
       'input-message input-message'
+      'label-context label-context'
+      'context       context'
       'privacy       privacy'
       'submit        submit';
 
@@ -33,6 +35,8 @@
         'label-subject input-subject aside'
         'label-message .             aside'
         'input-message input-message input-message'
+        'label-context label-context label-context'
+        'context       context       context'
         'privacy       privacy       privacy'
         'submit        submit        .';
     }
@@ -45,6 +49,8 @@
         'label-subject input-subject illustration  aside'
         'label-message .             illustration  aside'
         'input-message input-message input-message input-message'
+        'label-context label-context label-context label-context'
+        'input-context input-context input-context input-context'
         'privacy       privacy       privacy       privacy'
         'submit        submit        .             .';
     }
@@ -80,6 +86,10 @@
 .label {
   grid-column: label-start / label-end;
   font-weight: bold;
+
+  &-wide {
+    grid-column-end: -1;
+  }
 }
 
 .input {

--- a/src/tools/dashboard/components/Row.tsx
+++ b/src/tools/dashboard/components/Row.tsx
@@ -200,10 +200,7 @@ const NiceStatus = ({ job, jobLink, jobUrl }: NiceStatusProps) => {
                       referrer: location,
                       formValues: {
                         subject: `Failed ${job.type} job`,
-                        message: `
---------------- prefilled job details ---------------
-
-*** Error ***
+                        context: `*** Job error ***
 ${job.errorDescription}
 
 ${
@@ -211,7 +208,12 @@ ${
     ? `*** Job ID *** 
 ${job.remoteID}`
     : `*** Input *** 
-${Object.entries(job.parameters).map(([key, value]) => `${key}: ${value}`)}`
+${Object.entries(job.parameters)
+  .map(
+    ([key, value]) =>
+      `${key}: ${typeof value === 'object' ? JSON.stringify(value) : value}`
+  )
+  .join(',\n')}`
 }
 `,
                       },


### PR DESCRIPTION
## Purpose
Improve contact form

## Approach
- When stringifying values from jobs, make sure that objects (e.g. taxonomy) are stringified properly to avoid `[Object object]' in the message
-  Display in a read-only field all the job context that will be sent to the helpdesk:
  - Avoid user modifying it
  - Can enforce having the user add some context
- Add to that new visible field other information that we were including that might not have been clear to a user that it was shared with us, better for privacy

## Testing
Manual check from failed job (align 2 sequences with same ID), home page, and entry page entry feedback link

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
