### PR TITLE
Uniparc proteome adv search

### DIFF
--- a/src/query-builder/utils/__tests__/fieldInitializer.spec.ts
+++ b/src/query-builder/utils/__tests__/fieldInitializer.spec.ts
@@ -20,4 +20,35 @@ describe('field initializer', () => {
       )
     ).toEqual('9606');
   });
+
+  describe('proteome / proteomecomponent', () => {
+    it('should return the proteome ID part for the `proteome` field', () => {
+      expect(
+        initializer(getSearchTerm('proteome'), {
+          proteomecomponent: 'UP000005640:chromosome',
+        })
+      ).toEqual('UP000005640');
+    });
+
+    it('should return the component part for the `proteome_component` field', () => {
+      expect(
+        initializer(getSearchTerm('proteome_component'), {
+          proteomecomponent: 'UP000005640:chromosome',
+        })
+      ).toEqual('chromosome');
+    });
+
+    it('should return the proteome ID and an empty component when no `:` is present', () => {
+      expect(
+        initializer(getSearchTerm('proteome'), {
+          proteomecomponent: 'UP000005640',
+        })
+      ).toEqual('UP000005640');
+      expect(
+        initializer(getSearchTerm('proteome_component'), {
+          proteomecomponent: 'UP000005640',
+        })
+      ).toEqual('');
+    });
+  });
 });

--- a/src/query-builder/utils/__tests__/queryStringProcessor.spec.ts
+++ b/src/query-builder/utils/__tests__/queryStringProcessor.spec.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import { getSearchTerm } from '../../components/__tests__/__mocks__/configureSearchTerms';
 import { parse, stringify } from '../queryStringProcessor';
 import testData from './__mocks__/clauseQueryTestData';
 
@@ -8,6 +9,55 @@ describe('search querystring stringifier', () => {
   testData.forEach(({ description, queryString, clauses }) => {
     test(description, () => {
       expect(stringify(clauses)).toBe(queryString);
+    });
+  });
+
+  describe('proteome + proteomecomponent fusion', () => {
+    test('combines proteome ID and component into a single proteomecomponent clause', () => {
+      expect(
+        stringify([
+          {
+            id: 0,
+            searchTerm: getSearchTerm('proteome'),
+            logicOperator: 'AND',
+            queryBits: {
+              proteome: 'UP000005640',
+              proteomecomponent: 'chromosome',
+            },
+          },
+        ])
+      ).toBe('(proteomecomponent:"UP000005640:chromosome")');
+    });
+
+    test('does not include a separate proteome clause when both queryBits are present', () => {
+      const result = stringify([
+        {
+          id: 0,
+          searchTerm: getSearchTerm('proteome'),
+          logicOperator: 'AND',
+          queryBits: {
+            proteome: 'UP000005640',
+            proteomecomponent: 'chromosome',
+          },
+        },
+      ]);
+      expect(result).not.toMatch(/\(proteome:/);
+      expect(result).not.toMatch(/AND/);
+    });
+
+    test('leaves a proteome-only clause untouched', () => {
+      expect(
+        stringify([
+          {
+            id: 0,
+            searchTerm: getSearchTerm('proteome'),
+            logicOperator: 'AND',
+            queryBits: {
+              proteome: 'UP000005640',
+            },
+          },
+        ])
+      ).toBe('(proteome:UP000005640)');
     });
   });
 

--- a/src/query-builder/utils/fieldInitializer.ts
+++ b/src/query-builder/utils/fieldInitializer.ts
@@ -34,6 +34,14 @@ const initializer = (
     return '*';
   }
 
+  if (
+    (field.term === 'proteome' || field.term === 'proteomecomponent') &&
+    initialValue?.proteomecomponent
+  ) {
+    const [proteomeId, component] = initialValue.proteomecomponent.split(':');
+    return (field.term === 'proteome' ? proteomeId : component) || '';
+  }
+
   // Deal with autocomplete fields as they have two terms with different behavior:
   //   1. autoCompleteQueryTerm: for ID searches eg organism_id
   //   2. term: for text searches eg organism_name

--- a/src/query-builder/utils/queryStringProcessor.ts
+++ b/src/query-builder/utils/queryStringProcessor.ts
@@ -50,6 +50,13 @@ export const stringify = (clauses: Clause[] = []): string => {
       }`;
       const goValue = clause.queryBits?.go || '*';
       queryJoined = `(${goKey}:${goValue})`;
+    } else if (
+      clause.queryBits.proteome &&
+      clause.queryBits.proteomecomponent
+    ) {
+      // Combine proteome ID + component into a single proteomecomponent clause
+      // and suppress the separate `proteome:` clause.
+      queryJoined = `(proteomecomponent:"${clause.queryBits.proteome}:${clause.queryBits.proteomecomponent}")`;
     } else {
       queryJoined = query
         .map(([key, value]) => {


### PR DESCRIPTION
## Purpose
https://embl.atlassian.net/browse/TRM-33980

## Approach
Split the query into proteome id and component in field initializer 
Join the querybits when submitted to search

## Testing
Added tests

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
