### PR TITLE
Update CARD xref to indicate resistance mechanism.

### DIFF
--- a/src/uniprotkb/components/protein-data-views/XRefView.tsx
+++ b/src/uniprotkb/components/protein-data-views/XRefView.tsx
@@ -35,6 +35,7 @@ import { AFDBOutOfSync } from './AFDBOutOfSync';
 import EMBLView from './EMBLView';
 import { RichText } from './FreeTextView';
 import PDBView from './PDBView';
+import styles from './styles/x-ref-view.module.scss';
 
 const formatSuffixWithCount = (prefix: string, number: string) => {
   const count = parseInt(number, 10);
@@ -134,17 +135,20 @@ export const XRef = ({
   let resistanceMechanismNode;
   if (database === 'CARD' && properties) {
     resistanceMechanismNode = (
-      <>
-        <br />
-        <ExternalLink
-          url={processUrlTemplate(uriLink, {
-            id: properties[PropertyKey.ResistanceMechanismIdentifier],
-          })}
-        >
-          {properties[PropertyKey.ResistanceMechanismIdentifier]}
-        </ExternalLink>
-        {properties[PropertyKey.ResistanceMechanismName]}
-      </>
+      <div className={styles['resistance-mechanism-container']}>
+        <span className={styles['resistance-angle']}>∟</span> Resistance
+        mechanism:
+        <div className={styles['resistance-details']}>
+          <ExternalLink
+            url={processUrlTemplate(uriLink, {
+              id: properties[PropertyKey.ResistanceMechanismIdentifier],
+            })}
+          >
+            {properties[PropertyKey.ResistanceMechanismIdentifier]}
+          </ExternalLink>
+          {properties[PropertyKey.ResistanceMechanismName]}
+        </div>
+      </div>
     );
   }
 

--- a/src/uniprotkb/components/protein-data-views/styles/x-ref-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/x-ref-view.module.scss
@@ -1,0 +1,12 @@
+.resistance-mechanism-container {
+  margin-left: 0.75rem;
+
+  .resistance-angle {
+    position: relative;
+    top: -5px;
+  }
+
+  .resistance-details {
+    margin-left: 0.9rem;
+  }
+}


### PR DESCRIPTION
Small PR to try to indicate to users the two parts of the CARD xref.

Before:
<img width="497" height="164" alt="Screenshot 2025-07-11 at 16 45 21" src="https://github.com/user-attachments/assets/0f1d6507-9f24-4165-a212-6d8081077e6d" />

After:
<img width="435" height="200" alt="Screenshot 2025-07-11 at 16 45 16" src="https://github.com/user-attachments/assets/2ea80ee5-4247-4697-9d1a-4e95a0c4cd76" />

Context from @tgttunstall:
> the first xref is the direct link to the sequence in card db i.e the seq in up-kb (sp or trembl) with a 100% identity and coverage match with card sequence.
the second xref (which I understand is not a true xref) is the link to the resistance mechanism for that particular protein as part of the functional description/ontology  term.
so in this case it is that the protein renders the drug inactive (mechanism) and this inactivation leads to drug (antibiotic) resistance.
The 'real' xref is to the direct sequence in card.
