### PR TITLE
Fix go cellular column

### DIFF
--- a/src/uniprotkb/adapters/functionConverter.ts
+++ b/src/uniprotkb/adapters/functionConverter.ts
@@ -5,6 +5,7 @@ import {
   getEntryTypeFromString,
 } from '../../shared/config/entryTypeIcon';
 import { type Xref } from '../../shared/types/apiModel';
+import * as logging from '../../shared/utils/logging';
 import { type TaxonomyDatum } from '../../supporting-data/taxonomy/adapters/taxonomyConverter';
 import { UniProtKBColumn } from '../types/columnTypes';
 import {
@@ -77,6 +78,20 @@ export type GOAspectName =
 type GOAspectShort = 'C' | 'F' | 'P';
 
 export type GOTermID = `GO:${number}${string}`;
+
+/**
+ * Narrow a raw string to a `GOTermID` after verifying the `GO:` prefix.
+ * Falls back to casting (with a dev-time warning) if the prefix is absent —
+ * we keep this permissive because callers today rely on upstream xref filters
+ * to guarantee the prefix, and we don't want to silently drop legitimate data
+ * if the API ever returns an unexpected shape.
+ */
+export const asGoTermId = (id: string): GOTermID => {
+  if (!id.startsWith('GO:')) {
+    logging.warn(`Expected GO ID to start with "GO:", got "${id}"`);
+  }
+  return id as GOTermID;
+};
 
 export type GoTerm = {
   id: GOTermID;

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -1224,6 +1224,9 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.go, {
   ),
   render(data) {
     const { goTerms } = data[EntrySection.Function] as FunctionUIModel;
+    // Biological Process and Molecular Function terms live in the Function
+    // section; Cellular Component terms live in the Subcellular Location
+    // section. This column shows all three aspects, so merge both sources.
     const allTerms = [
       ...(goTerms ? Array.from(goTerms.values()).flat() : []),
       ...getCellularComponentGoTerms(data),
@@ -1235,6 +1238,9 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.go, {
 const GoId = ({ data }: { data: UniProtkbUIModel }) => {
   const { goTerms } = data[EntrySection.Function] as FunctionUIModel;
   const databaseInfoMaps = useDatabaseInfoMaps();
+  // Biological Process and Molecular Function terms live in the Function
+  // section; Cellular Component terms live in the Subcellular Location
+  // section. This column shows all three aspects, so merge both sources.
   const allTerms = [
     ...(goTerms ? Array.from(goTerms.values()).flat() : []),
     ...getCellularComponentGoTerms(data),

--- a/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBColumnConfiguration.tsx
@@ -45,11 +45,19 @@ import {
 import { diseaseAndDrugsFeaturesToColumns } from '../adapters/diseaseAndDrugs';
 import { familyAndDomainsFeaturesToColumns } from '../adapters/familyAndDomainsConverter';
 import {
+  asGoTermId,
   functionFeaturesToColumns,
   type FunctionUIModel,
   type GOAspectLabel,
   type GoTerm,
 } from '../adapters/functionConverter';
+
+// Cellular Component GO terms are not carried on the Function section model
+// (see getAspectGroupedGoTermsWithoutCellComp in functionConverter.ts) — they
+// live on the Subcellular Location section as GoXref[]. Tighten this so any
+// future caller that tries to route CC through getGOColumnForAspect fails at
+// compile time instead of silently rendering nothing.
+type NonCellCompAspectLabel = Exclude<GOAspectLabel, 'Cellular Component'>;
 import { type Interactant } from '../adapters/interactionConverter';
 import { type ProteinDescription } from '../adapters/namesAndTaxonomyConverter';
 import { proteinProcessingFeaturesToColumns } from '../adapters/proteinProcessingConverter';
@@ -61,7 +69,11 @@ import {
   structureFeaturesToColumns,
   type StructureUIModel,
 } from '../adapters/structureConverter';
-import { subcellularLocationFeaturesToColumns } from '../adapters/subcellularLocationConverter';
+import {
+  type GoXref,
+  subcellularLocationFeaturesToColumns,
+  type SubcellularLocationUIModel,
+} from '../adapters/subcellularLocationConverter';
 import { type UniProtkbUIModel } from '../adapters/uniProtkbConverter';
 import {
   AbsorptionView,
@@ -149,7 +161,7 @@ const getFeatureColumn = (
   },
 });
 
-const getGOColumnForAspect = (aspect: GOAspectLabel) => ({
+const getGOColumnForAspect = (aspect: NonCellCompAspectLabel) => ({
   ...getLabelAndTooltip(
     `Gene Ontology - ${aspect}`,
     'Gene Ontology (GO) terms associated with the entry',
@@ -163,6 +175,26 @@ const getGOColumnForAspect = (aspect: GOAspectLabel) => ({
     );
   },
 });
+
+// Cellular Component GO terms are not shown in the Function section (they're
+// intentionally filtered out there — see getAspectGroupedGoTermsWithoutCellComp
+// in functionConverter.ts) and instead live on the Subcellular Location
+// section as GoXref[]. Adapt them to the GoTerm shape expected by GOTermsView.
+const goXrefToGoTerm = (xref: GoXref): GoTerm => ({
+  id: asGoTermId(xref.id),
+  database: 'GO',
+  aspect: 'Cellular Component',
+  termDescription: xref.properties.GoTerm,
+  evidences: xref.evidences,
+  properties: xref.properties,
+});
+
+const getCellularComponentGoTerms = (data: UniProtkbUIModel): GoTerm[] => {
+  const { goXrefs } = data[
+    EntrySection.SubCellularLocation
+  ] as SubcellularLocationUIModel;
+  return goXrefs?.map(goXrefToGoTerm) ?? [];
+};
 
 const UniProtKBColumnConfiguration: ColumnConfiguration<
   UniProtKBColumn,
@@ -1166,10 +1198,19 @@ UniProtKBColumnConfiguration.set(
   UniProtKBColumn.goP,
   getGOColumnForAspect('Biological Process')
 );
-UniProtKBColumnConfiguration.set(
-  UniProtKBColumn.goC,
-  getGOColumnForAspect('Cellular Component')
-);
+UniProtKBColumnConfiguration.set(UniProtKBColumn.goC, {
+  ...getLabelAndTooltip(
+    'Gene Ontology - Cellular Component',
+    'Gene Ontology (GO) terms associated with the entry',
+    'gene_ontology'
+  ),
+  render: (data) => {
+    const cellularComponentTerms = getCellularComponentGoTerms(data);
+    return cellularComponentTerms.length ? (
+      <GOTermsView data={cellularComponentTerms} translate="yes" />
+    ) : null;
+  },
+});
 UniProtKBColumnConfiguration.set(
   UniProtKBColumn.goF,
   getGOColumnForAspect('Molecular Function')
@@ -1183,34 +1224,38 @@ UniProtKBColumnConfiguration.set(UniProtKBColumn.go, {
   ),
   render(data) {
     const { goTerms } = data[EntrySection.Function] as FunctionUIModel;
-    return (
-      goTerms && <GOTermsView data={Array.from(goTerms.values()).flat()} />
-    );
+    const allTerms = [
+      ...(goTerms ? Array.from(goTerms.values()).flat() : []),
+      ...getCellularComponentGoTerms(data),
+    ];
+    return allTerms.length ? <GOTermsView data={allTerms} /> : null;
   },
 });
 
 const GoId = ({ data }: { data: UniProtkbUIModel }) => {
   const { goTerms } = data[EntrySection.Function] as FunctionUIModel;
   const databaseInfoMaps = useDatabaseInfoMaps();
-  if (!goTerms) {
+  const allTerms = [
+    ...(goTerms ? Array.from(goTerms.values()).flat() : []),
+    ...getCellularComponentGoTerms(data),
+  ];
+  if (!allTerms.length) {
     return null;
   }
   return (
     <section className="text-block">
       <ExpandableList descriptionString="IDs" displayNumberOfHiddenItems>
-        {Array.from(goTerms.values())
-          .flat()
-          .map(
-            ({ id }: GoTerm) =>
-              id && (
-                <ExternalLink
-                  key={id}
-                  url={getUrlFromDatabaseInfo(databaseInfoMaps, 'GO', { id })}
-                >
-                  {id}
-                </ExternalLink>
-              )
-          )}
+        {allTerms.map(
+          ({ id }: GoTerm) =>
+            id && (
+              <ExternalLink
+                key={id}
+                url={getUrlFromDatabaseInfo(databaseInfoMaps, 'GO', { id })}
+              >
+                {id}
+              </ExternalLink>
+            )
+        )}
       </ExpandableList>
     </section>
   );

--- a/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
+++ b/src/uniprotkb/config/__tests__/UniProtKBColumnConfiguration.spec.tsx
@@ -1,9 +1,18 @@
+import { screen } from '@testing-library/react';
+
+import customRender from '../../../shared/__test-helpers__/customRender';
 import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
+import mockGoXrefs from '../../__mocks__/goXrefs';
 import data from '../../__mocks__/uniProtKBEntryModelData';
+import {
+  getAndPrepareSubcellGoXrefs,
+  type SubcellularLocationUIModel,
+} from '../../adapters/subcellularLocationConverter';
 import uniProtKbConverter, {
   type UniProtkbUIModel,
 } from '../../adapters/uniProtkbConverter';
-import { type UniProtKBColumn } from '../../types/columnTypes';
+import { UniProtKBColumn } from '../../types/columnTypes';
+import EntrySection from '../../types/entrySection';
 import databaseInfoMaps from '../../utils/__tests__/__mocks__/databaseInfoMaps';
 import UniProtKBColumnConfiguration from '../UniProtKBColumnConfiguration';
 
@@ -36,4 +45,55 @@ describe('UniProtKBColumnConfiguration component', () => {
     UniProtKBColumnConfiguration,
     transformedData
   );
+
+  // Regression test for the go_c column that previously always rendered empty:
+  // the column render reads CC GO terms from the Subcellular Location section,
+  // not the Function section (where they are deliberately filtered out).
+  describe('Cellular Component GO columns (regression)', () => {
+    // Build a UIModel with CC GoXrefs on the Subcellular Location section.
+    const preparedGoXrefs = getAndPrepareSubcellGoXrefs(mockGoXrefs);
+    const subcellularSection: SubcellularLocationUIModel = {
+      ...(transformedData[
+        EntrySection.SubCellularLocation
+      ] as SubcellularLocationUIModel),
+      primaryAccession: transformedData.primaryAccession,
+      goXrefs: preparedGoXrefs,
+    };
+    const dataWithCellCompGo: UniProtkbUIModel = {
+      ...transformedData,
+      [EntrySection.SubCellularLocation]: subcellularSection,
+    };
+
+    const getColumn = (key: UniProtKBColumn) => {
+      const column = UniProtKBColumnConfiguration.get(key);
+      if (!column) {
+        throw new Error(`Column "${key}" is not configured`);
+      }
+      return column;
+    };
+
+    it('renders Cellular Component terms in the go_c column', () => {
+      customRender(
+        <>{getColumn(UniProtKBColumn.goC).render(dataWithCellCompGo)}</>
+      );
+      // From mockGoXrefs — the "C:" prefix is stripped by the converter.
+      expect(screen.getByText('extracellular region')).toBeInTheDocument();
+      expect(screen.getByText('extracellular space')).toBeInTheDocument();
+    });
+
+    it('includes Cellular Component terms in the combined go column', () => {
+      customRender(
+        <>{getColumn(UniProtKBColumn.go).render(dataWithCellCompGo)}</>
+      );
+      expect(screen.getByText('extracellular region')).toBeInTheDocument();
+    });
+
+    it('includes Cellular Component GO IDs in the go_id column', () => {
+      customRender(
+        <>{getColumn(UniProtKBColumn.goId).render(dataWithCellCompGo)}</>
+      );
+      expect(screen.getByText('GO:0005576')).toBeInTheDocument();
+      expect(screen.getByText('GO:0005615')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Purpose

- Fix regression where the `go_c` (GO — Cellular Component) column in the UniProtKB results table always rendered empty, even for entries with CC terms.
- Example URL reproducing the bug: `/uniprotkb?fields=accession,reviewed,id,go_p,go_f,go_c&query=(organism_id:9606)&view=table`.
- Root cause: when CC was removed from the entry-page Function section, `functionConverter.ts` began filtering CC out of `FunctionUIModel.goTerms` (`getAspectGroupedGoTermsWithoutCellComp`). The `go_c`, combined `go`, and `go_id` column renders all read from that same source, so they lost their CC content silently.

## Approach

- Rewired the `go_c` column to pull CC terms from `EntrySection.SubCellularLocation.goXrefs` (where they now live) and adapt them to the `GoTerm` shape `GOTermsView` expects via a small `goXrefToGoTerm` helper.
- Same fix applied to the combined `go` column and the `go_id` column so they aggregate all three aspects again (restoring pre-regression behavior).
- Tightened `getGOColumnForAspect`'s parameter to `Exclude<GOAspectLabel, 'Cellular Component'>` so the same mistake cannot silently recur.
- Added `asGoTermId(id: string): GOTermID` in `functionConverter.ts` to replace an unchecked `as GOTermID` cast with a narrowing helper that warns on malformed IDs.
- Function section entry-page behavior is unchanged — CC is still excluded from `FunctionUIModel.goTerms`.

## Testing

- Added three regression tests in `UniProtKBColumnConfiguration.spec.tsx` under `Cellular Component GO columns (regression)` using the existing `mockGoXrefs` fixture:
  - `go_c` renders CC term names (`extracellular region`, `extracellular space`).
  - Combined `go` column includes those CC terms.
  - `go_id` includes the CC GO IDs (`GO:0005576`, `GO:0005615`).
- Explicit DOM assertions (not snapshots) so the exact empty-render bug can't silently regress.

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.