### PR TITLE
Add warning message for out of sync AF models

### DIFF
--- a/src/shared/contexts/AFDBOutOfSync.tsx
+++ b/src/shared/contexts/AFDBOutOfSync.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+export const AFDBOutOfSyncContext = createContext<boolean | undefined>(
+  undefined
+);

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -58,6 +58,8 @@ import { extractIsoformNames } from '../../adapters/extractIsoformsConverter';
 import { subcellularLocationSectionHasContent } from './SubcellularLocationSection';
 import { getEntrySectionNameAndId } from '../../utils/entrySection';
 
+import { AFDBOutOfSyncContext } from '../../../shared/contexts/AFDBOutOfSync';
+
 import dataToSchema from './entry.structured';
 
 import {
@@ -135,6 +137,9 @@ const HistoryTab = lazy(
       /* webpackChunkName: "uniprotkb-entry-history" */ './tabs/history/History'
     )
 );
+
+// Watch out, hardcoded!
+const AFDB_CUTOFF_DATE = new Date('2021-09-30');
 
 const hasExternalLinks = (transformedData: UniProtkbUIModel) =>
   UniProtKBEntryConfig.some(({ id }) => {
@@ -397,6 +402,12 @@ const Entry = () => {
     hasGenomicCoordinates = coordinatesHeadPayload.status === 200;
   }
 
+  const isAFDBOutOfSync =
+    new Date(
+      transformedData?.sequences.entryAudit?.lastSequenceUpdateDate ||
+        '2000-01-01'
+    ) > AFDB_CUTOFF_DATE;
+
   if (error || !match?.params.accession || !transformedData) {
     return <ErrorHandler status={status} error={error} fullPage />;
   }
@@ -451,367 +462,370 @@ const Entry = () => {
           <ProteinOverview data={data} />
         </ErrorBoundary>
       )}
-      <Tabs active={match.params.subPage}>
-        <Tab
-          title={
-            <Link
-              className={isObsolete ? helper.disabled : undefined}
-              tabIndex={isObsolete ? -1 : undefined}
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                TabLocation.Entry
-              )}
-            >
-              Entry
-            </Link>
-          }
-          id={TabLocation.Entry}
-        >
-          {!isObsolete && data.sequence && (
-            <>
-              {displayDownloadPanel && (
-                <EntryDownloadPanel
-                  handleToggle={handleToggleDownload}
-                  isoformsAvailable={Boolean(listOfIsoformAccessions.length)}
-                  sequence={data.sequence.value}
-                />
-              )}
-              <div className="button-group">
-                <ToolsDropdown
-                  selectedEntries={[accession]}
-                  blast
-                  align={
-                    listOfIsoformAccessions.length > 1 && (
-                      <AlignButton
-                        selectedEntries={listOfIsoformAccessions}
-                        textSuffix="isoforms"
-                      />
-                    )
-                  }
-                  mapID
-                />
-                <EntryDownloadButton handleToggle={handleToggleDownload} />
-                <AddToBasketButton selectedEntries={accession} />
-                <CommunityAnnotationLink accession={accession} />
-                <a
-                  href={externalUrls.CommunityCurationAdd(accession)}
-                  className="button tertiary"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Add a publication
-                </a>
-                {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                <ContactLink
-                  to={{
-                    pathname: LocationToPath[Location.ContactUpdate],
-                    search: stringifyQuery({
-                      entry: accession,
-                      entryType:
-                        transformedData?.entryType === EntryType.REVIEWED
-                          ? 'Reviewed (Swiss-Prot)'
-                          : 'Unreviewed (TrEMBL)',
-                    }),
-                  }}
-                  className="button tertiary"
-                >
-                  Entry feedback
-                </ContactLink>
-              </div>
-              <EntryMain
-                transformedData={transformedData}
-                importedVariants={importedVariants}
-                communityReferences={communityReferences}
-                isoforms={listOfIsoformNames}
-              />
-            </>
-          )}
-        </Tab>
-        <Tab
-          title={
-            <Link
-              className={cn({
-                [helper.disabled]:
-                  importedVariants === 'loading' || !importedVariants,
-                loading: importedVariants === 'loading',
-              })}
-              tabIndex={
-                importedVariants !== 'loading' && importedVariants
-                  ? undefined
-                  : -1
-              }
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                importedVariants === 'loading' || !importedVariants
-                  ? TabLocation.Entry
-                  : TabLocation.VariantViewer
-              )}
-            >
-              Variant viewer
-              {data.sequence &&
-                !mediumScreen &&
-                importedVariants !== 'loading' &&
-                importedVariants > 0 && (
-                  <>
-                    {' '}
-                    <Chip compact>
-                      <LongNumber>{importedVariants}</LongNumber>
-                    </Chip>
-                  </>
-                )}
-            </Link>
-          }
-          id={TabLocation.VariantViewer}
-          onPointerOver={VariationViewerTab.preload}
-          onFocus={VariationViewerTab.preload}
-        >
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary>
-              <HTMLHead
-                title={[
-                  pageTitle,
-                  'Variants viewer',
-                  searchableNamespaceLabels[Namespace.uniprotkb],
-                ]}
-              />
-              {data.sequence && (
-                <VariationViewerTab
-                  importedVariants={importedVariants}
-                  primaryAccession={accession}
-                  title="Variants"
-                />
-              )}
-            </ErrorBoundary>
-          </Suspense>
-        </Tab>
-        <Tab
-          title={
-            smallScreen ? null : (
+      <AFDBOutOfSyncContext.Provider value={isAFDBOutOfSync}>
+        <Tabs active={match.params.subPage}>
+          <Tab
+            title={
               <Link
                 className={isObsolete ? helper.disabled : undefined}
                 tabIndex={isObsolete ? -1 : undefined}
                 to={getEntryPath(
                   Namespace.uniprotkb,
                   accession,
-                  TabLocation.FeatureViewer
+                  TabLocation.Entry
                 )}
               >
-                Feature viewer
+                Entry
               </Link>
-            )
-          }
-          id={TabLocation.FeatureViewer}
-          onPointerOver={FeatureViewerTab.preload}
-          onFocus={FeatureViewerTab.preload}
-        >
-          {smallScreen ? (
-            <Redirect
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                TabLocation.Entry
-              )}
-            />
-          ) : (
+            }
+            id={TabLocation.Entry}
+          >
+            {!isObsolete && data.sequence && (
+              <>
+                {displayDownloadPanel && (
+                  <EntryDownloadPanel
+                    handleToggle={handleToggleDownload}
+                    isoformsAvailable={Boolean(listOfIsoformAccessions.length)}
+                    sequence={data.sequence.value}
+                  />
+                )}
+                <div className="button-group">
+                  <ToolsDropdown
+                    selectedEntries={[accession]}
+                    blast
+                    align={
+                      listOfIsoformAccessions.length > 1 && (
+                        <AlignButton
+                          selectedEntries={listOfIsoformAccessions}
+                          textSuffix="isoforms"
+                        />
+                      )
+                    }
+                    mapID
+                  />
+                  <EntryDownloadButton handleToggle={handleToggleDownload} />
+                  <AddToBasketButton selectedEntries={accession} />
+                  <CommunityAnnotationLink accession={accession} />
+                  <a
+                    href={externalUrls.CommunityCurationAdd(accession)}
+                    className="button tertiary"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Add a publication
+                  </a>
+                  {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                  <ContactLink
+                    to={{
+                      pathname: LocationToPath[Location.ContactUpdate],
+                      search: stringifyQuery({
+                        entry: accession,
+                        entryType:
+                          transformedData?.entryType === EntryType.REVIEWED
+                            ? 'Reviewed (Swiss-Prot)'
+                            : 'Unreviewed (TrEMBL)',
+                      }),
+                    }}
+                    className="button tertiary"
+                  >
+                    Entry feedback
+                  </ContactLink>
+                </div>
+                <EntryMain
+                  transformedData={transformedData}
+                  importedVariants={importedVariants}
+                  communityReferences={communityReferences}
+                  isoforms={listOfIsoformNames}
+                />
+              </>
+            )}
+          </Tab>
+          <Tab
+            title={
+              <Link
+                className={cn({
+                  [helper.disabled]:
+                    importedVariants === 'loading' || !importedVariants,
+                  loading: importedVariants === 'loading',
+                })}
+                tabIndex={
+                  importedVariants !== 'loading' && importedVariants
+                    ? undefined
+                    : -1
+                }
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  importedVariants === 'loading' || !importedVariants
+                    ? TabLocation.Entry
+                    : TabLocation.VariantViewer
+                )}
+              >
+                Variant viewer
+                {data.sequence &&
+                  !mediumScreen &&
+                  importedVariants !== 'loading' &&
+                  importedVariants > 0 && (
+                    <>
+                      {' '}
+                      <Chip compact>
+                        <LongNumber>{importedVariants}</LongNumber>
+                      </Chip>
+                    </>
+                  )}
+              </Link>
+            }
+            id={TabLocation.VariantViewer}
+            onPointerOver={VariationViewerTab.preload}
+            onFocus={VariationViewerTab.preload}
+          >
             <Suspense fallback={<Loader />}>
               <ErrorBoundary>
                 <HTMLHead
                   title={[
                     pageTitle,
-                    'Feature viewer',
+                    'Variants viewer',
                     searchableNamespaceLabels[Namespace.uniprotkb],
                   ]}
                 />
                 {data.sequence && (
-                  <FeatureViewerTab
-                    accession={accession}
+                  <VariationViewerTab
                     importedVariants={importedVariants}
-                    sequence={data.sequence.value}
+                    primaryAccession={accession}
+                    title="Variants"
                   />
                 )}
               </ErrorBoundary>
             </Suspense>
