### PR TITLE
Fix FTP links on UniProtKB landing page

### DIFF
--- a/src/shared/config/ftpUrls.ts
+++ b/src/shared/config/ftpUrls.ts
@@ -8,14 +8,14 @@ const ftpUniProt = 'https://ftp.ebi.ac.uk/pub/databases/uniprot/';
 
 const ftpUrls = {
   uniprot: ftpUniProt,
-  uniprotkb: joinUrl(ftpUniProt, 'knowledgebase/complete'),
+  uniprotkb: joinUrl(ftpUniProt, 'knowledgebase'),
   uniprotkbReviewed: joinUrl(
     ftpUniProt,
-    'knowledgebase/complete/uniprot_sprot'
+    'knowledgebase/uniprot_sprot'
   ),
   uniprotkbUnreviewed: joinUrl(
     ftpUniProt,
-    'knowledgebase/complete/uniprot_trembl'
+    'knowledgebase/uniprot_trembl'
   ),
   referenceProteomes: (id?: string, superkingdom?: string, taxonId?: number) =>
     joinUrl(


### PR DESCRIPTION
## Purpose

The FTP links on the [UniProtKB landing page](https://www.uniprot.org/uniprotkb) are broken because they point to the `/pub/databases/uniprot/knowledgebase/complete` directory on the EMBL-EBI FTP server, but `complete` doesn't exist (files are directly under `knowledgebase`.

## Approach

The URL config module is updated to remove the `/complete` leaf.

## Testing

Locally build the project. FTP links are working as expected.

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
