### PR TITLE
Address security issues.

### DIFF
--- a/src/help/components/contextual/ContextualHelp.tsx
+++ b/src/help/components/contextual/ContextualHelp.tsx
@@ -57,7 +57,7 @@ const ContextualHelp = () => {
           const target = generatePath(LocationToPath[Location.HelpEntry], {
             accession: element.dataset.articleId,
           });
-          window.open(target.replace('%23', '#'), 'external_help');
+          window.open(target.replaceAll('%23', '#'), 'external_help');
         } else {
           setArticlePath(element.dataset.articleId);
           setDisplayButton(false);

--- a/src/help/components/entry/Entry.tsx
+++ b/src/help/components/entry/Entry.tsx
@@ -38,7 +38,7 @@ import { type HelpEntryResponse } from '../../types/apiModel';
 import RelatedArticles from './RelatedArticles';
 import styles from './styles/entry.module.scss';
 
-const internalRE = /^(https?:)?\/\/www.uniprot.org\//i;
+const internalRE = /^(https?:)?\/\/www\.uniprot\.org\//i;
 const sameAppURL =
   typeof window !== 'undefined'
     ? new RegExp(window.location.origin + BASE_URL, 'i')

--- a/src/jobs/id-mapping/config/IdMappingColumnConfiguration.tsx
+++ b/src/jobs/id-mapping/config/IdMappingColumnConfiguration.tsx
@@ -32,12 +32,19 @@ IdMappingColumnConfiguration.set(IDMappingColumn.from, fromColumnConfig);
 
 const origin = 'https://www.uniprot.org';
 
+const isSameOrigin = (url: string) => {
+  if (url === origin) {
+    return true;
+  }
+  return url.startsWith(`${origin}/`) || url.startsWith(`${origin}?`);
+};
+
 IdMappingColumnConfiguration.set(IDMappingColumn.to, {
   label: 'To',
   render: (row) => {
     const { url, to } = row as MappingTo & MappingFrom;
-    if (url?.startsWith(origin)) {
-      return <Link to={url.replace(origin, '')}>{to}</Link>;
+    if (url && isSameOrigin(url)) {
+      return <Link to={url.slice(origin.length)}>{to}</Link>;
     }
     return <ExternalLink url={url || null}>{to}</ExternalLink>;
   },

--- a/src/shared/hooks/useDataApi.ts
+++ b/src/shared/hooks/useDataApi.ts
@@ -123,7 +123,7 @@ const createReducer =
     }
   };
 
-const botProtectedPatterns = [/www.ebi.ac.uk\/proteins\/api/];
+const botProtectedPatterns = [/www\.ebi\.ac\.uk\/proteins\/api/];
 
 function useDataApi<T>(
   url?: string | null,

--- a/src/shared/utils/logging.ts
+++ b/src/shared/utils/logging.ts
@@ -18,7 +18,7 @@ export const warn: LoggingHelper = (message, context) => {
       level: 'warning',
     });
   } else if (!isTest) {
-    console.warn(message, context);
+    console.warn('%o', message, context);
   }
 };
 
@@ -28,13 +28,13 @@ export const error: LoggingHelper = (message, context) => {
     captureException(message, context);
   }
   if (!isTest) {
-    console.error(message, context);
+    console.error('%o', message, context);
   }
 };
 
 /* istanbul ignore next */
 export const debug: LoggingHelper = (message, context) => {
   if (!isProduction && !isTest) {
-    console.debug(message, context);
+    console.debug('%o', message, context);
   }
 };

--- a/src/shared/utils/tooltip.ts
+++ b/src/shared/utils/tooltip.ts
@@ -6,10 +6,23 @@ import {
   offset,
   shift,
 } from '@floating-ui/dom';
+import sanitizeHtml, { defaults, type IOptions } from 'sanitize-html';
 
 import styles from './styles/tooltip.module.scss';
 
 type StaticSide = 'bottom' | 'left' | 'top' | 'right';