-          )}
-        </Tab>
-        <Tab
-          title={
-            <Link
-              className={cn({
-                [helper.disabled]:
-                  hasGenomicCoordinates === 'loading' || !hasGenomicCoordinates,
-                loading: hasGenomicCoordinates === 'loading',
-              })}
-              tabIndex={
-                hasGenomicCoordinates !== 'loading' && hasGenomicCoordinates
-                  ? undefined
-                  : -1
-              }
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                hasGenomicCoordinates === 'loading' || !hasGenomicCoordinates
-                  ? TabLocation.Entry
-                  : TabLocation.GenomicCoordinates
-              )}
-            >
-              Genomic coordinates
-            </Link>
-          }
-          id={TabLocation.GenomicCoordinates}
-          onPointerOver={GenomicCoordinatesTab.preload}
-          onFocus={GenomicCoordinatesTab.preload}
-        >
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary>
-              <HTMLHead
-                title={[
-                  pageTitle,
-                  'Genomic coordinates',
-                  searchableNamespaceLabels[Namespace.uniprotkb],
-                ]}
-              />
-              <GenomicCoordinatesTab
-                primaryAccession={accession}
-                isoforms={
-                  transformedData[EntrySection.Sequence].alternativeProducts
-                    ?.isoforms
-                }
-                maneSelect={
-                  // Get all unique unversioned MANE-Select IDs
-                  new Set(
-                    transformedData[EntrySection.Sequence].xrefData
-                      ?.find(
-                        (xrefDatum) =>
-                          xrefDatum.category === DatabaseCategory.GENOME
-                      )
-                      ?.databases.find(
-                        (database) => database.database === 'MANE-Select'
-                      )
-                      ?.xrefs.map((xref) => xref.id?.split('.')[0])
-                      .filter((id: string | undefined): id is string =>
-                        Boolean(id)
-                      )
-                  )
-                }
-                title={
-                  <span data-article-id="genomic-coordinates">
-                    Genomic coordinates
-                  </span>
-                }
-              />
-            </ErrorBoundary>
-          </Suspense>
-        </Tab>
-        <Tab
-          title={
-            <Link
-              className={isObsolete ? helper.disabled : undefined}
-              tabIndex={isObsolete ? -1 : undefined}
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                TabLocation.Publications
-              )}
-            >
-              Publications
-            </Link>
-          }
-          id={TabLocation.Publications}
-          onPointerOver={PublicationsTab.preload}
-          onFocus={PublicationsTab.preload}
-        >
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary>
-              <div className="button-group">
-                <CommunityAnnotationLink accession={accession} />
-                <a
-                  href={externalUrls.CommunityCurationAdd(accession)}
-                  className="button tertiary"
-                  target="_blank"
-                  rel="noopener noreferrer"
+          </Tab>
+          <Tab
+            title={
+              smallScreen ? null : (
+                <Link
+                  className={isObsolete ? helper.disabled : undefined}
+                  tabIndex={isObsolete ? -1 : undefined}
+                  to={getEntryPath(
+                    Namespace.uniprotkb,
+                    accession,
+                    TabLocation.FeatureViewer
+                  )}
                 >
-                  Add a publication
-                </a>
-              </div>
-              <HTMLHead
-                title={[
-                  pageTitle,
-                  'Publications',
-                  searchableNamespaceLabels[Namespace.uniprotkb],
-                ]}
+                  Feature viewer
+                </Link>
+              )
+            }
+            id={TabLocation.FeatureViewer}
+            onPointerOver={FeatureViewerTab.preload}
+            onFocus={FeatureViewerTab.preload}
+          >
+            {smallScreen ? (
+              <Redirect
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  TabLocation.Entry
+                )}
               />
