### PR TITLE
add help i's to title in pep search, idmap

### DIFF
--- a/src/jobs/id-mapping/components/IDMappingForm.tsx
+++ b/src/jobs/id-mapping/components/IDMappingForm.tsx
@@ -245,7 +245,7 @@ const IDMappingForm = ({ initialFormValues, formConfigData }: Props) => {
   return (
     <>
       <HTMLHead title={title} />
-      <PageIntro heading={title} />
+      <PageIntro heading={<span data-article-id="id_mapping">{title}</span>} />
       <form
         onSubmit={submitIDMappingJob}
         onReset={handleReset}

--- a/src/jobs/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
+++ b/src/jobs/id-mapping/components/__tests__/__snapshots__/IDMappingForm.spec.tsx.snap
@@ -8,7 +8,11 @@ exports[`IDMappingForm test Renders the form 1`] = `
     <h1
       class=""
     >
-      Retrieve/ID mapping
+      <span
+        data-article-id="id_mapping"
+      >
+        Retrieve/ID mapping
+      </span>
     </h1>
   </div>
   <form

--- a/src/jobs/peptide-search/components/PeptideSearchForm.tsx
+++ b/src/jobs/peptide-search/components/PeptideSearchForm.tsx
@@ -240,7 +240,9 @@ const PeptideSearchForm = ({ initialFormValues }: Props) => {
   return (
     <>
       <HTMLHead title={title} />
-      <PageIntro heading={title} />
+      <PageIntro
+        heading={<span data-article-id="peptide_search">{title}</span>}
+      />
       <form
         onSubmit={submitPeptideSearchJob}
         onReset={handleReset}

--- a/src/jobs/peptide-search/components/__tests__/__snapshots__/PeptideSearchForm.spec.tsx.snap
+++ b/src/jobs/peptide-search/components/__tests__/__snapshots__/PeptideSearchForm.spec.tsx.snap
@@ -8,7 +8,11 @@ exports[`PeptideSearchForm test Renders the form 1`] = `
     <h1
       class=""
     >
-      Peptide search
+      <span
+        data-article-id="peptide_search"
+      >
+        Peptide search
+      </span>
     </h1>
   </div>
   <form


### PR DESCRIPTION
## Purpose

Adding contextual help to ID mapping and peptide search tools

## Approach

Created respective help documents and linked them to the title of each page

## Testing

n/a

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
