### PR TITLE
handle multiple identifiers, invalidate form, and add error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "core-js": "3.38.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.254",
+    "franklin-sites": "0.0.255",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "8.0.0",

--- a/src/jobs/align/components/AlignForm.tsx
+++ b/src/jobs/align/components/AlignForm.tsx
@@ -249,6 +249,7 @@ const AlignForm = ({ initialFormValues }: Props) => {
               value={parsedSequences.map((sequence) => sequence.raw).join('\n')}
               minimumSequences={2}
               maximumSequences={ALIGN_LIMIT}
+              noDuplicateID
             />
           </section>
           <section className="tools-form-section">

--- a/src/jobs/align/state/alignFormReducer.ts
+++ b/src/jobs/align/state/alignFormReducer.ts
@@ -19,7 +19,9 @@ export type AlignFormAction = ActionType<typeof alignFormActions>;
 const isInvalid = (parsedSequences: SequenceObject[]) =>
   parsedSequences.length > ALIGN_LIMIT ||
   parsedSequences.length <= 1 ||
-  parsedSequences.some((parsedSequence) => !parsedSequence.valid);
+  parsedSequences.some((parsedSequence) => !parsedSequence.valid) ||
+  new Set(parsedSequences.map(({ name }) => name)).size !==
+    parsedSequences.length;
 
 const getJobName = (parsedSequences: SequenceObject[]) => {
   const firstName = parsedSequences.find((item) => item.name)?.name;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7172,10 +7172,10 @@ foundation-sites@6.8.1:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.8.1.tgz#9b17e9371c18916a375985571b33bdbe4c347555"
   integrity sha512-9JAuLqVgzf7EIRUqVKeYN68dU/SGe0aNJPgnejdfJKSWnBFdQLF3Zvy9WEQ1gE/gnyvwG3Ia3LkkEd9774n0bQ==
 
-franklin-sites@0.0.254:
-  version "0.0.254"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.254.tgz#0992beacc1271db93a8538857896b46fe4e70508"
-  integrity sha512-DM3UdHsIftxHWATNdDC+qcMCgUV05dJ1yvdLizm1qxbCPMyL15GyrwsBEnIhvOo6WsA5SqdLRUhcAmQ+8rpZhA==
+franklin-sites@0.0.255:
+  version "0.0.255"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.255.tgz#fb0646f750f05a6d92d14fdf614bab40551c3d2e"
+  integrity sha512-EQSjbbPjTciB+GnW2mcZfV3ABYAuKGFcgFWqVhhZxRZ9hP/G/NGAp41fEDa9QexyT+NIIl32hbDIIHU+tkhCGA==
   dependencies:
     classnames "2.5.1"
     d3 "5.16.0"


### PR DESCRIPTION
## Purpose
[TRM-32812](https://embl.atlassian.net/browse/TRM-32812) Invalidate Align form when using duplicate identifiers. Need to update to franklin https://github.com/ebi-uniprot/franklin-sites/pull/268 to also display the error messages from the SequenceSubmission component

## Approach
Check number of unique names vs number of parsed sequence objects

## Testing
Manual checks

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