-              <PublicationsTab accession={accession} />
-            </ErrorBoundary>
-          </Suspense>
-        </Tab>
-        <Tab
-          title={
-            <Link
-              className={isObsolete ? helper.disabled : undefined}
-              tabIndex={isObsolete ? -1 : undefined}
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                TabLocation.ExternalLinks
-              )}
-            >
-              External links
-            </Link>
-          }
-          id={TabLocation.ExternalLinks}
-          onPointerOver={ExternalLinksTab.preload}
-          onFocus={ExternalLinksTab.preload}
-        >
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary>
-              <HTMLHead
-                title={[
-                  pageTitle,
-                  'External links',
-                  searchableNamespaceLabels[Namespace.uniprotkb],
-                ]}
-              />
-              <ExternalLinksTab transformedData={transformedData} />
-            </ErrorBoundary>
-          </Suspense>
-        </Tab>
-        <Tab
-          title={
-            <Link
-              to={getEntryPath(
-                Namespace.uniprotkb,
-                accession,
-                TabLocation.History
-              )}
-            >
-              History
-            </Link>
-          }
-          id={TabLocation.History}
-          onPointerOver={HistoryTab.preload}
-          onFocus={HistoryTab.preload}
-        >
-          <Suspense fallback={<Loader />}>
-            <ErrorBoundary>
-              <HTMLHead
-                title={[
-                  isObsolete ? accession : pageTitle,
-                  'History',
-                  searchableNamespaceLabels[Namespace.uniprotkb],
-                ]}
-              />
-              <HistoryTab
-                accession={isObsolete ? match.params.accession : accession}
-                lastVersion={data.entryAudit?.entryVersion}
-                uniparc={data.extraAttributes?.uniParcId}
-                reason={data.inactiveReason}
-              />
-            </ErrorBoundary>
-          </Suspense>
-        </Tab>
-      </Tabs>
+            ) : (
+              <Suspense fallback={<Loader />}>
+                <ErrorBoundary>
+                  <HTMLHead
+                    title={[
+                      pageTitle,
+                      'Feature viewer',
+                      searchableNamespaceLabels[Namespace.uniprotkb],
+                    ]}
+                  />
+                  {data.sequence && (
+                    <FeatureViewerTab
+                      accession={accession}
+                      importedVariants={importedVariants}
+                      sequence={data.sequence.value}
+                    />
+                  )}
+                </ErrorBoundary>
+              </Suspense>
+            )}
+          </Tab>
+          <Tab
+            title={
+              <Link
+                className={cn({
+                  [helper.disabled]:
+                    hasGenomicCoordinates === 'loading' ||
+                    !hasGenomicCoordinates,
+                  loading: hasGenomicCoordinates === 'loading',
+                })}
+                tabIndex={
+                  hasGenomicCoordinates !== 'loading' && hasGenomicCoordinates
+                    ? undefined
+                    : -1
+                }
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  hasGenomicCoordinates === 'loading' || !hasGenomicCoordinates
+                    ? TabLocation.Entry
+                    : TabLocation.GenomicCoordinates
+                )}
+              >
+                Genomic coordinates
+              </Link>
+            }
+            id={TabLocation.GenomicCoordinates}
+            onPointerOver={GenomicCoordinatesTab.preload}
+            onFocus={GenomicCoordinatesTab.preload}
+          >
+            <Suspense fallback={<Loader />}>
+              <ErrorBoundary>
+                <HTMLHead
+                  title={[
+                    pageTitle,
+                    'Genomic coordinates',
+                    searchableNamespaceLabels[Namespace.uniprotkb],
+                  ]}
+                />
+                <GenomicCoordinatesTab
+                  primaryAccession={accession}
+                  isoforms={
+                    transformedData[EntrySection.Sequence].alternativeProducts
+                      ?.isoforms
+                  }
+                  maneSelect={
+                    // Get all unique unversioned MANE-Select IDs
+                    new Set(
+                      transformedData[EntrySection.Sequence].xrefData
+                        ?.find(
+                          (xrefDatum) =>
+                            xrefDatum.category === DatabaseCategory.GENOME
+                        )
+                        ?.databases.find(
+                          (database) => database.database === 'MANE-Select'
+                        )
+                        ?.xrefs.map((xref) => xref.id?.split('.')[0])
+                        .filter((id: string | undefined): id is string =>
+                          Boolean(id)
+                        )
+                    )
+                  }
+                  title={
+                    <span data-article-id="genomic-coordinates">
+                      Genomic coordinates
+                    </span>
+                  }
+                />
+              </ErrorBoundary>
+            </Suspense>
+          </Tab>
+          <Tab
+            title={
+              <Link
+                className={isObsolete ? helper.disabled : undefined}
+                tabIndex={isObsolete ? -1 : undefined}
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  TabLocation.Publications
+                )}
+              >
+                Publications
+              </Link>
+            }
+            id={TabLocation.Publications}
+            onPointerOver={PublicationsTab.preload}
+            onFocus={PublicationsTab.preload}
+          >
+            <Suspense fallback={<Loader />}>
+              <ErrorBoundary>
+                <div className="button-group">
+                  <CommunityAnnotationLink accession={accession} />
+                  <a
+                    href={externalUrls.CommunityCurationAdd(accession)}
+                    className="button tertiary"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Add a publication
+                  </a>
+                </div>
+                <HTMLHead
+                  title={[
+                    pageTitle,
+                    'Publications',
+                    searchableNamespaceLabels[Namespace.uniprotkb],
+                  ]}
+                />
+                <PublicationsTab accession={accession} />
+              </ErrorBoundary>
+            </Suspense>
+          </Tab>
+          <Tab
+            title={
+              <Link
+                className={isObsolete ? helper.disabled : undefined}
+                tabIndex={isObsolete ? -1 : undefined}
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  TabLocation.ExternalLinks
+                )}
+              >
+                External links
+              </Link>
+            }
+            id={TabLocation.ExternalLinks}
+            onPointerOver={ExternalLinksTab.preload}
+            onFocus={ExternalLinksTab.preload}
+          >
+            <Suspense fallback={<Loader />}>
+              <ErrorBoundary>
+                <HTMLHead
+                  title={[
+                    pageTitle,
+                    'External links',
+                    searchableNamespaceLabels[Namespace.uniprotkb],
+                  ]}
+                />
+                <ExternalLinksTab transformedData={transformedData} />
+              </ErrorBoundary>
+            </Suspense>
+          </Tab>
+          <Tab
+            title={
+              <Link
+                to={getEntryPath(
+                  Namespace.uniprotkb,
+                  accession,
+                  TabLocation.History
+                )}
+              >
+                History
+              </Link>
+            }
+            id={TabLocation.History}
+            onPointerOver={HistoryTab.preload}
+            onFocus={HistoryTab.preload}
+          >
+            <Suspense fallback={<Loader />}>
+              <ErrorBoundary>
+                <HTMLHead
+                  title={[
+                    isObsolete ? accession : pageTitle,
+                    'History',
+                    searchableNamespaceLabels[Namespace.uniprotkb],
+                  ]}
+                />
+                <HistoryTab
+                  accession={isObsolete ? match.params.accession : accession}
+                  lastVersion={data.entryAudit?.entryVersion}
+                  uniparc={data.extraAttributes?.uniParcId}
+                  reason={data.inactiveReason}
+                />
+              </ErrorBoundary>
+            </Suspense>
+          </Tab>
+        </Tabs>
+      </AFDBOutOfSyncContext.Provider>
     </SidebarLayout>
   );
 };

