### PR TITLE
Table with protvista uniprot structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "marked": "17.0.1",
     "marked-gfm-heading-id": "4.1.3",
     "p-map": "7.0.4",
-    "protvista-uniprot": "file:.yalc/protvista-uniprot",
+    "protvista-uniprot": "4.9.0",
     "react": "19.2.3",
     "react-diff-viewer-continued": "3.4.0",
     "react-dom": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "marked": "17.0.1",
     "marked-gfm-heading-id": "4.1.3",
     "p-map": "7.0.4",
-    "protvista-uniprot": "4.7.2",
+    "protvista-uniprot": "file:.yalc/protvista-uniprot",
     "react": "19.2.3",
     "react-diff-viewer-continued": "3.4.0",
     "react-dom": "19.2.3",

--- a/src/jobs/utils/__mocks__/toolTipFeatureTestData.json
+++ b/src/jobs/utils/__mocks__/toolTipFeatureTestData.json
@@ -20,7 +20,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "begin": 28,
+      "start": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -49,7 +49,7 @@
     "tooltipFeature": {
       "ftId": "72f1d160-225f-11eb-b210-87bf075e497c",
       "type": "Domain",
-      "begin": 75,
+      "start": 75,
       "end": 226,
       "description": "Photolyase/cryptochrome alpha/beta"
     }
@@ -68,7 +68,7 @@
     },
     "tooltipFeature": {
       "type": "Chain",
-      "begin": 18,
+      "start": 18,
       "end": 286,
       "description": "N-APP",
       "ftId": "PRO_0000381966"
@@ -87,7 +87,7 @@
     },
     "tooltipFeature": {
       "type": "Chain",
-      "begin": 18,
+      "start": 18,
       "end": 286,
       "ftId": "PRO_0000381966"
     }
@@ -111,7 +111,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "begin": 28,
+      "start": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -142,7 +142,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "begin": 28,
+      "start": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -177,7 +177,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "begin": 28,
+      "start": 28,
       "end": 189,
       "description": "E1",
       "evidences": [

--- a/src/jobs/utils/__mocks__/toolTipFeatureTestData.json
+++ b/src/jobs/utils/__mocks__/toolTipFeatureTestData.json
@@ -20,7 +20,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "start": 28,
+      "begin": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -49,7 +49,7 @@
     "tooltipFeature": {
       "ftId": "72f1d160-225f-11eb-b210-87bf075e497c",
       "type": "Domain",
-      "start": 75,
+      "begin": 75,
       "end": 226,
       "description": "Photolyase/cryptochrome alpha/beta"
     }
@@ -68,7 +68,7 @@
     },
     "tooltipFeature": {
       "type": "Chain",
-      "start": 18,
+      "begin": 18,
       "end": 286,
       "description": "N-APP",
       "ftId": "PRO_0000381966"
@@ -87,7 +87,7 @@
     },
     "tooltipFeature": {
       "type": "Chain",
-      "start": 18,
+      "begin": 18,
       "end": 286,
       "ftId": "PRO_0000381966"
     }
