### PR TITLE
Refprotmove warnings

### DIFF
--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -66,7 +66,10 @@ const Entry = () => {
           searchableNamespaceLabels[Namespace.proteomes],
         ]}
       />
-      <RefProtMoveProteomesEntryMessage />
+      <RefProtMoveProteomesEntryMessage
+        id={transformedData.id}
+        taxonomy={transformedData.taxonomy}
+      />
       <h1>
         {searchableNamespaceLabels[Namespace.proteomes]}
         {' · '}

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -8,6 +8,7 @@ import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
 import ErrorHandler from '../../../shared/components/error-pages/ErrorHandler';
 import HTMLHead from '../../../shared/components/HTMLHead';
 import { SingleColumnLayout } from '../../../shared/components/layouts/SingleColumnLayout';
+import { RefProtMoveProteomesEntryMessage } from '../../../shared/components/RefProtMoveMessages';
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
 import {
@@ -65,6 +66,7 @@ const Entry = () => {
           searchableNamespaceLabels[Namespace.proteomes],
         ]}
       />
+      <RefProtMoveProteomesEntryMessage />
       <h1>
         {searchableNamespaceLabels[Namespace.proteomes]}
         {' · '}

--- a/src/proteomes/components/landing-page/LandingPage.tsx
+++ b/src/proteomes/components/landing-page/LandingPage.tsx
@@ -1,10 +1,5 @@
 import cn from 'classnames';
-import {
-  LongNumber,
-  Message,
-  ReferenceProteomeIcon,
-  TremblIcon,
-} from 'franklin-sites';
+import { LongNumber, ReferenceProteomeIcon, TremblIcon } from 'franklin-sites';
 import { useState } from 'react';
 import { generatePath, Link } from 'react-router-dom';
 import joinUrl from 'url-join';
@@ -13,6 +8,7 @@ import { Location, LocationToPath } from '../../../app/config/urls';
 import SpeciesIllustration from '../../../images/species_illustration.img.svg';
 import ExternalLink from '../../../shared/components/ExternalLink';
 import HTMLHead from '../../../shared/components/HTMLHead';
+import { RefProtMoveResultsMessage } from '../../../shared/components/RefProtMoveMessages';
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import ftpUrls from '../../../shared/config/ftpUrls';
 // import YouTubeEmbed from '../../../shared/components/YouTubeEmbed';
@@ -179,18 +175,7 @@ const LandingPage = () => {
             </Link>
           </p>
         </div>
-
-        <Message level="warning" className="uniprot-grid-cell--span-12">
-          We will be improving our pipelines for the selection of Reference
-          Proteomes over the next few months (September 2025–February 2026).
-          <br />
-          This might affect your data analysis,{' '}
-          <ExternalLink url="https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html">
-            please read this short article
-          </ExternalLink>{' '}
-          if you want to know more.
-        </Message>
-
+        <RefProtMoveResultsMessage namespace={Namespace.proteomes} />
         {/* Statistics */}
         <section className="uniprot-grid-cell--small-span-12 uniprot-grid-cell--medium-span-9">
           <h2>Statistics</h2>

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -56,10 +56,18 @@ const UniProtKBGenericMain: FC<{
                     `Organism: ${scientificName}`,
                     `Taxon ID: ${taxonId}`,
                   ].join('\n'),
+                  subject: `Question about UniProtKB entry ${accession} being removed in 2026_01`,
                 },
               },
             }
-          : undefined
+          : {
+              pathname: LocationToPath[Location.ContactGeneric],
+              state: {
+                formValues: {
+                  subject: `Question about UniProtKB/TrEMBL changes in 2026_01`,
+                },
+              },
+            }
       }
     >
       contact us
@@ -103,10 +111,18 @@ const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
                     `Taxon ID: ${taxonomy.taxonId}`,
                     `Mnemonic: ${taxonomy.mnemonic}`,
                   ].join('\n'),
+                  subject: `Question about Proteome ${id} being removed in 2026_01`,
                 },
               },
             }
