### PR TITLE
add isoforms to the sequence suggestion

### DIFF
--- a/src/jobs/components/__tests__/ChecksumSuggester.spec.tsx
+++ b/src/jobs/components/__tests__/ChecksumSuggester.spec.tsx
@@ -16,6 +16,8 @@ mock.onGet().reply(200, {
         'P05067-1',
         'D3DSD3.1',
         'P05067',
+        // Not existing, but just for testing
+        'P00000-0',
       ],
       oldestCrossRefCreated: '1991-11-01',
       mostRecentCrossRefUpdated: '2024-11-27',
@@ -32,6 +34,9 @@ describe('ChecksumSuggester', () => {
     expect(
       await screen.findByRole('link', { name: 'view all' })
     ).toHaveAttribute('href', '/uniprotkb?query=%28uniparc%3AUPI000002DB1C%29');
+    expect(
+      await screen.findByRole('link', { name: 'P00000-0' })
+    ).toHaveAttribute('href', '/uniprotkb/P00000#P00000-0');
     expect(
       await screen.findByRole('link', { name: 'UPI000002DB1C' })
     ).toHaveAttribute('href', '/uniparc/UPI000002DB1C');


### PR DESCRIPTION
## Purpose
See Elisabeth's email: "pre-blast detection of identical sequences"

## Approach
Add a new category of suggestion for isoforms
Make sure to remove isoforms for which the canonical might already be listed (same accession + same sequence, it's probably the canonical)

## Testing
- [UPI000007412B](https://www.uniprot.org/uniparc/UPI000007412B): Elisabeth's example, 1 UPKB, 1 isoform
- [UPI00000E8E2B](http://www.uniprot.org/uniparc/UPI00000E8E2B): 33 UPKB, 2 isoforms (see link to UniParc entry with the right facet activated)
- [UPI001E25D3C8](http://www.uniprot.org/uniparc/UPI001E25D3C8): 0 UPKB, 1 isoform
- [UPI000002DB1C](http://www.uniprot.org/uniparc/UPI000002DB1C): 2 UPKB, 0 isoforms (UniParc contained P05067-1 that was filtered out)

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- ~[ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.~
