### PR TITLE
Ribbon selection

### DIFF
--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -269,6 +269,8 @@ export const useGOData = (
 } => {
   const { data: slimSetsData, loading: loadingSlimSets } =
     useDataApi<GOSLimSets>(goTerms && SLIM_SETS_URL);
+  // We need to retrieve this from the organism taxon ID because the lineage
+  // info in UniProtKB is just the names and not the taxon IDs
   const { data: taxonData, loading: taxonLoading } =
     useDataApi<TaxonomyAPIModel>(
       taxonId ? apiUrls.entry.entry(`${taxonId}`, Namespace.taxonomy) : null

--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { groupBy } from 'lodash-es';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
@@ -276,13 +276,16 @@ export const useGOData = (
     const entryTaxonIds =
       taxonData?.lineage &&
       new Set(taxonData?.lineage.map((l) => `${l.taxonId}`));
-    return !slimSetName && entryTaxonIds
-      ? slimSetsData?.goSlimSets?.find((slimSet) =>
-          slimSet.taxIds
-            .split(',')
-            .some((taxonId) => entryTaxonIds.has(taxonId))
-        )
-      : slimSetsData?.goSlimSets?.find((slimSet) => slimSet.id === slimSetName);
+    const selectedSlimSetByTaxon =
+      !slimSetName &&
+      entryTaxonIds &&
+      slimSetsData?.goSlimSets?.find((slimSet) =>
+        slimSet.taxIds.split(',').some((taxonId) => entryTaxonIds.has(taxonId))
+      );
+    return (
+      selectedSlimSetByTaxon ||
+      slimSetsData?.goSlimSets?.find((slimSet) => slimSet.id === slimSetName)
+    );
   }, [slimSetName, slimSetsData?.goSlimSets, taxonData?.lineage]);
 
   const slimSets = slimSetsData?.goSlimSets?.map((slimSet) => slimSet.id);

--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -279,8 +279,12 @@ export const useGOData = (
     const selectedSlimSetByTaxon =
       !slimSetName &&
       entryTaxonIds &&
-      slimSetsData?.goSlimSets?.find((slimSet) =>
-        slimSet.taxIds.split(',').some((taxonId) => entryTaxonIds.has(taxonId))
+      slimSetsData?.goSlimSets?.find(
+        (slimSet) =>
+          slimSet.role.includes('Ribbon') &&
+          slimSet.taxIds
+            .split(',')
+            .some((taxonId) => entryTaxonIds.has(taxonId))
       );
     return (
       selectedSlimSetByTaxon ||

--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -26,6 +26,8 @@ const SLIM_SETS_URL =
 
 const SLIMMING_URL = 'https://www.ebi.ac.uk/QuickGO/services/ontology/go/slim';
 
+const DEFAULT_SLIMMING_SET = 'goslim_agr';
+
 export type SlimSet = {
   name: string;
   id: string;
@@ -283,15 +285,12 @@ export const useGOData = (
   );
 
   const onSlimSetSelect = useCallback(
-    (s: string) => {
-      const slimSetNameToFind = s || 'goslim_agr';
-      const found = slimSets?.find(
-        (slimSet) => slimSet.id === slimSetNameToFind
-      );
+    (slimSetId: string) => {
+      const found = slimSets?.find((slimSet) => slimSet.id === slimSetId);
       if (found) {
         setSelectedSlimSet(found);
       }
-      // TODO: what now?
+      logging.warn(`${slimSetId} not found in slimming set data.`);
     },
     [slimSets]
   );
@@ -308,11 +307,13 @@ export const useGOData = (
     if (selectedSlimSetByTaxon) {
       setSelectedSlimSet(selectedSlimSetByTaxon);
     }
-    const goSlimAgr = slimSets?.find((slimSet) => slimSet.id === 'goslim_agr');
-    if (goSlimAgr) {
-      setSelectedSlimSet(goSlimAgr);
+    const defaultSlimmingSet = slimSets?.find(
+      (slimSet) => slimSet.id === DEFAULT_SLIMMING_SET
+    );
+    if (defaultSlimmingSet) {
+      setSelectedSlimSet(defaultSlimmingSet);
     }
-    // TODO: what now?
+    logging.warn(`${DEFAULT_SLIMMING_SET} not found in slimming set data.`);
   }, [slimSets, taxonData?.lineage]);
 
   const slimmingUrl = useMemo(() => {

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -256,7 +256,7 @@ const GoRibbon = ({
       )}
       <div className={styles['quickgo-link']}>
         <ExternalLink url={externalUrls.QuickGOAnnotations(primaryAccession)}>
-          Access the complete set of GO annotations on QuickGO{' '}
+          Access the complete set of GO annotations on QuickGO
         </ExternalLink>
       </div>
     </div>

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -97,47 +97,9 @@ const GoRibbon = ({
 
   const nodeRef = useRef<HTMLElement>();
 
-  const [selectedSet, setSelectedSet] = useState(() => {
-    let defaultSS = 'goslim_generic';
-    if (organismData?.scientificName && organismData?.lineage) {
-      const taxonomyInfo = [
-        ...organismData.lineage,
-        organismData.scientificName,
-      ];
-
-      // SlimSets based on Taxonomy
-      const slimSetByTaxon = {
-        // eslint-disable-next-line camelcase
-        goslim_plant: [
-          'Viridiplantae',
-          'Bangiophyceae',
-          'Florideophyceae',
-          'Stylonematophyceae',
-          'Rhodellophyceae',
-          'Compsopogonophyceae',
-        ],
-        // prokaryotes: ['Bacteria', 'Archaea'],
-      };
-
-      // Check if the taxon matches a slimset
-      Object.entries(slimSetByTaxon).forEach(([key, value]) => {
-        const presentTaxon = taxonomyInfo?.filter(
-          (t) => value.includes(String(t)) // Lineage is Array of strings here
-        );
-        if (presentTaxon?.length) {
-          defaultSS = key;
-        }
-      });
-    }
-    return defaultSS;
-  });
-
   // NOTE: loading is also available, do we want to do anything with it?
-  const { loading, slimmedData, selectedSlimSet, slimSets } = useGOData(
-    goTerms,
-    organismData?.taxonId,
-    selectedSet
-  );
+  const { loading, slimmedData, selectedSlimSet, onSlimSetSelect, slimSets } =
+    useGOData(goTerms, organismData?.taxonId);
 
   const [elementLoaded, setElementLoaded] = useSafeState(false);
 
@@ -278,12 +240,12 @@ const GoRibbon = ({
         <label className={styles['set-selector']}>
           <div>Slimming set:</div>
           <select
-            onChange={(e) => setSelectedSet(e.target.value)}
-            value={selectedSet}
+            onChange={(e) => onSlimSetSelect(e.target.value)}
+            value={selectedSlimSet?.id}
           >
             {slimSets.map((slimSet) => (
-              <option value={slimSet} key={slimSet}>
-                {slimSet.replace('goslim_', '').replace('_ribbon', '')}
+              <option value={slimSet.id} key={slimSet.id}>
+                {slimSet.shortLabel}
               </option>
             ))}
           </select>

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -220,11 +220,6 @@ const GoRibbon = ({
       <div className={styles.preamble} data-article-id="gene-ontology">
         Gene Ontology (GO) annotations organized by slimming set.
       </div>
-      <div className={styles['quickgo-link']}>
-        <ExternalLink url={externalUrls.QuickGOAnnotations(primaryAccession)}>
-          Access the complete set of GO annotations on QuickGO{' '}
-        </ExternalLink>
-      </div>
 
       {!isSmallScreen && (
         <LazyComponent fallback={null}>
@@ -259,6 +254,11 @@ const GoRibbon = ({
           getRowId={getRowId}
         />
       )}
+      <div className={styles['quickgo-link']}>
+        <ExternalLink url={externalUrls.QuickGOAnnotations(primaryAccession)}>
+          Access the complete set of GO annotations on QuickGO{' '}
+        </ExternalLink>
+      </div>
     </div>
   );
 };

--- a/src/uniprotkb/components/entry/GoRibbon.tsx
+++ b/src/uniprotkb/components/entry/GoRibbon.tsx
@@ -135,6 +135,7 @@ const GoRibbon = ({
   // NOTE: loading is also available, do we want to do anything with it?
   const { loading, slimmedData, selectedSlimSet, slimSets } = useGOData(
     goTerms,
+    organismData?.taxonId,
     selectedSet
   );
 


### PR DESCRIPTION
## Purpose

[Expose and use new QuickGO API info about subsets](https://embl.atlassian.net/browse/TRM-32386)

## Approach

- Move slimming set selection state into useGOData custom hook.
- Upon initial load, traverse entry lineage backwards to try to find more specific taxons first.
- Move quick go link below table.

## Testing

None

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