-          : undefined
+          : {
+              pathname: LocationToPath[Location.ContactGeneric],
+              state: {
+                formValues: {
+                  subject: `Question about Proteomes changes in 2026_01`,
+                },
+              },
+            }
       }
     >
       contact us

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Message } from 'franklin-sites';
+import { ExternalLink, Loader, Message } from 'franklin-sites';
 import { FC } from 'react';
 
 import { Location, LocationToPath } from '../../app/config/urls';
@@ -175,9 +175,12 @@ export const RefProtMoveUniProtKBEntryMessage: FC<{
   scientificName: string;
   taxonId: string;
 }> = ({ accession, upids, scientificName, taxonId }) => {
-  const { data } = useDataApi<CheckMoveResponse>(
+  const { data, loading } = useDataApi<CheckMoveResponse>(
     upids.length ? stringifyUrl(checkMoveUrl, { upids }) : null
   );
+  if (loading) {
+    return <Loader />;
+  }
   return !data?.move?.length ? null : (
     <Message
       level="failure"

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -1,0 +1,111 @@
+import { ExternalLink, Message } from 'franklin-sites';
+import { FC } from 'react';
+
+import ContactLink from '../../contact/components/ContactLink';
+import useDataApi from '../hooks/useDataApi';
+import { Namespace } from '../types/namespaces';
+import { stringifyUrl } from '../utils/url';
+
+const blogEntryUrl =
+  'https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html';
+
+const checkMoveUrl =
+  'https://wwwdev.ebi.ac.uk/uniprot/api/refprotmove-check/check-move';
+
+const UniProtKBGenericPreamble = () => (
+  <>
+    The UniProtKB Unreviewed/TrEMBL database will reduce in size in release
+    2026_01 (planned for the first quarter of 2026).
+  </>
+);
+
+const UniProtKBRemovePreamble = () => (
+  <>
+    This entry (accession) is under consideration for removal in release 2026_01
+    (planned for the first quarter of 2026).
+  </>
+);
+
+const UniProtKBGenericMain = () => (
+  <>
+    <br />
+    <br />
+    From 2026_01 onwards, UniProtKB Unreviewed/TrEMBL will only include
+    reference proteomes and selected entries with experimental or biologically
+    important data. Entries removed from UniProtKB will remain accessible in
+    UniParc. Please see{' '}
+    <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
+    information, or <ContactLink>contact us</ContactLink> with any questions.
+  </>
+);
+
+const UniProtKBGenericMessage = () => (
+  <>
+    <UniProtKBGenericPreamble />
+    <UniProtKBGenericMain />
+  </>
+);
+
+const ProteomesMessage = () => (
+  <>
+    ⚠️We are updating the reference proteomes selection procedure. As a result,
+    the UniProtKB Unreviewed/TrEMBL database will become smaller in release
+    2026_01 (planned for the first quarter of 2026) and will only include
+    reference proteomes and selected entries with experimental or biologically
+    important data.
+    <br />
+    <br />
+    Entries removed from UniProtKB will remain accessible in UniParc. Please see{' '}
+    <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
+    information, or <ContactLink>contact us</ContactLink> with any questions.
+  </>
+);
+
+export const RefProtMoveResultsMessage: FC<{
+  namespace: Namespace;
+}> = ({ namespace }) => {
+  if (namespace !== Namespace.uniprotkb && namespace !== Namespace.proteomes) {
+    return null;
+  }
+
+  return (
+    <Message
+      level="warning"
+      className="uniprot-grid-cell--span-12"
+      style={{ marginBottom: '-0.75rem', marginTop: '0.5rem' }}
+    >
+      {(namespace === Namespace.uniprotkb && <UniProtKBGenericMessage />) ||
+        (namespace === Namespace.proteomes && <ProteomesMessage />)}
+    </Message>
+  );
+};
+
+type CheckMoveResponse = {
+  move?: string[];
+  stay?: string[];
+  unknown?: string[];
+};
+
+export const RefProtMoveUniProtKBEntryMessage: FC<{
+  upids?: string[];
+}> = ({ upids }) => {
+  const { data, loading } = useDataApi<CheckMoveResponse>(
+    stringifyUrl(checkMoveUrl, { upids })
+  );
+  const isEntryUnderReview = !!data?.move?.length;
+  return (
+    <Message
+      level="warning"
+      className="uniprot-grid-cell--span-12"
+      style={{ marginBottom: '1rem', marginTop: '1rem' }}
+    >
+      {!loading &&
+        (isEntryUnderReview ? (
+          <UniProtKBRemovePreamble />
+        ) : (
+          <UniProtKBGenericPreamble />
+        ))}
+      <UniProtKBGenericMain />
+    </Message>
+  );
+};

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -164,7 +164,7 @@ export const RefProtMoveUniProtKBEntryMessage: FC<{
   );
   return !data?.move?.length ? null : (
     <Message
-      level="warning"
+      level="failure"
       className="uniprot-grid-cell--span-12"
       style={{ marginBottom: '1rem', marginTop: '1rem' }}
     >

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -16,7 +16,7 @@ const checkMoveUrl =
 
 const UniProtKBGenericPreamble = () => (
   <>
-    The UniProtKB Unreviewed/TrEMBL database will reduce in size in release
+    The Unreviewed UniProtKB/TrEMBL database will reduce in size in release
     2026_01 (planned for the first quarter of 2026).
   </>
 );
@@ -37,7 +37,7 @@ const UniProtKBGenericMain: FC<{
   <>
     <br />
     <br />
-    From 2026_01 onwards, UniProtKB Unreviewed/TrEMBL will only include
+    From 2026_01 onwards, Unreviewed UniProtKB/TrEMBL will only include
     reference proteomes and selected entries with experimental or biologically
     important data. Entries removed from UniProtKB will remain accessible in
     UniParc. Please see{' '}

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -221,8 +221,6 @@ export const RefProtMoveUniProtKBEntryMessage: FC<{
   // and 2: not saved as biologically relevant
   const display = !hasSavedProteome && !isBiologicallyRelevant;
 
-  console.table({ isBiologicallyRelevant, hasSavedProteome, display });
-
   if (loading || !display) {
     // Don't render anything, avoid space being used then disappearing
     return null;

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -19,10 +19,10 @@ const UniProtKBGenericPreamble = () => (
   </>
 );
 
-const UniProtKBRemovePreamble = () => (
+const UniProtKBRemovePreamble: FC<{ accession: string }> = ({ accession }) => (
   <>
-    This entry (accession) is under consideration for removal in release 2026_01
-    (planned for the first quarter of 2026).
+    This entry ({accession}) is under consideration for removal in release
+    2026_01 (planned for the first quarter of 2026).
   </>
 );
 
@@ -48,7 +48,7 @@ const UniProtKBGenericMessage = () => (
 
 const ProteomesMessage = () => (
   <>
-    ⚠️We are updating the reference proteomes selection procedure. As a result,
+    We are updating the reference proteomes selection procedure. As a result,
     the UniProtKB Unreviewed/TrEMBL database will become smaller in release
     2026_01 (planned for the first quarter of 2026) and will only include
     reference proteomes and selected entries with experimental or biologically
@@ -80,6 +80,16 @@ export const RefProtMoveResultsMessage: FC<{
   );
 };
 
+export const RefProtMoveProteomesEntryMessage = () => (
+  <Message
+    level="warning"
+    className="uniprot-grid-cell--span-12"
+    style={{ marginBottom: '1rem', marginTop: '1rem' }}
+  >
+    <ProteomesMessage />
+  </Message>
+);
+
 type CheckMoveResponse = {
   move?: string[];
   stay?: string[];
@@ -87,10 +97,11 @@ type CheckMoveResponse = {
 };
 
 export const RefProtMoveUniProtKBEntryMessage: FC<{
-  upids?: string[];
-}> = ({ upids }) => {
+  accession: string;
+  upids: string[];
+}> = ({ accession, upids }) => {
   const { data, loading } = useDataApi<CheckMoveResponse>(
-    stringifyUrl(checkMoveUrl, { upids })
+    upids.length ? stringifyUrl(checkMoveUrl, { upids }) : null
   );
   const isEntryUnderReview = !!data?.move?.length;
   return (
@@ -101,7 +112,7 @@ export const RefProtMoveUniProtKBEntryMessage: FC<{
     >
       {!loading &&
         (isEntryUnderReview ? (
-          <UniProtKBRemovePreamble />
+          <UniProtKBRemovePreamble accession={accession} />
         ) : (
           <UniProtKBGenericPreamble />
         ))}

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -48,11 +48,11 @@ const UniProtKBGenericMessage = () => (
 
 const ProteomesMessage = () => (
   <>
-    We are updating the reference proteomes selection procedure. As a result,
-    the UniProtKB Unreviewed/TrEMBL database will become smaller in release
-    2026_01 (planned for the first quarter of 2026) and will only include
-    reference proteomes and selected entries with experimental or biologically
-    important data.
+    We are updating the reference proteomes selection procedure (planned for the
+    first quarter of 2026). While all proteomes will remain accessible through
+    the proteomes database, proteins in UniProtKB will only include reference
+    proteomes and selected entries with experimental or biologically important
+    data.
     <br />
     <br />
     Entries removed from UniProtKB will remain accessible in UniParc. Please see{' '}

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -1,9 +1,11 @@
 import { ExternalLink, Loader, Message } from 'franklin-sites';
 import { FC } from 'react';
+import joinUrl from 'url-join';
 
 import { Location, LocationToPath } from '../../app/config/urls';
 import ContactLink from '../../contact/components/ContactLink';
 import { TaxonomyDatum } from '../../supporting-data/taxonomy/adapters/taxonomyConverter';
+import { apiPrefix } from '../config/apiUrls/apiPrefix';
 import useDataApi from '../hooks/useDataApi';
 import { Namespace } from '../types/namespaces';
 import { stringifyUrl } from '../utils/url';
@@ -11,8 +13,7 @@ import { stringifyUrl } from '../utils/url';
 const blogEntryUrl =
   'https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html';
 
-const checkMoveUrl =
-  'https://wwwdev.ebi.ac.uk/uniprot/api/refprotmove-check/check-move';
+const checkMoveUrl = joinUrl(apiPrefix, 'refprotmove-check/check-move');
 
 const UniProtKBGenericPreamble = () => (
   <>

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -1,10 +1,12 @@
 import { ExternalLink, Message } from 'franklin-sites';
 import { FC } from 'react';
 
+import { Location, LocationToPath } from '../../app/config/urls';
 import ContactLink from '../../contact/components/ContactLink';
+import { TaxonomyDatum } from '../../supporting-data/taxonomy/adapters/taxonomyConverter';
 import useDataApi from '../hooks/useDataApi';
 import { Namespace } from '../types/namespaces';
-import { stringifyUrl } from '../utils/url';
+import { stringifyQuery, stringifyUrl } from '../utils/url';
 
 const blogEntryUrl =
   'https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html';
@@ -46,7 +48,10 @@ const UniProtKBGenericMessage = () => (
   </>
 );
 
-const ProteomesMessage = () => (
+const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
+  id,
+  taxonomy,
+}) => (
   <>
     We are updating the reference proteomes selection procedure (planned for the
     first quarter of 2026). While all proteomes will remain accessible through
@@ -57,7 +62,29 @@ const ProteomesMessage = () => (
     <br />
     Entries removed from UniProtKB will remain accessible in UniParc. Please see{' '}
     <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
-    information, or <ContactLink>contact us</ContactLink> with any questions.
+    information, or{' '}
+    <ContactLink
+      to={
+        id && taxonomy
+          ? {
+              pathname: LocationToPath[Location.ContactGeneric],
+              state: {
+                formValues: {
+                  context: [
+                    `Proteome ID: ${id}`,
+                    `Organism: ${taxonomy.scientificName}`,
+                    `Taxon ID: ${taxonomy.taxonId}`,
+                    `Mnemonic: ${taxonomy.mnemonic}`,
+                  ].join('\n'),
+                },
+              },
+            }
+          : undefined
+      }
+    >
+      contact us
+    </ContactLink>{' '}
+    with any questions.
   </>
 );
 
@@ -80,13 +107,16 @@ export const RefProtMoveResultsMessage: FC<{
   );
 };
 
-export const RefProtMoveProteomesEntryMessage = () => (
+export const RefProtMoveProteomesEntryMessage: FC<{
+  id: string;
+  taxonomy: TaxonomyDatum;
+}> = ({ id, taxonomy }) => (
   <Message
     level="warning"
     className="uniprot-grid-cell--span-12"
     style={{ marginBottom: '1rem', marginTop: '1rem' }}
   >
-    <ProteomesMessage />
+    <ProteomesMessage id={id} taxonomy={taxonomy} />
   </Message>
 );
 

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Message } from 'franklin-sites';
+import { Message } from 'franklin-sites';
 import { FC, useMemo } from 'react';
 import joinUrl from 'url-join';
 
@@ -13,6 +13,7 @@ import { apiPrefix } from '../config/apiUrls/apiPrefix';
 import useDataApi from '../hooks/useDataApi';
 import { Namespace } from '../types/namespaces';
 import { stringifyUrl } from '../utils/url';
+import ExternalLink from './ExternalLink';
 
 const blogEntryUrl =
   'https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html';

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -39,8 +39,8 @@ const UniProtKBGenericMain: FC<{
     <br />
     From 2026_01 onwards, Unreviewed UniProtKB/TrEMBL will only include
     reference proteomes and selected entries with experimental or biologically
-    important data. Entries removed from UniProtKB will remain accessible in
-    UniParc. Please see{' '}
+    important data. Entries removed from Unreviewed UniProtKB/TrEMBL will remain
+    accessible in UniParc. Please see{' '}
     <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
     information, or{' '}
     <ContactLink
@@ -90,12 +90,13 @@ const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
   <>
     We are updating the reference proteomes selection procedure (planned for the
     first quarter of 2026). While all proteomes will remain accessible through
-    the proteomes database, proteins in UniProtKB will only include reference
-    proteomes and selected entries with experimental or biologically important
-    data.
+    the proteomes database, proteins in Unreviewed UniProtKB/TrEMBL will only
+    include reference proteomes and selected entries with experimental or
+    biologically important data.
     <br />
     <br />
-    Entries removed from UniProtKB will remain accessible in UniParc. Please see{' '}
+    Entries removed from Unreviewed UniProtKB/TrEMBL will remain accessible in
+    UniParc. Please see{' '}
     <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
     information, or{' '}
     <ContactLink

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -22,7 +22,7 @@ const checkMoveUrl = joinUrl(apiPrefix, 'refprotmove-check/check-move');
 
 const UniProtKBGenericPreamble = () => (
   <>
-    The Unreviewed UniProtKB/TrEMBL database will reduce in size in release
+    The Unreviewed UniProtKB/TrEMBL database will reduce in size from release
     2026_01 (planned for the first quarter of 2026).
   </>
 );
@@ -42,10 +42,11 @@ const UniProtKBGenericMain: FC<{
   <>
     <br />
     <br />
-    From 2026_01 onwards, Unreviewed UniProtKB/TrEMBL will only include
-    reference proteomes and selected entries with experimental or biologically
-    important data. Entries removed from Unreviewed UniProtKB/TrEMBL will remain
-    accessible in UniParc. Please see{' '}
+    From 2026_01 onwards, Unreviewed UniProtKB/TrEMBL will include only proteins
+    from reference proteomes and selected entries with experimental or
+    biologically important data. Entries removed from Unreviewed
+    UniProtKB/TrEMBL will remain accessible in the UniParc sequence archive.
+    Please see{' '}
     <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
     information, or{' '}
     <ContactLink
@@ -69,7 +70,7 @@ const UniProtKBGenericMain: FC<{
               pathname: LocationToPath[Location.ContactGeneric],
               state: {
                 formValues: {
-                  subject: `Question about UniProtKB/TrEMBL changes in 2026_01`,
+                  subject: `Question about Unreviewed UniProtKB/TrEMBL changes in 2026_01`,
                 },
               },
             }
@@ -93,15 +94,16 @@ const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
   taxonomy,
 }) => (
   <>
-    We are updating the reference proteomes selection procedure (planned for the
-    first quarter of 2026). While all proteomes will remain accessible through
-    the proteomes database, proteins in Unreviewed UniProtKB/TrEMBL will only
-    include reference proteomes and selected entries with experimental or
-    biologically important data.
+    We are updating the reference proteome selection procedure. As a result,
+    some proteomes may lose their reference proteome status, but all proteomes
+    will remain accessible in the Proteomes database. Additionally, starting
+    with release 2026_01, Unreviewed UniProtKB/TrEMBL will include only proteins
+    from reference proteomes selected by the new procedure, along with selected
+    entries with experimental or biologically important data.
     <br />
     <br />
     Entries removed from Unreviewed UniProtKB/TrEMBL will remain accessible in
-    UniParc. Please see{' '}
+    the UniParc sequence archive. Please see{' '}
     <ExternalLink url={blogEntryUrl}>this short article</ExternalLink> for more
     information, or{' '}
     <ContactLink
@@ -117,7 +119,7 @@ const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
                     `Taxon ID: ${taxonomy.taxonId}`,
                     `Mnemonic: ${taxonomy.mnemonic}`,
                   ].join('\n'),
-                  subject: `Question about Proteome ${id} being removed in 2026_01`,
+                  subject: `Question about proteome ${id} status in 2026_01`,
                 },
               },
             }
@@ -125,7 +127,7 @@ const ProteomesMessage: FC<{ id?: string; taxonomy?: TaxonomyDatum }> = ({
               pathname: LocationToPath[Location.ContactGeneric],
               state: {
                 formValues: {
-                  subject: `Question about Proteomes changes in 2026_01`,
+                  subject: `Question about proteomes changes in 2026_01`,
                 },
               },
             }

--- a/src/shared/components/RefProtMoveMessages.tsx
+++ b/src/shared/components/RefProtMoveMessages.tsx
@@ -22,10 +22,10 @@ const UniProtKBGenericPreamble = () => (
 );
 
 const UniProtKBRemovePreamble: FC<{ accession: string }> = ({ accession }) => (
-  <>
+  <b>
     This entry ({accession}) is under consideration for removal in release
     2026_01 (planned for the first quarter of 2026).
-  </>
+  </b>
 );
 
 const UniProtKBGenericMain: FC<{

--- a/src/shared/components/results/ResultsData.tsx
+++ b/src/shared/components/results/ResultsData.tsx
@@ -34,7 +34,6 @@ import useViewMode from '../../hooks/useViewMode';
 import { APIModel } from '../../types/apiModel';
 import { Namespace, SearchableNamespace } from '../../types/namespaces';
 import { getIdKeyForData } from '../../utils/getIdKey';
-import ExternalLink from '../ExternalLink';
 import styles from './styles/results-data.module.scss';
 
 type Props = {
@@ -208,18 +207,6 @@ const ResultsData = ({
         </Message>
       )}
 
-      {namespace === Namespace.proteomes ? (
-        <Message level="warning" className="uniprot-grid-cell--span-12">
-          We will be improving our pipelines for the selection of Reference
-          Proteomes over the next few months (September 2025–February 2026).
-          <br />
-          This might affect your data analysis,{' '}
-          <ExternalLink url="https://insideuniprot.blogspot.com/2025/06/capturing-diversity-of-life.html">
-            please read this short article
-          </ExternalLink>{' '}
-          if you want to know more.
-        </Message>
-      ) : null}
       {content}
     </div>
   );

--- a/src/shared/components/results/ResultsDataHeader.tsx
+++ b/src/shared/components/results/ResultsDataHeader.tsx
@@ -5,6 +5,7 @@ import { toolsResultsLocationToLabel } from '../../../app/config/urls';
 import useJobFromUrl from '../../hooks/useJobFromUrl';
 import useNS from '../../hooks/useNS';
 import { Namespace, namespaceAndToolsLabels } from '../../types/namespaces';
+import { RefProtMoveResultsMessage } from '../RefProtMoveMessages';
 import ResultsButtons from './ResultsButtons';
 
 const ResultsDataHeader: FC<
@@ -33,6 +34,7 @@ const ResultsDataHeader: FC<
   const { jobResultsLocation } = useJobFromUrl();
   return (
     <>
+      <RefProtMoveResultsMessage namespace={namespace} />
       <PageIntro
         heading={
           jobResultsLocation

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -460,9 +460,12 @@ const Entry = () => {
             />
           </HTMLHead>
           <RefProtMoveUniProtKBEntryMessage
-            upids={data.uniProtKBCrossReferences
-              ?.filter((db) => db.database === 'Proteomes')
-              ?.map((db) => db.id)}
+            accession={accession}
+            upids={
+              data.uniProtKBCrossReferences
+                ?.filter((db) => db.database === 'Proteomes' && db.id)
+                ?.map((db) => db.id) as string[]
+            }
           />
           <h1>
             <EntryTitle

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -32,6 +32,7 @@ import HTMLHead from '../../../shared/components/HTMLHead';
 import InPageNav from '../../../shared/components/InPageNav';
 import { SidebarLayout } from '../../../shared/components/layouts/SideBarLayout';
 import sidebarStyles from '../../../shared/components/layouts/styles/sidebar-layout.module.scss';
+import { RefProtMoveUniProtKBEntryMessage } from '../../../shared/components/RefProtMoveMessages';
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import externalUrls from '../../../shared/config/externalUrls';
 import { AFDBOutOfSyncContext } from '../../../shared/contexts/AFDBOutOfSync';
@@ -458,6 +459,11 @@ const Entry = () => {
               value={data.genes?.[0]?.geneName?.value}
             />
           </HTMLHead>
+          <RefProtMoveUniProtKBEntryMessage
+            upids={data.uniProtKBCrossReferences
+              ?.filter((db) => db.database === 'Proteomes')
+              ?.map((db) => db.id)}
+          />
           <h1>
             <EntryTitle
               mainTitle={data.primaryAccession}

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -466,6 +466,8 @@ const Entry = () => {
                 ?.filter((db) => db.database === 'Proteomes' && db.id)
                 ?.map((db) => db.id) as string[]
             }
+            scientificName={data.organism?.scientificName || ''}
+            taxonId={(data.organism?.taxonId || '').toString()}
           />
           <h1>
             <EntryTitle

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -459,16 +459,7 @@ const Entry = () => {
               value={data.genes?.[0]?.geneName?.value}
             />
           </HTMLHead>
-          <RefProtMoveUniProtKBEntryMessage
-            accession={accession}
-            upids={
-              data.uniProtKBCrossReferences
-                ?.filter((db) => db.database === 'Proteomes' && db.id)
-                ?.map((db) => db.id) as string[]
-            }
-            scientificName={data.organism?.scientificName || ''}
-            taxonId={(data.organism?.taxonId || '').toString()}
-          />
+          <RefProtMoveUniProtKBEntryMessage entry={data} />
           <h1>
             <EntryTitle
               mainTitle={data.primaryAccession}


### PR DESCRIPTION
# Note

- To be merged on Friday if no further feedback received
- Will need to change endpoint refprotmove-fastapi from wwwdev when ready to be deployed

## Purpose

Show warnings for upcoming refprotmove.

## Approach

- Collect warnings into a single file
- Use refprotmove-fastapi endpoint within UniProtKB entries only.
- Elsewhere just show static messages

## Testing

None.

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