@@ -111,7 +111,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "start": 28,
+      "begin": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -142,7 +142,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "start": 28,
+      "begin": 28,
       "end": 189,
       "description": "E1",
       "evidences": [
@@ -177,7 +177,7 @@
     "tooltipFeature": {
       "ftId": "251179d6-225c-11eb-8a47-55ba8956ec3b",
       "type": "Domain",
-      "start": 28,
+      "begin": 28,
       "end": 189,
       "description": "E1",
       "evidences": [

--- a/src/jobs/utils/feature.ts
+++ b/src/jobs/utils/feature.ts
@@ -1,53 +1,31 @@
-import { type ReactNode } from 'react';
+import { type getFeatureTooltip } from 'protvista-uniprot';
 import urljoin from 'url-join';
 
 import { type ProcessedFeature } from '../../shared/components/views/FeaturesView';
-import {
-  type Ligand,
-  type LigandPart,
-} from '../../uniprotkb/components/protein-data-views/LigandDescriptionView';
 import { getEvidenceLink } from '../../uniprotkb/config/evidenceUrls';
-import type FeatureType from '../../uniprotkb/types/featureType';
 
-export type Source = {
-  id: string;
-  name: string;
-  url?: string;
-  alternativeUrl?: string;
-};
-
-export type Evidence = {
-  code: string;
-  source?: Source;
-};
-
-export type TooltipFeature = {
-  type: FeatureType;
-  start: number;
-  end: number;
-  ftId?: string;
-  evidences?: Evidence[];
-  description?: ReactNode;
-  ligand?: Ligand;
-  ligandPart?: LigandPart;
-};
+type TooltipFeature = Parameters<typeof getFeatureTooltip>[0];
 
 export const prepareFeatureForTooltip = (
   feature: ProcessedFeature
 ): TooltipFeature => {
   const tooltipFeature: TooltipFeature = {
     type: feature.type,
-    start: feature.start,
+    begin: feature.start,
     end: feature.end,
   };
 
   if (feature.description) {
     if (feature.type === 'Binding site') {
-      tooltipFeature.ligand = feature.ligand;
-      tooltipFeature.ligandPart = feature.ligandPart;
+      if (feature.ligand) {
+        tooltipFeature.ligand = { name: feature.ligand.name };
+      }
+      if (feature.ligandPart?.name) {
+        tooltipFeature.ligandPart = { name: feature.ligandPart.name };
+      }
       tooltipFeature.description = feature.ligandDescription;
     } else {
-      tooltipFeature.description = feature.description;
+      tooltipFeature.description = feature.description as string | undefined;
     }
   }
 
@@ -60,27 +38,21 @@ export const prepareFeatureForTooltip = (
   }
 
   tooltipFeature.evidences = feature.evidences.map((e) => {
-    const tooltipEvidence: Evidence = { code: e.evidenceCode };
-    if (e.id && e.source) {
-      const source: Source = {
-        id: e.id,
-        name: e.source,
-      };
-      const { url, isInternal } = getEvidenceLink(e.source, e.id);
-      if (url) {
-        source.url = isInternal
-          ? urljoin('https://www.uniprot.org/', url)
-          : url;
-      }
-      if (e.source === 'PubMed') {
-        const { url: alternativeUrl } = getEvidenceLink('EuropePMC', e.id);
-        if (alternativeUrl) {
-          source.alternativeUrl = alternativeUrl;
-        }
-      }
-      tooltipEvidence.source = source;
+    if (!e.id || !e.source) {
+      return { code: e.evidenceCode };
     }
-    return tooltipEvidence;
+    const { url, isInternal } = getEvidenceLink(e.source, e.id);
+    const source: Record<string, string> = { id: e.id, name: e.source };
+    if (url) {
+      source.url = isInternal ? urljoin('https://www.uniprot.org/', url) : url;
+    }
+    if (e.source === 'PubMed') {
+      const { url: alternativeUrl } = getEvidenceLink('EuropePMC', e.id);
+      if (alternativeUrl) {
+        source.alternativeUrl = alternativeUrl;
+      }
+    }
+    return { code: e.evidenceCode, source };
   });
 
   return tooltipFeature;

--- a/src/jobs/utils/feature.ts
+++ b/src/jobs/utils/feature.ts
@@ -11,7 +11,7 @@ export const prepareFeatureForTooltip = (
 ): TooltipFeature => {
   const tooltipFeature: TooltipFeature = {
     type: feature.type,
-    begin: feature.start,
+    start: feature.start,
     end: feature.end,
   };
 

--- a/src/shared/components/table/TableFromData.tsx
+++ b/src/shared/components/table/TableFromData.tsx
@@ -17,11 +17,13 @@ const UNFILTERED_OPTION = 'All' as const;
 type TableHeaderFromDataProps<T> = {
   column: TableFromDataColumn<T>;
   options?: Set<string>;
+  selectedValue: string;
   onFilterChange: (columnId: string, filterValue: string) => void;
 };
 function TableHeaderFromData<T>({
   column,
   options,
+  selectedValue,
   onFilterChange,
 }: TableHeaderFromDataProps<T>) {
   return (
@@ -32,6 +34,7 @@ function TableHeaderFromData<T>({
           <br />
           <select
             style={{ width: 'fit-content' }}
+            value={selectedValue}
             onChange={(e) => onFilterChange(column.id, e.target.value)}
           >
             {[UNFILTERED_OPTION, ...options].map((option) => (
@@ -46,16 +49,31 @@ function TableHeaderFromData<T>({
   );
 }
 
+function getCellString<T>(
+  column: TableFromDataColumn<T>,
+  datum: T
+): string | undefined {
+  if (!column.getValue) {
+    return undefined;
+  }
+  const v = column.getValue(datum);
+  if (v === null || v === undefined) {
+    return undefined;
+  }
+  return String(v);
+}
+
 function filterDatum<T>(
   datum: T,
   columns: TableFromDataColumn<T>[],
   filterValues: ColumnsToSelectedFilter
-) {
+): boolean {
   return columns.every((column) => {
     const filterValue = filterValues[column.id];
-    return typeof filterValue !== 'undefined' && column.filter
-      ? column.filter(datum, filterValue)
-      : true;
+    if (filterValue === undefined || !column.getValue) {
+      return true;
+    }
+    return getCellString(column, datum) === filterValue;
   });
 }
 
@@ -63,11 +81,8 @@ export type TableFromDataColumn<T> = {
   id: string;
   label: ReactNode;
   render: (datum: T) => ReactNode;
-  filter?: (datum: T, filterValue: string) => boolean;
-  getOption?: (datum: T) => string | number;
+  getValue?: (datum: T) => string | number | null | undefined;
 };
-
-const OPTION_TYPES = new Set(['string', 'number']);
 
 type Props<T> = HTMLAttributes<HTMLTableElement> & {
   data: T[];
@@ -103,14 +118,13 @@ function TableFromData<T>({
   const columnIdToFilterOptions = useMemo(() => {
     const columnIdToFilterOptions: Record<string, Set<string>> = {};
     for (const column of columns) {
-      if (column.filter) {
+      if (column.getValue) {
         columnIdToFilterOptions[column.id] = new Set(
           data
-            .map((datum) => {
-              const r = (column.getOption || column.render)(datum);
-              return OPTION_TYPES.has(typeof r) ? r : null;
+            .flatMap((datum) => {
+              const v = getCellString(column, datum);
+              return v === undefined ? [] : [v];
             })
-            .filter((datum): datum is string => datum !== null)
             .sort(collator.compare)
         );
       }
@@ -147,6 +161,9 @@ function TableFromData<T>({
             column={column}
             key={column.id}
             options={columnIdToFilterOptions[column.id]}
+            selectedValue={
+              columnsToSelectedOption[column.id] ?? UNFILTERED_OPTION
+            }
             onFilterChange={handleFilterChange}
           />
         ))}

--- a/src/shared/components/views/FeaturesView.tsx
+++ b/src/shared/components/views/FeaturesView.tsx
@@ -66,9 +66,8 @@ export type ProcessedFeature = Feature & {
 export type FeatureColumnConfiguration<T> = {
   id: string;
   label: ReactNode;
-  filter?: (data: T, input: string) => boolean;
   render: (data: T) => ReactNode;
-  getOption?: (data: T) => string | number; // Fallback if render fn doesn't return string or number
+  getValue?: (data: T) => string | number | null | undefined;
 };
 
 type FeatureViewProps<T extends ProcessedFeature> = {

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -1,12 +1,12 @@
-import type ProtvistaUniprot from 'protvista-uniprot';
 import type { ProtvistaUniprotStructure } from 'protvista-uniprot';
 
 declare global {
   type ProtvistaUniprotElement = React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLElement>,
     HTMLElement
-  > &
-    Pick<ProtvistaUniprot, 'accession' | 'sequence'>;
+  > & {
+    accession?: string;
+  };
 
   type ProtvistaUniprotStructureElement = React.DetailedHTMLProps<
     React.HTMLAttributes<ProtvistaUniprotStructure>,

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -14,11 +14,8 @@ declare global {
   > &
     Pick<
       ProtvistaUniprotStructure,
-      'accession' | 'checksum' | 'sequence' | 'isoforms'
-    > & {
-      // Kebab-case JSX attribute name; the class field is `noTable`.
-      'no-table'?: boolean;
-    };
+      'accession' | 'checksum' | 'sequence' | 'isoforms' | 'noTable'
+    >;
 
   namespace React.JSX {
     interface IntrinsicElements {

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -1,27 +1,24 @@
+import type ProtvistaUniprot from 'protvista-uniprot';
 import type { ProtvistaUniprotStructure } from 'protvista-uniprot';
 
 declare global {
   type ProtvistaUniprotElement = React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLElement>,
     HTMLElement
-  > & {
-    accession?: string;
-    checksum?: string;
-    sequence?: string;
-    isoforms?: object;
-    'no-table'?: boolean;
-  };
+  > &
+    Pick<ProtvistaUniprot, 'accession' | 'sequence'>;
 
   type ProtvistaUniprotStructureElement = React.DetailedHTMLProps<
     React.HTMLAttributes<ProtvistaUniprotStructure>,
     ProtvistaUniprotStructure
-  > & {
-    accession?: string;
-    checksum?: string;
-    sequence?: string;
-    isoforms?: object;
-    'no-table'?: boolean;
-  };
+  > &
+    Pick<
+      ProtvistaUniprotStructure,
+      'accession' | 'checksum' | 'sequence' | 'isoforms'
+    > & {
+      // Kebab-case JSX attribute name; the class field is `noTable`.
+      'no-table'?: boolean;
+    };
 
   namespace React.JSX {
     interface IntrinsicElements {

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -1,17 +1,32 @@
-type ProtvistaUniprotElement = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLElement>,
-  HTMLElement
-> & {
-  accession?: string;
-  checksum?: string;
-  sequence?: string;
-  isoforms?: object;
-  'no-table'?: boolean;
-};
+import type { ProtvistaUniprotStructure } from 'protvista-uniprot';
 
-declare namespace React.JSX {
-  interface IntrinsicElements {
-    'protvista-uniprot': ProtvistaUniprotElement;
-    'protvista-uniprot-structure': ProtvistaUniprotElement;
+declare global {
+  type ProtvistaUniprotElement = React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLElement>,
+    HTMLElement
+  > & {
+    accession?: string;
+    checksum?: string;
+    sequence?: string;
+    isoforms?: object;
+    'no-table'?: boolean;
+  };
+
+  type ProtvistaUniprotStructureElement = React.DetailedHTMLProps<
+    React.HTMLAttributes<ProtvistaUniprotStructure>,
+    ProtvistaUniprotStructure
+  > & {
+    accession?: string;
+    checksum?: string;
+    sequence?: string;
+    isoforms?: object;
+    'no-table'?: boolean;
+  };
+
+  namespace React.JSX {
+    interface IntrinsicElements {
+      'protvista-uniprot': ProtvistaUniprotElement;
+      'protvista-uniprot-structure': ProtvistaUniprotStructureElement;
+    }
   }
 }

--- a/src/types/protvista-uniprot.d.ts
+++ b/src/types/protvista-uniprot.d.ts
@@ -6,6 +6,7 @@ type ProtvistaUniprotElement = React.DetailedHTMLProps<
   checksum?: string;
   sequence?: string;
   isoforms?: object;
+  'no-table'?: boolean;
 };
 
 declare namespace React.JSX {

--- a/src/uniprotkb/components/entry/InteractionSection.tsx
+++ b/src/uniprotkb/components/entry/InteractionSection.tsx
@@ -102,8 +102,7 @@ const columns: TableFromDataColumn<Interaction>[] = [
     id: 'type',
     label: 'Type',
     render: (data) => (data.organismDiffer ? 'XENO' : 'BINARY'), // NOTE: Add 'SELF'
-    filter: (data, input) =>
-      (data.organismDiffer ? 'XENO' : 'BINARY') === input,
+    getValue: (data) => (data.organismDiffer ? 'XENO' : 'BINARY'),
   },
   {
     id: 'entry-1',
@@ -125,9 +124,7 @@ const columns: TableFromDataColumn<Interaction>[] = [
           {data.interactantOne.geneName} {data.interactantOne.chainId}
         </>
       ),
-    getOption: (data) => data.interactantOne.uniProtKBAccession || 'Other',
-    filter: (data, input) =>
-      (data.interactantOne.uniProtKBAccession || 'Other') === input,
+    getValue: (data) => data.interactantOne.uniProtKBAccession || 'Other',
   },
   {
     id: 'entry-2',

--- a/src/uniprotkb/components/entry/StructureSection.tsx
+++ b/src/uniprotkb/components/entry/StructureSection.tsx
@@ -25,7 +25,7 @@ const StructureView = lazy(
 
 type Props = {
   data: UIModel & {
-    isoforms?: IsoformSequences[];
+    isoforms?: IsoformSequences;
   };
   primaryAccession: string;
   crc64?: string;

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5476,7 +5476,17 @@ exports[`Entry view should render for non-human entry 1`] = `
           </div>
           <protvista-uniprot-structure
             accession="P0DTR4"
+            no-table=""
           />
+          <div
+            class="loader-container"
+          >
+            <test-file-stub
+              class="loader"
+              height="100"
+              width="100"
+            />
+          </div>
         </div>
         <h3>
           3D structure databases

--- a/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5476,7 +5476,7 @@ exports[`Entry view should render for non-human entry 1`] = `
           </div>
           <protvista-uniprot-structure
             accession="P0DTR4"
-            no-table=""
+            notable=""
           />
           <div
             class="loader-container"

--- a/src/uniprotkb/components/entry/homologs/AgrOrthology.tsx
+++ b/src/uniprotkb/components/entry/homologs/AgrOrthology.tsx
@@ -82,18 +82,14 @@ export const columns: TableFromDataColumn<AgrOrthologsResult>[] = [
   {
     id: 'species',
     label: 'Species',
-    filter: (data, filterValue) =>
-      data.geneToGeneOrthologyGenerated.objectGene.taxon.name === filterValue,
+    getValue: (data) => data.geneToGeneOrthologyGenerated.objectGene.taxon.name,
     render: (data) => data.geneToGeneOrthologyGenerated.objectGene.taxon.name,
   },
   {
     id: 'gene-symbol',
     label: 'Gene Symbol',
-    getOption: (data) =>
+    getValue: (data) =>
       data.geneToGeneOrthologyGenerated.objectGene.geneSymbol.displayText || '',
-    filter: (data, filterValue) =>
-      data.geneToGeneOrthologyGenerated.objectGene.geneSymbol.displayText ===
-      filterValue,
     render: (data) => {
       const query = getXrefAndTaxonQuery(
         data.geneToGeneOrthologyGenerated.objectGene
@@ -120,22 +116,18 @@ export const columns: TableFromDataColumn<AgrOrthologsResult>[] = [
   {
     id: 'best',
     label: 'Best',
-    filter: (data, filterValue) =>
-      filterValue ===
-      (isBest(data.geneToGeneOrthologyGenerated.isBestScore.name)
-        ? 'Yes'
-        : 'No'),
+    getValue: (data) =>
+      isBest(data.geneToGeneOrthologyGenerated.isBestScore.name) ? 'Yes' : 'No',
     render: (data) =>
       isBest(data.geneToGeneOrthologyGenerated.isBestScore.name) ? 'Yes' : 'No',
   },
   {
     id: 'best-reverse',
     label: 'Best Reverse',
-    filter: (data, filterValue) =>
-      filterValue ===
-      (isBest(data.geneToGeneOrthologyGenerated.isBestScoreReverse.name)
+    getValue: (data) =>
+      isBest(data.geneToGeneOrthologyGenerated.isBestScoreReverse.name)
         ? 'Yes'
-        : 'No'),
+        : 'No',
     render: (data) =>
       isBest(data.geneToGeneOrthologyGenerated.isBestScoreReverse.name)
         ? 'Yes'

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -121,8 +121,8 @@ const applyFilters = (variants: TransformedVariant[], filters: string[]) => {
 };
 
 const getHighlightedCoordinates = (feature?: TransformedVariant) =>
-  feature?.begin && feature?.end
-    ? `${feature.begin}:${feature.end}`
+  feature?.start && feature?.end
+    ? `${feature.start}:${feature.end}`
     : undefined;
 
 const getRowId = (data: TransformedVariant) => data.accession;

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -63,7 +63,13 @@ const StructureView = ({
       setStructures(
         data.map((row, i) => ({ ...row, rowKey: `${row.id}:${i}` }))
       );
-      setSelectedId(structureEl.selectedId);
+      const current = structureEl.selectedId;
+      const next =
+        current && data.some((r) => r.id === current) ? current : data[0]?.id;
+      if (next && next !== current) {
+        structureEl.selectedId = next;
+      }
+      setSelectedId(next);
       setLoading(false);
     };
     // Catch up in case the event fired before this listener was attached.

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -12,6 +12,7 @@ import TableFromData, {
   type TableFromDataColumn,
 } from '../../../shared/components/table/TableFromData';
 import useCustomElement from '../../../shared/hooks/useCustomElement';
+import helper from '../../../shared/styles/helper.module.scss';
 import { Namespace } from '../../../shared/types/namespaces';
 import { type IsoformSequences } from '../../adapters/structureConverter';
 import { TabLocation } from '../../types/entry';
@@ -151,7 +152,7 @@ const StructureView = ({
         render: (row) => {
           if (row.source === 'PDB') {
             return (
-              <>
+              <span className={helper['no-wrap']}>
                 <ExternalLink
                   url={`https://www.ebi.ac.uk/pdbe-srv/view/entry/${row.id}`}
                 >
@@ -169,7 +170,7 @@ const StructureView = ({
                 <ExternalLink url={`https://www.ebi.ac.uk/pdbsum/${row.id}`}>
                   PDBsum
                 </ExternalLink>
-              </>
+              </span>
             );
           }
           if (row.source === 'AlphaFold DB' && primaryAccession) {
@@ -221,12 +222,14 @@ const StructureView = ({
               </ExternalLink>
             );
           }
-          return links.length
-            ? links.reduce<React.ReactNode[]>(
+          return links.length ? (
+            <span className={helper['no-wrap']}>
+              {links.reduce<React.ReactNode[]>(
                 (acc, link, i) => (i ? [...acc, ' · ', link] : [link]),
                 []
-              )
-            : null;
+              )}
+            </span>
+          ) : null;
         },
       }
     );

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -1,9 +1,16 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { Loader, Message } from 'franklin-sites';
-import { useRef } from 'react';
+import { DownloadIcon, Loader, Message } from 'franklin-sites';
+import {
+  type ProcessedStructureData,
+  type ProtvistaUniprotStructure,
+} from 'protvista-uniprot';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { getEntryPath } from '../../../app/config/urls';
+import ExternalLink from '../../../shared/components/ExternalLink';
+import TableFromData, {
+  type TableFromDataColumn,
+} from '../../../shared/components/table/TableFromData';
 import useCustomElement from '../../../shared/hooks/useCustomElement';
 import { Namespace } from '../../../shared/types/namespaces';
 import { type IsoformSequences } from '../../adapters/structureConverter';
@@ -33,20 +40,204 @@ const StructureView = ({
     'protvista-uniprot-structure'
   );
 
-  const structureRef = useRef<any>(null);
+  const [structureEl, setStructureElState] =
+    useState<ProtvistaUniprotStructure | null>(null);
+  const [structures, setStructures] = useState<ProcessedStructureData[]>([]);
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
 
-  const setStructureRef = (el: any) => {
-    if (el) {
-      structureRef.current = el;
-      if (isoforms?.length) {
-        el.isoforms = isoforms;
-      }
+  const setStructureEl = useCallback((el: HTMLElement | null) => {
+    setStructureElState(el as ProtvistaUniprotStructure | null);
+  }, []);
+
+  useEffect(() => {
+    if (structureEl && isoforms?.length) {
+      structureEl.isoforms =
+        isoforms as unknown as ProtvistaUniprotStructure['isoforms'];
     }
-  };
+  }, [structureEl, isoforms]);
+
+  useEffect(() => {
+    if (!structureEl) {
+      return;
+    }
+    const handler = (e: Event) => {
+      const { detail } = e as CustomEvent<
+        ReadonlyArray<ProcessedStructureData>
+      >;
+      setStructures([...detail]);
+      setSelectedId(structureEl.selectedId);
+      setLoading(false);
+    };
+    structureEl.addEventListener('structures-loaded', handler);
+    return () => structureEl.removeEventListener('structures-loaded', handler);
+  }, [structureEl]);
+
+  const handleRowClick = useCallback(
+    (row: ProcessedStructureData) => {
+      setSelectedId(row.id);
+      if (structureEl) {
+        structureEl.selectedId = row.id;
+      }
+    },
+    [structureEl]
+  );
+
+  const columns = useMemo((): TableFromDataColumn<ProcessedStructureData>[] => {
+    const cols: TableFromDataColumn<ProcessedStructureData>[] = [
+      {
+        id: 'source',
+        label: 'Source',
+        render: (row) => <strong>{row.source}</strong>,
+        filter: (row, value) => row.source === value,
+        getOption: (row) => row.source,
+      },
+      {
+        id: 'id',
+        label: 'Identifier',
+        render: (row) => row.id,
+      },
+    ];
+
+    if (isoforms?.length) {
+      cols.push({
+        id: 'isoform',
+        label: 'Isoform',
+        render: (row) => {
+          if (!row.isoformId) {
+            return null;
+          }
+          return (
+            <Link
+              to={getEntryPath(
+                Namespace.uniprotkb,
+                row.isoformId,
+                TabLocation.Entry
+              )}
+            >
+              {row.isoformId}
+              {row.isoformIsCanonical && ' (Canonical)'}
+            </Link>
+          );
+        },
+      });
+    }
+
+    cols.push(
+      {
+        id: 'method',
+        label: 'Method',
+        render: (row) => row.method ?? null,
+        filter: (row, value) => row.method === value,
+      },
+      {
+        id: 'resolution',
+        label: 'Resolution',
+        render: (row) => row.resolution?.replace(/ A\b/g, ' Å') ?? null,
+      },
+      {
+        id: 'chain',
+        label: 'Chain',
+        render: (row) => row.chain ?? null,
+      },
+      {
+        id: 'positions',
+        label: 'Positions',
+        render: (row) => row.positions ?? null,
+      },
+      {
+        id: 'links',
+        label: 'Links',
+        render: (row) => {
+          if (row.source === 'PDB') {
+            return (
+              <>
+                <ExternalLink
+                  url={`https://www.ebi.ac.uk/pdbe-srv/view/entry/${row.id}`}
+                >
+                  PDBe
+                </ExternalLink>
+                {' · '}
+                <ExternalLink url={`https://www.rcsb.org/structure/${row.id}`}>
+                  RCSB-PDB
+                </ExternalLink>
+                {' · '}
+                <ExternalLink url={`https://pdbj.org/mine/summary/${row.id}`}>
+                  PDBj
+                </ExternalLink>
+                {' · '}
+                <ExternalLink url={`https://www.ebi.ac.uk/pdbsum/${row.id}`}>
+                  PDBsum
+                </ExternalLink>
+              </>
+            );
+          }
+          if (row.source === 'AlphaFold DB' && primaryAccession) {
+            return (
+              <ExternalLink
+                url={`https://alphafold.ebi.ac.uk/entry/${primaryAccession}`}
+              >
+                AlphaFold DB
+              </ExternalLink>
+            );
+          }
+          if (row.sourceDBLink) {
+            return (
+              <ExternalLink url={row.sourceDBLink}>{row.source}</ExternalLink>
+            );
+          }
+          return null;
+        },
+      },
+      {
+        id: 'download',
+        label: 'Download',
+        render: (row) => {
+          const links: React.ReactNode[] = [];
+          if (row.downloadUrl) {
+            links.push(
+              <a
+                key="source"
+                href={row.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Source <DownloadIcon width="1em" />
+              </a>
+            );
+          }
+          if (
+            primaryAccession &&
+            (row.source === 'PDB' || row.source === 'AlphaFold DB')
+          ) {
+            const accession = row.source === 'PDB' ? row.id : primaryAccession;
+            const source = row.source === 'PDB' ? 'PDB' : 'AlphaFoldDB';
+            links.push(
+              <ExternalLink
+                key="foldseek"
+                url={`https://search.foldseek.com/search?accession=${accession}&source=${source}`}
+              >
+                Foldseek
+              </ExternalLink>
+            );
+          }
+          return links.length
+            ? links.reduce<React.ReactNode[]>(
+                (acc, link, i) => (i ? [...acc, ' · ', link] : [link]),
+                []
+              )
+            : null;
+        },
+      }
+    );
+
+    return cols;
+  }, [isoforms, primaryAccession]);
 
   if (!structureElement.defined && !structureElement.errored) {
     return <Loader />;
   }
+
   return (
     <div className={styles.container}>
       {primaryAccession && !viewerOnly && (
@@ -71,11 +262,24 @@ const StructureView = ({
         </>
       )}
       <protvista-uniprot-structure
-        ref={setStructureRef}
+        ref={setStructureEl}
         accession={primaryAccession}
         checksum={checksum}
         sequence={sequence}
+        no-table
       />
+      {!viewerOnly &&
+        (loading ? (
+          <Loader />
+        ) : (
+          <TableFromData
+            data={structures}
+            columns={columns}
+            getRowId={(row) => row.id}
+            onRowClick={handleRowClick}
+            markBackground={(row) => row.id === selectedId}
+          />
+        ))}
     </div>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -19,7 +19,7 @@ import { TabLocation } from '../../types/entry';
 import { AFDBOutOfSync } from './AFDBOutOfSync';
 import styles from './styles/structure-view.module.scss';
 
-type StructureRow = ProcessedStructureData & { _rowKey: string };
+type StructureRow = ProcessedStructureData & { rowKey: string };
 
 const StructureView = ({
   primaryAccession,
@@ -31,7 +31,7 @@ const StructureView = ({
   primaryAccession?: string;
   checksum?: string;
   sequence?: string;
-  isoforms?: IsoformSequences[];
+  isoforms?: IsoformSequences;
   viewerOnly?: boolean;
 }) => {
   const structureElement = useCustomElement(
@@ -43,20 +43,15 @@ const StructureView = ({
     'protvista-uniprot-structure'
   );
 
-  const [structureEl, setStructureElState] =
+  const [structureEl, setStructureEl] =
     useState<ProtvistaUniprotStructure | null>(null);
   const [structures, setStructures] = useState<StructureRow[]>([]);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
-  const setStructureEl = useCallback((el: HTMLElement | null) => {
-    setStructureElState(el as ProtvistaUniprotStructure | null);
-  }, []);
-
   useEffect(() => {
     if (structureEl && isoforms?.length) {
-      structureEl.isoforms =
-        isoforms as unknown as ProtvistaUniprotStructure['isoforms'];
+      structureEl.isoforms = isoforms;
     }
   }, [structureEl, isoforms]);
 
@@ -64,13 +59,22 @@ const StructureView = ({
     if (!structureEl) {
       return;
     }
+    const apply = (data: ReadonlyArray<ProcessedStructureData>) => {
+      setStructures(
+        data.map((row, i) => ({ ...row, rowKey: `${row.id}:${i}` }))
+      );
+      setSelectedId(structureEl.selectedId);
+      setLoading(false);
+    };
+    // Catch up in case the event fired before this listener was attached.
+    if (structureEl.data?.length) {
+      apply(structureEl.data);
+    }
     const handler = (e: Event) => {
       const { detail } = e as CustomEvent<
         ReadonlyArray<ProcessedStructureData>
       >;
-      setStructures(detail.map((s, i) => ({ ...s, _rowKey: String(i) })));
-      setSelectedId(structureEl.selectedId);
-      setLoading(false);
+      apply(detail);
     };
     structureEl.addEventListener('structures-loaded', handler);
     return () => structureEl.removeEventListener('structures-loaded', handler);
@@ -272,18 +276,22 @@ const StructureView = ({
         sequence={sequence}
         no-table
       />
-      {!viewerOnly &&
-        (loading ? (
-          <Loader />
-        ) : (
-          <TableFromData
-            data={structures}
-            columns={columns}
-            getRowId={(row) => row._rowKey}
-            onRowClick={handleRowClick}
-            markBackground={(row) => row.id === selectedId}
-          />
-        ))}
+      {!viewerOnly && loading && <Loader />}
+      {!viewerOnly && !loading && structures.length === 0 && (
+        <Message level="info">
+          No structure information available
+          {primaryAccession ? ` for ${primaryAccession}` : ''}.
+        </Message>
+      )}
+      {!viewerOnly && !loading && structures.length > 0 && (
+        <TableFromData
+          data={structures}
+          columns={columns}
+          getRowId={(row) => row.rowKey}
+          onRowClick={handleRowClick}
+          markBackground={(row) => row.id === selectedId}
+        />
+      )}
     </div>
   );
 };

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -274,7 +274,7 @@ const StructureView = ({
         accession={primaryAccession}
         checksum={checksum}
         sequence={sequence}
-        no-table
+        noTable
       />
       {!viewerOnly && loading && <Loader />}
       {!viewerOnly && !loading && structures.length === 0 && (

--- a/src/uniprotkb/components/protein-data-views/StructureView.tsx
+++ b/src/uniprotkb/components/protein-data-views/StructureView.tsx
@@ -19,6 +19,8 @@ import { TabLocation } from '../../types/entry';
 import { AFDBOutOfSync } from './AFDBOutOfSync';
 import styles from './styles/structure-view.module.scss';
 
+type StructureRow = ProcessedStructureData & { _rowKey: string };
+
 const StructureView = ({
   primaryAccession,
   sequence,
@@ -43,7 +45,7 @@ const StructureView = ({
 
   const [structureEl, setStructureElState] =
     useState<ProtvistaUniprotStructure | null>(null);
-  const [structures, setStructures] = useState<ProcessedStructureData[]>([]);
+  const [structures, setStructures] = useState<StructureRow[]>([]);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
@@ -66,7 +68,7 @@ const StructureView = ({
       const { detail } = e as CustomEvent<
         ReadonlyArray<ProcessedStructureData>
       >;
-      setStructures([...detail]);
+      setStructures(detail.map((s, i) => ({ ...s, _rowKey: String(i) })));
       setSelectedId(structureEl.selectedId);
       setLoading(false);
     };
@@ -90,8 +92,7 @@ const StructureView = ({
         id: 'source',
         label: 'Source',
         render: (row) => <strong>{row.source}</strong>,
-        filter: (row, value) => row.source === value,
-        getOption: (row) => row.source,
+        getValue: (row) => row.source,
       },
       {
         id: 'id',
@@ -129,7 +130,7 @@ const StructureView = ({
         id: 'method',
         label: 'Method',
         render: (row) => row.method ?? null,
-        filter: (row, value) => row.method === value,
+        getValue: (row) => row.method,
       },
       {
         id: 'resolution',
@@ -278,7 +279,7 @@ const StructureView = ({
           <TableFromData
             data={structures}
             columns={columns}
-            getRowId={(row) => row.id}
+            getRowId={(row) => row._rowKey}
             onRowClick={handleRowClick}
             markBackground={(row) => row.id === selectedId}
           />

--- a/src/uniprotkb/components/protein-data-views/VisualVariationView.tsx
+++ b/src/uniprotkb/components/protein-data-views/VisualVariationView.tsx
@@ -22,7 +22,7 @@ const VisualVariationView = ({ sequence, variants }: VariationViewProps) => {
   const setNightingaleVariation = useCallback(
     (node: NightingaleVariation) => {
       if (node && sequence && variants) {
-        node.colorConfig = colorConfig;
+        node.colorConfig = colorConfig as typeof node.colorConfig;
 
         node.data = { sequence, variants };
       }

--- a/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
@@ -1,0 +1,192 @@
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  type ProcessedStructureData,
+  type ProtvistaUniprotStructure,
+} from 'protvista-uniprot';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
+import StructureView from '../StructureView';
+
+const pdbStructure: ProcessedStructureData = {
+  id: '5R7Y',
+  source: 'PDB',
+  method: 'X-ray',
+  resolution: '2.5 A',
+  chain: 'A',
+  positions: '1-100',
+  protvistaFeatureId: 'feat-1',
+};
+
+const alphaFoldStructure: ProcessedStructureData = {
+  id: 'AF-P12345-F1-model_v4',
+  source: 'AlphaFold DB',
+  method: 'Predicted',
+  protvistaFeatureId: 'feat-2',
+  downloadUrl: 'https://alphafold.ebi.ac.uk/files/AF-P12345-F1-model_v4.pdb',
+};
+
+function fireStructuresLoaded(structures: ProcessedStructureData[]) {
+  const el = document.querySelector('protvista-uniprot-structure');
+  if (!el) {
+    throw new Error('protvista-uniprot-structure not found');
+  }
+  (el as unknown as ProtvistaUniprotStructure).selectedId = structures[0]?.id;
+  act(() => {
+    el.dispatchEvent(
+      new CustomEvent('structures-loaded', {
+        detail: structures,
+        bubbles: true,
+        composed: true,
+      })
+    );
+  });
+}
+
+describe('StructureView', () => {
+  it('shows no table before structures-loaded fires', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders the custom element with no-table attribute', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    const el = document.querySelector('protvista-uniprot-structure');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute('no-table');
+    expect(el).toHaveAttribute('accession', 'P12345');
+  });
+
+  it('renders the Feature Viewer message when primaryAccession is set and not viewerOnly', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    expect(
+      screen.getByRole('link', { name: 'Feature Viewer' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides the Feature Viewer message when viewerOnly', () => {
+    customRender(<StructureView primaryAccession="P12345" viewerOnly />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    expect(
+      screen.queryByRole('link', { name: 'Feature Viewer' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the table after structures-loaded fires', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure]);
+    expect(screen.getByRole('cell', { name: '5R7Y' })).toBeInTheDocument();
+  });
+
+  it('replaces "A" with "Å" in the resolution column', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure]);
+    expect(screen.getByRole('cell', { name: '2.5 Å' })).toBeInTheDocument();
+  });
+
+  it('renders PDB external links', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure]);
+    expect(screen.getByRole('link', { name: /PDBe/i })).toHaveAttribute(
+      'href',
+      'https://www.ebi.ac.uk/pdbe-srv/view/entry/5R7Y'
+    );
+    expect(screen.getByRole('link', { name: /RCSB-PDB/i })).toHaveAttribute(
+      'href',
+      'https://www.rcsb.org/structure/5R7Y'
+    );
+  });
+
+  it('renders AlphaFold DB link and Foldseek link', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([alphaFoldStructure]);
+    expect(screen.getByRole('link', { name: /AlphaFold DB/i })).toHaveAttribute(
+      'href',
+      'https://alphafold.ebi.ac.uk/entry/P12345'
+    );
+    expect(screen.getByRole('link', { name: /Foldseek/i })).toHaveAttribute(
+      'href',
+      'https://search.foldseek.com/search?accession=P12345&source=AlphaFoldDB'
+    );
+  });
+
+  it('renders a Source download link with the download icon', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([alphaFoldStructure]);
+    const sourceLink = screen.getByRole('link', { name: /Source/i });
+    expect(sourceLink).toHaveAttribute('href', alphaFoldStructure.downloadUrl);
+  });
+
+  it('hides the table when viewerOnly, even after structures-loaded', () => {
+    customRender(<StructureView primaryAccession="P12345" viewerOnly />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure]);
+    expect(
+      screen.queryByRole('cell', { name: '5R7Y' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('marks the selected row after a row click', async () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure, alphaFoldStructure]);
+
+    const afRow = screen
+      .getAllByRole('row')
+      .find((r) => r.textContent?.includes('AF-P12345'));
+    if (!afRow) {
+      throw new Error('AlphaFold row not found');
+    }
+    await userEvent.click(afRow);
+
+    // After click the element's selectedId should be updated
+    const el = document.querySelector(
+      'protvista-uniprot-structure'
+    ) as unknown as ProtvistaUniprotStructure;
+    expect(el.selectedId).toBe(alphaFoldStructure.id);
+  });
+
+  it('shows the Isoform column when isoforms prop is provided', () => {
+    const isoforms = [{ isoformId: 'P12345-2', sequence: 'MKVL' }];
+    customRender(
+      <StructureView primaryAccession="P12345" isoforms={[isoforms]} />,
+      { route: '/uniprotkb/P12345/entry' }
+    );
+    fireStructuresLoaded([
+      { ...pdbStructure, isoformId: 'P12345-2', isoformIsCanonical: false },
+    ]);
+    expect(
+      screen.getByRole('columnheader', { name: 'Isoform' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'P12345-2' })).toBeInTheDocument();
+  });
+
+  it('does not show the Isoform column without isoforms prop', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([pdbStructure]);
+    expect(
+      screen.queryByRole('columnheader', { name: 'Isoform' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
@@ -51,13 +51,12 @@ describe('StructureView', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
-  it('renders the custom element with no-table attribute', () => {
+  it('renders the custom element with the accession attribute', () => {
     customRender(<StructureView primaryAccession="P12345" />, {
       route: '/uniprotkb/P12345/entry',
     });
     const el = document.querySelector('protvista-uniprot-structure');
     expect(el).toBeInTheDocument();
-    expect(el).toHaveAttribute('no-table');
     expect(el).toHaveAttribute('accession', 'P12345');
   });
 

--- a/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/StructureView.spec.tsx
@@ -168,7 +168,7 @@ describe('StructureView', () => {
   it('shows the Isoform column when isoforms prop is provided', () => {
     const isoforms = [{ isoformId: 'P12345-2', sequence: 'MKVL' }];
     customRender(
-      <StructureView primaryAccession="P12345" isoforms={[isoforms]} />,
+      <StructureView primaryAccession="P12345" isoforms={isoforms} />,
       { route: '/uniprotkb/P12345/entry' }
     );
     fireStructuresLoaded([
@@ -187,6 +187,27 @@ describe('StructureView', () => {
     fireStructuresLoaded([pdbStructure]);
     expect(
       screen.queryByRole('columnheader', { name: 'Isoform' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when structures-loaded fires with []', () => {
+    customRender(<StructureView primaryAccession="P12345" />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([]);
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/No structure information available for P12345/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the empty-state message in viewerOnly mode', () => {
+    customRender(<StructureView primaryAccession="P12345" viewerOnly />, {
+      route: '/uniprotkb/P12345/entry',
+    });
+    fireStructuresLoaded([]);
+    expect(
+      screen.queryByText(/No structure information available/i)
     ).not.toBeInTheDocument();
   });
 });

--- a/src/uniprotkb/components/protein-data-views/__tests__/UniProtKBFeaturesView.filter.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/UniProtKBFeaturesView.filter.spec.tsx
@@ -1,0 +1,100 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
+import UniProtKBFeaturesView, {
+  type FeatureDatum,
+} from '../UniProtKBFeaturesView';
+
+const exact = { modifier: 'EXACT' as const };
+
+const features: FeatureDatum[] = [
+  {
+    type: 'Domain',
+    featureId: 'PRO_DOM_1',
+    description: 'BRCT 1',
+    location: { start: { value: 1, ...exact }, end: { value: 10, ...exact } },
+    source: 'UniProt',
+  },
+  {
+    type: 'Domain',
+    featureId: 'PRO_DOM_2',
+    description: 'BRCT 2',
+    location: { start: { value: 20, ...exact }, end: { value: 30, ...exact } },
+    source: 'UniProt',
+  },
+  {
+    type: 'Region',
+    featureId: 'PRO_REG_1',
+    description: 'Disordered',
+    location: { start: { value: 40, ...exact }, end: { value: 60, ...exact } },
+    source: 'UniProt',
+  },
+  {
+    type: 'Active site',
+    featureId: 'PRO_ACT_1',
+    description: 'Nucleophile',
+    location: { start: { value: 70, ...exact }, end: { value: 70, ...exact } },
+    source: 'PTMeXchange',
+  },
+];
+
+describe('UniProtKBFeaturesView filter dropdowns', () => {
+  it('renders a Type column dropdown populated with the distinct feature types', () => {
+    customRender(
+      <UniProtKBFeaturesView primaryAccession="P12345" features={features} />
+    );
+
+    const typeHeader = screen.getByRole('columnheader', { name: /Type/i });
+    const select = within(typeHeader).getByRole('combobox');
+    const options = within(select)
+      .getAllByRole('option')
+      .map((o) => o.textContent);
+    expect(options).toEqual(
+      expect.arrayContaining(['All', 'Active site', 'Domain', 'Region'])
+    );
+  });
+
+  it('filters rows when a Type is selected', async () => {
+    customRender(
+      <UniProtKBFeaturesView primaryAccession="P12345" features={features} />
+    );
+
+    expect(screen.getAllByRole('row')).toHaveLength(1 + features.length);
+
+    const typeHeader = screen.getByRole('columnheader', { name: /Type/i });
+    const select = within(typeHeader).getByRole('combobox');
+    await userEvent.selectOptions(select, 'Domain');
+
+    const rows = screen.getAllByRole('row').slice(1); // drop header
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => expect(row).toHaveTextContent('Domain'));
+  });
+
+  it('omits the Source column dropdown by default', () => {
+    customRender(
+      <UniProtKBFeaturesView primaryAccession="P12345" features={features} />
+    );
+    expect(
+      screen.queryByRole('columnheader', { name: /Source/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a Source dropdown when showSourceColumn is set', () => {
+    customRender(
+      <UniProtKBFeaturesView
+        primaryAccession="P12345"
+        features={features}
+        showSourceColumn
+      />
+    );
+    const sourceHeader = screen.getByRole('columnheader', { name: /Source/i });
+    const select = within(sourceHeader).getByRole('combobox');
+    const options = within(select)
+      .getAllByRole('option')
+      .map((o) => o.textContent);
+    expect(options).toEqual(
+      expect.arrayContaining(['All', 'PTMeXchange', 'UniProt'])
+    );
+  });
+});

--- a/src/uniprotkb/components/protein-data-views/styles/structure-view.module.scss
+++ b/src/uniprotkb/components/protein-data-views/styles/structure-view.module.scss
@@ -1,5 +1,8 @@
-/* By default don't display the messages */
-.container :global(.message) {
+/* Hide StructureView's own banner-level messages by default; they're
+   conditionally shown below based on the embedded structure viewer's state.
+   Use the direct-child combinator so messages rendered inside nested
+   components (e.g. TableFromData's empty-state warning) are not caught. */
+.container > :global(.message) {
   display: none;
 }
 
@@ -7,7 +10,7 @@
 @supports selector(:has(*)) {
   .container:has(nightingale-structure) {
     /* Info message about feature viewer */
-    & :global(.message--info) {
+    & > :global(.message--info) {
       display: grid;
       margin-block-start: 0.5em;
     }
@@ -16,7 +19,7 @@
   /* Target the message only if there's a protvista-structure with the
   "structureid" attribute set to something that looks like an AFDB ID */
   .container:has(nightingale-structure[structure-id^='AF']) {
-    & :global(.message--warning) {
+    & > :global(.message--warning) {
       /* Display and revert to the default style of the message */
       display: grid;
       margin-block-start: 0.5em;

--- a/src/uniprotkb/config/UniProtKBFeatureColumnConfiguration.tsx
+++ b/src/uniprotkb/config/UniProtKBFeatureColumnConfiguration.tsx
@@ -28,7 +28,7 @@ export const columnConfiguration: FeatureColumnConfiguration<ProcessedFeature>[]
     {
       id: 'type',
       label: 'Type',
-      filter: (data, input) => data.type === input,
+      getValue: (data) => data.type,
       render: (data) => data.type,
     },
     {
@@ -87,7 +87,7 @@ export const columnConfiguration: FeatureColumnConfiguration<ProcessedFeature>[]
     {
       id: 'source',
       label: 'Source',
-      filter: (data, input) => data.source === input,
+      getValue: (data) => data.source,
       render: (data) => data.source,
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11264,8 +11264,10 @@ protvista-tooltip@^3.8.22:
     lit-element "^2.4.0"
     lodash-es "^4.17.11"
 
-"protvista-uniprot@file:.yalc/protvista-uniprot":
-  version "4.8.2"
+protvista-uniprot@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/protvista-uniprot/-/protvista-uniprot-4.9.0.tgz#3909765d1a82fec9b4a41c9b6f5268dd929d5dd6"
+  integrity sha512-5fLd8KmnDriNJfY9W2Da+siwNUP6x2zih1BjSEAcxNWJWLKf7tcIn4sE4+6Iaa3LwgnI6G7a7hNKRyqkphB8kg==
   dependencies:
     "@nightingale-elements/nightingale-colored-sequence" "5.6.0"
     "@nightingale-elements/nightingale-filter" "5.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,10 +1870,29 @@
     d3 "7.9.0"
     lodash-es "4.17.15"
 
+"@nightingale-elements/nightingale-variation-canvas@^5.10.1":
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/@nightingale-elements/nightingale-variation-canvas/-/nightingale-variation-canvas-5.10.1.tgz#728be21266c546b82dd8d7cfb64211e6a76145f2"
+  integrity sha512-cs/xRyziWrAb+ZQcs2ghINrsWwqh7UyXS/psEs7ovUsnn8WdV1UiE0gCt+x5yU5GjWkdSFelY5AUKYTf2rEwnw==
+  dependencies:
+    "@nightingale-elements/nightingale-new-core" "^5.6.0"
+    "@nightingale-elements/nightingale-variation" "^5.10.1"
+    d3 "7.9.0"
+
 "@nightingale-elements/nightingale-variation@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@nightingale-elements/nightingale-variation/-/nightingale-variation-5.6.0.tgz#10d63198610f9a26aafaeaf22d7d450a81c09981"
   integrity sha512-/X+dgO+xo/YtihT4Jw0noniqvCBIFNI4PqomsnDfTGax0flTTkGSAlvJgpGT0DNG4M5uepd7yh5fPi1y0H1kXw==
+  dependencies:
+    "@nightingale-elements/nightingale-new-core" "^5.6.0"
+    "@nightingale-elements/nightingale-track" "^5.6.0"
+    d3 "7.8.5"
+    lodash-es "4.17.15"
+
+"@nightingale-elements/nightingale-variation@^5.10.1":
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/@nightingale-elements/nightingale-variation/-/nightingale-variation-5.10.1.tgz#77aa98554e2d6220dc772e439205495d59d65c45"
+  integrity sha512-xF1ACEqnrCkjBhE00O25Yr8CgGW+UO9OIHRj2F8iSbL7gfPLsvxDs8fRxXJdJWVHhoeIk+W46d1NjGcTy4lMVQ==
   dependencies:
     "@nightingale-elements/nightingale-new-core" "^5.6.0"
     "@nightingale-elements/nightingale-track" "^5.6.0"
@@ -5314,11 +5333,6 @@ core-js@3.47.0, core-js@^3.15.2:
   version "3.47.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.47.0.tgz#436ef07650e191afeb84c24481b298bd60eb4a17"
   integrity sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==
-
-core-js@3.48.0:
-  version "3.48.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.48.0.tgz#1f813220a47bbf0e667e3885c36cd6f0593bf14d"
-  integrity sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -9387,7 +9401,7 @@ lit-element@^4.0.4, lit-element@^4.2.0:
     "@lit/reactive-element" "^2.1.0"
     lit-html "^3.3.0"
 
-lit-html@^1.1.1, lit-html@^1.3.0:
+lit-html@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.4.1.tgz#0c6f3ee4ad4eb610a49831787f0478ad8e9ae5e0"
   integrity sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==
@@ -9518,10 +9532,10 @@ lodash-es@4.17.22, lodash-es@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.22.tgz#eb7d123ec2470d69b911abe34f85cb694849b346"
   integrity sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==
 
-lodash-es@4.17.23:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -11128,9 +11142,9 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 "postcss@^7.0.30 || ^8.0.0", postcss@^8.0.0, postcss@^8.3.11, postcss@^8.4.33, postcss@^8.4.35:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
-  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
@@ -11242,17 +11256,6 @@ property-information@^7.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.1.0.tgz#b622e8646e02b580205415586b40804d3e8bfd5d"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
-protvista-datatable@3.8.22:
-  version "3.8.22"
-  resolved "https://registry.yarnpkg.com/protvista-datatable/-/protvista-datatable-3.8.22.tgz#791091a4eecee87aca8d7b8440dd267abd6e9e8d"
-  integrity sha512-QJ4V9HpUhdeXEL49ZvaEUEU+Vk3Gtt/F+/WUMfHZBtRPsHHvWQoNLXMFFCfDsUGemQaXUh/DmW5zUgliUMeKMQ==
-  dependencies:
-    lit-element "^2.4.0"
-    lit-html "^1.3.0"
-    protvista-utils "^3.8.22"
-    type-fest "^1.2.1"
-    uuid "^8.3.1"
-
 protvista-tooltip@^3.8.22:
   version "3.8.22"
   resolved "https://registry.yarnpkg.com/protvista-tooltip/-/protvista-tooltip-3.8.22.tgz#8ddd5f1997fd2128d6ef9d9a4d61090816ebbe8a"
@@ -11261,10 +11264,8 @@ protvista-tooltip@^3.8.22:
     lit-element "^2.4.0"
     lodash-es "^4.17.11"
 
-protvista-uniprot@4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/protvista-uniprot/-/protvista-uniprot-4.7.2.tgz#0fbe01f32faaea722f18205b105eaad8ca2d52ed"
-  integrity sha512-w6n5eiyzXTIIQbf4N9mgLaopMXdgNxtB6oPTkvBApuxz673Tyz0lPwgztGxk3GlNxwPo45iOGg9x88D6pUTzvw==
+"protvista-uniprot@file:.yalc/protvista-uniprot":
+  version "4.8.2"
   dependencies:
     "@nightingale-elements/nightingale-colored-sequence" "5.6.0"
     "@nightingale-elements/nightingale-filter" "5.6.0"
@@ -11276,19 +11277,11 @@ protvista-uniprot@4.7.2:
     "@nightingale-elements/nightingale-sequence-heatmap" "5.6.2"
     "@nightingale-elements/nightingale-structure" "5.8.0"
     "@nightingale-elements/nightingale-track-canvas" "5.6.0"
-    "@nightingale-elements/nightingale-variation" "5.6.0"
+    "@nightingale-elements/nightingale-variation-canvas" "^5.10.1"
     color-hash "2.0.2"
-    core-js "3.48.0"
     lit "3.3.2"
-    lodash-es "4.17.23"
-    protvista-datatable "3.8.22"
+    lodash-es "4.18.1"
     timing-functions "2.0.1"
-    url-join "5.0.0"
-
-protvista-utils@^3.8.22:
-  version "3.8.22"
-  resolved "https://registry.yarnpkg.com/protvista-utils/-/protvista-utils-3.8.22.tgz#0d97ad6958a5aa889b43ce2d48d8565b3c9ec2e3"
-  integrity sha512-u2AJGsS6n+uBNgqpIYyvKbeMWEO7IHdziTw3QA2uMfa2KUshpnFZ8h2g0FJUwEyxIC+JQqiNFGQd/ASBj9rqTQ==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -13300,11 +13293,6 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-type-fest@^1.2.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
-  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
-
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -13662,7 +13650,7 @@ uuid@^11.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
-uuid@^8.3.1, uuid@^8.3.2:
+uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
## Notes

- Depends on https://github.com/ebi-webcomponents/protvista/pull/169
- Currently has hardcoded yalc references which I will remove upon release protvista

## Purpose

Replace `protvista-uniprot-structure`'s default table with our React-rendered table so it shares the look, sort, filter, and accessibility behavior of the rest of the entry page.

## Approach

- Pass `noTable` to the custom element to suppress its built-in table; subscribe to its `structures-loaded` event and feed the data into `TableFromData`.
- Selection stays bidirectional: row clicks set `structureEl.selectedId` (driving the 3D viewer); the upstream's first-row default plus a stale-id guard keep the table and viewer in sync across isoform switches.
- Tightened `src/types/protvista-uniprot.d.ts`.
- Fixed table filtering

## Testing

New `StructureView.spec.tsx` covering: pre-load empty state, table render after `structures-loaded`, isoform column visibility, PDB / AlphaFold / Foldseek link rendering, resolution Å substitution, row-click selection, viewer-only mode, and empty-data messaging.

## Checklist

- [ ] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
