### PR TITLE
Add warning message in Async download for heavy queries

### DIFF
--- a/src/proteomes/components/entry/ComponentsButtons.tsx
+++ b/src/proteomes/components/entry/ComponentsButtons.tsx
@@ -109,7 +109,7 @@ const ComponentsButtons = ({
       {displayDownloadPanel && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Download"
+            title={<span data-article-id="downloads">Download</span>}
             position="left"
             onClose={handleToggleDownload}
             pathname={pathname}

--- a/src/proteomes/components/entry/ComponentsDownload.tsx
+++ b/src/proteomes/components/entry/ComponentsDownload.tsx
@@ -27,7 +27,9 @@ import { DownloadUrlOptions } from '../../../shared/types/results';
 import sticky from '../../../shared/styles/sticky.module.scss';
 import styles from '../../../shared/components/download/styles/download.module.scss';
 
-const getPreviewFileFormat = (fileFormat: FileFormat): FileFormat | undefined =>
+const getPreviewFileFormat = (
+  fileFormat: FileFormat
+): FileFormat | undefined =>
   fileFormat === FileFormat.excel ? FileFormat.tsv : fileFormat;
 
 type DownloadProps = {
@@ -319,7 +321,7 @@ const ComponentsDownload = ({
       </fieldset>
       {hasColumns && (
         <>
-          <legend>Customize columns</legend>
+          <legend data-article-id="customize">Customize columns</legend>
           <ColumnSelect
             onChange={setSelectedColumns}
             selectedColumns={selectedColumns}

--- a/src/shared/components/action-buttons/CustomiseButton.tsx
+++ b/src/shared/components/action-buttons/CustomiseButton.tsx
@@ -83,7 +83,7 @@ const CustomiseButton = ({ namespace }: { namespace: Namespace }) => {
       {displayCustomisePanel && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Customize columns"
+            title={<span data-article-id="customize">Customize columns</span>}
             position="left"
             onClose={handleClose}
             className={styles['customise-table-panel']}

--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -359,7 +359,7 @@ const Download = (props: DownloadProps<JobTypes>) => {
 
       {showColumnSelect(state, props, job) && (
         <>
-          <legend>Customize columns</legend>
+          <legend data-article-id="customize">Customize columns</legend>
           <ColumnSelect
             onChange={(columns) =>
               dispatch(updateSelectedColumns(columns, fieldData))

--- a/src/shared/components/entry/EntryDownload.tsx
+++ b/src/shared/components/entry/EntryDownload.tsx
@@ -817,7 +817,7 @@ const EntryDownload = ({
         selectedDataset !== Dataset.interProRepresentativeDomains &&
         downloadColumns && (
           <>
-            <legend>Customize columns</legend>
+            <legend data-article-id="customize">Customize columns</legend>
             <ColumnSelect
               onChange={(columns) => setDownloadColumns(columns)}
               selectedColumns={downloadColumns}

--- a/src/shared/components/entry/EntryDownloadPanel.tsx
+++ b/src/shared/components/entry/EntryDownloadPanel.tsx
@@ -29,7 +29,7 @@ const EntryDownloadPanel = ({
   return (
     <Suspense fallback={null}>
       <SlidingPanel
-        title="Download"
+        title={<span data-article-id="downloads">Download</span>}
         position="left"
         onClose={handleToggle}
         pathname={pathname}

--- a/src/shared/components/results/ResultsButtons.tsx
+++ b/src/shared/components/results/ResultsButtons.tsx
@@ -197,7 +197,7 @@ const ResultsButtons: FC<
       {displayDownloadPanel && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Download"
+            title={<span data-article-id="downloads">Download</span>}
             // Meaning, in basket mini view, slide from the right
             position={inBasketMini ? 'right' : 'left'}
             onClose={handleToggleDownload}

--- a/src/shared/components/results/TaxonomyFacet.tsx
+++ b/src/shared/components/results/TaxonomyFacet.tsx
@@ -86,7 +86,9 @@ const TaxonomyFacet: FC<
       {displayQueryBuilder && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Advanced Search"
+            title={
+              <span data-article-id="advanced_search">Advanced Search</span>
+            }
             position="left"
             onClose={handleClose}
             pathname={pathname}

--- a/src/shared/components/search/SearchContainer.tsx
+++ b/src/shared/components/search/SearchContainer.tsx
@@ -337,7 +337,9 @@ const SearchContainer = ({
       {displayQueryBuilder && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Advanced Search"
+            title={
+              <span data-article-id="advanced_search">Advanced Search</span>
+            }
             position="left"
             onClose={handleToggleQueryBuilder}
             pathname={location.pathname}

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -20,6 +20,7 @@ import { FormParameters } from '../types/asyncDownloadFormParameters';
 import { APIModel } from '../../../shared/types/apiModel';
 import { FacetObject, SearchResults } from '../../../shared/types/results';
 import { SelectedFacet } from '../../../uniprotkb/types/resultsTypes';
+import { namespaceAndToolsLabels } from '../../../shared/types/namespaces';
 
 import styles from './styles/async-download-confirmation.module.scss';
 import '../../styles/ToolsForm.scss';
@@ -112,9 +113,10 @@ const AsyncDownloadConfirmation = ({
     >
       {jobParameters.query === '*' ? (
         <Message className={styles['warning-message']} level="warning">
-          This job will take longer to finish, as your search is against all of
-          UniProt, making it a highly resource-intensive process. We kindly
-          request you to download the file once it becomes available.
+          This job will take longer to finish, as your search is against the
+          whole of {namespaceAndToolsLabels[jobParameters.namespace]}, making it
+          a highly resource-intensive process. We kindly request that you
+          download the file once it becomes available.
         </Message>
       ) : null}
       {jobParameters.query !== '*' &&

--- a/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
+++ b/src/tools/async-download/components/AsyncDownloadConfirmation.tsx
@@ -6,11 +6,15 @@ import {
   InfoList,
   Loader,
   LongNumber,
+  Message,
 } from 'franklin-sites';
 import { InfoListItem } from 'franklin-sites/dist/types/components/info-list';
+import { generatePath, Link } from 'react-router-dom';
 
 import useNSQuery from '../../../shared/hooks/useNSQuery';
 import useDataApiWithStale from '../../../shared/hooks/useDataApiWithStale';
+
+import { LocationToPath, Location } from '../../../app/config/urls';
 
 import { FormParameters } from '../types/asyncDownloadFormParameters';
 import { APIModel } from '../../../shared/types/apiModel';
@@ -100,11 +104,35 @@ const AsyncDownloadConfirmation = ({
       content: jobParameters.columns.join(', ') || '',
     },
   ];
+
   return (
     <Card
       header={<h4>Review your file generation request</h4>}
       className={styles['confirm-async-download']}
     >
+      {jobParameters.query === '*' ? (
+        <Message className={styles['warning-message']} level="warning">
+          This job will take longer to finish, as your search is against all of
+          UniProt, making it a highly resource-intensive process. We kindly
+          request you to download the file once it becomes available.
+        </Message>
+      ) : null}
+      {jobParameters.query !== '*' &&
+      jobParameters.query?.split(' ').length === 1 &&
+      !jobParameters.query?.includes(':') ? (
+        <Message className={styles['warning-message']} level="warning">
+          Your query is a free-text search, which may yield more results than
+          anticipated. We recommend using the{' '}
+          <Link
+            to={generatePath(LocationToPath[Location.HelpEntry], {
+              accession: 'advanced_search',
+            })}
+          >
+            Advanced Search
+          </Link>{' '}
+          feature to refine and narrow down your results.
+        </Message>
+      ) : null}
       <InfoList
         infoData={infoData
           .filter((d): d is InfoListItem => !!d)

--- a/src/tools/async-download/components/styles/async-download-confirmation.module.scss
+++ b/src/tools/async-download/components/styles/async-download-confirmation.module.scss
@@ -1,6 +1,7 @@
 .confirm-async-download {
   display: inline-block;
 
+  .warning-message,
   .info-list {
     margin-top: 1rem;
   }

--- a/src/uniprotkb/components/entry/tabs/history/History.tsx
+++ b/src/uniprotkb/components/entry/tabs/history/History.tsx
@@ -410,7 +410,7 @@ const EntryHistoryList = ({
       {displayDownloadPanel && (
         <Suspense fallback={null}>
           <SlidingPanel
-            title="Download"
+            title={<span data-article-id="downloads">Download</span>}
             // Meaning, in basket mini view, slide from the right
             position="left"
             onClose={() => setDisplayDownloadPanel(false)}


### PR DESCRIPTION
## Purpose
https://www.ebi.ac.uk/panda/jira/browse/TRM-31837

## Approach
Added warning in the second step of Async download.
Added contextual help links for column customisation, download, advance search wherever applicable.

## Testing
What test(s) did you write to validate and verify your changes?

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
