### PR TITLE
fix issue when canonical is not -1, also improve network usage

### DIFF
--- a/src/uniparc/components/sub-entry/SubEntrySimilarProteinsTabContent.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySimilarProteinsTabContent.tsx
@@ -89,14 +89,12 @@ const SimilarProteinsTabContent = ({ clusterType, clusters }: Props) => {
       {hasSimilarProteins.map(
         ({ total, cluster, uniprotkbResults, uniprotkbQuery }) => (
           <section key={cluster.id} className="text-block">
-            <section>
-              <SimilarProteinsTable
-                cluster={cluster}
-                total={total}
-                uniprotkbResults={uniprotkbResults}
-                uniprotkbQuery={uniprotkbQuery}
-              />
-            </section>
+            <SimilarProteinsTable
+              cluster={cluster}
+              total={total}
+              uniprotkbResults={uniprotkbResults}
+              uniprotkbQuery={uniprotkbQuery}
+            />
             <hr />
           </section>
         )
@@ -111,15 +109,13 @@ const SimilarProteinsTabContent = ({ clusterType, clusters }: Props) => {
               </span>
             ))}
           </h4>
-          <section>
-            {`No similar proteins at ${
-              uniRefEntryTypeToPercent[clusterType as UniRefEntryType]
-            } identity for ${pluralise(
-              'this isoform.',
-              noSimilarProteins.length,
-              'these isoforms.'
-            )}`}
-          </section>
+          {`No similar proteins at ${
+            uniRefEntryTypeToPercent[clusterType as UniRefEntryType]
+          } identity for ${pluralise(
+            'this isoform.',
+            noSimilarProteins.length,
+            'these isoforms.'
+          )}`}
           <hr />
         </section>
       )}

--- a/src/uniprotkb/adapters/__tests__/extractIsoformsConverter.spec.ts
+++ b/src/uniprotkb/adapters/__tests__/extractIsoformsConverter.spec.ts
@@ -5,6 +5,6 @@ import modelData from '../../__mocks__/uniProtKBEntryModelData';
 describe('Accessions data converter', () => {
   it('should extract all isoforms', () => {
     const isoformData = extractIsoforms(modelData);
-    expect(isoformData).toEqual(['isoID1']);
+    expect(isoformData).toEqual({ canonical: 'P21802', isoforms: ['isoID1'] });
   });
 });

