### PR TITLE
Fix bug in ft_binding column

### DIFF
--- a/src/help/config/featureTypeHelpMappings.ts
+++ b/src/help/config/featureTypeHelpMappings.ts
@@ -17,7 +17,6 @@ const FeatureTypeHelpMappings: Omit<Record<FeatureType, string>, 'Other'> = {
   'Coiled coil': 'coiled',
   Motif: 'motif',
   'Active site': 'act_site',
-  BINDING: 'binding',
   'Binding site': 'binding',
   Site: 'site',
   Intramembrane: 'intramem',

--- a/src/uniprotkb/adapters/functionConverter.ts
+++ b/src/uniprotkb/adapters/functionConverter.ts
@@ -143,7 +143,6 @@ export const functionFeaturesToColumns: Readonly<
   'DNA binding': UniProtKBColumn.ftDnaBind,
   'Active site': UniProtKBColumn.ftActSite,
   'Binding site': UniProtKBColumn.ftBinding,
-  BINDING: UniProtKBColumn.ftBinding,
   Site: UniProtKBColumn.ftSite,
 };
 

--- a/src/uniprotkb/types/featureType.ts
+++ b/src/uniprotkb/types/featureType.ts
@@ -13,7 +13,6 @@ export type FunctionFeatures =
   | 'DNA binding'
   | 'Active site'
   | 'Binding site'
-  | 'BINDING'
   | 'Site';
 
 export type SubcellularLocationFeatures =


### PR DESCRIPTION
## Purpose

https://www.ebi.ac.uk/panda/jira/browse/TRM-32511

## Approach
Looking at the past commit reference, I believe 'BINDING' was added as featureType for website code to recognise the data from Proteins API. At that time, we were adding the type as tooltip title in here instead of protvista-uniprot. Since all tooltip work is handled by protvista, we do not need it here. Hence, there is no clash between BINDING and Binding site column as the former doesn't exist in rest API's feature types

## Testing

What test(s) did you write to validate and verify your changes?

## Checklist

- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
