### PR TITLE
Update protvista-tooltip styles.

### DIFF
--- a/src/shared/utils/styles/tooltip.module.scss
+++ b/src/shared/utils/styles/tooltip.module.scss
@@ -22,6 +22,7 @@
 
   * {
     color: #fff !important;
+    font-family: Lato, sans-serif;
   }
 
   a {
@@ -38,6 +39,22 @@
 
   hr {
     margin-bottom: 0.5rem;
+  }
+
+  :global(.text-indent-1) {
+    text-indent: 1em;
+  }
+
+  :global(.text-indent-2) {
+    text-indent: 2em;
+  }
+
+  :global(.nowrap) {
+    white-space: nowrap;
+  }
+
+  :global(.margin-bottom) {
+    margin-bottom: 1em;
   }
 }
 


### PR DESCRIPTION
## Purpose

[Remove inline styles from protvista-uniprot](https://embl.atlassian.net/browse/TRM-32372)

Needs this https://github.com/ebi-webcomponents/protvista-uniprot/pull/80 to be linked.

## Approach

Added a few more styles for the stylesheet

## Testing

None

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
