### PR TITLE
Use variation canvas table improvements

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -94,6 +94,20 @@ jest.mock('react', () => ({
 
 global.ResizeObserver = ResizeObserver;
 
+// requestIdleCallback isn't implemented in jsdom; fire synchronously in tests
+// so deferred-mount effects run as if idle time were already available.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).requestIdleCallback = (
+  cb: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void
+) => {
+  cb({ didTimeout: false, timeRemaining: () => 50 });
+  return 0;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).cancelIdleCallback = () => {
+  // Mock implementation
+};
+
 /* "Fail on console error" util */
 // Uncomment to have jest stop when a console error is shown in order to fix it
 // Recommended to use with Jest's "--bail" option

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -104,9 +104,7 @@ global.ResizeObserver = ResizeObserver;
   return 0;
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(global as any).cancelIdleCallback = () => {
-  // Mock implementation
-};
+(global as any).cancelIdleCallback = () => {};
 
 /* "Fail on console error" util */
 // Uncomment to have jest stop when a console error is shown in order to fix it

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@sentry/types": "10.34.0",
     "@swissprot/rhea-reaction-viz-test": "0.0.25",
     "@swissprot/swissbiopics-visualizer": "0.0.29",
+    "@tanstack/react-virtual": "3.13.24",
     "axios": "1.13.2",
     "classnames": "2.5.1",
     "complexviewer": "2.2.9",

--- a/src/shared/components/table/Table.tsx
+++ b/src/shared/components/table/Table.tsx
@@ -21,19 +21,36 @@ const Table = ({
   children,
   className,
   expandable,
+  virtualize,
+  containerRef,
   id,
   ...props
 }: HTMLAttributes<HTMLTableElement> & {
   expandable?: boolean;
+  virtualize?: boolean;
+  containerRef?: React.RefObject<HTMLDivElement | null>;
   id?: string;
 }) => {
-  const [containerRef, expandTable, setExpandTable, showButton] =
+  const [expandableContainerRef, expandTable, setExpandTable, showButton] =
     useExpandTable(expandable);
+
+  if (virtualize) {
+    return (
+      <div
+        ref={containerRef}
+        className={cn(styles.container, styles['virtualize-container'])}
+      >
+        <table className={cn(styles.table, className)} id={id} {...props}>
+          {children}
+        </table>
+      </div>
+    );
+  }
 
   return expandable ? (
     <div>
       <div
-        ref={containerRef}
+        ref={expandableContainerRef}
         className={cn(styles.container, {
           [styles.collapsed]: expandable && !expandTable,
         })}

--- a/src/shared/components/table/TableFromData.tsx
+++ b/src/shared/components/table/TableFromData.tsx
@@ -5,7 +5,6 @@ import {
   type HTMLAttributes,
   type ReactNode,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -166,11 +165,9 @@ function TableFromData<T>({
 
   // Forward the virtualizer instance to the parent via ref. Used by the
   // scroll-to-row hook to jump to rows that aren't currently mounted.
-  useEffect(() => {
-    if (virtualizerRef) {
-      virtualizerRef.current = shouldVirtualize ? virtualizer : null;
-    }
-  }, [virtualizerRef, virtualizer, shouldVirtualize]);
+  if (virtualizerRef) {
+    virtualizerRef.current = shouldVirtualize ? virtualizer : null;
+  }
 
   if (shouldVirtualize) {
     const virtualItems = virtualizer.getVirtualItems();
@@ -178,8 +175,7 @@ function TableFromData<T>({
     const topPadding = virtualItems[0]?.start ?? 0;
     const bottomPadding =
       totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0);
-    // +1 for the leading toggle column rendered by Table.Head/Table.Row.
-    const spacerColSpan = columns.length + 1;
+    const spacerColSpan = columns.length + (rowExtraContent ? 1 : 0);
 
     // One <tbody> per logical row (multiple tbodies in a single <table> is
     // valid HTML). Required because Table.Row outputs both a main <tr> and an

--- a/src/shared/components/table/TableFromData.tsx
+++ b/src/shared/components/table/TableFromData.tsx
@@ -1,10 +1,13 @@
+import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual';
 import cn from 'classnames';
 import { Message } from 'franklin-sites';
 import {
   type HTMLAttributes,
   type ReactNode,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -13,6 +16,10 @@ import styles from './styles/table.module.scss';
 import Table from './Table';
 
 const UNFILTERED_OPTION = 'All' as const;
+
+const VIRTUALIZE_ROW_THRESHOLD = 200;
+const VIRTUALIZE_ROW_OVERSCAN = 10;
+const VIRTUALIZE_ESTIMATED_ROW_HEIGHT = 36;
 
 type TableHeaderFromDataProps<T> = {
   column: TableFromDataColumn<T>;
@@ -79,6 +86,8 @@ type Props<T> = HTMLAttributes<HTMLTableElement> & {
   markBorder?: (datum: T) => boolean;
   noTranslateBody?: boolean;
   expandable?: boolean;
+  virtualize?: boolean;
+  virtualizerRef?: React.RefObject<Virtualizer<HTMLDivElement, Element> | null>;
   id?: string;
 };
 
@@ -96,6 +105,8 @@ function TableFromData<T>({
   markBorder,
   noTranslateBody,
   expandable = true,
+  virtualize = false,
+  virtualizerRef,
   ...props
 }: Props<T>) {
   const [columnsToSelectedOption, setColumnsToSelectedOption] =
@@ -135,6 +146,108 @@ function TableFromData<T>({
       ),
     [columns, data, columnsToSelectedOption]
   );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Virtualization is opt-in and only kicks in once the data exceeds the
+  // threshold; below that the cost of virtualization (extra DOM, measurement)
+  // outweighs the benefit and the original rendering path is used.
+  const shouldVirtualize =
+    virtualize && filteredData.length > VIRTUALIZE_ROW_THRESHOLD;
+
+  const virtualizer = useVirtualizer({
+    count: shouldVirtualize ? filteredData.length : 0,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => VIRTUALIZE_ESTIMATED_ROW_HEIGHT,
+    overscan: VIRTUALIZE_ROW_OVERSCAN,
+    // Match the per-row `data-index` attribute used by `measureElement`.
+    indexAttribute: 'data-index',
+  });
+
+  // Forward the virtualizer instance to the parent via ref. Used by the
+  // scroll-to-row hook to jump to rows that aren't currently mounted.
+  useEffect(() => {
+    if (virtualizerRef) {
+      virtualizerRef.current = shouldVirtualize ? virtualizer : null;
+    }
+  }, [virtualizerRef, virtualizer, shouldVirtualize]);
+
+  if (shouldVirtualize) {
+    const virtualItems = virtualizer.getVirtualItems();
+    const totalSize = virtualizer.getTotalSize();
+    const topPadding = virtualItems[0]?.start ?? 0;
+    const bottomPadding =
+      totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0);
+    // +1 for the leading toggle column rendered by Table.Head/Table.Row.
+    const spacerColSpan = columns.length + 1;
+
+    // One <tbody> per logical row (multiple tbodies in a single <table> is
+    // valid HTML). Required because Table.Row outputs both a main <tr> and an
+    // optional expanded extra-content <tr>; wrapping each pair in its own
+    // tbody lets the virtualizer measure the combined height with a single
+    // ResizeObserver and reflow following rows when the user expands one.
+    return (
+      <Table virtualize containerRef={containerRef} {...props}>
+        <Table.Head toggleAll={Boolean(rowExtraContent)}>
+          {columns.map((column) => (
+            <TableHeaderFromData
+              column={column}
+              key={column.id}
+              options={columnIdToFilterOptions[column.id]}
+              onFilterChange={handleFilterChange}
+            />
+          ))}
+        </Table.Head>
+        {topPadding > 0 && (
+          <tbody aria-hidden="true" className={styles['virtual-spacer']}>
+            <tr style={{ height: topPadding }}>
+              {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+              <td colSpan={spacerColSpan} />
+            </tr>
+          </tbody>
+        )}
+        {virtualItems.map((virtualItem) => {
+          const datum = filteredData[virtualItem.index];
+          return (
+            <tbody
+              key={getRowId(datum)}
+              data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
+              className={styles['virtual-row']}
+              translate={noTranslateBody ? 'no' : undefined}
+            >
+              <Table.Row
+                isOdd={virtualItem.index % 2 === 1}
+                extraContent={
+                  rowExtraContent && (
+                    <td colSpan={columns.length}>{rowExtraContent(datum)}</td>
+                  )
+                }
+                onClick={(expanded: boolean) => onRowClick?.(datum, expanded)}
+                className={cn({
+                  [styles['mark-background']]: markBackground?.(datum),
+                  [styles['mark-border']]: markBorder?.(datum),
+                })}
+                data-id={getRowId(datum)}
+              >
+                {columns.map((column) => (
+                  <td key={column.id}>{column.render(datum)}</td>
+                ))}
+              </Table.Row>
+            </tbody>
+          );
+        })}
+        {bottomPadding > 0 && (
+          <tbody aria-hidden="true" className={styles['virtual-spacer']}>
+            <tr style={{ height: bottomPadding }}>
+              {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+              <td colSpan={spacerColSpan} />
+            </tr>
+          </tbody>
+        )}
+      </Table>
+    );
+  }
 
   return (
     <Table

--- a/src/shared/components/table/__tests__/TableFromData.spec.tsx
+++ b/src/shared/components/table/__tests__/TableFromData.spec.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import customRender from '../../../__test-helpers__/customRender';
+import TableFromData, { type TableFromDataColumn } from '../TableFromData';
+
+type Row = { id: string; name: string; age: number };
+
+const columns: TableFromDataColumn<Row>[] = [
+  { id: 'name', label: 'Name', render: (d) => d.name },
+  { id: 'age', label: 'Age', render: (d) => d.age },
+];
+
+const makeRows = (n: number): Row[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `r${i}`,
+    name: `name-${i}`,
+    age: i,
+  }));
+
+describe('TableFromData', () => {
+  it('renders the non-virtualized branch when virtualize is not set', () => {
+    customRender(
+      <TableFromData
+        columns={columns}
+        data={makeRows(5)}
+        getRowId={(d) => d.id}
+      />
+    );
+    // All five rows in the DOM since we're not virtualizing.
+    expect(screen.getByText('name-0')).toBeInTheDocument();
+    expect(screen.getByText('name-4')).toBeInTheDocument();
+  });
+
+  it('renders the non-virtualized branch when row count is below threshold even with virtualize=true', () => {
+    customRender(
+      <TableFromData
+        virtualize
+        columns={columns}
+        data={makeRows(50)}
+        getRowId={(d) => d.id}
+      />
+    );
+    // Below the 200 threshold, virtualization is not engaged.
+    // The bounded scroll container (.virtualize-container) should NOT be present.
+    expect(document.querySelector('.virtualize-container')).toBeNull();
+    expect(screen.getByText('name-0')).toBeInTheDocument();
+  });
+
+  it('engages virtualized rendering above the threshold', () => {
+    const data = makeRows(300);
+    customRender(
+      <TableFromData
+        virtualize
+        columns={columns}
+        data={data}
+        getRowId={(d) => d.id}
+        rowExtraContent={(d) => <span>extra-{d.id}</span>}
+      />
+    );
+    // Virtualize container is present.
+    const container = document.querySelector('[class*="virtualize-container"]');
+    expect(container).not.toBeNull();
+  });
+
+  it('passes filter changes through both branches', () => {
+    const filterColumns: TableFromDataColumn<Row>[] = [
+      { id: 'age', label: 'Age', render: (d) => d.age },
+      {
+        id: 'name-filter',
+        label: 'Name',
+        render: (d) => d.name,
+        filter: (d, value) => d.name === value,
+        getOption: (d) => d.name,
+      },
+    ];
+    customRender(
+      <TableFromData
+        columns={filterColumns}
+        data={makeRows(3)}
+        getRowId={(d) => d.id}
+      />
+    );
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'name-1' } });
+    // After filtering, only one body row should remain.
+    const bodyRows = document.querySelectorAll('tbody tr');
+    expect(bodyRows).toHaveLength(1);
+    expect(bodyRows[0]).toHaveTextContent('name-1');
+  });
+
+  it('shows a no-data message when filters exclude all rows', () => {
+    const filterColumns: TableFromDataColumn<Row>[] = [
+      ...columns,
+      {
+        id: 'name-filter',
+        label: 'Name',
+        render: (d) => d.name,
+        filter: () => false,
+        getOption: (d) => d.name,
+      },
+    ];
+    customRender(
+      <TableFromData
+        columns={filterColumns}
+        data={makeRows(3)}
+        getRowId={(d) => d.id}
+      />
+    );
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'name-1' } });
+    expect(
+      screen.getByText(/No data matches selected filters/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/table/__tests__/TableFromData.spec.tsx
+++ b/src/shared/components/table/__tests__/TableFromData.spec.tsx
@@ -42,7 +42,9 @@ describe('TableFromData', () => {
     );
     // Below the 200 threshold, virtualization is not engaged.
     // The bounded scroll container (.virtualize-container) should NOT be present.
-    expect(document.querySelector('.virtualize-container')).toBeNull();
+    expect(
+      document.querySelector('[class*="virtualize-container"]')
+    ).toBeNull();
     expect(screen.getByText('name-0')).toBeInTheDocument();
   });
 

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -150,6 +150,7 @@
 
 .virtualize-container {
   max-height: var(--table-virtualize-max-height, 600px);
+  overflow-y: auto;
 }
 
 .frozen {
@@ -162,9 +163,4 @@
 .virtual-spacer > tr > td {
   padding: 0;
   border: 0;
-}
-
-.virtual-row {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 36px;
 }

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -147,3 +147,24 @@
 .message--no-data {
   margin: 0.5rem;
 }
+
+.virtualize-container {
+  max-height: var(--table-virtualize-max-height, 600px);
+}
+
+.frozen {
+  opacity: 0.6;
+  pointer-events: none;
+  transition: opacity 120ms;
+  will-change: opacity;
+}
+
+.virtual-spacer > tr > td {
+  padding: 0;
+  border: 0;
+}
+
+.virtual-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 36px;
+}

--- a/src/shared/hooks/__tests__/useNightingaleFeatureTableScroll.spec.tsx
+++ b/src/shared/hooks/__tests__/useNightingaleFeatureTableScroll.spec.tsx
@@ -1,0 +1,112 @@
+import { type Virtualizer } from '@tanstack/react-virtual';
+import { renderHook } from '@testing-library/react';
+import { type RefObject } from 'react';
+
+import useNightingaleFeatureTableScroll from '../useNightingaleFeatureTableScroll';
+
+type Item = { id: string };
+
+const getRowId = (i: Item) => i.id;
+const TABLE_ID = 'test-table';
+
+const makeVirtualizerRef = (scrollToIndex: jest.Mock) =>
+  ({
+    current: { scrollToIndex } as unknown as Virtualizer<
+      HTMLDivElement,
+      Element
+    >,
+  }) as RefObject<Virtualizer<HTMLDivElement, Element> | null>;
+
+describe('useNightingaleFeatureTableScroll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns a no-op when the table is not in the DOM', () => {
+    const { result } = renderHook(() =>
+      useNightingaleFeatureTableScroll<Item>(getRowId, TABLE_ID)
+    );
+    expect(() => result.current({ id: 'r1' })).not.toThrow();
+  });
+
+  it('scrolls the row into view when it is mounted in the DOM', () => {
+    const scrollIntoView = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    document.body.innerHTML = `
+      <div>
+        <table id="${TABLE_ID}">
+          <thead><tr><th>head</th></tr></thead>
+          <tbody><tr data-id="r1"><td>row1</td></tr></tbody>
+        </table>
+      </div>
+    `;
+
+    const { result } = renderHook(() =>
+      useNightingaleFeatureTableScroll<Item>(getRowId, TABLE_ID)
+    );
+    result.current({ id: 'r1' });
+    expect(scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'smooth' })
+    );
+  });
+
+  it('falls back to virtualizer.scrollToIndex when the row is not mounted', () => {
+    document.body.innerHTML = `<table id="${TABLE_ID}"></table>`;
+    const scrollToIndex = jest.fn();
+    const data: Item[] = [{ id: 'r1' }, { id: 'r2' }, { id: 'r3' }];
+
+    const { result } = renderHook(() =>
+      useNightingaleFeatureTableScroll<Item>(
+        getRowId,
+        TABLE_ID,
+        makeVirtualizerRef(scrollToIndex),
+        data
+      )
+    );
+    result.current({ id: 'r3' });
+    expect(scrollToIndex).toHaveBeenCalledWith(2, { align: 'center' });
+  });
+
+  it('reads the latest virtualizer ref at call time, not at hook-creation time', () => {
+    document.body.innerHTML = `<table id="${TABLE_ID}"></table>`;
+    const scrollToIndex = jest.fn();
+    const virtualizerRef = {
+      current: null,
+    } as RefObject<Virtualizer<HTMLDivElement, Element> | null>;
+    const data: Item[] = [{ id: 'r1' }];
+
+    const { result } = renderHook(() =>
+      useNightingaleFeatureTableScroll<Item>(
+        getRowId,
+        TABLE_ID,
+        virtualizerRef,
+        data
+      )
+    );
+    // Simulate the child mounting and populating the ref after the parent has
+    // already created the callback closure.
+    virtualizerRef.current = {
+      scrollToIndex,
+    } as unknown as Virtualizer<HTMLDivElement, Element>;
+
+    result.current({ id: 'r1' });
+    expect(scrollToIndex).toHaveBeenCalledWith(0, { align: 'center' });
+  });
+
+  it('does nothing when the row is missing from the data array', () => {
+    document.body.innerHTML = `<table id="${TABLE_ID}"></table>`;
+    const scrollToIndex = jest.fn();
+
+    const { result } = renderHook(() =>
+      useNightingaleFeatureTableScroll<Item>(
+        getRowId,
+        TABLE_ID,
+        makeVirtualizerRef(scrollToIndex),
+        [{ id: 'other' }]
+      )
+    );
+    result.current({ id: 'missing' });
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/hooks/useNightingaleFeatureTableScroll.ts
+++ b/src/shared/hooks/useNightingaleFeatureTableScroll.ts
@@ -1,37 +1,52 @@
-import { useCallback } from 'react';
+import { type Virtualizer } from '@tanstack/react-virtual';
+import { type RefObject, useCallback } from 'react';
 
 function useNightingaleFeatureTableScroll<T>(
   getRowId: (feature: T) => string,
-  tableId: string
+  tableId: string,
+  // The ref (not the instance) is taken so the callback reads the latest
+  // virtualizer at execution time. The instance is set inside a child effect
+  // and isn't observable to the parent on the same render.
+  virtualizerRef?: RefObject<Virtualizer<HTMLDivElement, Element> | null>,
+  data?: T[] | null
 ) {
   return useCallback(
     (feature: T) => {
-      // Select elements based on the feature and tableId
-      const rowSelector = `tr[data-id="${getRowId(feature)}"]`;
+      const rowId = getRowId(feature);
+      const rowSelector = `tr[data-id="${rowId}"]`;
       const tableSelector = `table[id="${tableId}"]`;
       const row = document.querySelector<HTMLElement>(rowSelector);
       const table = document.querySelector<HTMLElement>(tableSelector);
 
-      if (!row || !table) {
-        return; // If we don't have a target row or table, bail early
+      if (!table) {
+        return;
       }
 
-      // Identify table parts and related elements
-      const thead = table.firstElementChild as HTMLElement | null;
-      const container = table.parentElement;
+      if (row) {
+        const thead = table.firstElementChild as HTMLElement | null;
+        const container = table.parentElement;
 
-      // Determine scroll positioning behavior: use nearest if we can offset
-      // for the sticky header height, otherwise fallback to center
-      let block: ScrollLogicalPosition = 'center';
-      if (container && thead) {
-        // Adjust container to account for the sticky header height
-        container.style.scrollPaddingTop = `${thead.offsetHeight}px`;
-        block = 'nearest';
+        let block: ScrollLogicalPosition = 'center';
+        if (container && thead) {
+          // Offset the sticky-header height so 'nearest' lands the row below it
+          container.style.scrollPaddingTop = `${thead.offsetHeight}px`;
+          block = 'nearest';
+        }
+
+        row.scrollIntoView({ behavior: 'smooth', block });
+        return;
       }
 
-      row.scrollIntoView({ behavior: 'smooth', block });
+      // Row isn't currently in the DOM (virtualized off-screen): jump by index.
+      const virtualizer = virtualizerRef?.current;
+      if (virtualizer && data) {
+        const idx = data.findIndex((d) => getRowId(d) === rowId);
+        if (idx >= 0) {
+          virtualizer.scrollToIndex(idx, { align: 'center' });
+        }
+      }
     },
-    [getRowId, tableId]
+    [getRowId, tableId, virtualizerRef, data]
   );
 }
 

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -3,6 +3,7 @@ import {
   type ProteinsAPIVariation,
   transformData,
 } from '@nightingale-elements/nightingale-variation-canvas';
+import { type Virtualizer } from '@tanstack/react-virtual';
 import cn from 'classnames';
 import { EllipsisReveal, Loader } from 'franklin-sites';
 import { filterConfig } from 'protvista-uniprot';
@@ -11,9 +12,11 @@ import {
   lazy,
   type ReactNode,
   Suspense,
+  useCallback,
   useEffect,
   useId,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from 'react';
@@ -24,6 +27,7 @@ import EntryDownloadButton from '../../../../../shared/components/entry/EntryDow
 import EntryDownloadPanel from '../../../../../shared/components/entry/EntryDownloadPanel';
 import ErrorHandler from '../../../../../shared/components/error-pages/ErrorHandler';
 import ExternalLink from '../../../../../shared/components/ExternalLink';
+import tableStyles from '../../../../../shared/components/table/styles/table.module.scss';
 import TableFromData, {
   type TableFromDataColumn,
 } from '../../../../../shared/components/table/TableFromData';
@@ -402,6 +406,40 @@ const RowExtraContent = (data: TransformedVariant) => (
   </Fragment>
 );
 
+type ViewerState = {
+  highlightedVariant: TransformedVariant | undefined;
+  committedViewRange: NightingaleViewRange | undefined;
+  isNavigating: boolean;
+};
+
+type ViewerAction =
+  | { type: 'setHighlight'; variant: TransformedVariant | undefined }
+  | { type: 'navigationStart' }
+  | { type: 'navigationEnd'; viewRange: NightingaleViewRange | undefined };
+
+const initialViewerState: ViewerState = {
+  highlightedVariant: undefined,
+  committedViewRange: undefined,
+  isNavigating: false,
+};
+
+function viewerReducer(state: ViewerState, action: ViewerAction): ViewerState {
+  switch (action.type) {
+    case 'setHighlight':
+      return { ...state, highlightedVariant: action.variant };
+    case 'navigationStart':
+      return state.isNavigating ? state : { ...state, isNavigating: true };
+    case 'navigationEnd':
+      return {
+        ...state,
+        isNavigating: false,
+        committedViewRange: action.viewRange ?? state.committedViewRange,
+      };
+    default:
+      return state;
+  }
+}
+
 type VariationViewProps = {
   importedVariants: number | 'loading';
   primaryAccession: string;
@@ -414,12 +452,16 @@ const VariationViewer = ({
   title,
 }: VariationViewProps) => {
   const isSmallScreen = useSmallScreen();
-  const [highlightedVariant, setHighlightedVariant] =
-    useState<TransformedVariant>();
-  const [nightingaleViewRange, setNightingaleViewRange] =
-    useState<NightingaleViewRange>();
+  const [state, dispatch] = useReducer(viewerReducer, initialViewerState);
+  const { highlightedVariant, committedViewRange, isNavigating } = state;
   const tableId = useId();
-  const tableScroll = useNightingaleFeatureTableScroll(getRowId, tableId);
+
+  const variationTableVirtualizerRef = useRef<Virtualizer<
+    HTMLDivElement,
+    Element
+  > | null>(null);
+  const liveRangeRef = useRef<NightingaleViewRange | undefined>(undefined);
+  const idleTimerRef = useRef<number | undefined>(undefined);
 
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
@@ -432,31 +474,6 @@ const VariationViewer = ({
 
   const [filters, setFilters] = useState<string[]>([]);
   const managerRef = useRef<NightingaleManager>(null);
-  useEffect(() => {
-    const { current: element } = managerRef;
-
-    if (!element) {
-      return;
-    }
-
-    const listener = (event: Event) => {
-      const { detail } = event as CustomEvent;
-      if (detail?.type === 'filters') {
-        setFilters(detail.value);
-      } else if (detail?.eventType === 'click' && detail?.feature) {
-        setHighlightedVariant(detail.feature);
-        tableScroll(detail.feature);
-      } else if (detail?.['display-start'] && detail?.['display-end']) {
-        setNightingaleViewRange(detail);
-      }
-    };
-
-    element.addEventListener('change', listener);
-
-    return () => element.removeEventListener('change', listener);
-  }, [data, tableScroll]);
-  // 'data' is not directly used in the effect, but we know it's when we're
-  // ready to attach the event listener and avoid re-calling this on each render
 
   // We pass the transformed data to both the variation viewer and the
   // data table as ids are set during the transformation - they are
@@ -481,6 +498,127 @@ const VariationViewer = ({
       sortedVariants &&
       applyFilters(sortedVariants as TransformedVariant[], filters),
     [sortedVariants, filters]
+  );
+
+  const tableScroll = useNightingaleFeatureTableScroll(
+    getRowId,
+    tableId,
+    variationTableVirtualizerRef,
+    filteredVariants
+  );
+
+  useEffect(() => {
+    const { current: element } = managerRef;
+
+    if (!element) {
+      return;
+    }
+
+    const listener = (event: Event) => {
+      const { detail } = event as CustomEvent;
+      if (detail?.type === 'filters') {
+        setFilters(detail.value);
+      } else if (detail?.eventType === 'click' && detail?.feature) {
+        dispatch({ type: 'setHighlight', variant: detail.feature });
+        tableScroll(detail.feature);
+      } else if (detail?.['display-start'] && detail?.['display-end']) {
+        liveRangeRef.current = detail;
+        dispatch({ type: 'navigationStart' });
+        if (idleTimerRef.current !== undefined) {
+          window.clearTimeout(idleTimerRef.current);
+        }
+        idleTimerRef.current = window.setTimeout(() => {
+          dispatch({
+            type: 'navigationEnd',
+            viewRange: liveRangeRef.current,
+          });
+          idleTimerRef.current = undefined;
+        }, 150);
+      }
+    };
+
+    element.addEventListener('change', listener);
+
+    return () => {
+      element.removeEventListener('change', listener);
+      if (idleTimerRef.current !== undefined) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = undefined;
+      }
+    };
+    // `data` isn't read here, but it's the signal that the manager has
+    // mounted; including it ensures the listener attaches after load.
+  }, [data, tableScroll]);
+
+  // Pair of complementary signals for navigation lifecycle: pointerdown/up
+  // catch brush drags; the 150ms debounce in the change listener catches
+  // wheel/pinch where there's no clear pointerup. Either signal alone may
+  // miss its case, but together they cover both. Depend on `data` so this
+  // runs after the manager actually mounts (it isn't rendered while loading).
+  useEffect(() => {
+    const manager = managerRef.current;
+    if (!manager) {
+      return undefined;
+    }
+    const onDown = () => dispatch({ type: 'navigationStart' });
+    const onUp = () => {
+      if (idleTimerRef.current !== undefined) {
+        window.clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = undefined;
+      }
+      dispatch({
+        type: 'navigationEnd',
+        viewRange: liveRangeRef.current,
+      });
+    };
+    manager.addEventListener('pointerdown', onDown, { capture: true });
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      manager.removeEventListener('pointerdown', onDown, { capture: true });
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [data]);
+
+  const [tableReady, setTableReady] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    if (typeof window.requestIdleCallback === 'function') {
+      const handle = window.requestIdleCallback(() => setTableReady(true), {
+        timeout: 500,
+      });
+      return () => window.cancelIdleCallback(handle);
+    }
+    const handle = window.setTimeout(() => setTableReady(true), 0);
+    return () => window.clearTimeout(handle);
+  }, []);
+
+  const memoizedColumns = useMemo(
+    () => getColumns(primaryAccession),
+    [primaryAccession]
+  );
+
+  const memoizedMarkBackground = useCallback(
+    (datum: TransformedVariant) =>
+      typeof highlightedVariant?.accession !== 'undefined' &&
+      datum.accession === highlightedVariant.accession,
+    [highlightedVariant?.accession]
+  );
+
+  const memoizedMarkBorder = useCallback(
+    (datum: TransformedVariant) =>
+      Boolean(committedViewRange) &&
+      withinRange(+datum.begin, +datum.end, committedViewRange),
+    [committedViewRange]
+  );
+
+  const handleRowClick = useCallback(
+    (datum: TransformedVariant) =>
+      dispatch({ type: 'setHighlight', variant: datum }),
+    []
   );
 
   if (loading || importedVariants === 'loading') {
@@ -557,22 +695,26 @@ const VariationViewer = ({
           />
         </Suspense>
       </NightingaleManagerComponent>
-      <TableFromData
-        id={tableId}
-        columns={getColumns(primaryAccession)}
-        data={filteredVariants}
-        getRowId={getRowId}
-        onRowClick={setHighlightedVariant}
-        rowExtraContent={RowExtraContent}
-        markBackground={(datum) =>
-          typeof highlightedVariant?.accession !== 'undefined' &&
-          datum.accession === highlightedVariant.accession
-        }
-        markBorder={(datum) =>
-          Boolean(nightingaleViewRange) &&
-          withinRange(+datum.begin, +datum.end, nightingaleViewRange)
-        }
-      />
+      {tableReady && (
+        <div
+          className={cn({
+            [tableStyles.frozen]: isNavigating,
+          })}
+        >
+          <TableFromData
+            id={tableId}
+            virtualize
+            virtualizerRef={variationTableVirtualizerRef}
+            columns={memoizedColumns}
+            data={filteredVariants}
+            getRowId={getRowId}
+            onRowClick={handleRowClick}
+            rowExtraContent={RowExtraContent}
+            markBackground={memoizedMarkBackground}
+            markBorder={memoizedMarkBorder}
+          />
+        </div>
+      )}
     </section>
   );
 };

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/__snapshots__/VariationViewer.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/__snapshots__/VariationViewer.spec.tsx.snap
@@ -17,609 +17,613 @@ exports[`VariationViewer component renders on data 1`] = `
       reflected-attributes="highlight,display-start,display-end,activefilters,filters,selectedid"
       style="display: block; line-height: 0;"
     />
-    <table
-      class="table"
+    <div
+      class=""
     >
-      <thead
-        class=""
+      <table
+        class="table"
       >
-        <tr
-          class="row"
+        <thead
+          class=""
         >
-          <th>
-            <div
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="dropdown"
-            >
-              <button
-                class="button tertiary"
-                type="button"
-              >
-                ±
-              </button>
-            </div>
-          </th>
-          <th>
-            Variant
-            <br />
-            ID(s)
-          </th>
-          <th>
-            Position(s)
-          </th>
-          <th>
-            Change
-          </th>
-          <th>
-            Description
-          </th>
-          <th>
-            Clinical
-            <br />
-            significance
-          </th>
-          <th>
-            Provenance
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class=""
-      >
-        <tr
-          class="row has-extra-content"
-          data-id="0.02"
-        >
-          <td>
-            <button
-              aria-controls="2"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            22
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N22S"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
-              >
-                N&gt;S
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content"
-          hidden=""
-          id="2"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row odd has-extra-content"
-          data-id="0.03"
-        >
-          <td>
-            <button
-              aria-controls="3"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            39-44
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              NK
-              <button
+          <tr
+            class="row"
+          >
+            <th>
+              <div
                 aria-expanded="false"
-                class="button tertiary ellipsis-reveal"
-                title="Show more"
-                type="button"
+                aria-haspopup="true"
+                class="dropdown"
               >
-                [...]
-              </button>
-              &gt;SK
+                <button
+                  class="button tertiary"
+                  type="button"
+                >
+                  ±
+                </button>
+              </div>
+            </th>
+            <th>
+              Variant
+              <br />
+              ID(s)
+            </th>
+            <th>
+              Position(s)
+            </th>
+            <th>
+              Change
+            </th>
+            <th>
+              Description
+            </th>
+            <th>
+              Clinical
+              <br />
+              significance
+            </th>
+            <th>
+              Provenance
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class=""
+        >
+          <tr
+            class="row has-extra-content"
+            data-id="0.02"
+          >
+            <td>
               <button
+                aria-controls="3"
                 aria-expanded="false"
-                class="button tertiary ellipsis-reveal"
-                title="Show more"
                 type="button"
               >
-                [...]
+                +
               </button>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content odd"
-          hidden=""
-          id="3"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row has-extra-content"
-          data-id="0.04"
-        >
-          <td>
-            <button
-              aria-controls="4"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            74
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N74D"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+            </td>
+            <td />
+            <td>
+              22
+            </td>
+            <td>
+              <span
+                class="change"
               >
-                N&gt;D
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content"
-          hidden=""
-          id="4"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row odd has-extra-content"
-          data-id="0.05"
-        >
-          <td>
-            <button
-              aria-controls="5"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            88-89
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              GD&gt;TN
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content odd"
-          hidden=""
-          id="5"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row has-extra-content"
-          data-id="0.06"
-        >
-          <td>
-            <button
-              aria-controls="6"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            98
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N98D"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N22S"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  N&gt;S
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
               >
-                N&gt;D
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content"
-          hidden=""
-          id="6"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row odd has-extra-content"
-          data-id="0.07"
-        >
-          <td>
-            <button
-              aria-controls="7"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            106
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I106L"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
               >
-                I&gt;L
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content odd"
-          hidden=""
-          id="7"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row has-extra-content"
-          data-id="0.08"
-        >
-          <td>
-            <button
-              aria-controls="8"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            120
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I120T"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content"
+            hidden=""
+            id="3"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row odd has-extra-content"
+            data-id="0.03"
+          >
+            <td>
+              <button
+                aria-controls="4"
+                aria-expanded="false"
+                type="button"
               >
-                I&gt;T
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content"
-          hidden=""
-          id="8"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row odd has-extra-content"
-          data-id="0.09"
-        >
-          <td>
-            <button
-              aria-controls="9"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            125
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 M125I"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              39-44
+            </td>
+            <td>
+              <span
+                class="change"
               >
-                M&gt;I
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content odd"
-          hidden=""
-          id="9"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row has-extra-content"
-          data-id="0.1"
-        >
-          <td>
-            <button
-              aria-controls="10"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            133
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 S133N"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                NK
+                <button
+                  aria-expanded="false"
+                  class="button tertiary ellipsis-reveal"
+                  title="Show more"
+                  type="button"
+                >
+                  [...]
+                </button>
+                &gt;SK
+                <button
+                  aria-expanded="false"
+                  class="button tertiary ellipsis-reveal"
+                  title="Show more"
+                  type="button"
+                >
+                  [...]
+                </button>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
               >
-                S&gt;N
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content"
-          hidden=""
-          id="10"
-        >
-          <td />
-        </tr>
-        <tr
-          class="row odd has-extra-content"
-          data-id="0.11"
-        >
-          <td>
-            <button
-              aria-controls="11"
-              aria-expanded="false"
-              type="button"
-            >
-              +
-            </button>
-          </td>
-          <td />
-          <td>
-            267
-          </td>
-          <td>
-            <span
-              class="change"
-            >
-              <a
-                class="external-link"
-                href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 H267N"
-                rel="noopener"
-                target="_blank"
-                title="View in ProtVar"
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
               >
-                H&gt;N
-              </a>
-            </span>
-          </td>
-          <td>
-            <div
-              class="bold"
-            >
-              strain: Type C / C-6814 (UniProt)
-            </div>
-          </td>
-          <td />
-          <td>
-            <span
-              class="bold"
-            >
-              UniProt
-            </span>
-          </td>
-        </tr>
-        <tr
-          class="row extra-content odd"
-          hidden=""
-          id="11"
-        >
-          <td />
-        </tr>
-      </tbody>
-    </table>
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content odd"
+            hidden=""
+            id="4"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row has-extra-content"
+            data-id="0.04"
+          >
+            <td>
+              <button
+                aria-controls="5"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              74
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N74D"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  N&gt;D
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content"
+            hidden=""
+            id="5"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row odd has-extra-content"
+            data-id="0.05"
+          >
+            <td>
+              <button
+                aria-controls="6"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              88-89
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                GD&gt;TN
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content odd"
+            hidden=""
+            id="6"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row has-extra-content"
+            data-id="0.06"
+          >
+            <td>
+              <button
+                aria-controls="7"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              98
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N98D"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  N&gt;D
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content"
+            hidden=""
+            id="7"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row odd has-extra-content"
+            data-id="0.07"
+          >
+            <td>
+              <button
+                aria-controls="8"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              106
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I106L"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  I&gt;L
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content odd"
+            hidden=""
+            id="8"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row has-extra-content"
+            data-id="0.08"
+          >
+            <td>
+              <button
+                aria-controls="9"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              120
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I120T"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  I&gt;T
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content"
+            hidden=""
+            id="9"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row odd has-extra-content"
+            data-id="0.09"
+          >
+            <td>
+              <button
+                aria-controls="10"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              125
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 M125I"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  M&gt;I
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content odd"
+            hidden=""
+            id="10"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row has-extra-content"
+            data-id="0.1"
+          >
+            <td>
+              <button
+                aria-controls="11"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              133
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 S133N"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  S&gt;N
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content"
+            hidden=""
+            id="11"
+          >
+            <td />
+          </tr>
+          <tr
+            class="row odd has-extra-content"
+            data-id="0.11"
+          >
+            <td>
+              <button
+                aria-controls="12"
+                aria-expanded="false"
+                type="button"
+              >
+                +
+              </button>
+            </td>
+            <td />
+            <td>
+              267
+            </td>
+            <td>
+              <span
+                class="change"
+              >
+                <a
+                  class="external-link"
+                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 H267N"
+                  rel="noopener"
+                  target="_blank"
+                  title="View in ProtVar"
+                >
+                  H&gt;N
+                </a>
+              </span>
+            </td>
+            <td>
+              <div
+                class="bold"
+              >
+                strain: Type C / C-6814 (UniProt)
+              </div>
+            </td>
+            <td />
+            <td>
+              <span
+                class="bold"
+              >
+                UniProt
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="row extra-content odd"
+            hidden=""
+            id="12"
+          >
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </DocumentFragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,6 +2937,18 @@
   resolved "https://registry.yarnpkg.com/@swissprot/swissbiopics-visualizer/-/swissbiopics-visualizer-0.0.29.tgz#1532c78ce0481ea1c0856605b3f34cd1c6b66970"
   integrity sha512-p9ee+6ASJlSRepS9yD30WimH0CeuSdKMuZ56Vu2tTrR+kJeqqFhREoDutWWW3io6e0LBukakitfqzXGU58Irlw==
 
+"@tanstack/react-virtual@3.13.24":
+  version "3.13.24"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz#77af3d5dcf77358d805b7b3b06d3221af7bd3f6f"
+  integrity sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==
+  dependencies:
+    "@tanstack/virtual-core" "3.14.0"
+
+"@tanstack/virtual-core@3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz#c8839d0d702b8af47c0e57d4ab72fc3ba8bbf3da"
+  integrity sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==
+
 "@testing-library/dom@10.4.1":
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"


### PR DESCRIPTION
## Purpose

The variation viewer's data table can contain thousands of rows, causing slow renders and scrolling issues. This adds opt-in rowvirtualisation to `TableFromData` so only visible rows are mounted.

## Approach

- Added `@tanstack/react-virtual` and a `virtualize` prop to `TableFromData`; virtualisation only activates above 200 rows to avoid
overhead on small datasets
- Used one `<tbody>` per logical row so `measureElement` captures both the main row and its expandable extra-content row as a unit
- Extended `useNightingaleFeatureTableScroll` to fall back to `virtualizer.scrollToIndex` when a target row is virtualised off-screen
- Refactored `VariationViewer` state to `useReducer`, stabilised callbacks with `useMemo`/`useCallback`, and deferred table mount via `requestIdleCallback` to let the viewer paint first
- Added a `frozen` overlay on the table during Nightingale navigation to suppress re-render churn while panning/zooming

## Testing

- New `TableFromData.spec.tsx`: non-virtualised path, below-threshold no-op, above-threshold container presence, filter changes,
empty-filter message
- New `useNightingaleFeatureTableScroll.spec.tsx`: DOM scroll, virtualiser fallback, stale-ref safety, missing-row no-op
- Updated `VariationViewer` snapshot to reflect the new wrapper div
- Polyfilled `requestIdleCallback`/`cancelIdleCallback` in `jest.setup.ts` for jsdom

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.