### PR TITLE
Enable Sequence Annotation page to show information about active external xref 

### DIFF
--- a/src/app/config/urls.ts
+++ b/src/app/config/urls.ts
@@ -96,7 +96,7 @@ export const LocationToPath: Record<Location, string> = {
   [Location.UniProtKBResults]: `/${Namespace.uniprotkb}`,
   [Location.UniRefEntry]: `/${Namespace.uniref}/:accession`,
   [Location.UniRefResults]: `/${Namespace.uniref}`,
-  [Location.UniParcSubEntry]: `/${Namespace.uniparc}/:accession/:subPage(entry|feature-viewer)/:subEntryId`,
+  [Location.UniParcSubEntry]: `/${Namespace.uniparc}/:accession/:subPage(entry|feature-viewer)/:xrefId`,
   [Location.UniParcEntry]: `/${Namespace.uniparc}/:accession/:subPage(entry|feature-viewer|structure-viewer)?`,
   [Location.UniParcResults]: `/${Namespace.uniparc}`,
   [Location.ProteomesEntry]: `/${Namespace.proteomes}/:accession`,

--- a/src/uniparc/adapters/uniParcSubEntryConverter.ts
+++ b/src/uniparc/adapters/uniParcSubEntryConverter.ts
@@ -15,7 +15,7 @@ export type UniParcSubEntryUIModel = {
     source?: Partial<UniParcXRef> | null;
     isUniprotkbEntry: boolean;
   };
-  unisave: UniSaveStatus;
+  unisave?: UniSaveStatus;
   unifire?: UniFireModel;
 };
 
