### PR TITLE
Community annotation

### DIFF
--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -108,3 +108,12 @@ protvista-manager {
 //     }
 //   }
 // }
+
+:root {
+  --table__even: #fff;
+  --table__header-background: #fff;
+  --table__header-text: #393b42;
+  --table__odd: #e4e8eb;
+  --table_border: #c2c4c4;
+  --table_hover: #f1f1f1;
+}

--- a/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
+++ b/src/automatic-annotations/shared/entry/ConditionsAnnotations.tsx
@@ -364,73 +364,6 @@ const ConditionsComponent = ({
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ExceptionComponent: any = () => null;
-
-/* We need to hide this, for now, replaced with the above component instead */
-// const ExceptionComponent = ({
-//   annotationWithExceptions,
-// }: {
-//   annotationWithExceptions: AnnotationWithExceptions;
-// }) => {
-//   const filteredExceptions = annotationWithExceptions.exceptions?.filter(
-//     (e: RuleException | undefined): e is RuleException => e !== undefined
-//   );
-//   if (!filteredExceptions?.length) {
-//     return null;
-//   }
-//   const originalAnnotation = omit(annotationWithExceptions, 'exceptions');
-//   return (
-//     <EvidenceTag
-//       className={styles.exceptions}
-//       label={pluralise('exception', filteredExceptions.length)}
-//       iconComponent={<InformationIcon style={{ marginTop: '0.3em' }} />}
-//     >
-//       <ul>
-//         {filteredExceptions.map((exception, index) => {
-//           // Only need to display the exception's annotation if it is distinct
-//           // from the main annotation
-//           const needsToDisplayAnnotation = !isEqual(
-//             originalAnnotation,
-//             exception.annotation
-//           );
-//           return (
-//             // eslint-disable-next-line react/no-array-index-key
-//             <li key={index}>
-//               {exception.category}:<br />
-//               {exception.accessions?.length ? (
-//                 <>
-//                   This applies to the following{' '}
-//                   {exception.accessions.length === 1
-//                     ? ''
-//                     : `${exception.accessions.length} `}
-//                   {pluralise('entry', exception.accessions.length, 'entries')}:{' '}
-//                   {exception.accessions.map((accession, index, array) => (
-//                     <Fragment key={accession}>
-//                       {listFormat(index, array)}
-//                       <AccessionView
-//                         id={accession}
-//                         namespace={Namespace.uniprotkb}
-//                       />
-//                     </Fragment>
-//                   ))}
-//                   .<br />
-//                 </>
-//               ) : null}
-//               {exception.annotation && needsToDisplayAnnotation && (
-//                 <InfoList
-//                   infoData={annotationsToInfoData([exception.annotation])}
-//                 />
-//               )}
-//               {exception.note && <span>Note: {exception.note}</span>}
-//             </li>
-//           );
-//         })}
-//       </ul>
-//     </EvidenceTag>
-//   );
-// };
-
 const GroupedAnnotation = (
   type: string,
   annotations: Array<AnnotationWithExceptions | PositionFeatureSet>
@@ -450,7 +383,6 @@ const GroupedAnnotation = (
                 >
                   {annotation.keyword.name}
                 </Link>
-                <ExceptionComponent annotationWithExceptions={annotation} />
               </li>
             )
         )}
@@ -471,7 +403,6 @@ const GroupedAnnotation = (
                 >
                   {annotation.dbReference.id}
                 </ExternalLink>
-                <ExceptionComponent annotationWithExceptions={annotation} />
               </li>
             )
         )}
@@ -492,7 +423,6 @@ const GroupedAnnotation = (
                 )}
                 contextKey="protein_name"
               />
-              <ExceptionComponent annotationWithExceptions={annotation} />
             </li>
           ))}
         </EllipsisReveal.Provider>
@@ -507,7 +437,6 @@ const GroupedAnnotation = (
             // eslint-disable-next-line react/no-array-index-key
             <li key={index}>
               <CSVView data={annotation.gene} contextKey="gene name" />
-              <ExceptionComponent annotationWithExceptions={annotation} />
             </li>
           ))}
         </EllipsisReveal.Provider>
@@ -545,7 +474,6 @@ const GroupedAnnotation = (
               comments={[annotation.comment as CatalyticActivityComment]}
               defaultHideAllReactions
             />
-            <ExceptionComponent annotationWithExceptions={annotation} />
           </li>
         ))}
       </ul>
@@ -558,7 +486,6 @@ const GroupedAnnotation = (
           // eslint-disable-next-line react/no-array-index-key
           <li key={index}>
             <CofactorView cofactors={[annotation.comment as CofactorComment]} />
-            <ExceptionComponent annotationWithExceptions={annotation} />
           </li>
         ))}
       </ul>
