### PR TITLE
Add search space information in BLAST form if taxonomy filter is selected

### DIFF
--- a/src/jobs/blast/components/BlastForm.tsx
+++ b/src/jobs/blast/components/BlastForm.tsx
@@ -3,6 +3,7 @@ import '../../styles/ToolsForm.scss';
 import cn from 'classnames';
 import {
   Chip,
+  Message,
   PageIntro,
   sequenceProcessor,
   SequenceSubmission,
@@ -15,9 +16,11 @@ import {
   useEffect,
   useReducer,
   useRef,
+  useState,
 } from 'react';
 import { useHistory } from 'react-router-dom';
 import { sleep } from 'timing-functions';
+import joinUrl from 'url-join';
 
 import { Location, LocationToPath } from '../../../app/config/urls';
 import { addMessage } from '../../../messages/state/messagesActions';
@@ -27,14 +30,18 @@ import {
 } from '../../../messages/types/messagesTypes';
 import AutocompleteWrapper from '../../../query-builder/components/AutocompleteWrapper';
 import HTMLHead from '../../../shared/components/HTMLHead';
+import { apiPrefix } from '../../../shared/config/apiUrls/apiPrefix';
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import { BLAST_LIMIT } from '../../../shared/config/limits';
+import { fileFormatToUrlParameter } from '../../../shared/config/resultsDownload';
 import { useReducedMotion } from '../../../shared/hooks/useMatchMedia';
 import useMessagesDispatch from '../../../shared/hooks/useMessagesDispatch';
 import useTextFileInput from '../../../shared/hooks/useTextFileInput';
 import sticky from '../../../shared/styles/sticky.module.scss';
 import { namespaceAndToolsLabels } from '../../../shared/types/namespaces';
+import { FileFormat } from '../../../shared/types/resultsDownload';
 import { sendGtagEventJobSubmit } from '../../../shared/utils/gtagEvents';
+import { stringifyUrl } from '../../../shared/utils/url';
 import { dispatchJobs } from '../../../shared/workers/jobs/getJobSharedWorker';
 import { createJob } from '../../../shared/workers/jobs/state/jobActions';
 import ChecksumSuggester from '../../components/ChecksumSuggester';
@@ -119,6 +126,7 @@ const BlastForm = ({ initialFormValues }: Props) => {
   // refs
   const sslRef = useRef<SequenceSearchLoaderInterface>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [searchSpaceTotal, setSearchSpaceTotal] = useState(Infinity);
 
   // hooks
   const dispatchMessages = useMessagesDispatch();
@@ -148,6 +156,49 @@ const BlastForm = ({ initialFormValues }: Props) => {
   const excludeTaxonField = excludeTaxonForDB(
     formValues[BlastFields.database].selected
   );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!excludeTaxonField && formValues[BlastFields.taxons].selected) {
+        const baseUrl = joinUrl(apiPrefix, 'uniprotkb', 'search');
+        let query = `(${(formValues[BlastFields.taxons].selected as SelectedTaxon[]).map((taxon) => `organism_id:${taxon.id}`).join(' OR ')})`;
+        switch (formValues[BlastFields.database].selected) {
+          case 'uniprotkb_refprotswissprot':
+            query += ' AND (keyword:KW-1185 AND reviewed:true)';
+            break;
+          case 'uniprotkb_reference_proteomes':
+            query += ' AND (keyword:KW-1185)';
+            break;
+          case 'uniprotkb_swissprot':
+            query += ' AND (reviewed:true)';
+            break;
+          case 'uniprotkb_pdb':
+            query += ' AND (structure_3d:true)';
+            break;
+          default:
+            break;
+        }
+        const url = stringifyUrl(baseUrl, {
+          format: fileFormatToUrlParameter[FileFormat.fasta],
+          includeIsoform: true,
+          query,
+        });
+        const headResponse = await fetch(url, {
+          method: 'HEAD',
+        });
+        if (headResponse.ok && headResponse.headers.get('X-Total-Results')) {
+          setSearchSpaceTotal(
+            Number(headResponse.headers.get('X-Total-Results'))
+          );
+        } else {
+          setSearchSpaceTotal(0);
+        }
+      } else {
+        setSearchSpaceTotal(Infinity);
+      }
+    };
+    fetchData();
+  }, [excludeTaxonField, formValues]);
 
   // TODO: eventually incorporate negativeTaxIDs into the form
 
@@ -409,6 +460,24 @@ const BlastForm = ({ initialFormValues }: Props) => {
                 </div>
               ))}
             </section>
