### PR TITLE
remove cellular component go terms from function section

### DIFF
--- a/src/uniprotkb/adapters/functionConverter.ts
+++ b/src/uniprotkb/adapters/functionConverter.ts
@@ -123,13 +123,8 @@ export const goAspects: {
     label: 'Biological Process',
     short: 'P',
   },
-
-  {
-    id: 'GO:0005575',
-    name: 'cellular_component',
-    label: 'Cellular Component',
-    short: 'C',
-  },
+  // We don't have the Cellular Component aspect because this is used to
+  // populate the Function section and not the Subcellular Location section
 ];
 
 const getAspect = (term: GOAspectName | GOAspectShort) =>
@@ -162,13 +157,16 @@ const commentsCategories: CommentType[] = [
   'BIOTECHNOLOGY',
 ];
 
-export const getAspectGroupedGoTerms = (
+export const getAspectGroupedGoTermsWithoutCellComp = (
   uniProtKBCrossReferences?: Xref[]
 ): GroupedGoTerms => {
   const goTerms = (uniProtKBCrossReferences || [])
     .filter(
       (xref: Xref | GoTerm): xref is GoTerm =>
-        xref.database === 'GO' && Boolean(xref.properties)
+        xref.database === 'GO' &&
+        Boolean(xref.properties) &&
+        // Remove the ones that are "Cellular Component" for Function section
+        !xref.properties?.GoTerm?.startsWith('C')
     )
     .map((term) => {
       const goTermProperty = term.properties && term.properties.GoTerm;
@@ -243,7 +241,7 @@ const convertFunction = (
   convertedSection.organismData = data?.organism;
   convertedSection.entryType = getEntryTypeFromString(data?.entryType);
 
-  const aspectGroupedGoTerms = getAspectGroupedGoTerms(
+  const aspectGroupedGoTerms = getAspectGroupedGoTermsWithoutCellComp(
     uniProtKBCrossReferences
   );
   if (aspectGroupedGoTerms?.size) {

--- a/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
+++ b/src/uniprotkb/adapters/slimming/GORibbonHandler.ts
@@ -100,7 +100,12 @@ export type AGRRibbonData = {
 
 export const getCategories = (slimSet: SlimSet): AGRRibbonCategory[] => {
   // Aspects at the top
-  const slimsByAspect = groupBy(slimSet.associations, 'aspect');
+  const slimsByAspect = groupBy(
+    slimSet.associations.filter(
+      (association) => association.aspect !== 'cellular_component'
+    ),
+    'aspect'
+  );
 
   // Convert to object
   const categoriesObj: AGRRibbonCategory[] = goAspects.map(

--- a/src/uniprotkb/adapters/slimming/__tests__/__mocks__/uniprotkbGroupedGoTerms.ts
+++ b/src/uniprotkb/adapters/slimming/__tests__/__mocks__/uniprotkbGroupedGoTerms.ts
@@ -1,8 +1,8 @@
 import mock from '../../../../__mocks__/nonHumanEntryModelData';
-import { getAspectGroupedGoTerms } from '../../../functionConverter';
+import { getAspectGroupedGoTermsWithoutCellComp } from '../../../functionConverter';
 import { convertXrefProperties } from '../../../uniProtkbConverter';
 
-const uniprotkbGroupedGoTerms = getAspectGroupedGoTerms(
+const uniprotkbGroupedGoTerms = getAspectGroupedGoTermsWithoutCellComp(
   convertXrefProperties(mock.uniProtKBCrossReferences)
 );
 export default uniprotkbGroupedGoTerms;

--- a/src/uniprotkb/adapters/slimming/__tests__/__snapshots__/GoRibbonHandler.spec.ts.snap
+++ b/src/uniprotkb/adapters/slimming/__tests__/__snapshots__/GoRibbonHandler.spec.ts.snap
@@ -262,121 +262,6 @@ exports[`GORibbonHandler should generate categories from slim set 1`] = `
     "id": "GO:0008150",
     "label": "biological_process",
   },
-  {
-    "description": "",
-    "groups": [
-      {
-        "description": "Show all Cellular Component annotations",
-        "id": "GO:0005575",
-        "label": "All Cellular Component",
-        "type": "All",
-      },
-      {
-        "description": "",
-        "id": "GO:0005576",
-        "label": "extracellular region",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005634",
-        "label": "nucleus",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005694",
-        "label": "chromosome",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005739",
-        "label": "mitochondrion",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005768",
-        "label": "endosome",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005773",
-        "label": "vacuole",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005783",
-        "label": "endoplasmic reticulum",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005794",
-        "label": "Golgi apparatus",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005829",
-        "label": "cytosol",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005856",
-        "label": "cytoskeleton",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005886",
-        "label": "plasma membrane",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0030054",
-        "label": "cell junction",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0031410",
-        "label": "cytoplasmic vesicle",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0032991",
-        "label": "protein-containing complex",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0042995",
-        "label": "cell projection",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0045202",
-        "label": "synapse",
-        "type": "Term",
-      },
-      {
-        "description": "",
-        "id": "GO:0005575",
-        "label": "Other Cellular Component",
-        "type": "Other",
-      },
-    ],
-    "id": "GO:0005575",
-    "label": "cellular_component",
-  },
 ]
 `;
 
@@ -409,28 +294,6 @@ exports[`GORibbonHandler should generate subjects from data 1`] = `
           "terms": [
             "GO:0004252",
             "GO:0008236",
-          ],
-        },
-      },
-      "GO:0005575": {
-        "ALL": {
-          "nb_annotations": 10,
-          "nb_classes": 5,
-          "terms": [
-            "GO:0070062",
-            "GO:0005576",
-            "GO:0005887",
-            "GO:0005654",
-            "GO:0005886",
-          ],
-        },
-      },
-      "GO:0005575-other": {
-        "ALL": {
-          "nb_annotations": 2,
-          "nb_classes": 1,
-          "terms": [
-            "GO:0005887",
           ],
         },
       },
@@ -504,8 +367,8 @@ exports[`GORibbonHandler should generate subjects from data 1`] = `
     },
     "id": "P05067",
     "label": "TP53",
-    "nb_annotations": 23,
-    "nb_classes": 11,
+    "nb_annotations": 13,
+    "nb_classes": 6,
     "taxon_id": "NCBITaxon:9606",
     "taxon_label": "Homo sapiens",
   },

--- a/src/uniprotkb/components/protein-data-views/SubcellularLocationGOView.tsx
+++ b/src/uniprotkb/components/protein-data-views/SubcellularLocationGOView.tsx
@@ -8,6 +8,7 @@ import { getUrlFromDatabaseInfo } from '../../../shared/utils/xrefs';
 import { GoXref } from '../../adapters/subcellularLocationConverter';
 import GOTermEvidenceTag from './GOTermEvidenceTag';
 import styles from './styles/subcellular-location-go-view.module.scss';
+import UniProtKBEvidenceTag from './UniProtKBEvidenceTag';
 
 export const getSwissBioPicLocationId = (id: string) => {
   // Get rid of leading 0s which is expected in SubCellViz
@@ -29,7 +30,7 @@ const SubcellularLocationGOView: FC<
   return (
     <>
       <ul className="no-bullet">
-        {goXrefs.map(({ id, properties }) => (
+        {goXrefs.map(({ id, properties, evidences }) => (
           <li
             key={id}
             // used in the case that this component is used in conjunction
@@ -46,6 +47,7 @@ const SubcellularLocationGOView: FC<
               {properties.GoTerm}
             </ExternalLink>
             <GOTermEvidenceTag evidence={properties.GoEvidenceType} />
+            <UniProtKBEvidenceTag evidences={evidences} goTermEvidence />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Purpose

[TRM-32733](https://embl.atlassian.net/browse/TRM-32733) Remove subcell GO annotations from ribbon and table in Function section

## Approach

In the function section adapter, remove any cellular component related GO term, also for the GO ribbon remove any GO term from the slimming sets in order to not display that at all in the ribbon.

These GO terms are already in the subcell location section, in the GO annotations tab. That being said, I noticed the evidences were not correctly displayed, so that has been added too (now displays publications)

## Testing

Updated snapshots + manual testing (mainly with P05067)

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