@@ -56,7 +56,7 @@ const constructPredictionEvidences = (
 const uniParcSubEntryConverter = (
   entryData: UniParcLiteAPIModel,
   subEntryData: UniParcXRef,
-  unisaveData: UniSaveStatus,
+  unisaveData?: UniSaveStatus,
   uniFireData?: UniFireModel
 ): UniParcSubEntryUIModel | null => {
   const transformedEntryData = uniParcConverter(entryData);

--- a/src/uniparc/components/entry/Overview.tsx
+++ b/src/uniparc/components/entry/Overview.tsx
@@ -16,7 +16,7 @@ const Overview = ({ data }: Props) => {
       ),
     },
     {
-      title: 'Sequence length',
+      title: 'Amino acids',
       content: data.sequence && <span>{data.sequence.length}</span>,
     },
     {

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -312,6 +312,7 @@ const SubEntry = () => {
           .
         </Message>
         <SubEntryContext
+          uniparcId={accession}
           subEntry={transformedData.subEntry}
           data={unisaveData?.data}
           showUniFireOption={!!canLoadUniFire}

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -44,6 +44,7 @@ import { type SearchResults } from '../../../shared/types/results';
 import * as logging from '../../../shared/utils/logging';
 import uniprotkbUrls from '../../../uniprotkb/config/apiUrls/apiUrls';
 import { type UniSaveStatus } from '../../../uniprotkb/types/uniSave';
+import { reUniProtKBAccession } from '../../../uniprotkb/utils/regexes';
 import {
   type UniParcLiteAPIModel,
   type UniParcXRef,
@@ -90,6 +91,7 @@ const SubEntry = () => {
   const [runUniFire, setRunUniFire] = useState(true);
 
   const { accession, subEntryId, subPage } = match?.params || {};
+  const isUniProtKB = reUniProtKBAccession.test(subEntryId || '');
 
   const baseURL = `${apiUrls.entry.entry(
     subEntryId && accession,
@@ -102,7 +104,7 @@ const SubEntry = () => {
   const uniparcData = useDataApi<UniParcLiteAPIModel>(baseURL);
   const subEntryData = useDataApi<SearchResults<UniParcXRef>>(xrefIdURL);
   const unisaveData = useDataApi<UniSaveStatus>(
-    uniprotkbUrls.unisave.status(subEntryId as string)
+    isUniProtKB ? uniprotkbUrls.unisave.status(subEntryId as string) : undefined
   );
 
   const subEntrytaxId = subEntryData.data?.results[0]?.organism?.taxonId;
@@ -174,7 +176,6 @@ const SubEntry = () => {
     subEntryData.error ||
     !subEntryData.data ||
     unisaveData.error ||
-    !unisaveData.data ||
     !match ||
     !accession ||
     !subEntryId
@@ -311,8 +312,8 @@ const SubEntry = () => {
           .
         </Message>
         <SubEntryContext
-          subEntryId={subEntryId}
-          data={unisaveData.data}
+          subEntry={transformedData.subEntry}
+          data={unisaveData?.data}
           showUniFireOption={!!canLoadUniFire}
           uniFireData={uniFireData.data}
           uniFireLoading={uniFireData.loading}

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -79,6 +79,11 @@ const getErrorStatus = (
   return undefined;
 };
 
+const reUniProtKBAccessionWithBounds = new RegExp(
+  `(?<!\\w)(?:${reUniProtKBAccession.source})(?!\\w)`,
+  'i'
+);
+
 const SubEntry = () => {
   const smallScreen = useSmallScreen();
   const dispatch = useMessagesDispatch();
@@ -91,7 +96,7 @@ const SubEntry = () => {
   const [runUniFire, setRunUniFire] = useState(true);
 
   const { accession, subEntryId, subPage } = match?.params || {};
-  const isUniProtKB = reUniProtKBAccession.test(subEntryId || '');
+  const isUniProtKB = reUniProtKBAccessionWithBounds.test(subEntryId || '');
 
   const baseURL = `${apiUrls.entry.entry(
     subEntryId && accession,

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -388,7 +388,11 @@ const SubEntry = () => {
         <Tab
           title={
             <Link
-              to={getSubEntryPath(accession, subEntryId, TabLocation.Entry)}
+              to={getSubEntryPath(
+                accession,
+                xrefId as string,
+                TabLocation.Entry
+              )}
             >
               Entry
             </Link>
@@ -415,7 +419,7 @@ const SubEntry = () => {
               <Link
                 to={getSubEntryPath(
                   accession,
-                  subEntryId,
+                  xrefId as string,
                   TabLocation.FeatureViewer
                 )}
               >
@@ -427,7 +431,11 @@ const SubEntry = () => {
         >
           {smallScreen ? (
             <Redirect
-              to={getSubEntryPath(accession, subEntryId, TabLocation.Entry)}
+              to={getSubEntryPath(
+                accession,
+                xrefId as string,
+                TabLocation.Entry
+              )}
             />
           ) : (
             <>

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -148,7 +148,9 @@ const SubEntry = () => {
   );
 
   let subEntryDataPerDatabase =
-    subEntryData.data?.results.length === 1
+    // If it is a UniProtKB entry, we want to get the xref data from the first database
+    // e.g. in case of TrEMBL that are merged into SP, there will be two entries (SP and TrEMBL), and we want to redirect to the active SP page
+    subEntryData?.data?.results.length && isUniProtKB
       ? subEntryData.data.results[0]
       : undefined;
 

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -132,7 +132,9 @@ const SubEntry = () => {
 
   let sourceDatabase: string | undefined;
   if (xrefId?.includes(':')) {
-    [sourceDatabase, subEntryId] = xrefId.split(':');
+    const colonIndex = xrefId.indexOf(':');
+    sourceDatabase = xrefId.slice(0, colonIndex);
+    subEntryId = xrefId.slice(colonIndex + 1);
   }
   const isUniProtKB = reUniProtKBAccessionWithBounds.test(subEntryId || '');
 

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -90,12 +90,18 @@ const SubEntry = () => {
   const match = useRouteMatch<{
     accession: string;
     subPage: string;
-    subEntryId: string;
+    xrefId: string;
   }>(LocationToPath[Location.UniParcSubEntry]);
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
   const [runUniFire, setRunUniFire] = useState(true);
 
-  const { accession, subEntryId, subPage } = match?.params || {};
+  const { accession, xrefId, subPage } = match?.params || {};
+  let subEntryId = xrefId;
+
+  let sourceDatabase: string | undefined;
+  if (xrefId?.includes(':')) {
+    [sourceDatabase, subEntryId] = xrefId.split(':');
+  }
   const isUniProtKB = reUniProtKBAccessionWithBounds.test(subEntryId || '');
 
   const baseURL = `${apiUrls.entry.entry(
@@ -112,12 +118,19 @@ const SubEntry = () => {
     isUniProtKB ? uniprotkbUrls.unisave.status(subEntryId as string) : undefined
   );
 
-  const subEntrytaxId = subEntryData.data?.results[0]?.organism?.taxonId;
-  const canLoadUniFire =
-    subEntrytaxId &&
-    accession &&
-    subEntryData.data?.results?.length &&
-    subEntryData.data.results[0].organism?.taxonId;
+  let subEntryDataPerDatabase =
+    subEntryData.data?.results.length === 1
+      ? subEntryData.data.results[0]
+      : undefined;
+
+  if (sourceDatabase) {
+    subEntryDataPerDatabase = subEntryData.data?.results?.filter(
+      (xref) => xref.database === sourceDatabase
+    )[0];
+  }
+  const subEntrytaxId = subEntryDataPerDatabase?.organism?.taxonId;
+  const canLoadUniFire = subEntrytaxId && accession && subEntryDataPerDatabase;
+
   const uniFireData = useDataApi<UniFireModel>(
     canLoadUniFire && runUniFire
       ? apiUrls.unifire.unifire(accession, `${subEntrytaxId}`)
@@ -196,7 +209,7 @@ const SubEntry = () => {
 
   const transformedData = uniParcSubEntryConverter(
     uniparcData.data,
-    subEntryData.data?.results[0],
+    subEntryDataPerDatabase as UniParcXRef,
     unisaveData.data,
     // If no data, it would be an empty string
     uniFireData.data || undefined
@@ -303,7 +316,7 @@ const SubEntry = () => {
                 >
                   {accession}
                 </Link>
-                {`  · ${subEntryId}`}
+                {`  · ${sourceDatabase ? `${sourceDatabase}:` : ``}${subEntryId}`}
               </>
             }
           />

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import { Loader, Message, Tab, Tabs } from 'franklin-sites';
+import { ExternalLink, Loader, Message, Tab, Tabs } from 'franklin-sites';
 import { useEffect, useState } from 'react';
 import { Link, Redirect, useRouteMatch } from 'react-router-dom';
 
@@ -59,6 +59,7 @@ import { TabLocation } from '../../types/entry';
 import SubEntrySection from '../../types/subEntrySection';
 import { getSubEntryPath } from '../../utils/subEntry';
 import UniParcFeaturesView from '../entry/UniParcFeaturesView';
+import { type DataDBModel } from '../entry/XRefsSection';
 import SubEntryContext from './SubEntryContext';
 import SubEntryMain from './SubEntryMain';
 import SubEntryOverview from './SubEntryOverview';
@@ -83,6 +84,31 @@ const reUniProtKBAccessionWithBounds = new RegExp(
   `(?<!\\w)(?:${reUniProtKBAccession.source})(?!\\w)`,
   'i'
 );
+
+type ExternalXrefLinkProps = { xref: UniParcXRef; dataDB: DataDBModel };
+
+const ExternalXrefLink = ({ xref, dataDB }: ExternalXrefLinkProps) => {
+  let { id } = xref;
+  if (!id || !xref.database) {
+    return null;
+  }
+  const template = dataDB.find(
+    ({ displayName }) => displayName === xref.database
+  )?.uriLink;
+  if (!template) {
+    return null;
+  }
+  // NOTE: exception for FusionGDB we need to remove the underscore number
+  if (xref.database === 'FusionGDB') {
+    id = id.replace(/_\d+$/, '');
+  }
+  return (
+    <ExternalLink url={template.replace('%id', id)}>
+      {`${xref.database}:${xref.id}`}
+      {xref.chain && ` (chain ${xref.chain})`}
+    </ExternalLink>
+  );
+};
 
 const SubEntry = () => {
   const smallScreen = useSmallScreen();
@@ -116,6 +142,9 @@ const SubEntry = () => {
   const subEntryData = useDataApi<SearchResults<UniParcXRef>>(xrefIdURL);
   const unisaveData = useDataApi<UniSaveStatus>(
     isUniProtKB ? uniprotkbUrls.unisave.status(subEntryId as string) : undefined
+  );
+  const dataDB = useDataApi<DataDBModel>(
+    !isUniProtKB ? apiUrls.configure.allDatabases(Namespace.uniparc) : undefined
   );
 
   let subEntryDataPerDatabase =
@@ -178,7 +207,12 @@ const SubEntry = () => {
     // eslint-disable-next-line reactHooks/exhaustive-deps
   }, []);
 
-  if (uniparcData.loading || subEntryData.loading || unisaveData.loading) {
+  if (
+    dataDB.loading ||
+    uniparcData.loading ||
+    subEntryData.loading ||
+    unisaveData.loading
+  ) {
     return (
       <Loader
         progress={
@@ -316,7 +350,15 @@ const SubEntry = () => {
                 >
                   {accession}
                 </Link>
-                {`  · ${sourceDatabase ? `${sourceDatabase}:` : ``}${subEntryId}`}
+                {`  · `}
+                {!isUniProtKB && dataDB.data ? (
+                  <ExternalXrefLink
+                    xref={transformedData.subEntry}
+                    dataDB={dataDB.data}
+                  />
+                ) : (
+                  subEntryId
+                )}
               </>
             }
           />

--- a/src/uniparc/components/sub-entry/SubEntry.tsx
+++ b/src/uniparc/components/sub-entry/SubEntry.tsx
@@ -58,6 +58,7 @@ import uniParcSubEntryConfig from '../../config/UniParcSubEntryConfig';
 import { TabLocation } from '../../types/entry';
 import SubEntrySection from '../../types/subEntrySection';
 import { getSubEntryPath } from '../../utils/subEntry';
+import { getXrefId } from '../../utils/uniparcXref';
 import UniParcFeaturesView from '../entry/UniParcFeaturesView';
 import { type DataDBModel } from '../entry/XRefsSection';
 import SubEntryContext from './SubEntryContext';
@@ -98,10 +99,7 @@ const ExternalXrefLink = ({ xref, dataDB }: ExternalXrefLinkProps) => {
   if (!template) {
     return null;
   }
-  // NOTE: exception for FusionGDB we need to remove the underscore number
-  if (xref.database === 'FusionGDB') {
-    id = id.replace(/_\d+$/, '');
-  }
+  id = getXrefId(id, xref.database);
   return (
     <ExternalLink url={template.replace('%id', id)}>
       {`${xref.database}:${xref.id}`}
@@ -143,28 +141,28 @@ const SubEntry = () => {
   const unisaveData = useDataApi<UniSaveStatus>(
     isUniProtKB ? uniprotkbUrls.unisave.status(subEntryId as string) : undefined
   );
-  const dataDB = useDataApi<DataDBModel>(
+  const dbData = useDataApi<DataDBModel>(
     !isUniProtKB ? apiUrls.configure.allDatabases(Namespace.uniparc) : undefined
   );
 
-  let subEntryDataPerDatabase =
+  const subEntryDataPerDatabase =
     // If it is a UniProtKB entry, we want to get the xref data from the first database
     // e.g. in case of TrEMBL that are merged into SP, there will be two entries (SP and TrEMBL), and we want to redirect to the active SP page
-    subEntryData?.data?.results.length && isUniProtKB
-      ? subEntryData.data.results[0]
-      : undefined;
+    (subEntryData?.data?.results.length &&
+      isUniProtKB &&
+      subEntryData.data.results[0]) ||
+    (sourceDatabase &&
+      subEntryData.data?.results?.find(
+        (xref) => xref.database === sourceDatabase
+      )) ||
+    undefined;
 
-  if (sourceDatabase) {
-    subEntryDataPerDatabase = subEntryData.data?.results?.filter(
-      (xref) => xref.database === sourceDatabase
-    )[0];
-  }
-  const subEntrytaxId = subEntryDataPerDatabase?.organism?.taxonId;
-  const canLoadUniFire = subEntrytaxId && accession && subEntryDataPerDatabase;
+  const subEntryTaxId = subEntryDataPerDatabase?.organism?.taxonId;
+  const canLoadUniFire = subEntryTaxId && accession && subEntryDataPerDatabase;
 
   const uniFireData = useDataApi<UniFireModel>(
     canLoadUniFire && runUniFire
-      ? apiUrls.unifire.unifire(accession, `${subEntrytaxId}`)
+      ? apiUrls.unifire.unifire(accession, `${subEntryTaxId}`)
       : null
   );
 
@@ -210,7 +208,7 @@ const SubEntry = () => {
   }, []);
 
   if (
-    dataDB.loading ||
+    dbData.loading ||
     uniparcData.loading ||
     subEntryData.loading ||
     unisaveData.loading
@@ -353,10 +351,10 @@ const SubEntry = () => {
                   {accession}
                 </Link>
                 {`  · `}
-                {!isUniProtKB && dataDB.data ? (
+                {!isUniProtKB && dbData.data ? (
                   <ExternalXrefLink
                     xref={transformedData.subEntry}
-                    dataDB={dataDB.data}
+                    dataDB={dbData.data}
                   />
                 ) : (
                   subEntryId

--- a/src/uniparc/components/sub-entry/SubEntryContext.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryContext.tsx
@@ -27,6 +27,7 @@ import styles from './styles/sub-entry-context.module.css';
 const iconSize = '1.125em';
 
 interface SubEntryContextProps {
+  uniparcId: string;
   subEntry: UniParcSubEntryUIModel['subEntry'];
   data?: UniSaveStatus;
   showUniFireOption: boolean;
@@ -50,6 +51,7 @@ const getDeletedReasonText = (reason?: DeletedReason) => {
 };
 
 const SubEntryContext = ({
+  uniparcId,
   subEntry,
   data,
   showUniFireOption,
@@ -58,10 +60,23 @@ const SubEntryContext = ({
   runUniFire,
   setRunUniFire,
 }: SubEntryContextProps) => {
-  const { id: subEntryId, isUniprotkbEntry } = subEntry;
+  const { id: subEntryId, isUniprotkbEntry, active } = subEntry;
 
   if (!subEntryId) {
     return null;
+  }
+
+  // Redirect to UniParc entry if is an inactive external xref
+  if (!isUniprotkbEntry && !active) {
+    return (
+      <Redirect
+        to={{
+          pathname: generatePath(LocationToPath[Location.UniParcEntry], {
+            accession: uniparcId,
+          }),
+        }}
+      />
+    );
   }
 
   const events = data?.events?.filter((event) => event.eventType === 'deleted');

--- a/src/uniparc/components/sub-entry/SubEntryContext.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryContext.tsx
@@ -68,55 +68,49 @@ const SubEntryContext = ({
 
   let contextInfo;
 
-  const uniFireButton = showUniFireOption ? (
-    <>
-      <span>
-        However, annotations may be generated on demand using automatic
-        annotation rules.
-      </span>
-      <div className={styles['predictions-status']}>
-        {!runUniFire && (
-          <Button
-            variant="primary"
-            onClick={() => setRunUniFire(true)}
-            className={styles['run-unifire-button']}
-            disabled={runUniFire}
-          >
-            Generate annotations
-          </Button>
-        )}
-        {runUniFire && uniFireLoading && (
-          <Button
-            variant="primary"
-            className={styles['run-unifire-button']}
-            disabled={true}
-          >
-            Generating annotations
-          </Button>
-        )}
-        {runUniFire && !uniFireLoading && !uniFireData?.accession && (
-          <>
-            <InformationIcon
-              className={cn(styles.icon, styles.info)}
-              width={iconSize}
-              height={iconSize}
-            />
-            No predictions generated
-          </>
-        )}
-        {runUniFire && !uniFireLoading && uniFireData?.accession && (
-          <>
-            <SuccessIcon
-              className={cn(styles.icon, styles.success)}
-              width={iconSize}
-              height={iconSize}
-            />
-            Predictions generated
-          </>
-        )}
-      </div>
-    </>
-  ) : null;
+  const uniFireButton = (
+    <div className={styles['predictions-status']}>
+      {!runUniFire && (
+        <Button
+          variant="primary"
+          onClick={() => setRunUniFire(true)}
+          className={styles['run-unifire-button']}
+          disabled={runUniFire}
+        >
+          Generate annotations
+        </Button>
+      )}
+      {runUniFire && uniFireLoading && (
+        <Button
+          variant="primary"
+          className={styles['run-unifire-button']}
+          disabled={true}
+        >
+          Generating annotations
+        </Button>
+      )}
+      {runUniFire && !uniFireLoading && !uniFireData?.accession && (
+        <>
+          <InformationIcon
+            className={cn(styles.icon, styles.info)}
+            width={iconSize}
+            height={iconSize}
+          />
+          No predictions generated
+        </>
+      )}
+      {runUniFire && !uniFireLoading && uniFireData?.accession && (
+        <>
+          <SuccessIcon
+            className={cn(styles.icon, styles.success)}
+            width={iconSize}
+            height={iconSize}
+          />
+          Predictions generated
+        </>
+      )}
+    </div>
+  );
 
   if (isUniprotkbEntry) {
     if (!events || events.length === 0) {
@@ -142,7 +136,16 @@ const SubEntryContext = ({
               <strong data-article-id="deleted_accessions">
                 {event.deletedReason?.toLocaleLowerCase() || 'deleted'}
               </strong>
-              . {uniFireButton}
+              .{' '}
+              {showUniFireOption ? (
+                <>
+                  <span>
+                    However, annotations may be generated on demand using
+                    automatic annotation rules.
+                  </span>
+                  {uniFireButton}
+                </>
+              ) : null}
             </div>
           ),
         },
@@ -186,8 +189,16 @@ const SubEntryContext = ({
             title: 'Status',
             content: (
               <div>
-                This is an active entry from <i>{subEntry.database}</i>.{' '}
-                {uniFireButton}
+                This is an active {subEntry.database} entry.{' '}
+                {showUniFireOption ? (
+                  <>
+                    <span>
+                      Annotations can be generated on demand using automatic
+                      annotation rules.
+                    </span>
+                    {uniFireButton}
+                  </>
+                ) : null}
               </div>
             ),
           },

--- a/src/uniparc/components/sub-entry/SubEntryContext.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryContext.tsx
@@ -18,14 +18,17 @@ import { pickArticle } from '../../../shared/utils/utils';
 import { type DeletedReason } from '../../../uniprotkb/adapters/uniProtkbConverter';
 import { TabLocation as UniprotkbTabLocation } from '../../../uniprotkb/types/entry';
 import { type UniSaveStatus } from '../../../uniprotkb/types/uniSave';
-import { type UniFireModel } from '../../adapters/uniParcSubEntryConverter';
+import type {
+  UniFireModel,
+  UniParcSubEntryUIModel,
+} from '../../adapters/uniParcSubEntryConverter';
 import styles from './styles/sub-entry-context.module.css';
 
 const iconSize = '1.125em';
 
 interface SubEntryContextProps {
-  subEntryId: string;
-  data: UniSaveStatus;
+  subEntry: UniParcSubEntryUIModel['subEntry'];
+  data?: UniSaveStatus;
   showUniFireOption: boolean;
   uniFireData?: UniFireModel;
   uniFireLoading?: boolean;
@@ -47,7 +50,7 @@ const getDeletedReasonText = (reason?: DeletedReason) => {
 };
 
 const SubEntryContext = ({
-  subEntryId,
+  subEntry,
   data,
   showUniFireOption,
   uniFireData,
@@ -55,113 +58,143 @@ const SubEntryContext = ({
   runUniFire,
   setRunUniFire,
 }: SubEntryContextProps) => {
+  const { id: subEntryId, isUniprotkbEntry } = subEntry;
+
+  if (!subEntryId) {
+    return null;
+  }
+
   const events = data?.events?.filter((event) => event.eventType === 'deleted');
 
-  if (!events || events.length === 0) {
-    return (
-      <Redirect
-        to={{
-          pathname: generatePath(LocationToPath[Location.UniProtKBEntry], {
-            accession: subEntryId,
-          }),
-        }}
+  let contextInfo;
+
+  const uniFireButton = showUniFireOption ? (
+    <>
+      <span>
+        However, annotations may be generated on demand using automatic
+        annotation rules.
+      </span>
+      <div className={styles['predictions-status']}>
+        {!runUniFire && (
+          <Button
+            variant="primary"
+            onClick={() => setRunUniFire(true)}
+            className={styles['run-unifire-button']}
+            disabled={runUniFire}
+          >
+            Generate annotations
+          </Button>
+        )}
+        {runUniFire && uniFireLoading && (
+          <Button
+            variant="primary"
+            className={styles['run-unifire-button']}
+            disabled={true}
+          >
+            Generating annotations
+          </Button>
+        )}
+        {runUniFire && !uniFireLoading && !uniFireData?.accession && (
+          <>
+            <InformationIcon
+              className={cn(styles.icon, styles.info)}
+              width={iconSize}
+              height={iconSize}
+            />
+            No predictions generated
+          </>
+        )}
+        {runUniFire && !uniFireLoading && uniFireData?.accession && (
+          <>
+            <SuccessIcon
+              className={cn(styles.icon, styles.success)}
+              width={iconSize}
+              height={iconSize}
+            />
+            Predictions generated
+          </>
+        )}
+      </div>
+    </>
+  ) : null;
+
+  if (isUniprotkbEntry) {
+    if (!events || events.length === 0) {
+      return (
+        <Redirect
+          to={{
+            pathname: generatePath(LocationToPath[Location.UniProtKBEntry], {
+              accession: subEntryId,
+            }),
+          }}
+        />
+      );
+    }
+
+    contextInfo = events.map((event) => {
+      const infoData = [
+        {
+          title: 'Status',
+          content: (
+            <div>
+              Removed from UniProtKB because {subEntryId}{' '}
+              {getDeletedReasonText(event.deletedReason)}{' '}
+              <strong data-article-id="deleted_accessions">
+                {event.deletedReason?.toLocaleLowerCase() || 'deleted'}
+              </strong>
+              . {uniFireButton}
+            </div>
+          ),
+        },
+        {
+          title: (
+            <div>
+              Available <br /> actions
+            </div>
+          ),
+          content: (
+            <div>
+              <Link
+                to={{
+                  pathname: getEntryPath(
+                    Namespace.uniprotkb,
+                    subEntryId,
+                    UniprotkbTabLocation.History
+                  ),
+                }}
+              >
+                View history
+              </Link>{' '}
+              in UniProtKB
+            </div>
+          ),
+        },
+      ];
+
+      return (
+        <InfoList
+          key={`${event.eventType}-${subEntryId}`}
+          infoData={infoData}
+        />
+      );
+    });
+  } else {
+    contextInfo = (
+      <InfoList
+        infoData={[
+          {
+            title: 'Status',
+            content: (
+              <div>
+                This is an active entry from <i>{subEntry.database}</i>.{' '}
+                {uniFireButton}
+              </div>
+            ),
+          },
+        ]}
       />
     );
   }
-
-  const contextInfo = events.map((event) => {
-    const infoData = [
-      {
-        title: 'Status',
-        content: (
-          <div>
-            Removed from UniProtKB because {subEntryId}{' '}
-            {getDeletedReasonText(event.deletedReason)}{' '}
-            <strong data-article-id="deleted_accessions">
-              {event.deletedReason?.toLocaleLowerCase() || 'deleted'}
-            </strong>
-            .{' '}
-            {showUniFireOption ? (
-              <>
-                <span>
-                  However, annotations may be generated on demand using
-                  automatic annotation rules.
-                </span>
-                <div className={styles['predictions-status']}>
-                  {!runUniFire && (
-                    <Button
-                      variant="primary"
-                      onClick={() => setRunUniFire(true)}
-                      className={styles['run-unifire-button']}
-                      disabled={runUniFire}
-                    >
-                      Generate annotations
-                    </Button>
-                  )}
-                  {runUniFire && uniFireLoading && (
-                    <Button
-                      variant="primary"
-                      className={styles['run-unifire-button']}
-                      disabled={true}
-                    >
-                      Generating annotations
-                    </Button>
-                  )}
-                  {runUniFire && !uniFireLoading && !uniFireData?.accession && (
-                    <>
-                      <InformationIcon
-                        className={cn(styles.icon, styles.info)}
-                        width={iconSize}
-                        height={iconSize}
-                      />
-                      No predictions generated
-                    </>
-                  )}
-                  {runUniFire && !uniFireLoading && uniFireData?.accession && (
-                    <>
-                      <SuccessIcon
-                        className={cn(styles.icon, styles.success)}
-                        width={iconSize}
-                        height={iconSize}
-                      />
-                      Predictions generated
-                    </>
-                  )}
-                </div>
-              </>
-            ) : null}
-          </div>
-        ),
-      },
-      {
-        title: (
-          <div>
-            Available <br /> actions
-          </div>
-        ),
-        content: (
-          <div>
-            <Link
-              to={{
-                pathname: getEntryPath(
-                  Namespace.uniprotkb,
-                  subEntryId,
-                  UniprotkbTabLocation.History
-                ),
-              }}
-            >
-              View history
-            </Link>{' '}
-            in UniProtKB
-          </div>
-        ),
-      },
-    ];
-
-    return (
-      <InfoList key={`${event.eventType}-${subEntryId}`} infoData={infoData} />
-    );
-  });
 
   return contextInfo && <Message level="info">{contextInfo}</Message>;
 };

--- a/src/uniparc/components/sub-entry/SubEntryInactive.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryInactive.tsx
@@ -7,7 +7,7 @@ import { type UniParcSubEntryUIModel } from '../../adapters/uniParcSubEntryConve
 const SubEntryInactive = ({ data }: { data: UniParcSubEntryUIModel }) => {
   const { unisave } = data;
 
-  let events = unisave.events;
+  let events = unisave?.events;
   if (events?.length && events.length > 1 && events[0].eventType === 'merged') {
     const demergedEntries = events.map((event) => event.targetAccession);
     events = [{ ...events[0], targetAccession: demergedEntries.join(', ') }];

--- a/src/uniparc/components/sub-entry/SubEntryKeywordsSection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryKeywordsSection.tsx
@@ -26,7 +26,7 @@ const SubEntryKeywordsSection = ({ data }: Props) => {
   if (keywordPredictions.length || goPredictions.length) {
     return (
       <Card
-        header={<h2>Keywords/GO</h2>}
+        header={<h2>Keywords & Gene Ontology</h2>}
         id="keywords_and_go"
         data-entry-section
       >

--- a/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
@@ -68,7 +68,8 @@ const SubEntryNamesAndTaxonomySection = ({
     return null;
   }
 
-  const { proteinName, geneName, organism, properties } = data.subEntry;
+  const { proteinName, geneName, organism, properties, proteomeId, component } =
+    data.subEntry;
   const { predictions } = data.unifire || { predictions: [] };
 
   const recommendedFullNamePrediction =
@@ -118,6 +119,10 @@ const SubEntryNamesAndTaxonomySection = ({
     ) || [];
 
   const proteomeComponentObject = getSubEntryProteomes(properties);
+
+  if (proteomeId && component) {
+    proteomeComponentObject[proteomeId] = component;
+  }
 
   const proteomeContent = Object.entries(proteomeComponentObject).map(
     ([proteomeId, component]) => (

--- a/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
@@ -64,7 +64,7 @@ const SubEntryNamesAndTaxonomySection = ({
       : null
   );
 
-  if (!data?.subEntry?.proteinName) {
+  if (!data?.subEntry) {
     return null;
   }
 
@@ -139,7 +139,7 @@ const SubEntryNamesAndTaxonomySection = ({
   const proteinNameInfoData = [
     {
       title: 'Name',
-      content: proteinName.length ? (
+      content: proteinName?.length ? (
         <NameContent predictions={proteinName} />
       ) : null,
     },

--- a/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryNamesAndTaxonomySection.tsx
@@ -220,16 +220,33 @@ const SubEntryNamesAndTaxonomySection = ({
     },
   ];
 
+  const hasProteinNameContent = proteinNameInfoData.some(
+    (item) => item.content
+  );
+  const hasGeneNameContent = geneNameInfoData.some((item) => item.content);
+
+  if (
+    !hasProteinNameContent &&
+    (!geneName || !hasGeneNameContent) &&
+    !organism &&
+    proteomeContent.length === 0
+  ) {
+    return null;
+  }
+
   return (
     <Card
       header={<h2>{entrySectionToLabel[SubEntrySection.NamesAndTaxonomy]}</h2>}
       id={SubEntrySection.NamesAndTaxonomy}
       data-entry-section
     >
-      <h3 data-article-id="protein_names">Protein Name</h3>
-      <InfoList infoData={proteinNameInfoData} />
-
-      {geneName && (
+      {hasProteinNameContent && (
+        <>
+          <h3 data-article-id="protein_names">Protein Name</h3>
+          <InfoList infoData={proteinNameInfoData} />
+        </>
+      )}
+      {(geneName || hasGeneNameContent) && (
         <>
           <h3 data-article-id="gene_name">Gene Name</h3>
           <InfoList infoData={geneNameInfoData} />

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -1,49 +1,52 @@
-import { InfoList } from 'franklin-sites';
+import { ExternalLink, InfoList, Loader } from 'franklin-sites';
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
+import apiUrls from '../../../shared/config/apiUrls/apiUrls';
+import useDataApi from '../../../shared/hooks/useDataApi';
+import { Namespace } from '../../../shared/types/namespaces';
+import { type UniParcXRef } from '../../adapters/uniParcConverter';
 import { type UniParcSubEntryUIModel } from '../../adapters/uniParcSubEntryConverter';
 import EntrySection from '../../types/subEntrySection';
+import { type DataDBModel } from '../entry/XRefsSection';
 
-// type ExternalXrefLinkProps = { xref: UniParcXRef; dataDB: DataDBModel };
+type ExternalXrefLinkProps = { xref: UniParcXRef; dataDB: DataDBModel };
 
-// const ExternalXrefLink = ({ xref, dataDB }: ExternalXrefLinkProps) => {
-//   let { id } = xref;
-//   if (!id || !xref.database) {
-//     return null;
-//   }
-//   const template = dataDB.find(
-//     ({ displayName }) => displayName === xref.database
-//   )?.uriLink;
-//   if (!template) {
-//     return null;
-//   }
-//   // NOTE: exception for FusionGDB we need to remove the underscore number
-//   if (xref.database === 'FusionGDB') {
-//     id = id.replace(/_\d+$/, '');
-//   }
-//   return (
-//     <ExternalLink url={template.replace('%id', id)}>
-//       {xref.id}
-//       {xref.chain && ` (chain ${xref.chain})`}
-//     </ExternalLink>
-//   );
-// };
+const ExternalXrefLink = ({ xref, dataDB }: ExternalXrefLinkProps) => {
+  let { id } = xref;
+  if (!id || !xref.database) {
+    return null;
+  }
+  const template = dataDB.find(
+    ({ displayName }) => displayName === xref.database
+  )?.uriLink;
+  if (!template) {
+    return null;
+  }
+  // NOTE: exception for FusionGDB we need to remove the underscore number
+  if (xref.database === 'FusionGDB') {
+    id = id.replace(/_\d+$/, '');
+  }
+  return (
+    <ExternalLink url={template.replace('%id', id)}>
+      {xref.id}
+      {xref.chain && ` (chain ${xref.chain})`}
+    </ExternalLink>
+  );
+};
 
 type Props = {
   data: UniParcSubEntryUIModel;
 };
 
 const SubEntryOverview = ({ data }: Props) => {
-  // Refactor later to avoid multiple calls for dataDB
-  // const dataDB = useDataApi<DataDBModel>(
-  //   apiUrls.configure.allDatabases(Namespace.uniparc)
-  // );
-
-  // if (dataDB.loading || !dataDB.data) {
-  //   return <Loader />;
-  // }
+  const dataDB = useDataApi<DataDBModel>(
+    apiUrls.configure.allDatabases(Namespace.uniparc)
+  );
+  if (dataDB.loading || !dataDB.data) {
+    return <Loader />;
+  }
 
   const infoData = [
     {
@@ -58,23 +61,22 @@ const SubEntryOverview = ({ data }: Props) => {
         <strong>{data.subEntry.geneName}</strong>
       ),
     },
-    // TODO: Re-add when we show non-UniProtKB entries in UniParc
-    // {
-    //   title: 'Database',
-    //   content: !data.subEntry.isUniprotkbEntry && data.subEntry.database,
-    // },
-    // {
-    //   title: 'Identifier',
-    //   content: !data.subEntry.isUniprotkbEntry && (
-    //     <ExternalXrefLink xref={data.subEntry} dataDB={dataDB.data} />
-    //   ),
-    // },
+    {
+      title: 'Database',
+      content: !data.subEntry.isUniprotkbEntry && data.subEntry.database,
+    },
+    {
+      title: 'Identifier',
+      content: !data.subEntry.isUniprotkbEntry && (
+        <ExternalXrefLink xref={data.subEntry} dataDB={dataDB.data} />
+      ),
+    },
     // Below is the source of the ID, not of the sequence, so in the case of
     // UPKB it'll be the accession, not the actual sequence source
-    // {
-    //   title: 'Sequence source',
-    //   content: data.subEntry.source?.database,
-    // },
+    {
+      title: 'Sequence source',
+      content: data.subEntry.source?.database,
+    },
     {
       title: <span data-article-id="organism-name">Organism</span>,
       content: (data.subEntry.organism?.scientificName ||

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -71,12 +71,6 @@ const SubEntryOverview = ({ data }: Props) => {
         <ExternalXrefLink xref={data.subEntry} dataDB={dataDB.data} />
       ),
     },
-    // Below is the source of the ID, not of the sequence, so in the case of
-    // UPKB it'll be the accession, not the actual sequence source
-    {
-      title: 'Sequence source',
-      content: data.subEntry.source?.database,
-    },
     {
       title: <span data-article-id="organism-name">Organism</span>,
       content: (data.subEntry.organism?.scientificName ||

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -14,21 +14,28 @@ const SubEntryOverview = ({ data }: Props) => {
   const infoData = [
     {
       title: <span data-article-id="protein_names">Protein</span>,
-      content: data.subEntry.proteinName && (
+      content: data.subEntry.proteinName ? (
         <strong>{data.subEntry.proteinName}</strong>
+      ) : (
+        <i>Unassigned</i>
       ),
     },
     {
       title: <span data-article-id="organism-name">Organism</span>,
-      content: (data.subEntry.organism?.scientificName ||
-        data.subEntry.organism?.taxonId) && (
-        <TaxonomyView data={data.subEntry.organism} />
-      ),
+      content:
+        data.subEntry.organism?.scientificName ||
+        data.subEntry.organism?.taxonId ? (
+          <TaxonomyView data={data.subEntry.organism} />
+        ) : (
+          <i>Unassigned</i>
+        ),
     },
     {
       title: <span data-article-id="gene_name">Gene</span>,
-      content: data.subEntry.geneName && (
-        <strong>{data.subEntry.geneName ?? ''}</strong>
+      content: data.subEntry.geneName ? (
+        <strong>{data.subEntry.geneName}</strong>
+      ) : (
+        <i>Unassigned</i>
       ),
     },
     {

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -62,10 +62,6 @@ const SubEntryOverview = ({ data }: Props) => {
       ),
     },
     {
-      title: 'Database',
-      content: !data.subEntry.isUniprotkbEntry && data.subEntry.database,
-    },
-    {
       title: 'Identifier',
       content: !data.subEntry.isUniprotkbEntry && (
         <ExternalXrefLink xref={data.subEntry} dataDB={dataDB.data} />

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -1,53 +1,16 @@
-import { ExternalLink, InfoList, Loader } from 'franklin-sites';
+import { InfoList } from 'franklin-sites';
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
-import apiUrls from '../../../shared/config/apiUrls/apiUrls';
-import useDataApi from '../../../shared/hooks/useDataApi';
-import { Namespace } from '../../../shared/types/namespaces';
-import { type UniParcXRef } from '../../adapters/uniParcConverter';
 import { type UniParcSubEntryUIModel } from '../../adapters/uniParcSubEntryConverter';
 import EntrySection from '../../types/subEntrySection';
-import { type DataDBModel } from '../entry/XRefsSection';
-
-type ExternalXrefLinkProps = { xref: UniParcXRef; dataDB: DataDBModel };
-
-const ExternalXrefLink = ({ xref, dataDB }: ExternalXrefLinkProps) => {
-  let { id } = xref;
-  if (!id || !xref.database) {
-    return null;
-  }
-  const template = dataDB.find(
-    ({ displayName }) => displayName === xref.database
-  )?.uriLink;
-  if (!template) {
-    return null;
-  }
-  // NOTE: exception for FusionGDB we need to remove the underscore number
-  if (xref.database === 'FusionGDB') {
-    id = id.replace(/_\d+$/, '');
-  }
-  return (
-    <ExternalLink url={template.replace('%id', id)}>
-      {xref.id}
-      {xref.chain && ` (chain ${xref.chain})`}
-    </ExternalLink>
-  );
-};
 
 type Props = {
   data: UniParcSubEntryUIModel;
 };
 
 const SubEntryOverview = ({ data }: Props) => {
-  const dataDB = useDataApi<DataDBModel>(
-    apiUrls.configure.allDatabases(Namespace.uniparc)
-  );
-  if (dataDB.loading || !dataDB.data) {
-    return <Loader />;
-  }
-
   const infoData = [
     {
       title: <span data-article-id="protein_names">Protein</span>,
@@ -59,12 +22,6 @@ const SubEntryOverview = ({ data }: Props) => {
       title: <span data-article-id="gene_name">Gene</span>,
       content: data.subEntry.geneName && (
         <strong>{data.subEntry.geneName}</strong>
-      ),
-    },
-    {
-      title: 'Identifier',
-      content: !data.subEntry.isUniprotkbEntry && (
-        <ExternalXrefLink xref={data.subEntry} dataDB={dataDB.data} />
       ),
     },
     {

--- a/src/uniparc/components/sub-entry/SubEntryOverview.tsx
+++ b/src/uniparc/components/sub-entry/SubEntryOverview.tsx
@@ -19,16 +19,16 @@ const SubEntryOverview = ({ data }: Props) => {
       ),
     },
     {
-      title: <span data-article-id="gene_name">Gene</span>,
-      content: data.subEntry.geneName && (
-        <strong>{data.subEntry.geneName}</strong>
-      ),
-    },
-    {
       title: <span data-article-id="organism-name">Organism</span>,
       content: (data.subEntry.organism?.scientificName ||
         data.subEntry.organism?.taxonId) && (
         <TaxonomyView data={data.subEntry.organism} />
+      ),
+    },
+    {
+      title: <span data-article-id="gene_name">Gene</span>,
+      content: data.subEntry.geneName && (
+        <strong>{data.subEntry.geneName ?? ''}</strong>
       ),
     },
     {

--- a/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
@@ -34,8 +34,14 @@ const SubEntrySequenceSection = ({
 }) => {
   const history = useHistory();
 
+  const sourceDatabases = data?.subEntry.properties?.filter(
+    (property) => property.key === 'sources'
+  );
+
   const dataDB = useDataApi<DataDBModel>(
-    apiUrls.configure.allDatabases(Namespace.uniparc)
+    sourceDatabases?.length
+      ? apiUrls.configure.allDatabases(Namespace.uniparc)
+      : undefined
   );
   const templateMap = useMemo(() => getTemplateMap(dataDB.data), [dataDB.data]);
 
@@ -66,10 +72,6 @@ const SubEntrySequenceSection = ({
       content: data.subEntry.source?.database, // TODO: add external link
     },
   ];
-
-  const sourceDatabases = data.subEntry.properties?.filter(
-    (property) => property.key === 'sources'
-  );
 
   const flagPredictions =
     data.unifire?.predictions.filter(

--- a/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
@@ -50,7 +50,7 @@ const SubEntrySequenceSection = ({
     return null;
   }
 
-  if (dataDB.loading || !dataDB.data) {
+  if (dataDB.loading) {
     return <Loader />;
   }
 

--- a/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySequenceSection.tsx
@@ -22,6 +22,7 @@ import { type Evidence } from '../../../uniprotkb/types/modelTypes';
 import { type UniParcSubEntryUIModel } from '../../adapters/uniParcSubEntryConverter';
 import { entrySectionToLabel } from '../../config/UniParcSubEntrySectionLabels';
 import EntrySection from '../../types/subEntrySection';
+import { getXrefId } from '../../utils/uniparcXref';
 import { type DataDBModel } from '../entry/XRefsSection';
 
 const getTemplateMap = (dataDB?: DataDBModel) =>
@@ -127,10 +128,7 @@ const SubEntrySequenceSection = ({
 
             const template = sourceDB && templateMap.get(sourceDB);
             let id = sourceID;
-            // NOTE: exception for FusionGDB we need to remove the underscore number
-            if (sourceDB === 'FusionGDB') {
-              id = id.replace(/_\d+$/, '');
-            }
+            id = getXrefId(id, sourceDB);
             const content = template ? (
               <ExternalLink url={template.replace('%id', id)}>
                 {sourceID}

--- a/src/uniparc/config/UniParcSubEntrySectionLabels.ts
+++ b/src/uniparc/config/UniParcSubEntrySectionLabels.ts
@@ -11,5 +11,5 @@ export const entrySectionToLabel = {
   [SubEntrySection.FamilyAndDomains]: 'Family & Domains',
   [SubEntrySection.Sequence]: 'Sequence',
   [SubEntrySection.SimilarProteins]: 'Similar Proteins',
-  [SubEntrySection.KeywordsAndGO]: 'Keywords/GO',
+  [SubEntrySection.KeywordsAndGO]: 'Keywords & Gene Ontology',
 };

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -160,15 +160,24 @@ const getAccessionColumn =
         if (xref.database === 'FusionGDB') {
           id = id.replace(/_\d+$/, '');
         }
-        cell = (
-          <ExternalLink
-            url={template.replace('%id', id)}
-            rel={xref.active ? undefined : 'nofollow'}
-          >
-            {xref.id}
-            {xref.chain && ` (chain ${xref.chain})`}
-          </ExternalLink>
-        );
+
+        if (xref.active) {
+          cell = (
+            <Link
+              to={getSubEntryPath(uniparcAccession, xref.id, TabLocation.Entry)}
+            >
+              {xref.id}
+              {xref.chain && ` (chain ${xref.chain})`}
+            </Link>
+          );
+        } else {
+          cell = (
+            <ExternalLink url={template.replace('%id', id)} rel="nofollow">
+              {xref.id}
+              {xref.chain && ` (chain ${xref.chain})`}
+            </ExternalLink>
+          );
+        }
       }
     }
     return (

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -164,7 +164,11 @@ const getAccessionColumn =
         if (xref.active) {
           cell = (
             <Link
-              to={getSubEntryPath(uniparcAccession, xref.id, TabLocation.Entry)}
+              to={getSubEntryPath(
+                uniparcAccession,
+                `${xref.database}:${xref.id}`,
+                TabLocation.Entry
+              )}
             >
               {xref.id}
               {xref.chain && ` (chain ${xref.chain})`}

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -22,6 +22,7 @@ import {
 } from '../adapters/uniParcConverter';
 import Timeline from '../components/entry/Timeline';
 import { getSubEntryPath } from '../utils/subEntry';
+import { getXrefId } from '../utils/uniparcXref';
 
 export enum UniParcXRefsColumn {
   // Names & taxonomy
@@ -156,10 +157,7 @@ const getAccessionColumn =
       const template = xref.database && templateMap.get(xref.database);
       if (template) {
         let { id } = xref;
-        // NOTE: exception for FusionGDB we need to remove the underscore number
-        if (xref.database === 'FusionGDB') {
-          id = id.replace(/_\d+$/, '');
-        }
+        id = getXrefId(id, xref.database as string);
 
         if (xref.active) {
           cell = (

--- a/src/uniparc/utils/subEntry.ts
+++ b/src/uniparc/utils/subEntry.ts
@@ -4,12 +4,12 @@ import { Location, LocationToPath } from '../../app/config/urls';
 
 export const getSubEntryPath = (
   accession: string,
-  subEntryId: string,
+  xrefId: string,
   subPage: string
 ) =>
   generatePath(LocationToPath[Location.UniParcSubEntry], {
     accession,
-    subEntryId,
+    xrefId,
     subPage,
   });
 

--- a/src/uniparc/utils/uniparcXref.ts
+++ b/src/uniparc/utils/uniparcXref.ts
@@ -1,0 +1,8 @@
+export const getXrefId = (id: string, database: string) => {
+  let xrefId = id;
+  // NOTE: exception for FusionGDB we need to remove the underscore number
+  if (database === 'FusionGDB') {
+    xrefId = xrefId.replace(/_\d+$/, '');
+  }
+  return xrefId;
+};

--- a/src/uniprotkb/components/entry/Entry.tsx
+++ b/src/uniprotkb/components/entry/Entry.tsx
@@ -437,7 +437,7 @@ const Entry = () => {
               pathname: generatePath(LocationToPath[Location.UniParcSubEntry], {
                 accession: uniparcId,
                 subPage: UniParcTabLocation.Entry,
-                subEntryId: match?.params.accession,
+                xrefId: match?.params.accession,
               }),
             });
           });

--- a/src/uniprotkb/components/entry/tabs/history/RemovedEntryMessage.tsx
+++ b/src/uniprotkb/components/entry/tabs/history/RemovedEntryMessage.tsx
@@ -57,7 +57,7 @@ const RemovedEntryHeading = ({
       pathname: generatePath(LocationToPath[Location.UniParcSubEntry], {
         accession: uniparc,
         subPage: UniParcTabLocation.Entry,
-        subEntryId: accession,
+        xrefId: accession,
       }),
     };
   } else {


### PR DESCRIPTION
## Purpose

https://embl.atlassian.net/browse/TRM-33574

## Approach

Restore the previous logic we had in place in overview section
Modify the context to accommodate external xref that is active. If inactive, redirect to UniParc page

## Testing
Deployed here - https://external-xref-sap.netlify.app/ for testing and feedback

What test(s) did you write to validate and verify your changes?

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
