### PR TITLE
Remove protein existence filter of value 0 from facets

### DIFF
--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -58,12 +58,13 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
   const { facets } = data;
 
   // Add relevant icons
-  const facetsWithIcons = facets.map((facet) =>
-    facet.name === 'reviewed' ||
-    facet.name === 'proteome_type' ||
-    facet.name === 'types' || // Types is Publication's source
-    facet.name === 'proteome' // Not icon but change letter casing until returned otherwise by the backend (better if there is proteometype returned)
-      ? {
+  const decoratedFacets = facets.map((facet) => {
+    switch (facet.name) {
+      case 'reviewed':
+      case 'proteome_type':
+      case 'types':
+      case 'proteome':
+        return {
           ...facet,
           values: facet.values?.map((facetValue) => ({
             ...facetValue,
@@ -76,17 +77,24 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
                 ? getDecoratedFacetLabel(facetValue)
                 : null,
           })),
-        }
-      : facet
-  );
+        };
+      case 'existence':
+        return {
+          ...facet,
+          values: facet.values?.filter((value) => value.value !== '0'),
+        };
+      default:
+        return facet;
+    }
+  });
 
-  const splitIndex = facetsWithIcons.findIndex(
+  const splitIndex = decoratedFacets.findIndex(
     (facet) => facet.name === 'model_organism' || facet.name === 'superkingdom'
   );
   const before =
-    splitIndex === -1 ? [] : facetsWithIcons.slice(0, splitIndex + 1);
+    splitIndex === -1 ? [] : decoratedFacets.slice(0, splitIndex + 1);
   const after =
-    splitIndex === -1 ? facetsWithIcons : facetsWithIcons.slice(splitIndex + 1);
+    splitIndex === -1 ? decoratedFacets : decoratedFacets.slice(splitIndex + 1);
 
   const facetClickHandler: (
     event: React.MouseEvent<HTMLElement>

--- a/src/shared/components/results/ResultsFacets.tsx
+++ b/src/shared/components/results/ResultsFacets.tsx
@@ -62,8 +62,8 @@ const ResultsFacets = memo<Props>(({ dataApiObject, namespaceOverride }) => {
     switch (facet.name) {
       case 'reviewed':
       case 'proteome_type':
-      case 'types':
-      case 'proteome':
+      case 'types': // Types is Publication's source
+      case 'proteome': // Not icon but change letter casing until returned otherwise by the backend (better if there is proteometype returned)
         return {
           ...facet,
           values: facet.values?.map((facetValue) => ({


### PR DESCRIPTION
## Purpose

https://embl.atlassian.net/browse/TRM-33695
Existence value is 0 for all inactive entries. Values are always from 1 to 5 in Curator's scale. Removing it in backend could be messier, Hence, it is taken care of in frontend side.

https://www.uniprot.org/uniprotkb?query=A0A405EYB9+OR+A0A024F5M8+OR+A0A1X4DE39

## Approach
Checking if the value: 0 exists for existence and remove it from facets

## Testing

What test(s) did you write to validate and verify your changes?

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