+            {searchSpaceTotal !== Infinity &&
+            (formValues[BlastFields.taxons]?.selected as SelectedTaxon[])
+              ?.length ? (
+              <Message level={searchSpaceTotal === 0 ? 'failure' : 'info'}>
+                {searchSpaceTotal === 0 ? (
+                  <span>
+                    There is no sequence matching the taxonomy filtering in the
+                    selected database
+                  </span>
+                ) : (
+                  <span>
+                    Total number of sequences in the selected database with the
+                    applied taxonomic filtering:{' '}
+                    <strong>{searchSpaceTotal}</strong>
+                  </span>
+                )}
+              </Message>
+            ) : null}
           </section>
           <section className="tools-form-section">
             <section className="tools-form-section__item">
@@ -481,7 +550,14 @@ const BlastForm = ({ initialFormValues }: Props) => {
               <button
                 className="button primary"
                 type="submit"
-                disabled={submitDisabled}
+                disabled={
+                  submitDisabled ||
+                  (searchSpaceTotal === 0 &&
+                    (
+                      formValues[BlastFields.taxons]
+                        ?.selected as SelectedTaxon[]
+                    ).length > 0)
+                }
                 onClick={submitBlastJob}
               >
                 {parsedSequences.length <= 1 ? (

--- a/src/jobs/blast/components/BlastForm.tsx
+++ b/src/jobs/blast/components/BlastForm.tsx
@@ -463,18 +463,24 @@ const BlastForm = ({ initialFormValues }: Props) => {
             {searchSpaceTotal !== Infinity &&
             (formValues[BlastFields.taxons]?.selected as SelectedTaxon[])
               ?.length ? (
-              <Message level={searchSpaceTotal === 0 ? 'failure' : 'info'}>
+              <Message
+                level={searchSpaceTotal === 0 ? 'failure' : 'info'}
+                className="taxonomy-selection-message"
+              >
                 {searchSpaceTotal === 0 ? (
-                  <span>
-                    There is no sequence matching the taxonomy filtering in the
-                    selected database
-                  </span>
+                  <>
+                    <strong>No sequences found for your selection</strong>
+                    <br />
+                    The chosen database has no results that match the selected
+                    taxonomy filter. Please adjust your filters to proceed
+                  </>
                 ) : (
-                  <span>
-                    Total number of sequences in the selected database with the
-                    applied taxonomic filtering:{' '}
-                    <strong>{searchSpaceTotal}</strong>
-                  </span>
+                  <>
+                    <strong>Sequences Available: {searchSpaceTotal}</strong>
+                    <br />
+                    This is the total number of sequences in the selected
+                    database that match your current taxonomy filter.
+                  </>
                 )}
               </Message>
             ) : null}

--- a/src/jobs/blast/components/__tests__/BlastForm.spec.tsx
+++ b/src/jobs/blast/components/__tests__/BlastForm.spec.tsx
@@ -1,11 +1,14 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { enableFetchMocks, FetchMock } from 'jest-fetch-mock';
 
 import { Location, LocationToPath } from '../../../../app/config/urls';
 import { mockSuggesterApi } from '../../../../query-builder/components/__tests__/__mocks__/autocompleteWrapperData';
 import customRender from '../../../../shared/__test-helpers__/customRender';
 import BlastForm from '../BlastForm';
+
+enableFetchMocks();
 
 const mock = new MockAdapter(axios);
 mock.onGet().reply(200, mockSuggesterApi.response);
@@ -131,6 +134,13 @@ describe('BlastForm test', () => {
   });
 
   it('Adds and removes a taxon', async () => {
+    (fetch as FetchMock).mockResponse('OK', {
+      status: 200,
+      headers: {
+        'X-Total-Results': '1000',
+      },
+    });
+
     const autocompleteInput = screen.getByRole('searchbox', {
       name: 'Restrict by taxonomy',
     });

--- a/src/jobs/styles/ToolsForm.scss
+++ b/src/jobs/styles/ToolsForm.scss
@@ -109,3 +109,7 @@
 .import-sequence-section {
   display: flex;
 }
+
+.taxonomy-selection-message {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Purpose
https://embl.atlassian.net/browse/TRM-32713

## Approach
Show information about the sequence numbers present if taxonomy filter is selected. In case of no sequences for the selected combination, show error message and disable submission

## Testing

What test(s) did you write to validate and verify your changes?

## Checklist

- [ ] My PR is scoped properly, and “does one thing only”
- [ ] I have reviewed my own code
- [ ] I have checked that linting checks pass and type safety is respected
- [ ] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