@@ -574,7 +501,6 @@ const GroupedAnnotation = (
               // eslint-disable-next-line react/no-array-index-key
               <li key={index}>
                 {annotation.comment.texts?.map((text) => text.value).join('. ')}
-                <ExceptionComponent annotationWithExceptions={annotation} />
               </li>
             )
         )}

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -1,3 +1,11 @@
+$table__header-text: #393b42;
+$table__header-background: #fff;
+$table__even: #fff;
+$table__odd: #e4e8eb;
+$table__header-text: #393b42;
+$table_border: #c2c4c4;
+$table_extra-content-background: #f1f1f1;
+
 .container {
   width: calc(100% + 2em);
   padding-inline: 1em;
@@ -9,13 +17,16 @@
   padding: 0;
   margin: 1em 0;
   border-spacing: 0;
-  border-block-end: 1px solid #c2c4c4;
+  border-block-end: 1px solid $table_border;
 
   & th {
     text-align: left;
     vertical-align: middle;
-    background-color: var(--protvista-datable__header-background, #fff);
-    color: var(--protvista-datable__header-text, #393b42);
+    background-color: var(
+      --table__header-background,
+      $table__header-background
+    );
+    color: var(--table__header-text, $table__header-text);
     text-overflow: ellipsis;
     text-transform: uppercase;
   }
@@ -23,7 +34,7 @@
   & td,
   & th {
     padding: 0.2rem 1ch;
-    border-block-start: 1px solid #c2c4c4;
+    border-block-start: 1px solid $table_border;
   }
 
   & thead :global(.dropdown) > button {
@@ -36,10 +47,10 @@
 }
 
 .row {
-  background-color: var(--protvista-datatable__even, #fff);
+  background-color: var(--table__even, #table__even);
 
   &.odd {
-    background-color: var(--protvista-datatable__odd, #e4e8eb);
+    background-color: var(--table__odd, $table__odd);
   }
 
   &:hover {
@@ -47,7 +58,7 @@
     /* => keep groups of rows highlighted in sync */
     &,
     & + .extra-content {
-      background-color: var(--protvista-datatable__hover, #f1f1f1);
+      background-color: var(--table__hover, $table_extra-content-background);
     }
   }
 
@@ -69,7 +80,7 @@
   }
 
   &.extra-content td {
-    border-color: #c2c4c455;
+    border-color: $table_border;
   }
 }
 
@@ -78,5 +89,5 @@
 /* Select a row that has a next .extra-content sibling that is hovered */
 /* => keep groups of rows highlighted in sync */
 .row:has(+ .extra-content:hover) {
-  background-color: var(--protvista-datatable__hover, #f1f1f1);
+  background-color: var(--table__hover, $table_extra-content-background);
 }

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -47,7 +47,7 @@ $table_extra-content-background: #f1f1f1;
 }
 
 .row {
-  background-color: var(--table__even, #table__even);
+  background-color: var(--table__even, $table__even);
 
   &.odd {
     background-color: var(--table__odd, $table__odd);

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -4,7 +4,7 @@ $table__even: #fff;
 $table__odd: #e4e8eb;
 $table__header-text: #393b42;
 $table_border: #c2c4c4;
-$table_extra-content-background: #f1f1f1;
+$table_hover: #f1f1f1;
 
 .container {
   width: calc(100% + 2em);
@@ -58,7 +58,7 @@ $table_extra-content-background: #f1f1f1;
     /* => keep groups of rows highlighted in sync */
     &,
     & + .extra-content {
-      background-color: var(--table__hover, $table_extra-content-background);
+      background-color: var(--table__hover, $table_hover);
     }
   }
 
@@ -89,5 +89,5 @@ $table_extra-content-background: #f1f1f1;
 /* Select a row that has a next .extra-content sibling that is hovered */
 /* => keep groups of rows highlighted in sync */
 .row:has(+ .extra-content:hover) {
-  background-color: var(--table__hover, $table_extra-content-background);
+  background-color: var(--table__hover, $table_hover);
 }

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -1,11 +1,3 @@
-$table__header-text: #393b42;
-$table__header-background: #fff;
-$table__even: #fff;
-$table__odd: #e4e8eb;
-$table__header-text: #393b42;
-$table_border: #c2c4c4;
-$table_hover: #f1f1f1;
-
 .container {
   width: calc(100% + 2em);
   padding-inline: 1em;
@@ -17,16 +9,13 @@ $table_hover: #f1f1f1;
   padding: 0;
   margin: 1em 0;
   border-spacing: 0;
-  border-block-end: 1px solid $table_border;
+  border-block-end: 1px solid var(--table_border);
 
   & th {
     text-align: left;
     vertical-align: middle;
-    background-color: var(
-      --table__header-background,
-      $table__header-background
-    );
-    color: var(--table__header-text, $table__header-text);
+    background-color: var(--table__header-background,);
+    color: var(--table__header-text);
     text-overflow: ellipsis;
     text-transform: uppercase;
   }
@@ -34,7 +23,7 @@ $table_hover: #f1f1f1;
   & td,
   & th {
     padding: 0.2rem 1ch;
-    border-block-start: 1px solid $table_border;
+    border-block-start: 1px solid var(--table_border);
   }
 
   & thead :global(.dropdown) > button {
@@ -47,10 +36,10 @@ $table_hover: #f1f1f1;
 }
 
 .row {
-  background-color: var(--table__even, $table__even);
+  background-color: var(--table__even);
 
   &.odd {
-    background-color: var(--table__odd, $table__odd);
+    background-color: var(--table__odd);
   }
 
   &:hover {
@@ -58,7 +47,7 @@ $table_hover: #f1f1f1;
     /* => keep groups of rows highlighted in sync */
     &,
     & + .extra-content {
-      background-color: var(--table__hover, $table_hover);
+      background-color: var(--table__hover);
     }
   }
 
@@ -80,7 +69,7 @@ $table_hover: #f1f1f1;
   }
 
   &.extra-content td {
-    border-color: $table_border;
+    border-color: var(--table_border);
   }
 }
 
@@ -89,5 +78,5 @@ $table_hover: #f1f1f1;
 /* Select a row that has a next .extra-content sibling that is hovered */
 /* => keep groups of rows highlighted in sync */
 .row:has(+ .extra-content:hover) {
-  background-color: var(--table__hover, $table_hover);
+  background-color: var(--table__hover);
 }

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -4,7 +4,6 @@ import { stringifyUrl } from '../utils/url';
 import { FileFormat } from '../types/resultsDownload';
 
 const IntActBase = '//www.ebi.ac.uk/intact/';
-const CommunityAnnotation = 'https://community.uniprot.org/bbsub';
 const externalUrls = {
   AlphaFoldPrediction: (id: string) =>
     `https://alphafold.ebi.ac.uk/api/prediction/${id}`,
@@ -64,14 +63,13 @@ const externalUrls = {
   PubMed: (id: string | number) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
   EuropePMC: (id: string | number) => `//europepmc.org/article/MED/${id}`,
   CommunityCurationGetByAccession: (id: string) =>
-    joinUrl(CommunityAnnotation, `bbsubinfo.html?accession=${id}`),
+    `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${id}`,
   CommunityCurationGetByAccessionAndPmid: (accession: string, pmid: string) =>
     joinUrl(
-      CommunityAnnotation,
-      `bbsubinfo.html?accession=${accession}&pmid=${pmid}`
+      `https://community.uniprot.org/bbsub/bbsubinfo.html?accession=${accession}&pmid=${pmid}`
     ),
   CommunityCurationAdd: (id: string | number) =>
-    joinUrl(CommunityAnnotation, `bbsub.html?accession=${id}`),
+    `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
   RheaSearch: (id: string | number) =>
     `https://www.rhea-db.org/rhea?query=${id}`,
   RheaEntry: (id: string | number) => `https://www.rhea-db.org/rhea/${id}`,

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -4,6 +4,7 @@ import { stringifyUrl } from '../utils/url';
 import { FileFormat } from '../types/resultsDownload';
 
 const IntActBase = '//www.ebi.ac.uk/intact/';
+const CommunityAnnotation = 'https://community.uniprot.org/bbsub';
 const externalUrls = {
   AlphaFoldPrediction: (id: string) =>
     `https://alphafold.ebi.ac.uk/api/prediction/${id}`,
@@ -63,11 +64,14 @@ const externalUrls = {
   PubMed: (id: string | number) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
   EuropePMC: (id: string | number) => `//europepmc.org/article/MED/${id}`,
   CommunityCurationGetByAccession: (id: string) =>
-    `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${id}`,
+    joinUrl(CommunityAnnotation, `bbsubinfo.html?accession=${id}`),
   CommunityCurationGetByAccessionAndPmid: (accession: string, pmid: string) =>
-    `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${accession}&pmid=${pmid}`,
+    joinUrl(
+      CommunityAnnotation,
+      `bbsubinfo.html?accession=${accession}&pmid=${pmid}`
+    ),
   CommunityCurationAdd: (id: string | number) =>
-    `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
+    joinUrl(CommunityAnnotation, `bbsub.html?accession=${id}`),
   RheaSearch: (id: string | number) =>
     `https://www.rhea-db.org/rhea?query=${id}`,
   RheaEntry: (id: string | number) => `https://www.rhea-db.org/rhea/${id}`,

--- a/src/shared/config/externalUrls.ts
+++ b/src/shared/config/externalUrls.ts
@@ -62,8 +62,10 @@ const externalUrls = {
   DOI: (id: string | number) => `https://dx.doi.org/${id}`,
   PubMed: (id: string | number) => `https://pubmed.ncbi.nlm.nih.gov/${id}`,
   EuropePMC: (id: string | number) => `//europepmc.org/article/MED/${id}`,
-  CommunityCurationGet: (id: string | number) =>
+  CommunityCurationGetByAccession: (id: string) =>
     `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${id}`,
+  CommunityCurationGetByAccessionAndPmid: (accession: string, pmid: string) =>
+    `https://community.uniprot.org/cgi-bin/bbsub_query?accession=${accession}&pmid=${pmid}`,
   CommunityCurationAdd: (id: string | number) =>
     `https://community.uniprot.org/bbsub/bbsub.html?accession=${id}`,
   RheaSearch: (id: string | number) =>

--- a/src/shared/utils/__tests__/utils.spec.ts
+++ b/src/shared/utils/__tests__/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   deepFindAllByKey,
   addBlastLinksToFreeText,
   keysToLowerCase,
+  excludeKeys,
 } from '../utils';
 
 describe('Model Utils', () => {
@@ -117,5 +118,18 @@ describe('keysToLowerCase', () => {
   });
   it('should return empty object with nothing provided', () => {
     expect(keysToLowerCase(undefined)).toEqual({});
+  });
+});
+
+describe('excludeKeys', () => {
+  it('should exclude specified keys', () => {
+    expect(excludeKeys({ a: 1, b: 2, c: 3 }, ['a', 'b'])).toEqual({ c: 3 });
+  });
+  it('should return object if keys do not exits', () => {
+    expect(excludeKeys({ a: 1, b: 2, c: 3 }, ['y', 'z'])).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+    });
   });
 });

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -115,7 +115,10 @@ export function excludeKeys<T>(
   o?: Record<Key, T>,
   keys?: Key[]
 ): Record<Key, T> | undefined {
-  if (typeof o === 'undefined' || typeof keys === 'undefined' || !keys.length) {
+  if (typeof o === 'undefined') {
+    return {};
+  }
+  if (typeof keys === 'undefined' || !keys.length) {
     return o;
   }
   const setKeys = new Set(keys);

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { getURLToJobWithData } from '../../app/config/urls';
 import { JobTypes } from '../../tools/types/toolsJobTypes';
 
+export type Key = string | number | symbol;
+
 export const formatPercentage = (n: number, maximumFractionDigits = 1) =>
   `${n.toLocaleString('en-US', {
     maximumFractionDigits,
@@ -33,7 +35,7 @@ export function removeItemFromList<T>(list: T[], index: number) {
   return [...list.slice(0, index), ...list.slice(index + 1)];
 }
 
-export const hasContent = (obj: Record<string | number | symbol, unknown>) =>
+export const hasContent = (obj: Record<Key, unknown>) =>
   Object.values(obj).some((val) => {
     if (Array.isArray(val)) {
       const valArray = val as unknown[];
@@ -108,3 +110,8 @@ export function keysToLowerCase<T>(o: { [k: string]: T } = {}): {
     Object.entries(o).map(([k, v]) => [k.toLowerCase(), v])
   );
 }
+
+export const excludeKeys = (o: Record<Key, unknown>, omit: Key[]) => {
+  const setOmit = new Set(omit);
+  return Object.fromEntries(Object.entries(o).filter(([k]) => !setOmit.has(k)));
+};

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -111,7 +111,13 @@ export function keysToLowerCase<T>(o: { [k: string]: T } = {}): {
   );
 }
 
-export const excludeKeys = (o: Record<Key, unknown>, omit: Key[]) => {
-  const setOmit = new Set(omit);
-  return Object.fromEntries(Object.entries(o).filter(([k]) => !setOmit.has(k)));
+export const excludeKeys = (
+  o?: Record<Key, unknown>,
+  keys?: Key[]
+): Record<Key, unknown> | undefined => {
+  if (typeof o === 'undefined' || typeof keys === 'undefined' || !keys.length) {
+    return o;
+  }
+  const setKeys = new Set(keys);
+  return Object.fromEntries(Object.entries(o).filter(([k]) => !setKeys.has(k)));
 };

--- a/src/shared/utils/utils.tsx
+++ b/src/shared/utils/utils.tsx
@@ -111,13 +111,13 @@ export function keysToLowerCase<T>(o: { [k: string]: T } = {}): {
   );
 }
 
-export const excludeKeys = (
-  o?: Record<Key, unknown>,
+export function excludeKeys<T>(
+  o?: Record<Key, T>,
   keys?: Key[]
-): Record<Key, unknown> | undefined => {
+): Record<Key, T> | undefined {
   if (typeof o === 'undefined' || typeof keys === 'undefined' || !keys.length) {
     return o;
   }
   const setKeys = new Set(keys);
   return Object.fromEntries(Object.entries(o).filter(([k]) => !setKeys.has(k)));
-};
+}

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -1,10 +1,14 @@
 import { FC } from 'react';
+import { generatePath, Link } from 'react-router-dom';
 import { Method } from 'axios';
 import { CommunityAnnotationIcon } from 'franklin-sites';
 
 import useDataApi from '../../../shared/hooks/useDataApi';
 
 import externalUrls from '../../../shared/config/externalUrls';
+
+import { Location, LocationToPath } from '../../../app/config/urls';
+import { TabLocation } from '../../types/entry';
 
 const fetchOptions: { method: Method } = {
   method: 'HEAD',
@@ -24,9 +28,18 @@ const CommunityAnnotationLink: FC<
     return null;
   }
   return (
-    <a href={url} className="button tertiary" target="_blank" rel="noreferrer">
+    <Link
+      to={{
+        pathname: generatePath(LocationToPath[Location.UniProtKBEntry], {
+          accession,
+          subPage: TabLocation.Publications,
+        }),
+        search: '?facets=types:0',
+      }}
+      className="button tertiary"
+    >
       <CommunityAnnotationIcon /> {`Community curation (${nSubmissions})`}
-    </a>
+    </Link>
   );
 };
 

--- a/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
+++ b/src/uniprotkb/components/entry/CommunityAnnotationLink.tsx
@@ -21,7 +21,7 @@ type CommunityAnnotationLinkProps = {
 const CommunityAnnotationLink: FC<
   React.PropsWithChildren<CommunityAnnotationLinkProps>
 > = ({ accession }) => {
-  const url = externalUrls.CommunityCurationGet(accession);
+  const url = externalUrls.CommunityCurationGetByAccession(accession);
   const { headers } = useDataApi(url, fetchOptions);
   const nSubmissions = +(headers?.['x-total-results'] || 0);
   if (!nSubmissions) {

--- a/src/uniprotkb/components/entry/CommunityCuration.tsx
+++ b/src/uniprotkb/components/entry/CommunityCuration.tsx
@@ -113,40 +113,58 @@ const GroupedCommunityReference = ({
         </tr>
       </thead>
       <tbody>
-        {references.map(({ citationId, communityAnnotation, source }) => (
-          <tr key={citationId}>
-            <td>
-              {citationId && (
-                <ExternalLink url={externalUrls.PubMed(citationId)}>
-                  PubMed:{citationId}
-                </ExternalLink>
-              )}
-            </td>
-            <td>
-              <SubmissionDate
-                accession={accession}
-                citationId={citationId}
-                submissionDate={communityAnnotation?.submissionDate}
-              />
-            </td>
-            <td>
-              {source?.id && source.id !== 'Anonymous' ? (
-                <ExternalLink
-                  url={processUrlTemplate(
-                    databaseInfoMaps?.databaseToDatabaseInfo[source.name]
-                      ?.uriLink,
-                    { id: source.id }
-                  )}
-                >
-                  <img src={ORCIDiDLogo} alt="" width="15" height="15" />
-                  {source.id}
-                </ExternalLink>
-              ) : (
-                source?.id || ''
-              )}
-            </td>
-          </tr>
-        ))}
+        {references
+          .sort((a, b) => {
+            if (
+              !a.communityAnnotation?.submissionDate &&
+              !b.communityAnnotation?.submissionDate
+            ) {
+              return 0;
+            }
+            if (
+              !a.communityAnnotation?.submissionDate ||
+              !b.communityAnnotation?.submissionDate
+            ) {
+              return 1;
+            }
+            return a.communityAnnotation.submissionDate.localeCompare(
+              b.communityAnnotation.submissionDate
+            );
+          })
+          .map(({ citationId, communityAnnotation, source }) => (
+            <tr key={citationId}>
+              <td>
+                {citationId && (
+                  <ExternalLink url={externalUrls.PubMed(citationId)}>
+                    PubMed:{citationId}
+                  </ExternalLink>
+                )}
+              </td>
+              <td>
+                <SubmissionDate
+                  accession={accession}
+                  citationId={citationId}
+                  submissionDate={communityAnnotation?.submissionDate}
+                />
+              </td>
+              <td>
+                {source?.id && source.id !== 'Anonymous' ? (
+                  <ExternalLink
+                    url={processUrlTemplate(
+                      databaseInfoMaps?.databaseToDatabaseInfo[source.name]
+                        ?.uriLink,
+                      { id: source.id }
+                    )}
+                  >
+                    <img src={ORCIDiDLogo} alt="" width="15" height="15" />
+                    {source.id}
+                  </ExternalLink>
+                ) : (
+                  source?.id || ''
+                )}
+              </td>
+            </tr>
+          ))}
       </tbody>
     </table>
   </Card>

--- a/src/uniprotkb/components/entry/CommunityCuration.tsx
+++ b/src/uniprotkb/components/entry/CommunityCuration.tsx
@@ -16,6 +16,7 @@ import { processUrlTemplate } from '../../../shared/utils/xrefs';
 import externalUrls from '../../../shared/config/externalUrls';
 
 import {
+  Citation,
   CommunityAnnotation,
   Reference,
 } from '../../../supporting-data/citations/adapters/citationsConverter';
@@ -61,13 +62,38 @@ const groupByCommunityAnnotation = (
   return annotationToCommunityReferences;
 };
 
+const SubmissionDate = ({
+  accession,
+  citationId,
+  submissionDate,
+}: {
+  accession: string;
+  citationId?: Citation['id'];
+  submissionDate?: string;
+}) => (
+  <ExternalLink
+    url={
+      citationId && citationId.match(/\d+/)
+        ? externalUrls.CommunityCurationGetByAccessionAndPmid(
+            accession,
+            citationId
+          )
+        : externalUrls.CommunityCurationGetByAccession(accession)
+    }
+  >
+    <time dateTime={submissionDate}>{submissionDate}</time>
+  </ExternalLink>
+);
+
 const GroupedCommunityReference = ({
   annotation,
+  accession,
   references,
   section,
   databaseInfoMaps,
 }: {
   annotation: string;
+  accession: string;
   references: Reference[];
   section: EntrySection;
   databaseInfoMaps: DatabaseInfoMaps | null;
@@ -96,9 +122,11 @@ const GroupedCommunityReference = ({
               )}
             </td>
             <td>
-              <time dateTime={communityAnnotation?.submissionDate}>
-                {communityAnnotation?.submissionDate}
-              </time>
+              <SubmissionDate
+                accession={accession}
+                citationId={citationId}
+                submissionDate={communityAnnotation?.submissionDate}
+              />
             </td>
             <td>
               {source?.id && source.id !== 'Anonymous' ? (
@@ -156,6 +184,7 @@ const CommunityCuration = ({
             ([annotation, references]) => (
               <GroupedCommunityReference
                 section={section}
+                accession={accession}
                 annotation={annotation}
                 references={references}
                 databaseInfoMaps={databaseInfoMaps}

--- a/src/uniprotkb/components/entry/CommunityCuration.tsx
+++ b/src/uniprotkb/components/entry/CommunityCuration.tsx
@@ -9,7 +9,6 @@ import cn from 'classnames';
 
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 
-import Table from '../../../shared/components/table/Table';
 import ORCIDiDLogo from '../../../images/ORCIDiD_icon.png';
 
 import { processUrlTemplate } from '../../../shared/utils/xrefs';
@@ -98,22 +97,24 @@ const GroupedCommunityReference = ({
   section: EntrySection;
   databaseInfoMaps: DatabaseInfoMaps | null;
 }) => (
-  <Card className={styles['reference-card']} key={annotation}>
+  <Card className={styles['reference-card']}>
     <h4>
       {section === EntrySection.NamesAndTaxonomy
         ? 'Community suggested name: '
         : ''}
       {annotation}
     </h4>
-    <Table>
-      <Table.Head>
-        <th>Source</th>
-        <th>Submission date</th>
-        <th>Contributor</th>
-      </Table.Head>
-      <Table.Body>
+    <table>
+      <thead>
+        <tr>
+          <th>Source</th>
+          <th>Submission date</th>
+          <th>Contributor</th>
+        </tr>
+      </thead>
+      <tbody>
         {references.map(({ citationId, communityAnnotation, source }) => (
-          <Table.Row key={citationId} isOdd={false}>
+          <tr key={citationId}>
             <td>
               {citationId && (
                 <ExternalLink url={externalUrls.PubMed(citationId)}>
@@ -144,10 +145,10 @@ const GroupedCommunityReference = ({
                 source?.id || ''
               )}
             </td>
-          </Table.Row>
+          </tr>
         ))}
-      </Table.Body>
-    </Table>
+      </tbody>
+    </table>
   </Card>
 );
 
@@ -183,6 +184,7 @@ const CommunityCuration = ({
           {Array.from(groupedCommunityReferences).map(
             ([annotation, references]) => (
               <GroupedCommunityReference
+                key={annotation}
                 section={section}
                 accession={accession}
                 annotation={annotation}

--- a/src/uniprotkb/components/entry/CommunityCuration.tsx
+++ b/src/uniprotkb/components/entry/CommunityCuration.tsx
@@ -64,6 +64,12 @@ const CommunityCuration = ({
                       </ExternalLink>
                     </span>
                   )}
+                  {communityAnnotation?.submissionDate && (
+                    <span>
+                      Submission date:&nbsp;&nbsp;
+                      {communityAnnotation?.submissionDate}
+                    </span>
+                  )}
                   {source && (
                     <span>
                       Contributor:&nbsp;&nbsp;

--- a/src/uniprotkb/components/entry/CommunityCuration.tsx
+++ b/src/uniprotkb/components/entry/CommunityCuration.tsx
@@ -98,12 +98,14 @@ const GroupedCommunityReference = ({
   databaseInfoMaps: DatabaseInfoMaps | null;
 }) => (
   <Card className={styles['reference-card']}>
-    <h4>
-      {section === EntrySection.NamesAndTaxonomy
-        ? 'Community suggested name: '
-        : ''}
-      {annotation}
-    </h4>
+    {section === EntrySection.NamesAndTaxonomy ? (
+      <h4>Community suggested name: {annotation}</h4>
+    ) : (
+      <>
+        <h4>Community annotation</h4>
+        <p>{annotation}</p>
+      </>
+    )}
     <table>
       <thead>
         <tr>

--- a/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
+++ b/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
@@ -13,7 +13,10 @@ import CommunityCuration from './CommunityCuration';
 import { hasContent, pluralise } from '../../../shared/utils/utils';
 import { getEntrySectionNameAndId } from '../../utils/entrySection';
 
-import { NamesAndTaxonomyUIModel } from '../../adapters/namesAndTaxonomyConverter';
+import {
+  GeneNamesData,
+  NamesAndTaxonomyUIModel,
+} from '../../adapters/namesAndTaxonomyConverter';
 
 import EntrySection from '../../types/entrySection';
 import UniProtKBEvidenceTag, {
@@ -27,6 +30,25 @@ import {
   ReferenceComment,
 } from '../../../supporting-data/citations/adapters/citationsConverter';
 import { Evidence } from '../../types/modelTypes';
+
+const getUniqueNames = (geneNames?: GeneNamesData) => {
+  const names = new Set();
+  for (const geneName of geneNames || []) {
+    if (geneName.geneName?.value) {
+      names.add(geneName.geneName.value);
+    }
+    for (const array of [
+      geneName.synonyms,
+      geneName.orfNames,
+      geneName.orderedLocusNames,
+    ]) {
+      for (const item of array || []) {
+        names.add(item.value);
+      }
+    }
+  }
+  return names;
+};
 
 type Props = {
   data: NamesAndTaxonomyUIModel;
@@ -85,6 +107,9 @@ const NamesAndTaxonomySection = ({
       }),
     [references]
   );
+
+  const uniqueAnnotatedNames = getUniqueNames(data.geneNamesData);
+  console.log(uniqueAnnotatedNames);
 
   const nameRelatedReferences = communityReferences.filter(
     (reference) => reference.communityAnnotation?.proteinOrGene

--- a/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
+++ b/src/uniprotkb/components/entry/NamesAndTaxonomySection.tsx
@@ -12,6 +12,7 @@ import CommunityCuration from './CommunityCuration';
 
 import {
   deepFindAllByKey,
+  excludeKeys,
   hasContent,
   pluralise,
 } from '../../../shared/utils/utils';
@@ -91,13 +92,18 @@ const NamesAndTaxonomySection = ({
   );
 
   const uniqueAnnotatedNames = new Set(
-    deepFindAllByKey(
-      {
-        proteinNames: data.proteinNamesData,
-        geneNames: data.geneNamesData,
-      },
-      'value'
-    )
+    !data.proteinNamesData
+      ? []
+      : deepFindAllByKey(
+          {
+            proteinNames: excludeKeys(data.proteinNamesData, [
+              'includes',
+              'contains',
+            ]),
+            geneNames: data.geneNamesData,
+          },
+          'value'
+        )
   );
 
   const nameRelatedReferences = communityReferences.filter(

--- a/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
+++ b/src/uniprotkb/components/entry/SubcellularLocationSection.tsx
@@ -5,7 +5,7 @@ import KeywordView from '../protein-data-views/KeywordView';
 import FeaturesView from '../protein-data-views/UniProtKBFeaturesView';
 import SubcellularLocationWithVizView from '../protein-data-views/SubcellularLocationWithVizView';
 
-import { hasContent } from '../../../shared/utils/utils';
+import { hasContent, Key } from '../../../shared/utils/utils';
 import { getEntrySectionNameAndId } from '../../utils/entrySection';
 
 import EntrySection from '../../types/entrySection';
@@ -19,7 +19,7 @@ type Props = {
 };
 
 export const subcellularLocationSectionHasContent = <
-  T extends Record<string | number | symbol, unknown>
+  T extends Record<Key, unknown>,
 >(
   data?: T
 ) => {

--- a/src/uniprotkb/components/entry/__tests__/CommunityAnnotationLink.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/CommunityAnnotationLink.spec.tsx
@@ -1,8 +1,10 @@
-import { screen, render } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import CommunityAnnotationLink from '../CommunityAnnotationLink';
 
 import useDataApi from '../../../../shared/hooks/useDataApi';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
 
 jest.mock('../../../../shared/hooks/useDataApi');
 
@@ -12,7 +14,7 @@ describe('CommunityAnnotationLink', () => {
       loading: false,
       headers: { 'x-total-results': 3 },
     });
-    const { asFragment } = render(
+    const { asFragment } = customRender(
       <CommunityAnnotationLink accession="P05067" />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -23,7 +25,7 @@ describe('CommunityAnnotationLink', () => {
       loading: false,
       headers: { 'x-total-results': 0 },
     });
-    render(<CommunityAnnotationLink accession="P05067" />);
+    customRender(<CommunityAnnotationLink accession="P05067" />);
     expect(screen.queryByText('Community curation')).not.toBeInTheDocument();
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/CommunityCuration.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/CommunityCuration.spec.tsx
@@ -39,7 +39,7 @@ describe('Community annotatation', () => {
         communityReferences={mock}
       />
     );
-    expect(await screen.findByText('Epicuticlin')).toBeInTheDocument();
+    expect(await screen.findByText(/Epicuticlin/)).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/CommunityCuration.spec.tsx
+++ b/src/uniprotkb/components/entry/__tests__/CommunityCuration.spec.tsx
@@ -1,34 +1,14 @@
 import { screen } from '@testing-library/react';
 
-import CommunityCuration from '../CommunityCuration';
+import CommunityCuration, {
+  groupByCommunityAnnotation,
+} from '../CommunityCuration';
 
 import customRender from '../../../../shared/__test-helpers__/customRender';
 
-import { Reference } from '../../../../supporting-data/citations/adapters/citationsConverter';
-import EntrySection from '../../../types/entrySection';
+import mock from './__mocks__/communityCurationData';
 
-const mock: Reference[] = [
-  {
-    source: {
-      name: 'ORCID',
-      id: '0000-0001-6057-9374',
-    },
-    citationId: '36301857',
-    sourceCategories: [
-      'Function',
-      'Expression',
-      'Interaction',
-      'Subcellular Location',
-    ],
-    communityAnnotation: {
-      proteinOrGene: 'Epicuticlin',
-      function:
-        'Disordered proteins organized in tandem repeats with molecular recognition features and tyrosine motifs (Pfam02756 and Pfam02757). The epicuticlins form the insoluble outermost layer of the cuticle and can interact with cuticular collagens.',
-      comment:
-        'The cDNA AJ408886 is one of several sequences of nematodes, which is now identified as forming the epicuticlin structure of nematodes.',
-    },
-  },
-];
+import EntrySection from '../../../types/entrySection';
 
 describe('Community annotatation', () => {
   it('should render the community annotation content', async () => {
@@ -39,7 +19,34 @@ describe('Community annotatation', () => {
         communityReferences={mock}
       />
     );
-    expect(await screen.findByText(/Epicuticlin/)).toBeInTheDocument();
+    expect(await screen.findByText(/Spike glycoprotein/)).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
+  });
+});
+
+describe('groupByCommunityAnnotation', () => {
+  it('should group by community annotation and sort all references by submission date and then sort all annotations by latest reference submission date', () => {
+    expect(
+      Array.from(
+        groupByCommunityAnnotation(EntrySection.NamesAndTaxonomy, mock)!
+      ).map(([annotation, references]) => [
+        annotation,
+        references.map((r) => r.communityAnnotation?.submissionDate),
+      ])
+    ).toEqual([
+      ['Spike glycoprotein; S.', ['2023-06-28']],
+      [
+        'S',
+        [
+          '2023-05-28',
+          '2023-05-28',
+          '2023-05-28',
+          '2022-01-28',
+          '2021-12-28',
+          undefined,
+        ],
+      ],
+      ['Spike S.', ['2022-01-05']],
+    ]);
   });
 });

--- a/src/uniprotkb/components/entry/__tests__/__mocks__/communityCurationData.ts
+++ b/src/uniprotkb/components/entry/__tests__/__mocks__/communityCurationData.ts
@@ -1,0 +1,123 @@
+import { Reference } from '../../../../../supporting-data/citations/adapters/citationsConverter';
+
+// This is from https://rest.uniprot.org/uniprotkb/P0DTC2/publications?facetFilter=(types:"0") but then
+// modified to be a bit more interesting ie missing/different submission dates
+const data: Reference[] = [
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '37000302',
+    sourceCategories: ['Phenotypes & Variants'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      disease: 'COVID-19 (DOID:0080600).',
+      comment:
+        'Epidemiological study describing preserved indel mutations in Spike protein on SARS-Co-V2 sublineages.',
+      submissionDate: '2022-01-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '36483199',
+    sourceCategories: ['Function', 'Phenotypes & Variants'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      function: 'IgG binding (GO:0019864).',
+      disease: 'COVID-19 (DOID:0080600).',
+      submissionDate: '2023-05-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '36052466',
+    sourceCategories: ['Phenotypes & Variants'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      disease: 'PASC (DOID:0080848). COVID-19 (DOID:0080600).',
+      comment:
+        'Detection of circulating spike protein in PASC patients, suggesting a viral reservoir in the body of long COVID patients.',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '35660160',
+    sourceCategories: ['Phenotypes & Variants', 'Structure'],
+    communityAnnotation: {
+      proteinOrGene: 'Spike glycoprotein; S.',
+      comment: 'Molecular simulation study.',
+      submissionDate: '2023-06-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '35300999',
+    sourceCategories: ['Function', 'Phenotypes & Variants', 'Structure'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      disease: 'COVID-19 (DOID:0080600).',
+      comment: 'Review',
+      submissionDate: '2023-05-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '35215888',
+    sourceCategories: ['Function', 'Phenotypes & Variants'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      function: 'Pathogen-derived receptor ligand activity (GO:0140295).',
+      disease: 'COVID-19',
+      comment: 'Evidence:Computational analysis.',
+      submissionDate: '2021-12-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0009-0006-0769-8175',
+    },
+    citationId: '35039785',
+    sourceCategories: ['Phenotypes & Variants'],
+    communityAnnotation: {
+      proteinOrGene: 'S',
+      disease: 'COVID-19 (DOID:0080600).',
+      comment:
+        'Epidemiological study describing indel variants, with all major indel types identified here occurred at the NTD domain of S protein.',
+      submissionDate: '2023-05-28',
+    },
+  },
+  {
+    source: {
+      name: 'ORCID',
+      id: '0000-0003-0651-4769',
+    },
+    citationId: '34930824',
+    sourceCategories: ['Function', 'PTM / Processing', 'Interaction'],
+    communityAnnotation: {
+      proteinOrGene: 'Spike S.',
+      function:
+        "Membrane fusion requires the proteolytic cleavage at the S2' site.",
+      comment: "R815 is a proteolytic cleavage site for S2' generation.",
+      submissionDate: '2022-01-05',
+    },
+  },
+];
+
+export default data;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityAnnotationLink.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityAnnotationLink.spec.tsx.snap
@@ -4,9 +4,7 @@ exports[`CommunityAnnotationLink should render with >0 number of submissions 1`]
 <DocumentFragment>
   <a
     class="button tertiary"
-    href="https://community.uniprot.org/cgi-bin/bbsub_query?accession=P05067"
-    rel="noreferrer"
-    target="_blank"
+    href="/uniprotkb/P05067/publications?facets=types:0"
   >
     <test-file-stub />
      Community curation (3)

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityCuration.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityCuration.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`Community annotatation should render the community annotation content 1
         <test-file-stub
           width="1ch"
         />
-        Community curation (1) 
+        Community curation (8) 
         <test-file-stub
           classname="chevron-icon"
           width="1ch"
@@ -37,7 +37,7 @@ exports[`Community annotatation should render the community annotation content 1
             class="card__content"
           >
             <h4>
-              Community suggested name: Epicuticlin
+              Community suggested name: Spike glycoprotein; S.
             </h4>
             <table>
               <thead>
@@ -58,11 +58,11 @@ exports[`Community annotatation should render the community annotation content 1
                   <td>
                     <a
                       class="external-link"
-                      href="https://pubmed.ncbi.nlm.nih.gov/36301857"
+                      href="https://pubmed.ncbi.nlm.nih.gov/35660160"
                       rel="noopener"
                       target="_blank"
                     >
-                      PubMed:36301857
+                      PubMed:35660160
                       <test-file-stub
                         data-testid="external-link-icon"
                         width="12.5"
@@ -72,7 +72,363 @@ exports[`Community annotatation should render the community annotation content 1
                   <td>
                     <a
                       class="external-link"
-                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=36301857"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=35660160"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2023-06-28"
+                      >
+                        2023-06-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+      <section
+        class="reference-card card"
+      >
+        <div
+          class="card__container"
+        >
+          <div
+            class="card__content"
+          >
+            <h4>
+              Community suggested name: S
+            </h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    Source
+                  </th>
+                  <th>
+                    Submission date
+                  </th>
+                  <th>
+                    Contributor
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/36483199"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:36483199
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=36483199"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2023-05-28"
+                      >
+                        2023-05-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/35300999"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:35300999
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=35300999"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2023-05-28"
+                      >
+                        2023-05-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/35039785"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:35039785
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=35039785"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2023-05-28"
+                      >
+                        2023-05-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/37000302"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:37000302
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=37000302"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2022-01-28"
+                      >
+                        2022-01-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/35215888"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:35215888
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=35215888"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2021-12-28"
+                      >
+                        2021-12-28
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0009-0006-0769-8175"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/36052466"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:36052466
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=36052466"
                       rel="noopener"
                       target="_blank"
                     >
@@ -86,7 +442,7 @@ exports[`Community annotatation should render the community annotation content 1
                   <td>
                     <a
                       class="external-link"
-                      href="https://orcid.org/0000-0001-6057-9374"
+                      href="https://orcid.org/0009-0006-0769-8175"
                       rel="noopener"
                       target="_blank"
                     >
@@ -96,7 +452,93 @@ exports[`Community annotatation should render the community annotation content 1
                         src="test-file-stub"
                         width="15"
                       />
-                      0000-0001-6057-9374
+                      0009-0006-0769-8175
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+      <section
+        class="reference-card card"
+      >
+        <div
+          class="card__container"
+        >
+          <div
+            class="card__content"
+          >
+            <h4>
+              Community suggested name: Spike S.
+            </h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    Source
+                  </th>
+                  <th>
+                    Submission date
+                  </th>
+                  <th>
+                    Contributor
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/34930824"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      PubMed:34930824
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=34930824"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time
+                        datetime="2022-01-05"
+                      >
+                        2022-01-05
+                      </time>
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0000-0003-0651-4769"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0000-0003-0651-4769
                       <test-file-stub
                         data-testid="external-link-icon"
                         width="12.5"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityCuration.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/CommunityCuration.spec.tsx.snap
@@ -36,78 +36,76 @@ exports[`Community annotatation should render the community annotation content 1
           <div
             class="card__content"
           >
-            <ul
-              class="info-list"
-            >
-              <li>
-                <div
-                  class="decorated-list-item"
-                >
-                  <div
-                    class="decorated-list-item__title tiny"
-                  >
-                    Community suggested names
-                  </div>
-                  <div
-                    class="decorated-list-item__content"
-                  >
-                    Epicuticlin
-                    <div
-                      class="contributor-details names-section"
+            <h4>
+              Community suggested name: Epicuticlin
+            </h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    Source
+                  </th>
+                  <th>
+                    Submission date
+                  </th>
+                  <th>
+                    Contributor
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://pubmed.ncbi.nlm.nih.gov/36301857"
+                      rel="noopener"
+                      target="_blank"
                     >
-                      <span>
-                        Source:  
-                        <a
-                          class="external-link"
-                          href="https://pubmed.ncbi.nlm.nih.gov/36301857"
-                          rel="noopener"
-                          target="_blank"
-                        >
-                          PMID - 36301857
-                          <test-file-stub
-                            data-testid="external-link-icon"
-                            width="12.5"
-                          />
-                        </a>
-                      </span>
-                      <span>
-                        Contributor:  
-                        <a
-                          class="external-link"
-                          href="https://orcid.org/0000-0001-6057-9374"
-                          rel="noopener"
-                          target="_blank"
-                        >
-                          <img
-                            alt=""
-                            height="15"
-                            src="test-file-stub"
-                            width="15"
-                          />
-                          0000-0001-6057-9374
-                          <test-file-stub
-                            data-testid="external-link-icon"
-                            width="12.5"
-                          />
-                        </a>
-                      </span>
-                      <a
-                        class="external-link"
-                        href="https://community.uniprot.org/cgi-bin/bbsub_query?accession=Q95PB5"
-                        rel="noopener"
-                        target="_blank"
-                      >
-                        View submission
-                        <test-file-stub
-                          data-testid="external-link-icon"
-                          width="12.5"
-                        />
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </li>
-            </ul>
+                      PubMed:36301857
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://community.uniprot.org/bbsub/bbsubinfo.html?accession=Q95PB5&pmid=36301857"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <time />
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      class="external-link"
+                      href="https://orcid.org/0000-0001-6057-9374"
+                      rel="noopener"
+                      target="_blank"
+                    >
+                      <img
+                        alt=""
+                        height="15"
+                        src="test-file-stub"
+                        width="15"
+                      />
+                      0000-0001-6057-9374
+                      <test-file-stub
+                        data-testid="external-link-icon"
+                        width="12.5"
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </section>

--- a/src/uniprotkb/components/entry/styles/community-curation.module.scss
+++ b/src/uniprotkb/components/entry/styles/community-curation.module.scss
@@ -51,33 +51,6 @@
       & th {
         padding: 0.2rem 3ch;
       }
-
-      & thead :global(.dropdown) > button {
-        font-family: monospace;
-        font-weight: bold;
-        font-size: 1em;
-        width: 2ch;
-        margin: 0;
-      }
     }
-  }
-
-  .contributor-details {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-
-    & span {
-      margin-right: 2rem;
-
-      img {
-        margin: 2px;
-      }
-    }
-  }
-
-  .names-section {
-    justify-content: flex-start;
-    margin-top: 0.5rem;
   }
 }

--- a/src/uniprotkb/components/entry/styles/community-curation.module.scss
+++ b/src/uniprotkb/components/entry/styles/community-curation.module.scss
@@ -43,7 +43,7 @@
       & th {
         text-align: left;
         vertical-align: middle;
-        color: $table__header-text;
+        color: var(--table__header-text);
         text-transform: uppercase;
       }
 

--- a/src/uniprotkb/components/entry/styles/community-curation.module.scss
+++ b/src/uniprotkb/components/entry/styles/community-curation.module.scss
@@ -1,3 +1,5 @@
+@import '../../../../shared/components/table/styles/table.module.scss';
+
 .community-annotation-details {
   .chevron-icon {
     transform: scale(1);
@@ -32,6 +34,32 @@
 
   .reference-card {
     background-color: #abc7d64d;
+
+    table {
+      padding: 0;
+      margin: 1em 0;
+      border-spacing: 0;
+
+      & th {
+        text-align: left;
+        vertical-align: middle;
+        color: $table__header-text;
+        text-transform: uppercase;
+      }
+
+      & td,
+      & th {
+        padding: 0.2rem 3ch;
+      }
+
+      & thead :global(.dropdown) > button {
+        font-family: monospace;
+        font-weight: bold;
+        font-size: 1em;
+        width: 2ch;
+        margin: 0;
+      }
+    }
   }
 
   .contributor-details {

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -9,7 +9,6 @@ import {
   Sequence,
   SequenceTools,
 } from 'franklin-sites';
-import { omit } from 'lodash-es';
 
 import ExternalLink from '../../shared/components/ExternalLink';
 import { ECNumbersView } from '../components/protein-data-views/ProteinNamesView';
@@ -91,7 +90,7 @@ import { PeptideSearchMatches } from '../../tools/peptide-search/components/Pept
 
 import useDatabaseInfoMaps from '../../shared/hooks/useDatabaseInfoMaps';
 
-import { deepFindAllByKey } from '../../shared/utils/utils';
+import { deepFindAllByKey, excludeKeys } from '../../shared/utils/utils';
 import { getAllKeywords } from '../utils/KeywordsUtil';
 import externalUrls from '../../shared/config/externalUrls';
 import { getEntryPath, LocationToPath, Location } from '../../app/config/urls';
@@ -214,7 +213,7 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.proteinName, {
     return (
       <span translate="yes">
         <CSVView
-          data={omit(proteinNamesData, 'contains')}
+          data={excludeKeys(proteinNamesData, ['contains'])}
           bolderFirst={Boolean(proteinNamesData?.recommendedName)}
           contextKey={UniProtKBColumn.proteinName}
           supplementaryData={proteinNamesData?.contains}


### PR DESCRIPTION
## Purpose

[Jira](https://www.ebi.ac.uk/panda/jira/browse/TRM-31447)

- [x] Display the submission date with the community annotation info shown on the page, use it to display the most recent first when there are multiple in the same section.
- [x] Point to the publications tab with the correct facets activated for the link at the top of the entry tab with the count of community annotations
- [x] Merge multiple submission into one when the content is the same, make sure to keep displaying all the other information and that visually they are linked together (pubmed id, user orcid, submission date, and link to submission)
- [x] Don't display protein name annotations if the exact same name is already in the entry

## Approach

- Exclude community names already existing in the curated names
- Group all community annotations by annotation
- Use a table to display community annotations, copy existing Table styles

## Testing

Updated and added unit test for new util fn.

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
