### PR TITLE
detect translated website and add message and context

### DIFF
--- a/src/contact/components/ContactForm.tsx
+++ b/src/contact/components/ContactForm.tsx
@@ -19,6 +19,8 @@ import HTMLHead from '../../shared/components/HTMLHead';
 import ContactLink from './ContactLink';
 import ExternalLink from '../../shared/components/ExternalLink';
 
+import { translatedWebsite } from '../../shared/utils/translatedWebsite';
+
 import {
   useFormLogic,
   ContactLocationState,
@@ -74,14 +76,17 @@ const ContactForm = () => {
     }
   }
 
-  const context = useMemo(
-    () =>
-      `${locationState?.formValues?.context || ''}
+  const context = useMemo(() => {
+    const isTranslatedWebsite = translatedWebsite();
+    let context = `${locationState?.formValues?.context || ''}
 Referred from: ${globalThis.location.origin}${referrerValue}
 User browser: ${navigator.userAgent}
-Website version: ${GIT_COMMIT_HASH}`.trim(),
-    [locationState?.formValues?.context, referrerValue]
-  );
+Website version: ${GIT_COMMIT_HASH}`.trim();
+    if (isTranslatedWebsite) {
+      context += `\nWebsite translated to: ${isTranslatedWebsite}`;
+    }
+    return context;
+  }, [locationState?.formValues?.context, referrerValue]);
 
   const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.target.setCustomValidity(

--- a/src/contact/components/ContactForm.tsx
+++ b/src/contact/components/ContactForm.tsx
@@ -77,13 +77,13 @@ const ContactForm = () => {
   }
 
   const context = useMemo(() => {
-    const isTranslatedWebsite = translatedWebsite();
+    const websiteTranslation = translatedWebsite();
     let context = `${locationState?.formValues?.context || ''}
 Referred from: ${globalThis.location.origin}${referrerValue}
 User browser: ${navigator.userAgent}
 Website version: ${GIT_COMMIT_HASH}`.trim();
-    if (isTranslatedWebsite) {
-      context += `\nWebsite translated to: ${isTranslatedWebsite}`;
+    if (websiteTranslation) {
+      context += `\nWebsite translated to: ${websiteTranslation}`;
     }
     return context;
   }, [locationState?.formValues?.context, referrerValue]);

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -264,7 +264,7 @@ const DidYouMean = ({
     content = <Loader />;
   }
 
-  const isTranslatedWebsite = useMemo(() => translatedWebsite(), []);
+  const websiteTranslation = useMemo(() => translatedWebsite(), []);
 
   return (
     <Message level="info" className={styles['did-you-mean-message']}>
@@ -276,7 +276,7 @@ const DidYouMean = ({
             If you can&apos;t find what you are looking for, please{' '}
             <ContactLink>contact us</ContactLink>.
           </p>
-          {isTranslatedWebsite && (
+          {websiteTranslation && (
             <p>
               Even though you translated the website,{' '}
               <strong>make sure that your query is in English</strong>.

--- a/src/shared/components/results/DidYouMean.tsx
+++ b/src/shared/components/results/DidYouMean.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useMemo, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { orderBy, truncate } from 'lodash-es';
 import { Loader, Message, sequenceProcessor } from 'franklin-sites';
@@ -12,6 +12,7 @@ import useSafeState from '../../hooks/useSafeState';
 
 import fetchData from '../../utils/fetchData';
 import { stringifyQuery, stringifyUrl } from '../../utils/url';
+import { translatedWebsite } from '../../utils/translatedWebsite';
 
 import {
   searchLocations,
@@ -73,6 +74,7 @@ const QuerySuggestionListItem = ({
               }}
               key={query}
               className={styles['query-suggestion-link']}
+              translate="no"
             >
               {cleanedQuery}
             </Link>
@@ -95,6 +97,7 @@ const PeptideSearchSuggestion = ({
         pathname: LocationToPath[Location.PeptideSearch],
         search: `peps=${potentialPeptide}`,
       }}
+      translate="no"
     >
       {truncate(potentialPeptide, truncateOptions)}?
     </Link>
@@ -261,28 +264,36 @@ const DidYouMean = ({
     content = <Loader />;
   }
 
+  const isTranslatedWebsite = useMemo(() => translatedWebsite(), []);
+
   return (
     <Message level="info" className={styles['did-you-mean-message']}>
-      <small>
-        {heading}
-        {content}
-        {renderContent && (
-          <>
+      {heading}
+      {content}
+      {renderContent && (
+        <>
+          <p>
             If you can&apos;t find what you are looking for, please{' '}
             <ContactLink>contact us</ContactLink>.
-            {currentNamespace === Namespace.uniparc ? (
-              <p>
-                Some cross-references, when there are too many of them on a
-                UniParc entry, are not indexed.
-                <br />
-                If you think your search corresponds to one of these, do{' '}
-                <ContactLink>get in touch</ContactLink> so we can provide you
-                the data.
-              </p>
-            ) : null}
-          </>
-        )}
-      </small>
+          </p>
+          {isTranslatedWebsite && (
+            <p>
+              Even though you translated the website,{' '}
+              <strong>make sure that your query is in English</strong>.
+            </p>
+          )}
+          {currentNamespace === Namespace.uniparc ? (
+            <p>
+              Some cross-references, when there are too many of them on a
+              UniParc entry, are not indexed.
+              <br />
+              If you think your search corresponds to one of these, do{' '}
+              <ContactLink>get in touch</ContactLink> so we can provide you the
+              data.
+            </p>
+          ) : null}
+        </>
+      )}
     </Message>
   );
 };

--- a/src/shared/components/results/styles/did-you-mean.module.scss
+++ b/src/shared/components/results/styles/did-you-mean.module.scss
@@ -1,9 +1,9 @@
 .did-you-mean-message {
   text-align: left;
-}
 
-.did-you-mean-message small {
-  font-size: 100%;
+  p:last-of-type {
+    margin-block-end: 0;
+  }
 }
 
 .suggestions {

--- a/src/shared/utils/translatedWebsite.ts
+++ b/src/shared/utils/translatedWebsite.ts
@@ -1,0 +1,20 @@
+/**
+ * Tries to detect if the website has been translated by a tool, if so tries to
+ * return the language that it has been translated into
+ */
+export const translatedWebsite = (): string | false => {
+  // Google Chrome and Firefox modify the html[lang] attribute
+  const { lang } = document.documentElement;
+  if (lang && lang !== 'en') {
+    return lang;
+  }
+
+  // Immersive Translate add-on
+  const imtState = document.documentElement.getAttribute('imt-state');
+  if (imtState && imtState !== 'original') {
+    // Not exposing into which language, but has definitely been translated
+    return 'unknown';
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Purpose
Better messaging when users use the website translated by a tool

## Approach
Handles translation in-browser for Chrome and Firefox, as well as the Immersive Translate browser add-on (used by many of our users as seen in hotjar feedback).
- Detect changes to the html in order to check if the website is translated
- Add that info to RT tickets as context
- Add a specific message when no results are found to handle the possibility that the user might have been searching in their language

Also:
- I noticed that search suggestions were translated (the link text, not the URL), so disabled the translation for these links to avoid misleading users.
- Simplified the HTML structure of the no results message

## Testing
Manual tests

## Checklist
- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