--- a/src/uniprotkb/adapters/extractIsoformsConverter.ts
+++ b/src/uniprotkb/adapters/extractIsoformsConverter.ts
@@ -11,9 +11,14 @@ const finder = (
 
 const extractIsoforms = (data: UniProtkbAPIModel) => {
   const alternativeProducts = data.comments?.find(finder);
-  return (
-    alternativeProducts?.isoforms.flatMap((isoform) => isoform.isoformIds) || []
-  );
+  const canonical =
+    alternativeProducts?.isoforms.find(
+      (isoform) => isoform.isoformSequenceStatus === 'Displayed'
+    )?.isoformIds[0] || data.primaryAccession;
+  const isoforms = alternativeProducts?.isoforms.flatMap(
+    (isoform) => isoform.isoformIds
+  ) || [data.primaryAccession];
+  return { canonical, isoforms };
 };
 
 export const extractIsoformNames = (data?: UniProtkbAPIModel) => {

--- a/src/uniprotkb/adapters/uniProtkbConverter.ts
+++ b/src/uniprotkb/adapters/uniProtkbConverter.ts
@@ -115,7 +115,10 @@ export type UniProtkbUIModel = {
   [EntrySection.Structure]: UIModel;
   [EntrySection.FamilyAndDomains]: UIModel;
   [EntrySection.ExternalLinks]: UIModel;
-  [EntrySection.SimilarProteins]: string[];
+  [EntrySection.SimilarProteins]: {
+    canonical: string;
+    isoforms: string[];
+  };
   references?: UniProtKBReference[];
   extraAttributes: UniProtkbAPIModel['extraAttributes'];
   from?: string; // ID Mapping

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
@@ -1,13 +1,12 @@
 import { Loader, Tabs, Tab } from 'franklin-sites';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { zip } from 'lodash-es';
 
 import SimilarProteinsTabContent from './SimilarProteinsTabContent';
 
-import useSafeState from '../../../../shared/hooks/useSafeState';
-
 import apiUrls from '../../../../shared/config/apiUrls/apiUrls';
 import fetchData from '../../../../shared/utils/fetchData';
+import { stringifyQuery } from '../../../../shared/utils/url';
 
 import { Namespace } from '../../../../shared/types/namespaces';
 import {
@@ -15,6 +14,9 @@ import {
   uniRefEntryTypeToPercent,
   UniRefLiteAPIModel,
 } from '../../../../uniref/adapters/uniRefConverter';
+import { UniProtkbUIModel } from '../../../adapters/uniProtkbConverter';
+import EntrySection from '../../../types/entrySection';
+import { UniRefColumn } from '../../../../uniref/config/UniRefColumnConfiguration';
 
 export type IsoformsAndCluster = {
   isoforms: string[];
@@ -53,44 +55,47 @@ export const getClusterMapping = (
   return mapping;
 };
 
-// TODO: check cases when the canonical might not be the first isoforms!!!
-const canonicalIsoformRE = /-1$/;
-
-type Props = {
-  isoforms: string[];
-  primaryAccession: string;
-};
-
-const SimilarProteins = ({ isoforms, primaryAccession }: Props) => {
-  const [mappingData, setMappingData] = useSafeState<ClusterMapping | null>(
-    null
-  );
-  const [mappingLoading, setMappingLoading] = useSafeState(true);
-
-  // Note, in the case of no other isoforms, the `isoforms` array is empty
-  const allIsoforms = useMemo(
-    () => Array.from(new Set([`${primaryAccession}-1`, ...isoforms])),
-    [primaryAccession, isoforms]
-  );
+const SimilarProteins = ({
+  canonical,
+  isoforms,
+}: UniProtkbUIModel[EntrySection.SimilarProteins]) => {
+  const [mappingData, setMappingData] = useState<ClusterMapping | null>(null);
+  const [mappingLoading, setMappingLoading] = useState(true);
 
   useEffect(() => {
-    const promises = allIsoforms.map((accession) =>
+    const controller = new AbortController();
+    const promises = isoforms.map((accession) =>
       fetchData<{
         results: UniRefLiteAPIModel[];
       }>(
-        `${apiUrls.search.searchPrefix(Namespace.uniref)}?query=(uniprot_id:${
-          // replace isoform name "-1" for canonical to get data from API
-          accession.replace(canonicalIsoformRE, '')
-        })`
+        apiUrls.search.search({
+          namespace: Namespace.uniref,
+          query: stringifyQuery({
+            uniprot_id:
+              accession === canonical
+                ? accession.replace(/-\d+$/, '')
+                : accession,
+          }),
+          columns: [UniRefColumn.id, UniRefColumn.identity],
+          facets: null,
+        }),
+        undefined,
+        { signal: controller.signal }
       )
     );
-    Promise.all(promises).then((responses) => {
-      const clusterData = responses.map((response) => response.data.results);
-      const mapping = getClusterMapping(allIsoforms, clusterData);
-      setMappingData(mapping);
-      setMappingLoading(false);
-    });
-  }, [allIsoforms, setMappingData, setMappingLoading]);
+    Promise.all(promises).then(
+      (responses) => {
+        const clusterData = responses.map((response) => response.data.results);
+        const mapping = getClusterMapping(isoforms, clusterData);
+        setMappingData(mapping);
+        setMappingLoading(false);
+      },
+      () => {
+        /* ignore fetch errors */
+      }
+    );
+    return () => controller.abort();
+  }, [canonical, isoforms]);
 
   if (mappingLoading) {
     return <Loader />;
@@ -106,6 +111,7 @@ const SimilarProteins = ({ isoforms, primaryAccession }: Props) => {
             key={clusterType}
           >
             <SimilarProteinsTabContent
+              canonical={canonical}
               clusterType={clusterType}
               isoformsAndClusters={Object.values(
                 mappingData[clusterType as UniRefEntryType]

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsSection.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsSection.tsx
@@ -5,18 +5,17 @@ import LazyComponent from '../../../../shared/components/LazyComponent';
 
 import { getEntrySectionNameAndId } from '../../../utils/entrySection';
 
+import { UniProtkbUIModel } from '../../../adapters/uniProtkbConverter';
 import EntrySection from '../../../types/entrySection';
 
 const SimilarProteins = lazy(
   () => import(/* webpackChunkName: "similar-proteins" */ './SimilarProteins')
 );
 
-type Props = {
-  isoforms: string[];
-  primaryAccession: string;
-};
-
-const SimilarProteinsSection = ({ isoforms, primaryAccession }: Props) => {
+const SimilarProteinsSection = ({
+  canonical,
+  isoforms,
+}: UniProtkbUIModel[EntrySection.SimilarProteins]) => {
   const { name, id } = getEntrySectionNameAndId(EntrySection.SimilarProteins);
   return (
     <Card
@@ -25,10 +24,7 @@ const SimilarProteinsSection = ({ isoforms, primaryAccession }: Props) => {
       data-entry-section
     >
       <LazyComponent>
-        <SimilarProteins
-          isoforms={isoforms}
-          primaryAccession={primaryAccession}
-        />
+        <SimilarProteins canonical={canonical} isoforms={isoforms} />
       </LazyComponent>
     </Card>
   );

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTable.tsx
@@ -10,6 +10,7 @@ import {
   Location,
   getEntryPath,
 } from '../../../../app/config/urls';
+import { stringifyQuery } from '../../../../shared/utils/url';
 
 import { UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
 import { UniProtKBColumn } from '../../../types/columnTypes';
@@ -22,7 +23,7 @@ export const columns = [
   UniProtKBColumn.reviewed,
   UniProtKBColumn.organismName,
   UniProtKBColumn.proteinName,
-  UniProtKBColumn.sequence,
+  UniProtKBColumn.length,
 ];
 
 const columnConfig = [
@@ -85,7 +86,7 @@ const SimilarProteinsTable = ({
       <Link
         to={{
           pathname: LocationToPath[Location.UniProtKBResults],
-          search: `query=${uniprotkbQuery}`,
+          search: stringifyQuery({ query: uniprotkbQuery }),
         }}
       >
         {'View '}

--- a/src/uniprotkb/components/entry/similar-proteins/__tests__/SimilarProteins.spec.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/__tests__/SimilarProteins.spec.tsx
@@ -18,10 +18,10 @@ import uniprotkbClusterSearch from './__mocks__/uniprotkbClusterSearch';
 const axiosMock = new MockAdapter(axios);
 axiosMock
   // find clusters for canonical
-  .onGet(/\/uniref\/search\?query=\(uniprot_id:P05067\)/)
+  .onGet(/query=%28uniprot_id%3DP05067%29/)
   .reply(200, unirefP05067)
   // find clusters for isoform 4
-  .onGet(/\/uniref\/search\?query=\(uniprot_id:P05067-4\)/)
+  .onGet(/query=%28uniprot_id%3DP05067-4%29/)
   .reply(200, unirefP05067isoform4)
   // find members of cluster (always same response for testing)
   .onGet(/\/uniprotkb\/search/)
@@ -35,7 +35,7 @@ describe('SimilarProteins tests', () => {
       rendered = customRender(
         <SimilarProteins
           isoforms={['P05067-1', 'P05067-4']}
-          primaryAccession="P05067"
+          canonical="P05067-1"
         />
       );
     });
@@ -55,7 +55,7 @@ describe('SimilarProteins tests', () => {
   it('should navigate to correct search page when clicking "View all"', async () => {
     fireEvent.click(screen.getByRole('link', { name: 'View all' }));
     expect(rendered.history.location.search).toEqual(
-      '?query=uniref_cluster_100:UniRef100_P05067 OR uniref_cluster_100:UniRef100_P05067-4'
+      '?query=uniref_cluster_100%3AUniRef100_P05067+OR+uniref_cluster_100%3AUniRef100_P05067-4'
     );
     expect(rendered.history.location.pathname).toEqual('/uniprotkb');
   });

--- a/src/uniprotkb/components/entry/similar-proteins/__tests__/__snapshots__/SimilarProteins.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/similar-proteins/__tests__/__snapshots__/SimilarProteins.spec.tsx.snap
@@ -53,114 +53,112 @@ exports[`SimilarProteins tests should fetch data and render 1`] = `
             P05067-1
           </span>
         </h4>
-        <section>
-          <a
-            href="/uniref/UniRef100_P05067"
+        <a
+          href="/uniref/UniRef100_P05067"
+        >
+          UniRef100_P05067
+        </a>
+        <div
+          class="overflow-y-container"
+        >
+          <table
+            class="data-table data-table--compact"
           >
-            UniRef100_P05067
-          </a>
-          <div
-            class="overflow-y-container"
-          >
-            <table
-              class="data-table data-table--compact"
+            <thead>
+              <tr>
+                <th
+                  class=""
+                  data-column-name="reviewed"
+                />
+                <th
+                  class=""
+                  data-column-name="protein_name"
+                >
+                  Protein name
+                </th>
+                <th
+                  class=""
+                  data-column-name="organism"
+                >
+                  Organism
+                </th>
+                <th
+                  class=""
+                  data-column-name="length"
+                >
+                  Length
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              translate="no"
             >
-              <thead>
-                <tr>
-                  <th
-                    class=""
-                    data-column-name="reviewed"
-                  />
-                  <th
-                    class=""
-                    data-column-name="protein_name"
+              <tr>
+                <td>
+                  <span
+                    class="entry-title__status icon--unreviewed"
+                    title="This marks an unreviewed UniProtKB entry"
                   >
-                    Protein name
-                  </th>
-                  <th
-                    class=""
-                    data-column-name="organism"
+                    <test-file-stub />
+                  </span>
+                </td>
+                <td>
+                  <a
+                    href="/uniprotkb/A0A2J8MQ83"
                   >
-                    Organism
-                  </th>
-                  <th
-                    class=""
-                    data-column-name="length"
+                    Amyloid-beta A4 protein
+                  </a>
+                </td>
+                <td>
+                  <a
+                    href="/taxonomy/9598"
+                    title="Pan troglodytes (Chimpanzee), taxon ID 9598"
+                    translate="no"
                   >
-                    Length
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                translate="no"
-              >
-                <tr>
-                  <td>
-                    <span
-                      class="entry-title__status icon--unreviewed"
-                      title="This marks an unreviewed UniProtKB entry"
-                    >
-                      <test-file-stub />
-                    </span>
-                  </td>
-                  <td>
-                    <a
-                      href="/uniprotkb/A0A2J8MQ83"
-                    >
-                      Amyloid-beta A4 protein
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href="/taxonomy/9598"
-                      title="Pan troglodytes (Chimpanzee), taxon ID 9598"
-                      translate="no"
-                    >
-                      Pan troglodytes (Chimpanzee)
-                    </a>
-                  </td>
-                  <td>
-                    180
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <span
-                      class="entry-title__status icon--unreviewed"
-                      title="This marks an unreviewed UniProtKB entry"
-                    >
-                      <test-file-stub />
-                    </span>
-                  </td>
-                  <td>
-                    <a
-                      href="/uniprotkb/A0A2J8UKJ9"
-                    >
-                      Amyloid-beta A4 protein
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href="/taxonomy/9601"
-                      title="Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii), taxon ID 9601"
-                      translate="no"
-                    >
-                      Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)
-                    </a>
-                  </td>
-                  <td>
-                    180
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <a
-            href="/uniprotkb?query=(uniref_cluster_100:UniRef100_P05067) NOT (accession:P05067)"
-          >
-            View these 2 entries in UniProtKB
-          </a>
-        </section>
+                    Pan troglodytes (Chimpanzee)
+                  </a>
+                </td>
+                <td>
+                  180
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span
+                    class="entry-title__status icon--unreviewed"
+                    title="This marks an unreviewed UniProtKB entry"
+                  >
+                    <test-file-stub />
+                  </span>
+                </td>
+                <td>
+                  <a
+                    href="/uniprotkb/A0A2J8UKJ9"
+                  >
+                    Amyloid-beta A4 protein
+                  </a>
+                </td>
+                <td>
+                  <a
+                    href="/taxonomy/9601"
+                    title="Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii), taxon ID 9601"
+                    translate="no"
+                  >
+                    Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)
+                  </a>
+                </td>
+                <td>
+                  180
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <a
+          href="/uniprotkb?query=%28uniref_cluster_100%3AUniRef100_P05067%29+NOT+%28accession%3AP05067%29"
+        >
+          View these 2 entries in UniProtKB
+        </a>
         <hr />
       </section>
       <section
@@ -171,119 +169,117 @@ exports[`SimilarProteins tests should fetch data and render 1`] = `
             P05067-4
           </span>
         </h4>
-        <section>
-          <a
-            href="/uniref/UniRef100_P05067-4"
+        <a
+          href="/uniref/UniRef100_P05067-4"
+        >
+          UniRef100_P05067-4
+        </a>
+        <div
+          class="overflow-y-container"
+        >
+          <table
+            class="data-table data-table--compact"
           >
-            UniRef100_P05067-4
-          </a>
-          <div
-            class="overflow-y-container"
-          >
-            <table
-              class="data-table data-table--compact"
+            <thead>
+              <tr>
+                <th
+                  class=""
+                  data-column-name="reviewed"
+                />
+                <th
+                  class=""
+                  data-column-name="protein_name"
+                >
+                  Protein name
+                </th>
+                <th
+                  class=""
+                  data-column-name="organism"
+                >
+                  Organism
+                </th>
+                <th
+                  class=""
+                  data-column-name="length"
+                >
+                  Length
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              translate="no"
             >
-              <thead>
-                <tr>
-                  <th
-                    class=""
-                    data-column-name="reviewed"
-                  />
-                  <th
-                    class=""
-                    data-column-name="protein_name"
+              <tr>
+                <td>
+                  <span
+                    class="entry-title__status icon--unreviewed"
+                    title="This marks an unreviewed UniProtKB entry"
                   >
-                    Protein name
-                  </th>
-                  <th
-                    class=""
-                    data-column-name="organism"
+                    <test-file-stub />
+                  </span>
+                </td>
+                <td>
+                  <a
+                    href="/uniprotkb/A0A2J8MQ83"
                   >
-                    Organism
-                  </th>
-                  <th
-                    class=""
-                    data-column-name="length"
+                    Amyloid-beta A4 protein
+                  </a>
+                </td>
+                <td>
+                  <a
+                    href="/taxonomy/9598"
+                    title="Pan troglodytes (Chimpanzee), taxon ID 9598"
+                    translate="no"
                   >
-                    Length
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                translate="no"
-              >
-                <tr>
-                  <td>
-                    <span
-                      class="entry-title__status icon--unreviewed"
-                      title="This marks an unreviewed UniProtKB entry"
-                    >
-                      <test-file-stub />
-                    </span>
-                  </td>
-                  <td>
-                    <a
-                      href="/uniprotkb/A0A2J8MQ83"
-                    >
-                      Amyloid-beta A4 protein
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href="/taxonomy/9598"
-                      title="Pan troglodytes (Chimpanzee), taxon ID 9598"
-                      translate="no"
-                    >
-                      Pan troglodytes (Chimpanzee)
-                    </a>
-                  </td>
-                  <td>
-                    180
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <span
-                      class="entry-title__status icon--unreviewed"
-                      title="This marks an unreviewed UniProtKB entry"
-                    >
-                      <test-file-stub />
-                    </span>
-                  </td>
-                  <td>
-                    <a
-                      href="/uniprotkb/A0A2J8UKJ9"
-                    >
-                      Amyloid-beta A4 protein
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href="/taxonomy/9601"
-                      title="Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii), taxon ID 9601"
-                      translate="no"
-                    >
-                      Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)
-                    </a>
-                  </td>
-                  <td>
-                    180
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <a
-            href="/uniprotkb?query=(uniref_cluster_100:UniRef100_P05067-4) NOT (accession:P05067-4)"
-          >
-            View these 2 entries in UniProtKB
-          </a>
-        </section>
+                    Pan troglodytes (Chimpanzee)
+                  </a>
+                </td>
+                <td>
+                  180
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span
+                    class="entry-title__status icon--unreviewed"
+                    title="This marks an unreviewed UniProtKB entry"
+                  >
+                    <test-file-stub />
+                  </span>
+                </td>
+                <td>
+                  <a
+                    href="/uniprotkb/A0A2J8UKJ9"
+                  >
+                    Amyloid-beta A4 protein
+                  </a>
+                </td>
+                <td>
+                  <a
+                    href="/taxonomy/9601"
+                    title="Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii), taxon ID 9601"
+                    translate="no"
+                  >
+                    Pongo abelii (Sumatran orangutan) (Pongo pygmaeus abelii)
+                  </a>
+                </td>
+                <td>
+                  180
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <a
+          href="/uniprotkb?query=%28uniref_cluster_100%3AUniRef100_P05067-4%29+NOT+%28accession%3AP05067-4%29"
+        >
+          View these 2 entries in UniProtKB
+        </a>
         <hr />
       </section>
       <a
         class="button primary"
-        href="/uniprotkb?query=uniref_cluster_100:UniRef100_P05067 OR uniref_cluster_100:UniRef100_P05067-4"
+        href="/uniprotkb?query=uniref_cluster_100%3AUniRef100_P05067+OR+uniref_cluster_100%3AUniRef100_P05067-4"
       >
         View all
       </a>

--- a/src/uniprotkb/config/UniProtEntryConfig.tsx
+++ b/src/uniprotkb/config/UniProtEntryConfig.tsx
@@ -140,8 +140,7 @@ const UniProtKBEntryConfig: {
     id: EntrySection.SimilarProteins,
     sectionContent: (data) => (
       <SimilarProteinsSection
-        isoforms={data[EntrySection.SimilarProteins]}
-        primaryAccession={data.primaryAccession}
+        {...data[EntrySection.SimilarProteins]}
         key={EntrySection.SimilarProteins}
       />
     ),


### PR DESCRIPTION
## Purpose
[TRM-32261](https://www.ebi.ac.uk/panda/jira/browse/TRM-32261) Fix issue when displaying similar proteins in the corresponding UniProtKB section when the canonical isoform is not `-1`

## Approach
Note: no way to query the canonical isoform from the UniRef endpoint with the `-<number`.

Changed UniProtKB converter and passed the information about which of the isoforms is the canonical one, in order to query the UniRef API with the entry accession instead of the isoform accession (with `-<number`).

Also, reduce the size of the requested payloads

Haven't changed the similar proteins logic for the UniParc xref pages (UniProtKB-like) as we would need to adjust the logic to the new UniParc API first anyway.

## Testing
Updated tests
Manual checks with:
- P05067 (multiple isoforms, `-1` is canonical)
- Q96G97 (multiple isoforms, `-2` is canonical, `-1` doesn't even exist)
- A0A087X0K9 (only 1 isoform, so it's canonical)

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
