### PR TITLE
Allow all searchable namespaces to fetch results config from backend, which allows for sortable columns.

### DIFF
--- a/src/shared/hooks/useColumns.tsx
+++ b/src/shared/hooks/useColumns.tsx
@@ -40,7 +40,7 @@ import { UniRefLiteAPIModel } from '../../uniref/adapters/uniRefConverter';
 import apiUrls from '../config/apiUrls/apiUrls';
 import { Column, ColumnConfigurations } from '../config/columns';
 import { APIModel } from '../types/apiModel';
-import { mainNamespaces, Namespace } from '../types/namespaces';
+import { Namespace, searchableNamespaces } from '../types/namespaces';
 import { getIdKeyForData } from '../utils/getIdKey';
 import * as logging from '../utils/logging';
 import { showTooltip } from '../utils/tooltip';
@@ -181,9 +181,7 @@ const useColumns = (
     getParamsFromURL(queryParamFromUrl);
 
   const { data: dataResultFields, loading } = useDataApi<ReceivedFieldData>(
-    // For now, assume no configure endpoint for supporting data
-    // TODO: change this when the backend is fixed https://www.ebi.ac.uk/panda/jira/browse/TRM-26571
-    namespace !== 'id-mapping' && mainNamespaces.has(namespace)
+    searchableNamespaces.has(namespace)
       ? apiUrls.configure.resultsFields(namespace)
       : null
   );

--- a/src/shared/types/namespaces.ts
+++ b/src/shared/types/namespaces.ts
@@ -71,6 +71,9 @@ export const searchableNamespaceLabels: Record<SearchableNamespace, string> = {
   [Namespace.unirule]: 'UniRule',
   [Namespace.arba]: 'ARBA',
 };
+export const searchableNamespaces = new Set(
+  Object.keys(searchableNamespaceLabels)
+);
 export const toolResults = 'toolResults' as const;
 export type ToolResults = typeof toolResults;
 export type Searchspace = SearchableNamespace | ToolResults;


### PR DESCRIPTION
[Enable sortable cross columns across all search namespaces](https://embl.atlassian.net/browse/TRM-33007)