### PR TITLE
Make new FASTA format available in download panel and proteome overview page

### DIFF
--- a/src/shared/components/download/Download.tsx
+++ b/src/shared/components/download/Download.tsx
@@ -102,7 +102,7 @@ export const proteomeFastaOption = (
 ) => (
   <fieldset>
     <p className={styles['new-fasta-header']}>
-      <span data-article-id="fasta-headers#uniparc-for-proteomes">
+      <span data-article-id="fasta-headers#uniparc-proteomes">
         FASTA header for proteomes
       </span>
       <small>

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -210,8 +210,8 @@ export const isUniParcProteomeSearch = (
     state.selectedFileFormat === FileFormat.fasta &&
     !state.nSelectedEntries
   ) {
-    const match = query?.match(new RegExp(reProteomeId, 'g'));
-    if (match && match.length === 1) {
+    const match = query?.match(reProteomeId);
+    if (match && match.length > 1) {
       return true;
     }
   }

--- a/src/shared/components/download/downloadUtils.ts
+++ b/src/shared/components/download/downloadUtils.ts
@@ -210,8 +210,8 @@ export const isUniParcProteomeSearch = (
     state.selectedFileFormat === FileFormat.fasta &&
     !state.nSelectedEntries
   ) {
-    const match = query?.match(reProteomeId);
-    if (match && match.length > 1) {
+    const match = query?.match(new RegExp(reProteomeId, 'g'));
+    if (match && match.length === 1) {
       return true;
     }
   }

--- a/src/shared/config/apiUrls/results.ts
+++ b/src/shared/config/apiUrls/results.ts
@@ -41,7 +41,7 @@ type Parameters = {
   jobId?: string;
 };
 
-export const reProteomeId = /(upid|proteome):(UP\d+)/;
+export const reProteomeId = /^\(*(upid|proteome):(UP\d+)\)*$/;
 
 export const download = ({
   base,

--- a/src/shared/config/apiUrls/results.ts
+++ b/src/shared/config/apiUrls/results.ts
@@ -41,7 +41,7 @@ type Parameters = {
   jobId?: string;
 };
 
-export const reProteomeId = /^\(*(upid|proteome):(UP\d+)\)*$/;
+export const reProteomeId = /^\(*(upid|proteome):(UP\d+)\)*$/i;
 
 export const download = ({
   base,


### PR DESCRIPTION
## Purpose

https://embl.atlassian.net/browse/TRM-32465

## Approach

Show additional header option if FASTA is selected for uniparc entries with protoeme id in the query in download panel.
Add a link in the overview page of proteome.
Add link to documentation

## Testing

Added new tests for util function, selection behaviour and search url generation.

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