+
+const tooltipSanitizeOptions: IOptions = {
+  allowedTags: [...defaults.allowedTags, 'img'],
+  allowedAttributes: {
+    ...defaults.allowedAttributes,
+    '*': ['id', 'class', 'style', 'data-article-id'],
+    img: ['src', 'alt'],
+    td: ['colspan', 'rowspan'],
+    th: ['colspan', 'rowspan'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto', 'ftp'],
+};
 
 const getTooltip = (content: string) => {
   const tooltip = document.createElement('div');
@@ -17,7 +30,7 @@ const getTooltip = (content: string) => {
   tooltip.className = styles.tooltip;
   const tooltipContent = document.createElement('div');
   tooltipContent.className = styles['tooltip-content'];
-  tooltipContent.innerHTML = content;
+  tooltipContent.innerHTML = sanitizeHtml(content, tooltipSanitizeOptions);
   tooltip.appendChild(tooltipContent);
   const arrowElement = document.createElement('div');
   arrowElement.className = styles.arrow;

--- a/src/uniprotkb/components/entry/homologs/__tests__/AgrOrthology.spec.tsx
+++ b/src/uniprotkb/components/entry/homologs/__tests__/AgrOrthology.spec.tsx
@@ -14,7 +14,7 @@ import mockData from './__mocks__/agr-orthologs';
 
 const mock = new MockAdapter(axios);
 mock
-  .onGet(/www.alliancegenome.org\/api\/gene\/HGNC:620\/orthologs/)
+  .onGet(/www\.alliancegenome\.org\/api\/gene\/HGNC:620\/orthologs/)
   .reply(200, mockData, { 'x-total-results': 0 });
 
 describe('AgrOrthology', () => {

--- a/src/uniprotkb/components/entry/homologs/__tests__/AgrParalogy.spec.tsx
+++ b/src/uniprotkb/components/entry/homologs/__tests__/AgrParalogy.spec.tsx
@@ -9,7 +9,7 @@ import mockData from './__mocks__/agr-paralogs';
 
 const mock = new MockAdapter(axios);
 mock
-  .onGet(/www.alliancegenome.org\/api\/gene\/HGNC:620\/paralogs/)
+  .onGet(/www\.alliancegenome\.org\/api\/gene\/HGNC:620\/paralogs/)
   .reply(200, mockData, { 'x-total-results': 0 });
 
 describe('AgrOrthology', () => {


### PR DESCRIPTION
## Purpose

Reduce security vulnerabilities:

- `js/incomplete-sanitization` — `ContextualHelp` only un-encoded the first `%23`
- `js/incomplete-hostname-regexp` — unescaped `.` in hostname regexes (`help/Entry`, `useDataApi`, two Agr `__tests__`)
- `js/incomplete-url-substring-sanitization` — id-mapping treated `https://www.uniprot.org.evil/...` as same-origin
- `js/tainted-format-string` — `logging.warn` passed a user value as the `console.warn` format string
- `js/xss-through-dom` — tooltip util wrote unsanitized HTML into `innerHTML`

## Approach

- `ContextualHelp`: `.replace('%23', '#')` → `.replaceAll('%23', '#')`
- Hostname regexes: escape every `.` (e.g. `www\.uniprot\.org`, `www\.ebi\.ac\.uk`, `www\.alliancegenome\.org`)
- `IdMappingColumnConfiguration`: added `isSameOrigin` requiring the origin to be followed by `/`, `?`, or end-of-string; switched the
 path extraction from `replace` to `slice`
- `logging`: moved the user value out of the format-string position by prefixing with the literal `'%o'` in `warn`, `error`, and `debug`
- `tooltip`: route `content` through `sanitize-html` before assigning to `innerHTML`, with an allowlist matching the HTML actually
emitted by nightingale/`protvista-uniprot` tooltips (`h4`–`h6`, `hr`, `p`, `ul`, `li`, `a`, `class`, `id`, `style`, `data-article-id`)

## Testing

Updated as needed.
## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.