### PR TITLE
Rhea upgrade

### DIFF
--- a/__mocks__/rawSvgMock.js
+++ b/__mocks__/rawSvgMock.js
@@ -1,0 +1,1 @@
+module.exports = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@sentry/react": "8.31.0",
     "@sentry/tracing": "7.27.0",
     "@sentry/types": "8.31.0",
-    "@swissprot/rhea-reaction-visualizer": "0.0.21",
+    "@swissprot/rhea-reaction-visualizer": "0.0.24",
     "@swissprot/swissbiopics-visualizer": "0.0.28",
     "axios": "1.7.9",
     "classnames": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@sentry/react": "8.31.0",
     "@sentry/tracing": "7.27.0",
     "@sentry/types": "8.31.0",
-    "@swissprot/rhea-reaction-visualizer": "0.0.24",
+    "@swissprot/rhea-reaction-viz-test": "0.0.24",
     "@swissprot/swissbiopics-visualizer": "0.0.28",
     "axios": "1.7.9",
     "classnames": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
       "<rootDir>/\\..+\\/"
     ],
     "moduleNameMapper": {
+      "\\.svg\\?raw$": "<rootDir>/__mocks__/rawSvgMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy",
       "^/(.*)$": "<rootDir>/src/$1",
@@ -128,7 +129,7 @@
     "core-js": "3.38.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "0.0.256",
+    "franklin-sites": "file:.yalc/franklin-sites",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "core-js": "3.38.1",
     "d3": "5.16.0",
     "deep-freeze": "0.0.1",
-    "franklin-sites": "file:.yalc/franklin-sites",
+    "franklin-sites": "0.0.258",
     "front-matter": "4.0.2",
     "history": "4.10.1",
     "idb": "8.0.0",

--- a/src/jobs/blast/components/results/__tests__/__snapshots__/BlastResultTable.spec.tsx.snap
+++ b/src/jobs/blast/components/results/__tests__/__snapshots__/BlastResultTable.spec.tsx.snap
@@ -210,18 +210,21 @@ Hit length: 486"
                 >
                   <button
                     class="chip chip--compact hsp_identity primary"
+                    title="Identity"
                     type="button"
                   >
                     7.1%
                   </button>
                   <button
                     class="chip chip--compact hsp_score secondary"
+                    title="Score"
                     type="button"
                   >
                     96
                   </button>
                   <button
                     class="chip chip--compact hsp_expect secondary"
+                    title="E-value"
                     type="button"
                   >
                     0.0048

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -42,3 +42,9 @@ declare module '*.module.css' {
 
 // Just for one test file
 declare module 'react-beautiful-dnd-test-utils';
+
+// Custom elements lib without types
+declare module '@swissprot/rhea-reaction-viz-test' {
+  const content: CustomElementConstructor;
+  export default content;
+}

--- a/src/types/rhea-reaction-visualizer.d.ts
+++ b/src/types/rhea-reaction-visualizer.d.ts
@@ -5,5 +5,6 @@ declare namespace JSX {
   interface IntrinsicElements {
     'rhea-reaction': any;
     'rhea-atommap': any;
+    'rhea-visualizer': any;
   }
 }

--- a/src/types/rhea-reaction-visualizer.d.ts
+++ b/src/types/rhea-reaction-visualizer.d.ts
@@ -4,5 +4,6 @@ declare module '@swissprot/rhea-reaction-visualizer';
 declare namespace JSX {
   interface IntrinsicElements {
     'rhea-reaction': any;
+    'rhea-atommap': any;
   }
 }

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -33,7 +33,9 @@ exports[`Entry view should render 1`] = `
           <div
             class="rhea-entry"
           >
-            <h4>
+            <div
+              class="small"
+            >
               <a
                 class="external-link"
                 href="https://www.rhea-db.org/rhea/12345"
@@ -46,16 +48,16 @@ exports[`Entry view should render 1`] = `
                   width="12.5"
                 />
               </a>
-            </h4>
-            <h4
-              class="tiny"
+            </div>
+            <div
+              class="small"
             >
               <a
                 href="#Isoform_3"
               >
                 Isoform 3
               </a>
-            </h4>
+            </div>
             some reaction
             <button
               aria-controls="1"
@@ -3752,7 +3754,9 @@ exports[`Entry view should render for non-human entry 1`] = `
           <div
             class="rhea-entry"
           >
-            <h4>
+            <div
+              class="small"
+            >
               <a
                 class="external-link"
                 href="https://www.rhea-db.org/rhea/14869"
@@ -3765,7 +3769,7 @@ exports[`Entry view should render for non-human entry 1`] = `
                   width="12.5"
                 />
               </a>
-            </h4>
+            </div>
             an N-acetyl-alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + H2O = an alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + acetate
             <button
               aria-controls="3"

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -30,161 +30,140 @@ exports[`Entry view should render 1`] = `
           >
             Catalytic activity
           </h3>
-          <ul
-            class="info-list"
+          <div
+            class="rhea-entry"
           >
-            <li>
-              <div
-                class="decorated-list-item"
+            <h4>
+              <a
+                class="external-link"
+                href="https://www.rhea-db.org/rhea/12345"
+                rel="noopener"
+                target="_blank"
               >
-                <div
-                  class="decorated-list-item__title tiny"
+                Rhea:12345
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+            </h4>
+            <h4
+              class="tiny"
+            >
+              <a
+                href="#Isoform_3"
+              >
+                Isoform 3
+              </a>
+            </h4>
+            some reaction
+            <button
+              aria-controls="1"
+              aria-expanded="false"
+              class="svg-colour-unreviewed evidence-tag"
+              data-testid="evidence-tag-trigger"
+              type="button"
+            >
+              <test-file-stub
+                height="12"
+                width="12"
+              />
+              <span
+                class="evidence-tag__label"
+              >
+                automatic annotation
+              </span>
+            </button>
+            <div
+              class="evidence-tag-content "
+              data-testid="evidence-tag-content"
+              id="1"
+            />
+            <div>
+              This reaction proceeds in the 
+              <span
+                data-testid="direction-text"
+              >
+                backward
+              </span>
+               direction.
+              <button
+                aria-controls="2"
+                aria-expanded="false"
+                class="svg-colour-unreviewed evidence-tag"
+                data-testid="evidence-tag-trigger"
+                type="button"
+              >
+                <test-file-stub
+                  height="12"
+                  width="12"
+                />
+                <span
+                  class="evidence-tag__label"
                 >
-                  <a
-                    class="external-link"
-                    href="https://www.rhea-db.org/rhea/12345"
-                    rel="noopener"
-                    target="_blank"
-                  >
-                    Rhea 12345
-                    <test-file-stub
-                      data-testid="external-link-icon"
-                      width="12.5"
-                    />
-                  </a>
-                </div>
-                <div
-                  class="decorated-list-item__content"
-                >
-                  <span
-                    class="text-block"
-                  >
-                    <h4
-                      class="tiny"
-                    >
-                      <a
-                        href="#Isoform_3"
-                      >
-                        Isoform 3
-                      </a>
-                    </h4>
-                    some reaction
-                    <button
-                      aria-controls="1"
-                      aria-expanded="false"
-                      class="svg-colour-unreviewed evidence-tag"
-                      data-testid="evidence-tag-trigger"
-                      type="button"
-                    >
-                      <test-file-stub
-                        height="12"
-                        width="12"
-                      />
-                      <span
-                        class="evidence-tag__label"
-                      >
-                        automatic annotation
-                      </span>
-                    </button>
-                    <div
-                      class="evidence-tag-content "
-                      data-testid="evidence-tag-content"
-                      id="1"
-                    />
-                    <div>
-                      This reaction proceeds in the 
-                      <span
-                        data-testid="direction-text"
-                      >
-                        backward
-                      </span>
-                       direction.
-                      <button
-                        aria-controls="2"
-                        aria-expanded="false"
-                        class="svg-colour-unreviewed evidence-tag"
-                        data-testid="evidence-tag-trigger"
-                        type="button"
-                      >
-                        <test-file-stub
-                          height="12"
-                          width="12"
-                        />
-                        <span
-                          class="evidence-tag__label"
-                        >
-                          Imported
-                        </span>
-                      </button>
-                      <div
-                        class="evidence-tag-content "
-                        data-testid="evidence-tag-content"
-                        id="2"
-                      />
-                    </div>
-                    <div>
-                      EC:1.2.4.5 (
-                      <a
-                        href="/uniprotkb?query=ec:1.2.4.5"
-                      >
-                        UniProtKB
-                      </a>
-                       | 
-                      <a
-                        class="external-link"
-                        href="https://enzyme.expasy.org/EC/1.2.4.5"
-                        rel="noopener"
-                        target="_blank"
-                      >
-                        ENZYME
-                        <test-file-stub
-                          data-testid="external-link-icon"
-                          width="12.5"
-                        />
-                      </a>
-                       | 
-                      <a
-                        class="external-link"
-                        href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
-                        rel="noopener"
-                        target="_blank"
-                      >
-                        Rhea
-                        <test-file-stub
-                          data-testid="external-link-icon"
-                          width="12.5"
-                        />
-                      </a>
-                      )
-                    </div>
-                    <div
-                      class="rhea-reaction-visualizer__toggle"
-                    >
-                      <button
-                        class="button tertiary"
-                        type="button"
-                      >
-                        Hide Rhea reaction
-                      </button>
-                      <test-file-stub
-                        width="1ch"
-                      />
-                    </div>
-                    <div
-                      class="rhea-reaction-visualizer__component"
-                    >
-                      <rhea-reaction
-                        rheaid="12345"
-                        showids="true"
-                        usehost="https://api.rhea-db.org"
-                        zoom="true"
-                      />
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </li>
-          </ul>
+                  Imported
+                </span>
+              </button>
+              <div
+                class="evidence-tag-content "
+                data-testid="evidence-tag-content"
+                id="2"
+              />
+            </div>
+            <div>
+              EC:1.2.4.5 (
+              <a
+                href="/uniprotkb?query=ec:1.2.4.5"
+              >
+                UniProtKB
+              </a>
+               | 
+              <a
+                class="external-link"
+                href="https://enzyme.expasy.org/EC/1.2.4.5"
+                rel="noopener"
+                target="_blank"
+              >
+                ENZYME
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+               | 
+              <a
+                class="external-link"
+                href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
+                rel="noopener"
+                target="_blank"
+              >
+                Rhea
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+              )
+            </div>
+            <div
+              class="rhea-reaction-visualizer__toggle"
+            >
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                Hide reaction details
+                <test-file-stub
+                  width="1ch"
+                />
+              </button>
+            </div>
+            <rhea-visualizer
+              rheaid="12345"
+              showids="true"
+              usehost="https://api.rhea-db.org"
+            />
+          </div>
         </div>
         <h3
           data-article-id="cofactor"
@@ -3770,86 +3749,65 @@ exports[`Entry view should render for non-human entry 1`] = `
           >
             Catalytic activity
           </h3>
-          <ul
-            class="info-list"
+          <div
+            class="rhea-entry"
           >
-            <li>
-              <div
-                class="decorated-list-item"
+            <h4>
+              <a
+                class="external-link"
+                href="https://www.rhea-db.org/rhea/14869"
+                rel="noopener"
+                target="_blank"
               >
-                <div
-                  class="decorated-list-item__title tiny"
-                >
-                  <a
-                    class="external-link"
-                    href="https://www.rhea-db.org/rhea/14869"
-                    rel="noopener"
-                    target="_blank"
-                  >
-                    Rhea 14869
-                    <test-file-stub
-                      data-testid="external-link-icon"
-                      width="12.5"
-                    />
-                  </a>
-                </div>
-                <div
-                  class="decorated-list-item__content"
-                >
-                  <span
-                    class="text-block"
-                  >
-                    an N-acetyl-alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + H2O = an alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + acetate
-                    <button
-                      aria-controls="3"
-                      aria-expanded="false"
-                      class="svg-colour-reviewed evidence-tag"
-                      data-testid="evidence-tag-trigger"
-                      type="button"
-                    >
-                      <test-file-stub
-                        height="12"
-                        width="12"
-                      />
-                      <span
-                        class="evidence-tag__label"
-                      >
-                        1 publication
-                      </span>
-                    </button>
-                    <div
-                      class="evidence-tag-content "
-                      data-testid="evidence-tag-content"
-                      id="3"
-                    />
-                    <div
-                      class="rhea-reaction-visualizer__toggle"
-                    >
-                      <button
-                        class="button tertiary"
-                        type="button"
-                      >
-                        Hide Rhea reaction
-                      </button>
-                      <test-file-stub
-                        width="1ch"
-                      />
-                    </div>
-                    <div
-                      class="rhea-reaction-visualizer__component"
-                    >
-                      <rhea-reaction
-                        rheaid="14869"
-                        showids="true"
-                        usehost="https://api.rhea-db.org"
-                        zoom="true"
-                      />
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </li>
-          </ul>
+                Rhea:14869
+                <test-file-stub
+                  data-testid="external-link-icon"
+                  width="12.5"
+                />
+              </a>
+            </h4>
+            an N-acetyl-alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + H2O = an alpha-D-galactosaminyl-(1-&gt;3)-[alpha-L-fucosyl-(1-&gt;2)]-beta-D-galactosyl derivative + acetate
+            <button
+              aria-controls="3"
+              aria-expanded="false"
+              class="svg-colour-reviewed evidence-tag"
+              data-testid="evidence-tag-trigger"
+              type="button"
+            >
+              <test-file-stub
+                height="12"
+                width="12"
+              />
+              <span
+                class="evidence-tag__label"
+              >
+                1 publication
+              </span>
+            </button>
+            <div
+              class="evidence-tag-content "
+              data-testid="evidence-tag-content"
+              id="3"
+            />
+            <div
+              class="rhea-reaction-visualizer__toggle"
+            >
+              <button
+                class="button tertiary"
+                type="button"
+              >
+                Hide reaction details
+                <test-file-stub
+                  width="1ch"
+                />
+              </button>
+            </div>
+            <rhea-visualizer
+              rheaid="14869"
+              showids="true"
+              usehost="https://api.rhea-db.org"
+            />
+          </div>
         </div>
         <h3
           data-article-id="cofactor"

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -5,12 +5,15 @@ import {
   Loader,
 } from 'franklin-sites';
 import { Fragment, useCallback, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { SetRequired } from 'type-fest';
 
+import { Location } from '../../../app/config/urls';
 import ExternalLink from '../../../shared/components/ExternalLink';
 import externalUrls from '../../../shared/config/externalUrls';
 import useCustomElement from '../../../shared/hooks/useCustomElement';
 import * as logging from '../../../shared/utils/logging';
+import { getLocationForPathname } from '../../../shared/utils/url';
 import {
   CatalyticActivityComment,
   PhysiologicalReaction,
@@ -339,9 +342,12 @@ const CatalyticActivityView = ({
   defaultHideAllReactions = false,
   noEvidence,
 }: CatalyticActivityProps) => {
+  const { pathname } = useLocation();
   if (!comments?.length) {
     return null;
   }
+  const currentLocation = getLocationForPathname(pathname);
+  const inUniProtKBEntry = currentLocation === Location.UniProtKBEntry;
   let firstRheaId: number;
   return (
     <div className={styles['catalytic-activity']}>
@@ -401,7 +407,7 @@ const CatalyticActivityView = ({
                   <ECNumbersView ecNumbers={[{ value: reaction.ecNumber }]} />
                 </div>
               )}
-              {!!rheaId && (
+              {inUniProtKBEntry && !!rheaId && (
                 <RheaReactionVisualizer
                   rheaId={rheaId}
                   show={

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -116,7 +116,7 @@ export const RheaReactionVisualizer = ({
   a.icon_link:focus { color: #0161a4; }
 
   /* The icon "mixin": applies to both places */
-  a.icon_link::after {
+a.icon_link:not(.no_icon)::after {
     content: '';
     background: currentColor;
     -webkit-mask-image: ${externalLinkMask};
@@ -176,6 +176,10 @@ export const RheaReactionVisualizer = ({
     const adaptTippyContent = (root: ShadowRoot) => {
       const links = root.querySelectorAll('.tippy-box .tippy-content a[href]');
       links.forEach((a) => {
+        if (a.textContent === 'Search proteins') {
+          // Don't have external link icon for UniProt links
+          a.classList.add('no_icon');
+        }
         a.classList.add('icon_link');
         a.setAttribute('target', '_blank');
         const rel = new Set(

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -173,28 +173,8 @@ export const RheaReactionVisualizer = ({
       shadowRoot.appendChild(styleElement);
     }
 
-    const adaptRheaLink = (container: Element) => {
-      const span = container.querySelector(':scope > span');
-      if (!span) {
-        return;
-      }
-      const link = container.querySelector(
-        ':scope > a.icon_link'
-      ) as HTMLAnchorElement | null;
-      if (!link) {
-        return;
-      }
-
-      let targetLink = link;
-      if (!link.contains(span)) {
-        targetLink = link.cloneNode(false) as HTMLAnchorElement;
-        container.insertBefore(targetLink, span);
-        targetLink.appendChild(span);
-        link.remove();
-      }
-      targetLink.target = '_blank';
-      targetLink.rel = 'noopener noreferrer';
-      targetLink.querySelector(':scope > svg')?.remove();
+    const removeRheaLink = (shadowRoot: ShadowRoot) => {
+      shadowRoot.querySelector('.rhea-reaction-source')?.remove();
     };
 
     const adaptTippyContent = (root: ShadowRoot) => {
@@ -218,9 +198,7 @@ export const RheaReactionVisualizer = ({
     };
 
     const adaptAll = () => {
-      shadowRoot
-        .querySelectorAll('.rhea-reaction-source')
-        .forEach(adaptRheaLink);
+      removeRheaLink(shadowRoot);
       adaptTippyContent(shadowRoot);
     };
 

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -109,6 +109,11 @@ export const RheaReactionVisualizer = ({
         text-decoration: none;
         font-weight: 600;
       }
+      .rhea-reaction-source > a.icon_link:hover,
+      .rhea-reaction-source > a.icon_link:focus {
+        /* Hardcoded equivalent of lighten($var(--fr--color-sapphire-blue), 10) */
+        color: #0161a4;
+      }
       .rhea-reaction-source > a.icon_link::after {
           content: '';
           background: currentColor;

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -3,6 +3,8 @@ import {
   ChevronUpIcon,
   Loader,
   ModalBackdrop,
+  Tab,
+  Tabs,
   useModal,
   Window,
 } from 'franklin-sites';
@@ -131,46 +133,54 @@ export const RheaReactionVisualizer = ({
           className="button tertiary"
           onClick={() => setShow(!show)}
         >
-          {`${show ? 'Hide' : 'View'} Rhea reaction and atom map`}
+          {`${show ? 'Hide' : 'View'} reaction and atom map`}
         </button>
         {show ? <ChevronUpIcon width="1ch" /> : <ChevronDownIcon width="1ch" />}
       </div>
       {show && (
-        <>
-          {rheaReactionElement.defined ? (
-            <>
-              <div className={styles['rhea-reaction-visualizer__component']}>
-                <rheaReactionElement.name
-                  rheaid={rheaId}
-                  showIds
-                  zoom
-                  ref={callback}
-                  usehost="https://api.rhea-db.org"
-                />
-              </div>
-              {displayModal && zoomImageData?.imgURL && (
-                <Modal
-                  handleExitModal={() => setDisplayModal(false)}
-                  height="30vh"
-                  width="30vw"
-                >
-                  <ZoomModalContent
-                    chebi={zoomImageData.chebi}
-                    imgURL={zoomImageData.imgURL}
+        <Tabs className={styles['rhea-reaction-visualizer__tabs']} bordered>
+          <Tab title="Reaction">
+            {rheaReactionElement.defined ? (
+              <>
+                <div className={styles['rhea-reaction-visualizer__component']}>
+                  <rheaReactionElement.name
+                    rheaid={rheaId}
+                    showIds
+                    zoom
+                    ref={callback}
+                    usehost="https://api.rhea-db.org"
                   />
-                </Modal>
-              )}
-            </>
-          ) : (
-            <Loader />
-          )}
-
-          {rheaAtommapElement.defined ? (
-            <rheaAtommapElement.name rheaid={rheaId} />
-          ) : (
-            <Loader />
-          )}
-        </>
+                </div>
+                {displayModal && zoomImageData?.imgURL && (
+                  <Modal
+                    handleExitModal={() => setDisplayModal(false)}
+                    height="30vh"
+                    width="30vw"
+                  >
+                    <ZoomModalContent
+                      chebi={zoomImageData.chebi}
+                      imgURL={zoomImageData.imgURL}
+                    />
+                  </Modal>
+                )}
+              </>
+            ) : (
+              <Loader />
+            )}
+          </Tab>
+          <Tab title="Atom map">
+            {rheaAtommapElement.defined ? (
+              <rheaAtommapElement.name
+                rheaid={rheaId}
+                nosource
+                usehost="https://www.rhea-db.org"
+                imagehost="https://www.rhea-db.org"
+              />
+            ) : (
+              <Loader />
+            )}
+          </Tab>
+        </Tabs>
       )}
     </>
   );

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,4 +1,9 @@
-import { ChevronDownIcon, ChevronUpIcon, Loader } from 'franklin-sites';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ExternalLinkIconRaw,
+  Loader,
+} from 'franklin-sites';
 import { Fragment, useCallback, useState } from 'react';
 import { SetRequired } from 'type-fest';
 
@@ -62,6 +67,9 @@ export const RheaReactionVisualizer = ({
     if (!shadowRoot.querySelector('style[data-rhea-overrides]')) {
       const styleElement = document.createElement('style');
       styleElement.setAttribute('data-rhea-overrides', '');
+      const externalLinkMask = `url("data:image/svg+xml;utf8,${encodeURIComponent(
+        ExternalLinkIconRaw
+      )}")`;
       styleElement.textContent = `
       .rhea-reaction-visualizer { border-bottom: 0.1rem solid var(--fr--color-platinum); }
       .name { font-size: 16px; }
@@ -97,14 +105,26 @@ export const RheaReactionVisualizer = ({
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
-        color: #014371;
+        color: var(--fr--color-sapphire-blue);
         text-decoration: none;
         font-weight: 600;
       }
-      .rhea-reaction-source > a.icon_link .externalLink {
-        width: 0.8rem;
-        height: 0.8rem;
-        flex: 0 0 auto;
+      .rhea-reaction-source > a.icon_link::after {
+          content: '';
+          background: currentColor;
+          -webkit-mask-image: ${externalLinkMask};
+          mask-image: ${externalLinkMask};
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+          -webkit-mask-size: contain;
+          mask-size: contain;
+          -webkit-mask-position: center;
+          mask-position: center;
+          display: inline-block;
+          width: 0.75em;
+          height: 0.75em;
+          margin: 0 0.5ch;
+        }
       }
     `;
       shadowRoot.appendChild(styleElement);

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -366,7 +366,7 @@ const CatalyticActivityView = ({
               <h4>
                 {rheaId ? (
                   <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
-                    Rhea {rheaId}
+                    Rhea:{rheaId}
                   </ExternalLink>
                 ) : (
                   ''

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -115,6 +115,14 @@ export const RheaReactionVisualizer = ({
             font-size: 16px;
           }
 
+          .info {
+            stroke: var(--fr--color-sapphire-blue);
+          }
+
+          .more path {
+            stroke: var(--fr--color-sapphire-blue);
+          }
+
           .tabs:first-child {
             border-left: 0.1rem solid var(--fr--color-platinum);
           }

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -192,15 +192,9 @@ export const RheaReactionVisualizer = ({
         targetLink.appendChild(span);
         link.remove();
       }
-
       targetLink.target = '_blank';
-      const rel = new Set((targetLink.rel || '').split(/\s+/).filter(Boolean));
-      rel.add('noopener');
-      rel.add('noreferrer');
-      targetLink.rel = Array.from(rel).join(' ');
-      if (targetLink.querySelector(':scope > svg')) {
-        targetLink.querySelector(':scope > svg')?.remove();
-      }
+      targetLink.rel = 'noopener noreferrer';
+      targetLink.querySelector(':scope > svg')?.remove();
     };
 
     const adaptTippyContent = (root: ShadowRoot) => {

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -110,7 +110,11 @@ export const RheaReactionVisualizer = ({
           .rhea-reaction-visualizer {
             border-bottom: 0.1rem solid var(--fr--color-platinum);
           }
-            
+
+          .name {
+            font-size: 16px;
+          }
+
           .tabs:first-child {
             border-left: 0.1rem solid var(--fr--color-platinum);
           }

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -82,9 +82,16 @@ export const RheaReactionVisualizer = ({
   const rheaReactionElement = useCustomElement(
     () =>
       import(
-        /* webpackChunkName: "rhea-reaction-visualizer" */ '@swissprot/rhea-reaction-visualizer'
+        /* webpackChunkName: "rhea-reaction-visualizer" */ '@swissprot/rhea-reaction-viz-test'
       ),
     'rhea-reaction'
+  );
+  const rheaAtommapElement = useCustomElement(
+    () =>
+      import(
+        /* webpackChunkName: "rhea-reaction-visualizer" */ '@swissprot/rhea-reaction-viz-test'
+      ),
+    'rhea-atommap'
   );
   const [show, setShow] = useState(initialShow);
   const [zoomImageData, setZoomImageData] = useState<ChebiImageData>();
@@ -112,7 +119,7 @@ export const RheaReactionVisualizer = ({
     [setDisplayModal]
   );
 
-  if (rheaReactionElement.errored) {
+  if (rheaReactionElement.errored || rheaAtommapElement.errored) {
     // It's fine, just don't display anything
     return null;
   }
@@ -129,34 +136,43 @@ export const RheaReactionVisualizer = ({
         </button>
         {show ? <ChevronUpIcon width="1ch" /> : <ChevronDownIcon width="1ch" />}
       </div>
-      {show &&
-        (rheaReactionElement.defined ? (
-          <>
-            <div className={styles['rhea-reaction-visualizer__component']}>
-              <rheaReactionElement.name
-                rheaid={rheaId}
-                showIds
-                zoom
-                ref={callback}
-                usehost="https://api.rhea-db.org"
-              />
-            </div>
-            {displayModal && zoomImageData?.imgURL && (
-              <Modal
-                handleExitModal={() => setDisplayModal(false)}
-                height="30vh"
-                width="30vw"
-              >
-                <ZoomModalContent
-                  chebi={zoomImageData.chebi}
-                  imgURL={zoomImageData.imgURL}
+      {show && (
+        <>
+          {rheaReactionElement.defined ? (
+            <>
+              <div className={styles['rhea-reaction-visualizer__component']}>
+                <rheaReactionElement.name
+                  rheaid={rheaId}
+                  showIds
+                  zoom
+                  ref={callback}
+                  usehost="https://api.rhea-db.org"
                 />
-              </Modal>
-            )}
-          </>
-        ) : (
-          <Loader />
-        ))}
+              </div>
+              {displayModal && zoomImageData?.imgURL && (
+                <Modal
+                  handleExitModal={() => setDisplayModal(false)}
+                  height="30vh"
+                  width="30vw"
+                >
+                  <ZoomModalContent
+                    chebi={zoomImageData.chebi}
+                    imgURL={zoomImageData.imgURL}
+                  />
+                </Modal>
+              )}
+            </>
+          ) : (
+            <Loader />
+          )}
+
+          {rheaAtommapElement.defined ? (
+            <rheaAtommapElement.name rheaid={rheaId} />
+          ) : (
+            <Loader />
+          )}
+        </>
+      )}
     </>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -248,7 +248,7 @@ export const RheaReactionVisualizer = ({
           className="button tertiary"
           onClick={() => setShow(!show)}
         >
-          {`${show ? 'Hide' : 'View'} reaction and atom map`}
+          {`${show ? 'Hide' : 'View'} reaction details`}
           {show ? (
             <ChevronUpIcon width="1ch" />
           ) : (

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,12 +1,5 @@
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  Loader,
-  ModalBackdrop,
-  useModal,
-  Window,
-} from 'franklin-sites';
-import { Fragment, useCallback, useRef, useState } from 'react';
+import { ChevronDownIcon, ChevronUpIcon, Loader } from 'franklin-sites';
+import { Fragment, useCallback, useState } from 'react';
 import { SetRequired } from 'type-fest';
 
 import ExternalLink from '../../../shared/components/ExternalLink';
@@ -44,31 +37,6 @@ type ChebiImageData = {
   imgURL: string;
 };
 
-export const ZoomModalContent = ({ chebi, imgURL }: ChebiImageData) => {
-  const imageRef = useRef<HTMLImageElement>(null);
-  const [loading, setLoading] = useState(true);
-  const image = new Image();
-  image.src = imgURL;
-  image.onload = () => {
-    if (imageRef && imageRef.current) {
-      imageRef.current.src = image.src;
-      setLoading(false);
-    }
-  };
-  return (
-    <div className={styles['zoom-image-container']}>
-      <img
-        ref={imageRef}
-        alt={chebi}
-        style={{ display: loading ? 'none' : 'block' }}
-      />
-      {loading && <Loader />}
-    </div>
-  );
-};
-
-type ZoomClickedEvent = { detail: ChebiImageData };
-
 type RheaReactionVisualizerProps = {
   rheaId: number;
   show: boolean;
@@ -87,26 +55,20 @@ export const RheaReactionVisualizer = ({
   );
 
   const [show, setShow] = useState(initialShow);
-  const [zoomImageData, setZoomImageData] = useState<ChebiImageData>();
-  const { displayModal, setDisplayModal, Modal } = useModal(
-    ModalBackdrop,
-    Window
-  );
-  const callback = useCallback<React.RefCallback<HTMLElement>>(
-    (node): void => {
-      if (node) {
-        node.addEventListener(
-          'zoomClicked',
-          ({ detail }: { detail: ChebiImageData }) => {
-            setZoomImageData(detail);
-            setDisplayModal(true);
-          }
-        );
-        if (!node.shadowRoot) {
-          return;
+  const callback = useCallback<React.RefCallback<HTMLElement>>((node): void => {
+    if (node) {
+      node.addEventListener(
+        'zoomClicked',
+        ({ detail }: { detail: ChebiImageData }) => {
+          setZoomImageData(detail);
+          setDisplayModal(true);
         }
-        const styleElement = document.createElement('style');
-        styleElement.textContent = `
+      );
+      if (!node.shadowRoot) {
+        return;
+      }
+      const styleElement = document.createElement('style');
+      styleElement.textContent = `
           .rhea-reaction-visualizer {
             border-bottom: 0.1rem solid var(--fr--color-platinum);
           }
@@ -158,11 +120,9 @@ export const RheaReactionVisualizer = ({
             border-top: 0.1rem solid var(--fr--color-platinum);
           }
         `;
-        node.shadowRoot.appendChild(styleElement);
-      }
-    },
-    [setDisplayModal]
-  );
+      node.shadowRoot.appendChild(styleElement);
+    }
+  }, []);
 
   if (rheaVisualizerElement.errored) {
     // It's fine, just don't display anything
@@ -183,27 +143,12 @@ export const RheaReactionVisualizer = ({
       </div>
       {show &&
         (rheaVisualizerElement.defined ? (
-          <>
-            <rheaVisualizerElement.name
-              rheaid={rheaId}
-              showIds
-              zoom
-              ref={callback}
-              usehost="https://api.rhea-db.org"
-            />
-            {displayModal && zoomImageData?.imgURL && (
-              <Modal
-                handleExitModal={() => setDisplayModal(false)}
-                height="30vh"
-                width="30vw"
-              >
-                <ZoomModalContent
-                  chebi={zoomImageData.chebi}
-                  imgURL={zoomImageData.imgURL}
-                />
-              </Modal>
-            )}
-          </>
+          <rheaVisualizerElement.name
+            rheaid={rheaId}
+            showIds
+            ref={callback}
+            usehost="https://api.rhea-db.org"
+          />
         ) : (
           <Loader />
         ))}

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -367,7 +367,7 @@ const CatalyticActivityView = ({
           }
           return (
             <div className={styles['rhea-entry']} key={rheaId}>
-              <h4>
+              <div className="small">
                 {rheaId ? (
                   <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
                     Rhea:{rheaId}
@@ -375,16 +375,16 @@ const CatalyticActivityView = ({
                 ) : (
                   ''
                 )}
-              </h4>
+              </div>
 
               {molecule && (
-                <h4 className="tiny">
+                <div className="small">
                   {noEvidence ? (
                     `${molecule}`
                   ) : (
                     <a href={`#${molecule.replaceAll(' ', '_')}`}>{molecule}</a>
                   )}
-                </h4>
+                </div>
               )}
               <RichText>{reaction.name}</RichText>
               {!noEvidence && (

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -134,6 +134,10 @@ a.icon_link:not(.no_icon)::after {
   }
 
   .tippy-box a.icon_link { color: white; text-decoration:underline }
+
+  rhea-reaction-block.smallMolecule:hover {
+      box-shadow: none;
+  }
     `;
       shadowRoot.appendChild(styleElement);
     }

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -1,7 +1,6 @@
 import {
   ChevronDownIcon,
   ChevronUpIcon,
-  InfoList,
   Loader,
   ModalBackdrop,
   useModal,
@@ -132,7 +131,7 @@ export const RheaReactionVisualizer = ({
           className="button tertiary"
           onClick={() => setShow(!show)}
         >
-          {`${show ? 'Hide' : 'View'} Rhea reaction`}
+          {`${show ? 'Hide' : 'View'} Rhea reaction and atom map`}
         </button>
         {show ? <ChevronUpIcon width="1ch" /> : <ChevronDownIcon width="1ch" />}
       </div>
@@ -250,71 +249,75 @@ const CatalyticActivityView = ({
     return null;
   }
   let firstRheaId: number;
-  const infoData = comments
-    .filter(
-      (comment): comment is SetRequired<CatalyticActivityComment, 'reaction'> =>
-        Boolean(comment.reaction)
-    )
-    .map(({ molecule, reaction, physiologicalReactions }) => {
-      // Using only the first rhea reaction reference because FW has assured us that
-      // there will be either 0 or 1 types of this reference (ie never > 1)
-
-      const rheaReactionReference =
-        reaction.reactionCrossReferences &&
-        reaction.reactionCrossReferences.find(isRheaReactionReference);
-      const rheaId =
-        rheaReactionReference && getRheaId(rheaReactionReference.id);
-      if (rheaId && !firstRheaId) {
-        firstRheaId = rheaId;
-      }
-      return {
-        title: rheaId ? (
-          <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
-            Rhea {rheaId}
-          </ExternalLink>
-        ) : (
-          ''
-        ),
-        content: (
-          <span className="text-block">
-            {molecule && (
-              <h4 className="tiny">
-                {noEvidence ? (
-                  `${molecule}`
-                ) : (
-                  <a href={`#${molecule.replaceAll(' ', '_')}`}>{molecule}</a>
-                )}
-              </h4>
-            )}
-            <RichText>{reaction.name}</RichText>
-            {!noEvidence && (
-              <UniProtKBEvidenceTag evidences={reaction.evidences} />
-            )}
-            {physiologicalReactions && physiologicalReactions.length && (
-              <ReactionDirection
-                physiologicalReactions={physiologicalReactions}
-                noEvidence={noEvidence}
-              />
-            )}
-            {reaction.ecNumber && (
-              <div>
-                <ECNumbersView ecNumbers={[{ value: reaction.ecNumber }]} />
-              </div>
-            )}
-            {!!rheaId && (
-              <RheaReactionVisualizer
-                rheaId={rheaId}
-                show={defaultHideAllReactions ? false : rheaId === firstRheaId}
-              />
-            )}
-          </span>
-        ),
-      };
-    });
   return (
     <div className={styles['catalytic-activity']}>
       {title && <h3 data-article-id="catalytic_activity">{title}</h3>}
-      <InfoList infoData={infoData} />
+      {comments
+        .filter(
+          (
+            comment
+          ): comment is SetRequired<CatalyticActivityComment, 'reaction'> =>
+            Boolean(comment.reaction)
+        )
+        .map(({ molecule, reaction, physiologicalReactions }) => {
+          // Using only the first rhea reaction reference because FW has assured us that
+          // there will be either 0 or 1 types of this reference (ie never > 1)
+
+          const rheaReactionReference =
+            reaction.reactionCrossReferences &&
+            reaction.reactionCrossReferences.find(isRheaReactionReference);
+          const rheaId =
+            rheaReactionReference && getRheaId(rheaReactionReference.id);
+          if (rheaId && !firstRheaId) {
+            firstRheaId = rheaId;
+          }
+          return (
+            <div className={styles['rhea-entry']} key={rheaId}>
+              <h4>
+                {rheaId ? (
+                  <ExternalLink url={externalUrls.RheaEntry(rheaId)}>
+                    Rhea {rheaId}
+                  </ExternalLink>
+                ) : (
+                  ''
+                )}
+              </h4>
+
+              {molecule && (
+                <h4 className="tiny">
+                  {noEvidence ? (
+                    `${molecule}`
+                  ) : (
+                    <a href={`#${molecule.replaceAll(' ', '_')}`}>{molecule}</a>
+                  )}
+                </h4>
+              )}
+              <RichText>{reaction.name}</RichText>
+              {!noEvidence && (
+                <UniProtKBEvidenceTag evidences={reaction.evidences} />
+              )}
+              {physiologicalReactions && physiologicalReactions.length && (
+                <ReactionDirection
+                  physiologicalReactions={physiologicalReactions}
+                  noEvidence={noEvidence}
+                />
+              )}
+              {reaction.ecNumber && (
+                <div>
+                  <ECNumbersView ecNumbers={[{ value: reaction.ecNumber }]} />
+                </div>
+              )}
+              {!!rheaId && (
+                <RheaReactionVisualizer
+                  rheaId={rheaId}
+                  show={
+                    defaultHideAllReactions ? false : rheaId === firstRheaId
+                  }
+                />
+              )}
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -101,36 +101,39 @@ export const RheaReactionVisualizer = ({
       }
       .tabpanel { border: none; border-top: 0.1rem solid var(--fr--color-platinum); }
 
-      .rhea-reaction-source > a.icon_link {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
-        color: var(--fr--color-sapphire-blue);
-        text-decoration: none;
-        font-weight: 600;
-      }
-      .rhea-reaction-source > a.icon_link:hover,
-      .rhea-reaction-source > a.icon_link:focus {
-        /* Hardcoded equivalent of lighten($var(--fr--color-sapphire-blue), 10) */
-        color: #0161a4;
-      }
-      .rhea-reaction-source > a.icon_link::after {
-          content: '';
-          background: currentColor;
-          -webkit-mask-image: ${externalLinkMask};
-          mask-image: ${externalLinkMask};
-          -webkit-mask-repeat: no-repeat;
-          mask-repeat: no-repeat;
-          -webkit-mask-size: contain;
-          mask-size: contain;
-          -webkit-mask-position: center;
-          mask-position: center;
-          display: inline-block;
-          width: 0.75em;
-          height: 0.75em;
-          margin: 0 0.5ch;
-        }
-      }
+     
+
+  a.icon_link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--fr--color-sapphire-blue);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  a.icon_link:hover,
+  a.icon_link:focus { color: #0161a4; }
+
+  /* The icon "mixin": applies to both places */
+  a.icon_link::after {
+    content: '';
+    background: currentColor;
+    -webkit-mask-image: ${externalLinkMask};
+    mask-image: ${externalLinkMask};
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-position: center;
+    mask-position: center;
+    display: inline-block;
+    width: 0.75em;
+    height: 0.75em;
+    margin: 0 0.5ch;
+  }
+
+  .tippy-box a.icon_link { color: white; text-decoration:underline }
     `;
       shadowRoot.appendChild(styleElement);
     }
@@ -141,7 +144,6 @@ export const RheaReactionVisualizer = ({
       if (!span) {
         return;
       }
-
       const link = container.querySelector(
         ':scope > a.icon_link'
       ) as HTMLAnchorElement | null;
@@ -171,10 +173,26 @@ export const RheaReactionVisualizer = ({
       targetLink.querySelector(':scope > svg')?.remove();
     };
 
+    const adaptTippyContent = (root: ShadowRoot) => {
+      const links = root.querySelectorAll('.tippy-box .tippy-content a[href]');
+      links.forEach((a) => {
+        a.classList.add('icon_link');
+        a.setAttribute('target', '_blank');
+        const rel = new Set(
+          (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean)
+        );
+        rel.add('noopener');
+        rel.add('noreferrer');
+        a.setAttribute('rel', Array.from(rel).join(' '));
+      });
+    };
+
     const adaptAll = () => {
       shadowRoot
         .querySelectorAll('.rhea-reaction-source')
         .forEach(adaptRheaLink);
+
+      adaptTippyContent(shadowRoot);
     };
 
     // Initial pass

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -57,13 +57,6 @@ export const RheaReactionVisualizer = ({
   const [show, setShow] = useState(initialShow);
   const callback = useCallback<React.RefCallback<HTMLElement>>((node): void => {
     if (node) {
-      node.addEventListener(
-        'zoomClicked',
-        ({ detail }: { detail: ChebiImageData }) => {
-          setZoomImageData(detail);
-          setDisplayModal(true);
-        }
-      );
       if (!node.shadowRoot) {
         return;
       }
@@ -119,8 +112,51 @@ export const RheaReactionVisualizer = ({
             border: none;
             border-top: 0.1rem solid var(--fr--color-platinum);
           }
+
+          .icon_link {
+            color: #014371;
+            text-decoration: none;
+            font-weight: 600;
+          }
         `;
       node.shadowRoot.appendChild(styleElement);
+
+      const adaptRheaLink = (container: Element) => {
+        const span = container.querySelector(':scope > span');
+        if (!span) {
+          return;
+        }
+        const link = container.querySelector(
+          ':scope > a.icon_link'
+        ) as HTMLAnchorElement | null;
+        if (!link || link.contains(span)) {
+          return;
+        }
+
+        // TODO: open in new tab
+        const newLink = link.cloneNode(false) as HTMLAnchorElement;
+        container.insertBefore(newLink, span);
+        newLink.appendChild(span);
+        const svg = link.querySelector('svg');
+        if (svg) {
+          newLink.appendChild(svg);
+        }
+        link.remove();
+      };
+
+      const adaptRheaLinks = () => {
+        node.shadowRoot
+          ?.querySelectorAll('.rhea-reaction-source')
+          .forEach(adaptRheaLink);
+      };
+
+      adaptRheaLinks();
+
+      // Observe future changes for when web component re-renders
+      const mo = new MutationObserver(() => adaptRheaLinks());
+      mo.observe(node.shadowRoot, { childList: true, subtree: true });
+
+      // TODO: add MutationObserver clean up
     }
   }, []);
 

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -107,6 +107,10 @@ export const RheaReactionVisualizer = ({
         }
         const styleElement = document.createElement('style');
         styleElement.textContent = `
+          .rhea-reaction-visualizer {
+            border-bottom: 0.1rem solid var(--fr--color-platinum);
+          }
+            
           .tabs:first-child {
             border-left: 0.1rem solid var(--fr--color-platinum);
           }

--- a/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
+++ b/src/uniprotkb/components/protein-data-views/CatalyticActivityView.tsx
@@ -249,8 +249,12 @@ export const RheaReactionVisualizer = ({
           onClick={() => setShow(!show)}
         >
           {`${show ? 'Hide' : 'View'} reaction and atom map`}
+          {show ? (
+            <ChevronUpIcon width="1ch" />
+          ) : (
+            <ChevronDownIcon width="1ch" />
+          )}
         </button>
-        {show ? <ChevronUpIcon width="1ch" /> : <ChevronDownIcon width="1ch" />}
       </div>
       {show &&
         (rheaVisualizerElement.defined ? (

--- a/src/uniprotkb/components/protein-data-views/__tests__/CatalyticActivityView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/CatalyticActivityView.spec.tsx
@@ -6,7 +6,6 @@ import CatalyticActivityView, {
   isRheaReactionReference,
   ReactionDirection,
   RheaReactionVisualizer,
-  ZoomModalContent,
 } from '../CatalyticActivityView';
 import catalyticActivityUIData from './__mocks__/catalyticActivityUIData';
 
@@ -109,14 +108,5 @@ describe('ReactionDirection component', () => {
       />
     );
     expect(asFragment().childElementCount).toEqual(0);
-  });
-});
-
-describe('ZoomModalContent component', () => {
-  it('should render', () => {
-    const { asFragment } = render(
-      <ZoomModalContent imgURL="https://image.png" chebi="chebi:12345" />
-    );
-    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
@@ -10,75 +10,62 @@ exports[`CatalyticActivityView component should render catalytic activity 1`] = 
     >
       Catalytic activity
     </h3>
-    <ul
-      class="info-list"
+    <div
+      class="rhea-entry"
     >
-      <li>
-        <div
-          class="decorated-list-item"
+      <h4 />
+      Reaction name
+      <div>
+        This reaction proceeds in the 
+        <span
+          data-testid="direction-text"
         >
-          <div
-            class="decorated-list-item__content"
-          >
-            <span
-              class="text-block"
-            >
-              Reaction name
-              <div>
-                This reaction proceeds in the 
-                <span
-                  data-testid="direction-text"
-                >
-                  forward
-                </span>
-                 and the 
-                <span
-                  data-testid="direction-text"
-                >
-                  backward
-                </span>
-                 directions.
-              </div>
-              <div>
-                EC:EC:12112 (
-                <a
-                  href="/uniprotkb?query=ec:EC:12112"
-                >
-                  UniProtKB
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://enzyme.expasy.org/EC/EC:12112"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  ENZYME
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Rhea
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                )
-              </div>
-            </span>
-          </div>
-        </div>
-      </li>
-    </ul>
+          forward
+        </span>
+         and the 
+        <span
+          data-testid="direction-text"
+        >
+          backward
+        </span>
+         directions.
+      </div>
+      <div>
+        EC:EC:12112 (
+        <a
+          href="/uniprotkb?query=ec:EC:12112"
+        >
+          UniProtKB
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://enzyme.expasy.org/EC/EC:12112"
+          rel="noopener"
+          target="_blank"
+        >
+          ENZYME
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
+          rel="noopener"
+          target="_blank"
+        >
+          Rhea
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+        )
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -88,75 +75,62 @@ exports[`CatalyticActivityView component should render catalytic activity when c
   <div
     class="catalytic-activity"
   >
-    <ul
-      class="info-list"
+    <div
+      class="rhea-entry"
     >
-      <li>
-        <div
-          class="decorated-list-item"
+      <h4 />
+      Reaction name
+      <div>
+        This reaction proceeds in the 
+        <span
+          data-testid="direction-text"
         >
-          <div
-            class="decorated-list-item__content"
-          >
-            <span
-              class="text-block"
-            >
-              Reaction name
-              <div>
-                This reaction proceeds in the 
-                <span
-                  data-testid="direction-text"
-                >
-                  forward
-                </span>
-                 and the 
-                <span
-                  data-testid="direction-text"
-                >
-                  backward
-                </span>
-                 directions.
-              </div>
-              <div>
-                EC:EC:12112 (
-                <a
-                  href="/uniprotkb?query=ec:EC:12112"
-                >
-                  UniProtKB
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://enzyme.expasy.org/EC/EC:12112"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  ENZYME
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Rhea
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                )
-              </div>
-            </span>
-          </div>
-        </div>
-      </li>
-    </ul>
+          forward
+        </span>
+         and the 
+        <span
+          data-testid="direction-text"
+        >
+          backward
+        </span>
+         directions.
+      </div>
+      <div>
+        EC:EC:12112 (
+        <a
+          href="/uniprotkb?query=ec:EC:12112"
+        >
+          UniProtKB
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://enzyme.expasy.org/EC/EC:12112"
+          rel="noopener"
+          target="_blank"
+        >
+          ENZYME
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://www.rhea-db.org/rhea?query=ec:EC:12112"
+          rel="noopener"
+          target="_blank"
+        >
+          Rhea
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+        )
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -204,33 +178,11 @@ exports[`RheaReactionVisualizer component should render RheaReactionVisualizer 1
       class="button tertiary"
       type="button"
     >
-      View Rhea reaction
-    </button>
-    <test-file-stub
-      width="1ch"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`ZoomModalContent component should render 1`] = `
-<DocumentFragment>
-  <div
-    class="zoom-image-container"
-  >
-    <img
-      alt="chebi:12345"
-      style="display: none;"
-    />
-    <div
-      class="loader-container"
-    >
+      View reaction details
       <test-file-stub
-        classname="loader"
-        height="100"
-        width="100"
+        width="1ch"
       />
-    </div>
+    </button>
   </div>
 </DocumentFragment>
 `;

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/CatalyticActivityView.spec.tsx.snap
@@ -13,7 +13,9 @@ exports[`CatalyticActivityView component should render catalytic activity 1`] = 
     <div
       class="rhea-entry"
     >
-      <h4 />
+      <div
+        class="small"
+      />
       Reaction name
       <div>
         This reaction proceeds in the 
@@ -78,7 +80,9 @@ exports[`CatalyticActivityView component should render catalytic activity when c
     <div
       class="rhea-entry"
     >
-      <h4 />
+      <div
+        class="small"
+      />
       Reaction name
       <div>
         This reaction proceeds in the 

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
@@ -11,10 +11,6 @@
   }
 
   .rhea-reaction-visualizer {
-    &__tabs {
-      min-height: 200px;
-      margin-top: -1.5rem;
-    }
     &__toggle {
       padding-top: 0.5 * $global-padding;
 
@@ -23,11 +19,6 @@
         top: -0.6rem;
         margin-left: 0.5rem;
       }
-    }
-
-    &__component {
-      width: 100%;
-      overflow-x: auto;
     }
   }
 

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
@@ -16,8 +16,9 @@
 
       svg {
         position: relative;
-        top: -0.6rem;
+        top: 2px;
         margin-left: 0.5rem;
+        width: 0.7rem;
       }
     }
   }

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
@@ -6,18 +6,15 @@
     width: 500px;
   }
 
-  > .rhea-entry:not(:last-child) {
-    border-bottom: 0.5px solid black;
+  > .rhea-entry {
     margin-bottom: $global-margin;
-    // padding-bottom: $global-padding;
   }
 
-  // .rhea-entry > div:not(:last-child) {
-  //   border-bottom: 0.5px solid black;
-  //   margin-bottom: $global-margin;
-  //   padding-bottom: $global-padding;
-  // }
   .rhea-reaction-visualizer {
+    &__tabs {
+      min-height: 200px;
+      margin-top: -1.5rem;
+    }
     &__toggle {
       padding-top: 0.5 * $global-padding;
 
@@ -51,5 +48,9 @@
 
   :global(.rhea-reaction-source) {
     display: none;
+  }
+
+  :global(label) {
+    display: inline;
   }
 }

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
@@ -6,14 +6,20 @@
     width: 500px;
   }
 
-  :global(.info-list) > li:not(:last-child) {
+  > .rhea-entry:not(:last-child) {
     border-bottom: 0.5px solid black;
     margin-bottom: $global-margin;
-    padding-bottom: $global-padding;
+    // padding-bottom: $global-padding;
   }
+
+  // .rhea-entry > div:not(:last-child) {
+  //   border-bottom: 0.5px solid black;
+  //   margin-bottom: $global-margin;
+  //   padding-bottom: $global-padding;
+  // }
   .rhea-reaction-visualizer {
     &__toggle {
-      padding-top: $global-padding;
+      padding-top: 0.5 * $global-padding;
 
       svg {
         position: relative;

--- a/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/catalytic-activity-view.module.scss
@@ -16,7 +16,6 @@
 
       svg {
         position: relative;
-        top: 2px;
         margin-left: 0.5rem;
         width: 0.7rem;
       }

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -195,103 +195,87 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
   <div
     class="catalytic-activity"
   >
-    <ul
-      class="info-list"
+    <div
+      class="rhea-entry"
     >
-      <li>
-        <div
-          class="decorated-list-item"
+      <h4>
+        <a
+          class="external-link"
+          href="https://www.rhea-db.org/rhea/12345"
+          rel="noopener"
+          target="_blank"
         >
-          <div
-            class="decorated-list-item__title tiny"
-          >
-            <a
-              class="external-link"
-              href="https://www.rhea-db.org/rhea/12345"
-              rel="noopener"
-              target="_blank"
-            >
-              Rhea 12345
-              <test-file-stub
-                data-testid="external-link-icon"
-                width="12.5"
-              />
-            </a>
-          </div>
-          <div
-            class="decorated-list-item__content"
-          >
-            <span
-              class="text-block"
-            >
-              <h4
-                class="tiny"
-              >
-                Isoform 3
-              </h4>
-              some reaction
-              <div>
-                This reaction proceeds in the 
-                <span
-                  data-testid="direction-text"
-                >
-                  backward
-                </span>
-                 direction.
-              </div>
-              <div>
-                EC:1.2.4.5 (
-                <a
-                  href="/uniprotkb?query=ec:1.2.4.5"
-                >
-                  UniProtKB
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://enzyme.expasy.org/EC/1.2.4.5"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  ENZYME
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                 | 
-                <a
-                  class="external-link"
-                  href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Rhea
-                  <test-file-stub
-                    data-testid="external-link-icon"
-                    width="12.5"
-                  />
-                </a>
-                )
-              </div>
-              <div
-                class="rhea-reaction-visualizer__toggle"
-              >
-                <button
-                  class="button tertiary"
-                  type="button"
-                >
-                  View Rhea reaction
-                </button>
-                <test-file-stub
-                  width="1ch"
-                />
-              </div>
-            </span>
-          </div>
-        </div>
-      </li>
-    </ul>
+          Rhea:12345
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+      </h4>
+      <h4
+        class="tiny"
+      >
+        Isoform 3
+      </h4>
+      some reaction
+      <div>
+        This reaction proceeds in the 
+        <span
+          data-testid="direction-text"
+        >
+          backward
+        </span>
+         direction.
+      </div>
+      <div>
+        EC:1.2.4.5 (
+        <a
+          href="/uniprotkb?query=ec:1.2.4.5"
+        >
+          UniProtKB
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://enzyme.expasy.org/EC/1.2.4.5"
+          rel="noopener"
+          target="_blank"
+        >
+          ENZYME
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+         | 
+        <a
+          class="external-link"
+          href="https://www.rhea-db.org/rhea?query=ec:1.2.4.5"
+          rel="noopener"
+          target="_blank"
+        >
+          Rhea
+          <test-file-stub
+            data-testid="external-link-icon"
+            width="12.5"
+          />
+        </a>
+        )
+      </div>
+      <div
+        class="rhea-reaction-visualizer__toggle"
+      >
+        <button
+          class="button tertiary"
+          type="button"
+        >
+          View reaction details
+          <test-file-stub
+            width="1ch"
+          />
+        </button>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
+++ b/src/uniprotkb/config/__tests__/__snapshots__/UniProtKBColumnConfiguration.spec.tsx.snap
@@ -198,7 +198,9 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
     <div
       class="rhea-entry"
     >
-      <h4>
+      <div
+        class="small"
+      >
         <a
           class="external-link"
           href="https://www.rhea-db.org/rhea/12345"
@@ -211,12 +213,12 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
             width="12.5"
           />
         </a>
-      </h4>
-      <h4
-        class="tiny"
+      </div>
+      <div
+        class="small"
       >
         Isoform 3
-      </h4>
+      </div>
       some reaction
       <div>
         This reaction proceeds in the 
@@ -261,19 +263,6 @@ exports[`UniProtKBColumnConfiguration component should render column "cc_catalyt
           />
         </a>
         )
-      </div>
-      <div
-        class="rhea-reaction-visualizer__toggle"
-      >
-        <button
-          class="button tertiary"
-          type="button"
-        >
-          View reaction details
-          <test-file-stub
-            width="1ch"
-          />
-        </button>
       </div>
     </div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,10 +2762,10 @@
   dependencies:
     apg-lite "^1.0.3"
 
-"@swissprot/rhea-reaction-visualizer@0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@swissprot/rhea-reaction-visualizer/-/rhea-reaction-visualizer-0.0.21.tgz#f11b9f72363a3c0d95b9b3c69911ca5b8f4cb3e6"
-  integrity sha512-gwoZGC+Or4Vsi4LIUaOoSi+H6ZWFH/mdTMvSD4OoAkPB16OtVlMIN6MlsgW43IEUJcK+epuWR6+WEPyN+AGKew==
+"@swissprot/rhea-reaction-visualizer@0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@swissprot/rhea-reaction-visualizer/-/rhea-reaction-visualizer-0.0.24.tgz#20adfa7124b8f5f22dd3a8804ab5a138382b2985"
+  integrity sha512-7uTWD71m3caw2ueMf4So2kHTjYpMXCPQ7LpYC34XtltW5VlYb3BCl+l/bSHPUaDM7DfC7KLbvtrV0Nk40r5o+A==
 
 "@swissprot/swissbiopics-visualizer@0.0.28":
   version "0.0.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7272,8 +7272,10 @@ foundation-sites@6.8.1:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.8.1.tgz#9b17e9371c18916a375985571b33bdbe4c347555"
   integrity sha512-9JAuLqVgzf7EIRUqVKeYN68dU/SGe0aNJPgnejdfJKSWnBFdQLF3Zvy9WEQ1gE/gnyvwG3Ia3LkkEd9774n0bQ==
 
-"franklin-sites@file:.yalc/franklin-sites":
-  version "0.0.260"
+franklin-sites@0.0.258:
+  version "0.0.258"
+  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.258.tgz#025029526efac9a1d2a5439b98b670902717507d"
+  integrity sha512-Eiw7owRWYXtv8hq1ExSk3GcX3BVUTVZOuPcN1zG9wn6hiYdEOYwbX7ImV3CDnSFMJE0kJZHN87T+NwjGEdt0xg==
   dependencies:
     classnames "2.5.1"
     d3 "5.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7272,10 +7272,8 @@ foundation-sites@6.8.1:
   resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.8.1.tgz#9b17e9371c18916a375985571b33bdbe4c347555"
   integrity sha512-9JAuLqVgzf7EIRUqVKeYN68dU/SGe0aNJPgnejdfJKSWnBFdQLF3Zvy9WEQ1gE/gnyvwG3Ia3LkkEd9774n0bQ==
 
-franklin-sites@0.0.256:
-  version "0.0.256"
-  resolved "https://registry.yarnpkg.com/franklin-sites/-/franklin-sites-0.0.256.tgz#d251aed15737b8f20d69d7d0e6c158dd129df1c6"
-  integrity sha512-i/j1wmw+5iBXanpMwFCEiFWutI1/eZ3NX5CvWmq0uIvpMdmfz603+b5s8g7cr0p6wOFXrgWalVLOjj/3D55Qgg==
+"franklin-sites@file:.yalc/franklin-sites":
+  version "0.0.260"
   dependencies:
     classnames "2.5.1"
     d3 "5.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,10 +2762,13 @@
   dependencies:
     apg-lite "^1.0.3"
 
-"@swissprot/rhea-reaction-visualizer@0.0.24":
+"@swissprot/rhea-reaction-viz-test@0.0.24":
   version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@swissprot/rhea-reaction-visualizer/-/rhea-reaction-visualizer-0.0.24.tgz#20adfa7124b8f5f22dd3a8804ab5a138382b2985"
-  integrity sha512-7uTWD71m3caw2ueMf4So2kHTjYpMXCPQ7LpYC34XtltW5VlYb3BCl+l/bSHPUaDM7DfC7KLbvtrV0Nk40r5o+A==
+  resolved "https://registry.yarnpkg.com/@swissprot/rhea-reaction-viz-test/-/rhea-reaction-viz-test-0.0.24.tgz#6bf833ddef17c437b6af543f10b20152ee86e7ae"
+  integrity sha512-Vepgap1ZQoalghWPeuEZkLGVH3xCg5FOZ5MORj/X4Bn0Ce6UQY03c74HYAmz6L3AzS7Lx1HWq8RHqxbOHvAumA==
+  dependencies:
+    normalize.css "^8.0.1"
+    tippy.js "^6.3.7"
 
 "@swissprot/swissbiopics-visualizer@0.0.28":
   version "0.0.28"
@@ -4634,9 +4637,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001688:
-  version "1.0.30001702"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz#cde16fa8adaa066c04aec2967b6cde46354644c4"
-  integrity sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==
+  version "1.0.30001735"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz"
+  integrity sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==
 
 canvas@^2.11.2:
   version "2.11.2"
@@ -10534,6 +10537,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize.css@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 npm-run-all@4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
@@ -13269,7 +13277,7 @@ tiny-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tippy.js@6.3.7:
+tippy.js@6.3.7, tippy.js@^6.3.7:
   version "6.3.7"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
   integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==


### PR DESCRIPTION
## Note

Depends upon this other PR
https://github.com/ebi-uniprot/franklin-sites/pull/269

## Purpose

[Implementation - update Rhea + usability improvements ](https://embl.atlassian.net/browse/TRM-32424)

## Approach


- [x] Install `@swissprot/rhea-reaction-viz-test`
- [x] Only show rhea-viz in UniProtKB entry page
- [x] Discard item list styling of rheas in favor of flatter presentation using heading elements
- [x] Apply UniProt styling:
    - [x] Add tab hover  
    - [x] Add bottom border on rhea reaction component  
    - [x] Increase font size for atom map labels  
    - [x] Change colors for the \>\> and the ? to be the same as other uniprot labels  
    - [x] ~Make entire “RHEA:63236” a link and restyle to be inline with our external links~
    - [x] Remove “RHEA:63236” link as already exists immediately above web component
    - [x] Get rid of hover behaviour on all cards/images  
    - [x] Style the tooltip links:  
          - [x] External (with arrow)  
                - [x] See the description of this molecule in ChEBI.  
                - [x] Search similar molecules in Rhea.  
                - [x] Search chemical reactions in Rhea for this molecule.  
                - [x] RXNMapper  
          - [x] Internal (no arrow)  
                - [x] Search proteins in UniProtKB for this molecule.

## Testing

Updated

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