--- a/src/uniprotkb/components/entry/EntryMain.tsx
+++ b/src/uniprotkb/components/entry/EntryMain.tsx
@@ -39,5 +39,4 @@ const EntryMain = ({
     <MedicalDisclaimer />
   </IsoformsContext.Provider>
 );
-
 export default EntryMain;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5528,9 +5528,13 @@ exports[`Entry view should render for non-human entry 1`] = `
       <div
         class="card__content"
       >
-        <protvista-uniprot-structure
-          accession="P0DTR4"
-        />
+        <div
+          class="container"
+        >
+          <protvista-uniprot-structure
+            accession="P0DTR4"
+          />
+        </div>
         <h3>
           3D structure databases
         </h3>

--- a/src/uniprotkb/components/protein-data-views/AFDBOutOfSync.tsx
+++ b/src/uniprotkb/components/protein-data-views/AFDBOutOfSync.tsx
@@ -1,0 +1,19 @@
+import { HTMLAttributes, useContext } from 'react';
+import { Message } from 'franklin-sites';
+
+import { AFDBOutOfSyncContext } from '../../../shared/contexts/AFDBOutOfSync';
+
+export const AFDBOutOfSync = ({ ...props }: HTMLAttributes<HTMLDivElement>) => {
+  const isAFDBOutOfSync = useContext(AFDBOutOfSyncContext);
+
+  if (!isAFDBOutOfSync) {
+    return null;
+  }
+
+  return (
+    <Message level="warning" {...props}>
+      Caution: This AlphaFold model was generated using a prior version of the
+      UniProt sequence that differs from that now shown
+    </Message>
+  );
+};

--- a/src/uniprotkb/components/protein-data-views/AFDBOutOfSync.tsx
+++ b/src/uniprotkb/components/protein-data-views/AFDBOutOfSync.tsx
@@ -1,9 +1,9 @@
-import { HTMLAttributes, useContext } from 'react';
+import { useContext } from 'react';
 import { Message } from 'franklin-sites';
 
 import { AFDBOutOfSyncContext } from '../../../shared/contexts/AFDBOutOfSync';
 
-export const AFDBOutOfSync = ({ ...props }: HTMLAttributes<HTMLDivElement>) => {
+export const AFDBOutOfSync = () => {
   const isAFDBOutOfSync = useContext(AFDBOutOfSyncContext);
 
   if (!isAFDBOutOfSync) {
@@ -11,7 +11,7 @@ export const AFDBOutOfSync = ({ ...props }: HTMLAttributes<HTMLDivElement>) => {
   }
 
   return (
-    <Message level="warning" {...props}>
+    <Message level="warning">
       Caution: This AlphaFold model was generated using a prior version of the
       UniProt sequence that differs from that now shown
     </Message>

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -1,6 +1,10 @@
 import { Loader } from 'franklin-sites';
 
+import { AFDBOutOfSync } from './AFDBOutOfSync';
+
 import useCustomElement from '../../../shared/hooks/useCustomElement';
+
+import styles from './styles/structure-view.module.css';
 
 const StructureView = ({ primaryAccession }: { primaryAccession: string }) => {
   const structureElement = useCustomElement(
@@ -15,7 +19,12 @@ const StructureView = ({ primaryAccession }: { primaryAccession: string }) => {
   if (!structureElement.defined && !structureElement.errored) {
     return <Loader />;
   }
-  return <protvista-uniprot-structure accession={primaryAccession} />;
+  return (
+    <div className={styles.container}>
+      <AFDBOutOfSync />
+      <protvista-uniprot-structure accession={primaryAccession} />
+    </div>
+  );
 };
 
 export default StructureView;

--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -8,6 +8,7 @@ import ExternalLink from '../../../shared/components/ExternalLink';
 import PDBView from './PDBView';
 import EMBLView from './EMBLView';
 import { RichText } from './FreeTextView';
+import { AFDBOutOfSync } from './AFDBOutOfSync';
 
 import useDatabaseInfoMaps from '../../../shared/hooks/useDatabaseInfoMaps';
 
@@ -277,12 +278,15 @@ const XRefsGroupedByCategory = ({
         </Link>
       ),
       content: (
-        <DatabaseList
-          xrefsGoupedByDatabase={database}
-          primaryAccession={primaryAccession}
-          crc64={crc64}
-          databaseToDatabaseInfo={databaseToDatabaseInfo}
-        />
+        <>
+          <DatabaseList
+            xrefsGoupedByDatabase={database}
+            primaryAccession={primaryAccession}
+            crc64={crc64}
+            databaseToDatabaseInfo={databaseToDatabaseInfo}
+          />
+          {database.database === 'AlphaFoldDB' && <AFDBOutOfSync />}
+        </>
       ),
     };
   });

--- a/src/uniprotkb/components/protein-data-views/styles/structure-view.module.css
+++ b/src/uniprotkb/components/protein-data-views/styles/structure-view.module.css
@@ -10,5 +10,6 @@
   .container:has(protvista-structure[structureid^='AF']) :global(.message) {
     /* Display and revert to the default style of the message */
     display: grid;
+    margin-block-start: 0.5em;
   }
 }

--- a/src/uniprotkb/components/protein-data-views/styles/structure-view.module.css
+++ b/src/uniprotkb/components/protein-data-views/styles/structure-view.module.css
@@ -1,0 +1,14 @@
+/* By default don't display the message */
+.container :global(.message) {
+  display: none;
+}
+
+/* If no support for has, we won't show the message, it's fine */
+@supports selector(:has(*)) {
+  /* Target the message only if there's a protvista-structure with the
+  "structureid" attribute set to something that looks like an AFDB ID */
+  .container:has(protvista-structure[structureid^='AF']) :global(.message) {
+    /* Display and revert to the default style of the message */
+    display: grid;
+  }
+}


### PR DESCRIPTION
## Purpose
Add warning message as per email thread `AlphaFold "banner" for sequences changed since AlphaFold2`. Wording following the suggested one. Approach based, as suggested, on cutoff date (so if there's a new release, we will need to update the hardcoded value)

## Approach
Add franklin warning message next to the xrefs (in structure section, both in entry tab and external links tab).
Add franklin warning message above the structure viewer only when the AF model is selected: requires CSS [`:has()`](https://caniuse.com/css-has), so if not supported just don't display the message at all)
Use react context to pass the out-of-sync info as the needed info was too far away within the tree of components.

## Testing
Manual checks, used P05067 for still valid model, and O75319 for out of sync one.

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
