### PR TITLE
Proteome similarity percentages in proteomes entry pages

### DIFF
--- a/src/proteomes/adapters/proteomesConverter.ts
+++ b/src/proteomes/adapters/proteomesConverter.ts
@@ -73,7 +73,7 @@ export type ProteomeType =
   | 'Reference and representative proteome'
   | 'Reference proteome'
   | 'Representative proteome'
-  | 'Non-reference proteome'
+  | 'Non Reference proteome'
   | 'Redundant proteome'
   | 'Other proteome'
   | 'Excluded';

--- a/src/proteomes/adapters/proteomesConverter.ts
+++ b/src/proteomes/adapters/proteomesConverter.ts
@@ -58,15 +58,22 @@ export type GenomeAssembly = {
   level: string; // Genome representation
 };
 
-export type RedundantProteome = {
-  id: string;
+export type RelatedProteome = {
+  proteomeId: string;
   similarity: number;
+  taxonomy: Pick<TaxonomyDatum, 'taxonId'>;
+};
+
+export type ResolvedRelatedProteome = RelatedProteome & {
+  scientificName?: string;
+  proteomeType?: ProteomeType;
 };
 
 export type ProteomeType =
   | 'Reference and representative proteome'
   | 'Reference proteome'
   | 'Representative proteome'
+  | 'Non Reference proteome'
   | 'Redundant proteome'
   | 'Other proteome'
   | 'Excluded';
@@ -90,22 +97,38 @@ export type ProteomesAPIModel = {
   isolate?: string;
   panproteome?: string;
   description: string;
-  redundantProteomes?: RedundantProteome[];
+  relatedProteomes?: RelatedProteome[];
   redundantTo?: string;
   proteinCount: number; // use this in the results table - calculated sum of the components proteinCount: components.reduce((total, { proteinCount }) => proteinCount + total, 0)
   proteomeStatistics: Statistics;
 };
 
-export type ProteomesUIModel = Omit<ProteomesAPIModel, 'panproteome'> & {
+export type ProteomesUIModel = Omit<
+  ProteomesAPIModel,
+  'panproteome' | 'relatedProteomes'
+> & {
   panproteome: ProteomesAPIModel['panproteome'] | ProteomesAPIModel;
+  relatedProteomes?: ResolvedRelatedProteome[];
 };
 
 const proteomesConverter = (
   data: ProteomesAPIModel,
-  panProteomeData?: ProteomesAPIModel
-): ProteomesUIModel => ({
-  ...data,
-  panproteome: panProteomeData || data.panproteome,
-});
+  panProteomeData?: ProteomesAPIModel,
+  similarProteomesData?: ProteomesAPIModel[]
+): ProteomesUIModel => {
+  const dataById = new Map(similarProteomesData?.map((p) => [p.id, p]));
+  return {
+    ...data,
+    panproteome: panProteomeData || data.panproteome,
+    relatedProteomes: data.relatedProteomes?.map((rp) => {
+      const resolved = dataById.get(rp.proteomeId);
+      return {
+        ...rp,
+        scientificName: resolved?.taxonomy?.scientificName,
+        proteomeType: resolved?.proteomeType,
+      };
+    }),
+  };
+};
 
 export default proteomesConverter;

--- a/src/proteomes/adapters/proteomesConverter.ts
+++ b/src/proteomes/adapters/proteomesConverter.ts
@@ -64,7 +64,7 @@ export type RelatedProteome = {
   taxonomy: Pick<TaxonomyDatum, 'taxonId'>;
 };
 
-export type ResolvedRelatedProteome = RelatedProteome & {
+export type EnrichedRelatedProteome = RelatedProteome & {
   scientificName?: string;
   proteomeType?: ProteomeType;
 };
@@ -73,7 +73,7 @@ export type ProteomeType =
   | 'Reference and representative proteome'
   | 'Reference proteome'
   | 'Representative proteome'
-  | 'Non Reference proteome'
+  | 'Non-reference proteome'
   | 'Redundant proteome'
   | 'Other proteome'
   | 'Excluded';
@@ -108,7 +108,7 @@ export type ProteomesUIModel = Omit<
   'panproteome' | 'relatedProteomes'
 > & {
   panproteome: ProteomesAPIModel['panproteome'] | ProteomesAPIModel;
-  relatedProteomes?: ResolvedRelatedProteome[];
+  relatedProteomes?: EnrichedRelatedProteome[];
 };
 
 const proteomesConverter = (

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -20,6 +20,7 @@ import {
   Namespace,
   searchableNamespaceLabels,
 } from '../../../shared/types/namespaces';
+import { type SearchResults } from '../../../shared/types/results';
 import generatePageTitle from '../../adapters/generatePageTitle';
 import proteomesConverter, {
   type ProteomesAPIModel,
@@ -44,11 +45,30 @@ const Entry = () => {
       : null
   );
 
+  const relatedProteomes = mainData.data?.relatedProteomes;
+  const similarProteomesData = useDataApi<SearchResults<ProteomesAPIModel>>(
+    relatedProteomes?.length
+      ? apiUrls.search.search({
+          namespace: Namespace.proteomes,
+          query: relatedProteomes
+            .map(({ proteomeId }) => `upid:${proteomeId}`)
+            .join(' OR '),
+          size: relatedProteomes.length,
+          facets: null,
+        })
+      : null
+  );
+
   const refprotmoveData = useDataApi<ProteomesCheckMoveResponse>(
     accession ? joinUrl(checkMoveUrl, 'proteomes', accession) : null
   );
 
-  if (mainData.loading || panProteomeData.loading || refprotmoveData.loading) {
+  if (
+    mainData.loading ||
+    panProteomeData.loading ||
+    similarProteomesData.loading ||
+    refprotmoveData.loading
+  ) {
     return <Loader progress={mainData.progress || panProteomeData.progress} />;
   }
 
@@ -64,7 +84,8 @@ const Entry = () => {
 
   const transformedData = proteomesConverter(
     mainData.data,
-    panProteomeData.data
+    panProteomeData.data,
+    similarProteomesData.data?.results
   );
 
   const moveStatus = refprotmoveData.data?.status;

--- a/src/proteomes/components/entry/Entry.tsx
+++ b/src/proteomes/components/entry/Entry.tsx
@@ -69,7 +69,7 @@ const Entry = () => {
     similarProteomesData.loading ||
     refprotmoveData.loading
   ) {
-    return <Loader progress={mainData.progress || panProteomeData.progress} />;
+    return <Loader progress={mainData.progress || similarProteomesData.progress || panProteomeData.progress} />;
   }
 
   if (mainData.error || panProteomeData.error || !accession || !mainData.data) {

--- a/src/proteomes/components/entry/Publications.tsx
+++ b/src/proteomes/components/entry/Publications.tsx
@@ -1,14 +1,20 @@
-import { DataList } from 'franklin-sites';
+import { Card, DataList } from 'franklin-sites';
 import { useMemo } from 'react';
 
 import { Namespace } from '../../../shared/types/namespaces';
 import { getIdKeyForNamespace } from '../../../shared/utils/getIdKey';
 import { type CitationsAPIModel } from '../../../supporting-data/citations/adapters/citationsConverter';
-import CitationsCard from '../../../supporting-data/citations/components/results/CitationsCard';
+import LiteratureCitation from '../../../supporting-data/citations/components/LiteratureCitation';
 import { type ProteomesAPIModel } from '../../adapters/proteomesConverter';
+import styles from '../styles/publications.module.scss';
 
 const dataRenderer = (citation: CitationsAPIModel) => (
-  <CitationsCard data={citation} headingLevel="h3" notSelectable />
+  <LiteratureCitation
+    data={citation}
+    headingLevel="h3"
+    linkToEntry
+    className={styles['inline-publication']}
+  />
 );
 
 const getIdKey = getIdKeyForNamespace(Namespace.citations);
@@ -30,10 +36,9 @@ const Publications = ({
   }
 
   return (
-    <section>
-      <h2>Publications</h2>
+    <Card header={<h2>Publications</h2>}>
       <DataList getIdKey={getIdKey} data={data} dataRenderer={dataRenderer} />
-    </section>
+    </Card>
   );
 };
 

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -142,7 +142,9 @@ const SimilarProteomes = ({
     <Card
       header={
         <h2>
-          <span data-article-id={HELP_ARTICLE_ID}>Proteome similarity</span>{' '}
+          <span data-article-id={HELP_ARTICLE_ID}>
+            Similar reference proteomes
+          </span>{' '}
           <Chip compact>New</Chip>
         </h2>
       }

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -38,7 +38,7 @@ const columns: Array<{
     ),
   },
   {
-    label: 'Similarity score',
+    label: 'Similarity percentage',
     name: 'similarity',
     render: ({ similarity }) => `${(similarity * 100).toFixed(1)}%`,
   },

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -129,7 +129,7 @@ const SimilarProteomes = ({
   } else if (proteomeType === 'Excluded') {
     body = <ExcludedPlaceholder exclusionReasons={exclusionReasons} />;
   } else if (
-    proteomeType === 'Reference proteome' ||
+    proteomeType === 'Reference proteome'
     proteomeType === 'Reference and representative proteome' ||
     proteomeType === 'Representative proteome'
   ) {

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -50,7 +50,7 @@ const ExcludedPlaceholder = ({
   exclusionReasons?: string[];
 }) => (
   <p>
-    No similarity score is available because this proteome has been{' '}
+    No similar proteomes are available because this proteome has been{' '}
     <span data-article-id="proteome_exclusion_reasons">excluded</span>
     {exclusionReasons?.length ? <> ({exclusionReasons.join(', ')})</> : null}.
   </p>
@@ -58,7 +58,7 @@ const ExcludedPlaceholder = ({
 
 const ReferencePlaceholder = () => (
   <p data-article-id={HELP_ARTICLE_ID}>
-    No similarity score is available for this proteome. This is typically
+    No similar proteome is available for this proteome. This is typically
     because the proteome is the only one for its species, or because no other
     reference proteome is similar enough to be listed here.
   </p>
@@ -67,8 +67,8 @@ const ReferencePlaceholder = () => (
 const GenericPlaceholder = () => (
   <>
     <p data-article-id={HELP_ARTICLE_ID}>
-      No similarity score is available for this proteome. A proteome may not
-      have a similarity score for one of the following reasons:
+      No similar proteome is available for this proteome. A proteome may not
+      have a similar proteome for one of the following reasons:
     </p>
     <ul>
       <li>

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -5,19 +5,19 @@ import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
 import AccessionView from '../../../shared/components/results/AccessionView';
 import { Namespace } from '../../../shared/types/namespaces';
 import {
+  type EnrichedRelatedProteome,
   type ProteomeType,
-  type ResolvedRelatedProteome,
 } from '../../adapters/proteomesConverter';
 import styles from '../styles/similar-proteomes.module.scss';
 
 const HELP_ARTICLE_ID = 'proteome_similarity';
 
-const getIdKey = ({ proteomeId }: ResolvedRelatedProteome) => proteomeId;
+const getIdKey = ({ proteomeId }: EnrichedRelatedProteome) => proteomeId;
 
 const columns: Array<{
   label: ReactNode;
   name: string;
-  render: (rp: ResolvedRelatedProteome) => ReactNode;
+  render: (rp: EnrichedRelatedProteome) => ReactNode;
 }> = [
   {
     label: 'Proteome',
@@ -99,7 +99,7 @@ const GenericPlaceholder = () => (
 );
 
 type Props = {
-  relatedProteomes?: ResolvedRelatedProteome[];
+  relatedProteomes?: EnrichedRelatedProteome[];
   proteomeType: ProteomeType;
   exclusionReasons?: string[];
 };
@@ -128,11 +128,7 @@ const SimilarProteomes = ({
     );
   } else if (proteomeType === 'Excluded') {
     body = <ExcludedPlaceholder exclusionReasons={exclusionReasons} />;
-  } else if (
-    proteomeType === 'Reference proteome'
-    proteomeType === 'Reference and representative proteome' ||
-    proteomeType === 'Representative proteome'
-  ) {
+  } else if (proteomeType === 'Reference proteome') {
     body = <ReferencePlaceholder />;
   } else {
     body = <GenericPlaceholder />;

--- a/src/proteomes/components/entry/SimilarProteomes.tsx
+++ b/src/proteomes/components/entry/SimilarProteomes.tsx
@@ -1,0 +1,155 @@
+import { Card, Chip, DataTable } from 'franklin-sites';
+import { type ReactNode, useMemo } from 'react';
+
+import TaxonomyView from '../../../shared/components/entry/TaxonomyView';
+import AccessionView from '../../../shared/components/results/AccessionView';
+import { Namespace } from '../../../shared/types/namespaces';
+import {
+  type ProteomeType,
+  type ResolvedRelatedProteome,
+} from '../../adapters/proteomesConverter';
+import styles from '../styles/similar-proteomes.module.scss';
+
+const HELP_ARTICLE_ID = 'proteome_similarity';
+
+const getIdKey = ({ proteomeId }: ResolvedRelatedProteome) => proteomeId;
+
+const columns: Array<{
+  label: ReactNode;
+  name: string;
+  render: (rp: ResolvedRelatedProteome) => ReactNode;
+}> = [
+  {
+    label: 'Proteome',
+    name: 'proteome_id',
+    render: ({ proteomeId, proteomeType }) => (
+      <AccessionView
+        id={proteomeId}
+        namespace={Namespace.proteomes}
+        entryType={proteomeType}
+      />
+    ),
+  },
+  {
+    label: 'Organism',
+    name: 'organism',
+    render: ({ taxonomy, scientificName }) => (
+      <TaxonomyView data={{ taxonId: taxonomy.taxonId, scientificName }} />
+    ),
+  },
+  {
+    label: 'Similarity score',
+    name: 'similarity',
+    render: ({ similarity }) => `${(similarity * 100).toFixed(1)}%`,
+  },
+];
+
+const ExcludedPlaceholder = ({
+  exclusionReasons,
+}: {
+  exclusionReasons?: string[];
+}) => (
+  <p>
+    No similarity score is available because this proteome has been{' '}
+    <span data-article-id="proteome_exclusion_reasons">excluded</span>
+    {exclusionReasons?.length ? <> ({exclusionReasons.join(', ')})</> : null}.
+  </p>
+);
+
+const ReferencePlaceholder = () => (
+  <p data-article-id={HELP_ARTICLE_ID}>
+    No similarity score is available for this proteome. This is typically
+    because the proteome is the only one for its species, or because no other
+    reference proteome is similar enough to be listed here.
+  </p>
+);
+
+const GenericPlaceholder = () => (
+  <>
+    <p data-article-id={HELP_ARTICLE_ID}>
+      No similarity score is available for this proteome. A proteome may not
+      have a similarity score for one of the following reasons:
+    </p>
+    <ul>
+      <li>
+        The proteome has been{' '}
+        <span data-article-id="proteome_exclusion_reasons">excluded</span>;
+      </li>
+      <li>
+        Novel proteomes from surveillance projects are not currently considered
+        for promotion to a reference proteome, and therefore the species might
+        not have reference proteomes;
+      </li>
+      <li>
+        Novel proteomes from metagenome assemblies are not currently considered
+        for promotion to a reference proteome, and therefore the species might
+        not have reference proteomes;
+      </li>
+      <li>
+        Novel proteomes from organisms with the status &lsquo;Candidatus&rsquo;
+        are not currently considered for promotion to a reference proteome;
+      </li>
+      <li>The proteome belongs to a taxonomically undefined species;</li>
+      <li>
+        The proteome is the only one for that species (N.B. being the only one
+        automatically makes it a reference proteome).
+      </li>
+    </ul>
+  </>
+);
+
+type Props = {
+  relatedProteomes?: ResolvedRelatedProteome[];
+  proteomeType: ProteomeType;
+  exclusionReasons?: string[];
+};
+
+const SimilarProteomes = ({
+  relatedProteomes,
+  proteomeType,
+  exclusionReasons,
+}: Props) => {
+  const sorted = useMemo(
+    () => relatedProteomes?.slice().sort((a, b) => b.similarity - a.similarity),
+    [relatedProteomes]
+  );
+
+  let body: ReactNode;
+  if (sorted?.length) {
+    body = (
+      <div className={styles.table}>
+        <DataTable
+          getIdKey={getIdKey}
+          density="compact"
+          columns={columns}
+          data={sorted}
+        />
+      </div>
+    );
+  } else if (proteomeType === 'Excluded') {
+    body = <ExcludedPlaceholder exclusionReasons={exclusionReasons} />;
+  } else if (
+    proteomeType === 'Reference proteome' ||
+    proteomeType === 'Reference and representative proteome' ||
+    proteomeType === 'Representative proteome'
+  ) {
+    body = <ReferencePlaceholder />;
+  } else {
+    body = <GenericPlaceholder />;
+  }
+
+  return (
+    <Card
+      header={
+        <h2>
+          <span data-article-id={HELP_ARTICLE_ID}>Proteome similarity</span>{' '}
+          <Chip compact>New</Chip>
+        </h2>
+      }
+    >
+      {body}
+    </Card>
+  );
+};
+
+export default SimilarProteomes;

--- a/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
@@ -1,0 +1,101 @@
+import { screen } from '@testing-library/react';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
+import { type ResolvedRelatedProteome } from '../../../adapters/proteomesConverter';
+import SimilarProteomes from '../SimilarProteomes';
+
+const sample: ResolvedRelatedProteome[] = [
+  {
+    proteomeId: 'UP000000001',
+    similarity: 0.72,
+    taxonomy: { taxonId: 11 },
+    scientificName: 'Foo species',
+  },
+  {
+    proteomeId: 'UP000000002',
+    similarity: 0.91,
+    taxonomy: { taxonId: 22 },
+    scientificName: 'Bar species',
+  },
+];
+
+describe('SimilarProteomes', () => {
+  it('renders the reference-specific placeholder for a Reference proteome with no data', () => {
+    customRender(<SimilarProteomes proteomeType="Reference proteome" />);
+    expect(
+      screen.getByText(
+        /typically because the proteome is the only one for its species/
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/taxonomically undefined species/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the generic placeholder for a Non Reference proteome with no data', () => {
+    customRender(<SimilarProteomes proteomeType="Non Reference proteome" />);
+    expect(
+      screen.getByText(/No similarity score is available for this proteome/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/taxonomically undefined species/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the generic placeholder when relatedProteomes is empty', () => {
+    customRender(
+      <SimilarProteomes
+        proteomeType="Non Reference proteome"
+        relatedProteomes={[]}
+      />
+    );
+    expect(
+      screen.getByText(/No similarity score is available for this proteome/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders an excluded-specific placeholder when proteomeType is Excluded', () => {
+    customRender(
+      <SimilarProteomes
+        proteomeType="Excluded"
+        exclusionReasons={['over-represented proteome']}
+      />
+    );
+    expect(screen.getByText(/this proteome has been/)).toBeInTheDocument();
+    expect(screen.getByText(/over-represented proteome/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/taxonomically undefined species/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a row per related proteome, sorted by similarity desc', () => {
+    customRender(
+      <SimilarProteomes
+        proteomeType="Non Reference proteome"
+        relatedProteomes={sample}
+      />
+    );
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveTextContent('UP000000002');
+    expect(screen.getByText('91.0%')).toBeInTheDocument();
+    expect(screen.getByText('72.0%')).toBeInTheDocument();
+    expect(screen.getByText('Bar species')).toBeInTheDocument();
+    expect(screen.getByText('Foo species')).toBeInTheDocument();
+  });
+
+  it('falls back to the taxon ID when scientificName is missing', () => {
+    customRender(
+      <SimilarProteomes
+        proteomeType="Non Reference proteome"
+        relatedProteomes={[
+          {
+            proteomeId: 'UP000000003',
+            similarity: 0.5,
+            taxonomy: { taxonId: 33 },
+          },
+        ]}
+      />
+    );
+    expect(screen.getByRole('link', { name: '33' })).toBeInTheDocument();
+  });
+});

--- a/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
@@ -1,10 +1,10 @@
 import { screen } from '@testing-library/react';
 
 import customRender from '../../../../shared/__test-helpers__/customRender';
-import { type ResolvedRelatedProteome } from '../../../adapters/proteomesConverter';
+import { type EnrichedRelatedProteome } from '../../../adapters/proteomesConverter';
 import SimilarProteomes from '../SimilarProteomes';
 
-const sample: ResolvedRelatedProteome[] = [
+const sample: EnrichedRelatedProteome[] = [
   {
     proteomeId: 'UP000000001',
     similarity: 0.72,
@@ -33,7 +33,7 @@ describe('SimilarProteomes', () => {
   });
 
   it('renders the generic placeholder for a Non Reference proteome with no data', () => {
-    customRender(<SimilarProteomes proteomeType="Non Reference proteome" />);
+    customRender(<SimilarProteomes proteomeType="Non-reference proteome" />);
     expect(
       screen.getByText(/No similar proteome is available for this proteome/)
     ).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('SimilarProteomes', () => {
   it('renders the generic placeholder when relatedProteomes is empty', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non Reference proteome"
+        proteomeType="Non-reference proteome"
         relatedProteomes={[]}
       />
     );
@@ -71,7 +71,7 @@ describe('SimilarProteomes', () => {
   it('renders a row per related proteome, sorted by similarity desc', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non Reference proteome"
+        proteomeType="Non-reference proteome"
         relatedProteomes={sample}
       />
     );
@@ -86,7 +86,7 @@ describe('SimilarProteomes', () => {
   it('falls back to the taxon ID when scientificName is missing', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non Reference proteome"
+        proteomeType="Non-reference proteome"
         relatedProteomes={[
           {
             proteomeId: 'UP000000003',

--- a/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
@@ -33,7 +33,7 @@ describe('SimilarProteomes', () => {
   });
 
   it('renders the generic placeholder for a Non Reference proteome with no data', () => {
-    customRender(<SimilarProteomes proteomeType="Non-reference proteome" />);
+    customRender(<SimilarProteomes proteomeType="Non Reference proteome" />);
     expect(
       screen.getByText(/No similar proteome is available for this proteome/)
     ).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('SimilarProteomes', () => {
   it('renders the generic placeholder when relatedProteomes is empty', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non-reference proteome"
+        proteomeType="Non Reference proteome"
         relatedProteomes={[]}
       />
     );
@@ -71,7 +71,7 @@ describe('SimilarProteomes', () => {
   it('renders a row per related proteome, sorted by similarity desc', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non-reference proteome"
+        proteomeType="Non Reference proteome"
         relatedProteomes={sample}
       />
     );
@@ -86,7 +86,7 @@ describe('SimilarProteomes', () => {
   it('falls back to the taxon ID when scientificName is missing', () => {
     customRender(
       <SimilarProteomes
-        proteomeType="Non-reference proteome"
+        proteomeType="Non Reference proteome"
         relatedProteomes={[
           {
             proteomeId: 'UP000000003',

--- a/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
+++ b/src/proteomes/components/entry/__tests__/SimilarProteomes.spec.tsx
@@ -35,7 +35,7 @@ describe('SimilarProteomes', () => {
   it('renders the generic placeholder for a Non Reference proteome with no data', () => {
     customRender(<SimilarProteomes proteomeType="Non Reference proteome" />);
     expect(
-      screen.getByText(/No similarity score is available for this proteome/)
+      screen.getByText(/No similar proteome is available for this proteome/)
     ).toBeInTheDocument();
     expect(
       screen.getByText(/taxonomically undefined species/)
@@ -50,7 +50,7 @@ describe('SimilarProteomes', () => {
       />
     );
     expect(
-      screen.getByText(/No similarity score is available for this proteome/)
+      screen.getByText(/No similar proteome is available for this proteome/)
     ).toBeInTheDocument();
   });
 

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5960,8 +5960,34 @@ exports[`EntryMain view should render 1`] = `
         <p
           data-article-id="proteome_similarity"
         >
-          No similar proteome is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
+          No similar proteome is available for this proteome. A proteome may not have a similar proteome for one of the following reasons:
         </p>
+        <ul>
+          <li>
+            The proteome has been 
+            <span
+              data-article-id="proteome_exclusion_reasons"
+            >
+              excluded
+            </span>
+            ;
+          </li>
+          <li>
+            Novel proteomes from surveillance projects are not currently considered for promotion to a reference proteome, and therefore the species might not have reference proteomes;
+          </li>
+          <li>
+            Novel proteomes from metagenome assemblies are not currently considered for promotion to a reference proteome, and therefore the species might not have reference proteomes;
+          </li>
+          <li>
+            Novel proteomes from organisms with the status ‘Candidatus’ are not currently considered for promotion to a reference proteome;
+          </li>
+          <li>
+            The proteome belongs to a taxonomically undefined species;
+          </li>
+          <li>
+            The proteome is the only one for that species (N.B. being the only one automatically makes it a reference proteome).
+          </li>
+        </ul>
       </div>
     </div>
   </section>

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -5960,7 +5960,7 @@ exports[`EntryMain view should render 1`] = `
         <p
           data-article-id="proteome_similarity"
         >
-          No similarity score is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
+          No similar proteome is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
         </p>
       </div>
     </div>

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -32,41 +32,6 @@ exports[`EntryMain view should render 1`] = `
         class="card__header card__header--with-separator"
       >
         <h2>
-          <span
-            data-article-id="proteome_similarity"
-          >
-            Proteome similarity
-          </span>
-           
-          <button
-            class="chip chip--compact"
-            type="button"
-          >
-            New
-          </button>
-        </h2>
-      </div>
-      <div
-        class="card__content"
-      >
-        <p
-          data-article-id="proteome_similarity"
-        >
-          No similarity score is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
-        </p>
-      </div>
-    </div>
-  </section>
-  <section
-    class="card"
-  >
-    <div
-      class="card__container"
-    >
-      <div
-        class="card__header card__header--with-separator"
-      >
-        <h2>
           Components
         </h2>
       </div>
@@ -1387,5033 +1352,4618 @@ exports[`EntryMain view should render 1`] = `
       </div>
     </div>
   </section>
-  <section>
-    <h2>
-      Publications
-    </h2>
-    <ul
-      class="data-list no-bullet"
+  <section
+    class="card"
+  >
+    <div
+      class="card__container"
     >
-      <li>
-        <section
-          class="card"
+      <div
+        class="card__header card__header--with-separator"
+      >
+        <h2>
+          Publications
+        </h2>
+      </div>
+      <div
+        class="card__content"
+      >
+        <ul
+          class="data-list no-bullet"
         >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/23932108"
+                    >
+                      Mapping the human reference genome's missing sequence by three-way admixture in Latino genomes.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Genovese+G.%22"
+                    >
+                      Genovese G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Handsaker+R.E.%22"
+                    >
+                      Handsaker R.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Li+H.%22"
+                    >
+                      Li H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kenny+E.E.%22"
+                    >
+                      Kenny E.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McCarroll+S.A.%22"
+                    >
+                      McCarroll S.A.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/23932108"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/23932108"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Mapping the human reference genome's missing sequence by three-way admixture in Latino genomes.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Genovese+G.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/23932108"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Genovese G.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Handsaker+R.E.%22"
-                        >
-                          Handsaker R.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Li+H.%22"
-                        >
-                          Li H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kenny+E.E.%22"
-                        >
-                          Kenny E.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McCarroll+S.A.%22"
-                        >
-                          McCarroll S.A.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/23932108"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1016/j.ajhg.2013.07.002"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Am. J. Hum. Genet. 93:411-421 (
+                            <time
+                              datetime="2013-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/23932108"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1016/j.ajhg.2013.07.002"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Am. J. Hum. Genet. 93:411-421 (
-                                <time
-                                  datetime="2013-01-01T00:00:00.000Z"
-                                >
-                                  2013
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2013
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/18477386"
+                    >
+                      Finishing the finished human chromosome 22 sequence.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cole+C.G.%22"
+                    >
+                      Cole C.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McCann+O.T.%22"
+                    >
+                      McCann O.T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Collins+J.E.%22"
+                    >
+                      Collins J.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Oliver+K.%22"
+                    >
+                      Oliver K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Willey+D.%22"
+                    >
+                      Willey D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gribble+S.M.%22"
+                    >
+                      Gribble S.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Yang+F.%22"
+                    >
+                      Yang F.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McLaren+K.%22"
+                    >
+                      McLaren K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
+                    >
+                      Rogers J.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dunham+I.%22"
+                    >
+                      Dunham I.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/18477386"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/18477386"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Finishing the finished human chromosome 22 sequence.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Cole+C.G.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/18477386"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Cole C.G.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McCann+O.T.%22"
-                        >
-                          McCann O.T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Collins+J.E.%22"
-                        >
-                          Collins J.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Oliver+K.%22"
-                        >
-                          Oliver K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Willey+D.%22"
-                        >
-                          Willey D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gribble+S.M.%22"
-                        >
-                          Gribble S.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Yang+F.%22"
-                        >
-                          Yang F.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McLaren+K.%22"
-                        >
-                          McLaren K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
-                        >
-                          Rogers J.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dunham+I.%22"
-                        >
-                          Dunham I.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/18477386"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1186/gb-2008-9-5-r78"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Genome Biol. 9:R78-R78 (
+                            <time
+                              datetime="2008-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/18477386"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1186/gb-2008-9-5-r78"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Genome Biol. 9:R78-R78 (
-                                <time
-                                  datetime="2008-01-01T00:00:00.000Z"
-                                >
-                                  2008
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2008
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/10508508"
+                    >
+                      Reanalysis and revision of the Cambridge reference sequence for human mitochondrial DNA.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Andrews+R.M.%22"
+                    >
+                      Andrews R.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kubacka+I.%22"
+                    >
+                      Kubacka I.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chinnery+P.F.%22"
+                    >
+                      Chinnery P.F.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lightowlers+R.N.%22"
+                    >
+                      Lightowlers R.N.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Turnbull+D.M.%22"
+                    >
+                      Turnbull D.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Howell+N.%22"
+                    >
+                      Howell N.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/10508508"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/10508508"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Reanalysis and revision of the Cambridge reference sequence for human mitochondrial DNA.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Andrews+R.M.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/10508508"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Andrews R.M.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kubacka+I.%22"
-                        >
-                          Kubacka I.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chinnery+P.F.%22"
-                        >
-                          Chinnery P.F.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lightowlers+R.N.%22"
-                        >
-                          Lightowlers R.N.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Turnbull+D.M.%22"
-                        >
-                          Turnbull D.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Howell+N.%22"
-                        >
-                          Howell N.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/10508508"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/13779"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nat Genet 23:147-147 (
+                            <time
+                              datetime="1999-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/10508508"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/13779"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nat Genet 23:147-147 (
-                                <time
-                                  datetime="1999-01-01T00:00:00.000Z"
-                                >
-                                  1999
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              1999
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/23435088"
+                    >
+                      Using population admixture to help complete maps of the human genome.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Genovese+G.%22"
+                    >
+                      Genovese G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Handsaker+R.E.%22"
+                    >
+                      Handsaker R.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Li+H.%22"
+                    >
+                      Li H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Altemose+N.%22"
+                    >
+                      Altemose N.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lindgren+A.M.%22"
+                    >
+                      Lindgren A.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chambert+K.%22"
+                    >
+                      Chambert K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Pasaniuc+B.%22"
+                    >
+                      Pasaniuc B.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Price+A.L.%22"
+                    >
+                      Price A.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Reich+D.%22"
+                    >
+                      Reich D.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McCarroll+S.A.%22"
+                    >
+                      McCarroll S.A.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/23435088"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/23435088"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Using population admixture to help complete maps of the human genome.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Genovese+G.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/23435088"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Genovese G.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Handsaker+R.E.%22"
-                        >
-                          Handsaker R.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Li+H.%22"
-                        >
-                          Li H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Altemose+N.%22"
-                        >
-                          Altemose N.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lindgren+A.M.%22"
-                        >
-                          Lindgren A.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chambert+K.%22"
-                        >
-                          Chambert K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Pasaniuc+B.%22"
-                        >
-                          Pasaniuc B.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Price+A.L.%22"
-                        >
-                          Price A.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Reich+D.%22"
-                        >
-                          Reich D.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McCarroll+S.A.%22"
-                        >
-                          McCarroll S.A.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/23435088"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/ng.2565"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nat Genet 45:406-414 (
+                            <time
+                              datetime="2013-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/23435088"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/ng.2565"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nat Genet 45:406-414 (
-                                <time
-                                  datetime="2013-01-01T00:00:00.000Z"
-                                >
-                                  2013
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2013
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/7219534"
+                    >
+                      Sequence and organization of the human mitochondrial genome.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Anderson+S.%22"
+                    >
+                      Anderson S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Bankier+A.T.%22"
+                    >
+                      Bankier A.T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Barrell+B.G.%22"
+                    >
+                      Barrell B.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22de+Bruijn+M.H.%22"
+                    >
+                      de Bruijn M.H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Coulson+A.R.%22"
+                    >
+                      Coulson A.R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Drouin+J.%22"
+                    >
+                      Drouin J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Eperon+I.C.%22"
+                    >
+                      Eperon I.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nierlich+D.P.%22"
+                    >
+                      Nierlich D.P.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Roe+B.A.%22"
+                    >
+                      Roe B.A.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Young+I.G.%22"
+                    >
+                      Young I.G.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/7219534"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/7219534"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Sequence and organization of the human mitochondrial genome.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Anderson+S.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/7219534"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Anderson S.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Bankier+A.T.%22"
-                        >
-                          Bankier A.T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Barrell+B.G.%22"
-                        >
-                          Barrell B.G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22de+Bruijn+M.H.%22"
-                        >
-                          de Bruijn M.H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Coulson+A.R.%22"
-                        >
-                          Coulson A.R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Drouin+J.%22"
-                        >
-                          Drouin J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Eperon+I.C.%22"
-                        >
-                          Eperon I.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Nierlich+D.P.%22"
-                        >
-                          Nierlich D.P.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Roe+B.A.%22"
-                        >
-                          Roe B.A.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Young+I.G.%22"
-                        >
-                          Young I.G.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/7219534"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/290457a0"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 290:457-465 (
+                            <time
+                              datetime="1981-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/7219534"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/290457a0"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 290:457-465 (
-                                <time
-                                  datetime="1981-01-01T00:00:00.000Z"
-                                >
-                                  1981
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              1981
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/10830953"
+                    >
+                      The DNA sequence of human chromosome 21.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chromosome+21+mapping+and+sequencing+consortium%22"
+                    >
+                      Chromosome 21 mapping and sequencing consortium
+                    </a>
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hattori+M.%22"
+                    >
+                      Hattori M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fujiyama+A.%22"
+                    >
+                      Fujiyama A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
+                    >
+                      Taylor T.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Watanabe+H.%22"
+                    >
+                      Watanabe H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Yada+T.%22"
+                    >
+                      Yada T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Park+H.S.%22"
+                    >
+                      Park H.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Toyoda+A.%22"
+                    >
+                      Toyoda A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ishii+K.%22"
+                    >
+                      Ishii K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Totoki+Y.%22"
+                    >
+                      Totoki Y.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Yaspo+M.L.%22"
+                    >
+                      Yaspo M.L.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/10830953"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/10830953"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence of human chromosome 21.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Chromosome+21+mapping+and+sequencing+consortium%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/10830953"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Chromosome 21 mapping and sequencing consortium
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        <br />
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hattori+M.%22"
-                        >
-                          Hattori M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fujiyama+A.%22"
-                        >
-                          Fujiyama A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
-                        >
-                          Taylor T.D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Watanabe+H.%22"
-                        >
-                          Watanabe H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Yada+T.%22"
-                        >
-                          Yada T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Park+H.S.%22"
-                        >
-                          Park H.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Toyoda+A.%22"
-                        >
-                          Toyoda A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ishii+K.%22"
-                        >
-                          Ishii K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Totoki+Y.%22"
-                        >
-                          Totoki Y.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Yaspo+M.L.%22"
-                        >
-                          Yaspo M.L.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/10830953"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/35012518"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 405:311-319 (
+                            <time
+                              datetime="2000-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/10830953"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/35012518"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 405:311-319 (
-                                <time
-                                  datetime="2000-01-01T00:00:00.000Z"
-                                >
-                                  2000
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2000
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/11237011"
+                    >
+                      Initial sequencing and analysis of the human genome.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22International+Human+Genome+Sequencing+Consortium%22"
+                    >
+                      International Human Genome Sequencing Consortium
+                    </a>
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
+                    >
+                      Lander E.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Linton+L.M.%22"
+                    >
+                      Linton L.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Birren+B.%22"
+                    >
+                      Birren B.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                    >
+                      Nusbaum C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                    >
+                      Zody M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Baldwin+J.%22"
+                    >
+                      Baldwin J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Devon+K.%22"
+                    >
+                      Devon K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dewar+K.%22"
+                    >
+                      Dewar K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Doyle+M.%22"
+                    >
+                      Doyle M.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chen+Y.J.%22"
+                    >
+                      Chen Y.J.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/11237011"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/11237011"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Initial sequencing and analysis of the human genome.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22International+Human+Genome+Sequencing+Consortium%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/11237011"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          International Human Genome Sequencing Consortium
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        <br />
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
-                        >
-                          Lander E.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Linton+L.M.%22"
-                        >
-                          Linton L.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Birren+B.%22"
-                        >
-                          Birren B.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
-                        >
-                          Nusbaum C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
-                        >
-                          Zody M.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Baldwin+J.%22"
-                        >
-                          Baldwin J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Devon+K.%22"
-                        >
-                          Devon K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dewar+K.%22"
-                        >
-                          Dewar K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Doyle+M.%22"
-                        >
-                          Doyle M.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chen+Y.J.%22"
-                        >
-                          Chen Y.J.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/11237011"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/35057062"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 409:860-921 (
+                            <time
+                              datetime="2001-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/11237011"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/35057062"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 409:860-921 (
-                                <time
-                                  datetime="2001-01-01T00:00:00.000Z"
-                                >
-                                  2001
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2001
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/11780052"
+                    >
+                      The DNA sequence and comparative analysis of human chromosome 20.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Deloukas+P.%22"
+                    >
+                      Deloukas P.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Matthews+L.H.%22"
+                    >
+                      Matthews L.H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ashurst+J.%22"
+                    >
+                      Ashurst J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Burton+J.%22"
+                    >
+                      Burton J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gilbert+J.G.%22"
+                    >
+                      Gilbert J.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Jones+M.%22"
+                    >
+                      Jones M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Stavrides+G.%22"
+                    >
+                      Stavrides G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Almeida+J.P.%22"
+                    >
+                      Almeida J.P.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Babbage+A.K.%22"
+                    >
+                      Babbage A.K.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
+                    >
+                      Rogers J.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/11780052"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/11780052"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and comparative analysis of human chromosome 20.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Deloukas+P.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/11780052"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Deloukas P.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Matthews+L.H.%22"
-                        >
-                          Matthews L.H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ashurst+J.%22"
-                        >
-                          Ashurst J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Burton+J.%22"
-                        >
-                          Burton J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gilbert+J.G.%22"
-                        >
-                          Gilbert J.G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Jones+M.%22"
-                        >
-                          Jones M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Stavrides+G.%22"
-                        >
-                          Stavrides G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Almeida+J.P.%22"
-                        >
-                          Almeida J.P.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Babbage+A.K.%22"
-                        >
-                          Babbage A.K.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
-                        >
-                          Rogers J.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/11780052"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/414865a"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 414:865-871 (
+                            <time
+                              datetime="2001-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/11780052"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/414865a"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 414:865-871 (
-                                <time
-                                  datetime="2001-01-01T00:00:00.000Z"
-                                >
-                                  2001
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2001
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/12508121"
+                    >
+                      The DNA sequence and analysis of human chromosome 14.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Heilig+R.%22"
+                    >
+                      Heilig R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Eckenberg+R.%22"
+                    >
+                      Eckenberg R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Petit+J.L.%22"
+                    >
+                      Petit J.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fonknechten+N.%22"
+                    >
+                      Fonknechten N.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Da+Silva+C.%22"
+                    >
+                      Da Silva C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cattolico+L.%22"
+                    >
+                      Cattolico L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Levy+M.%22"
+                    >
+                      Levy M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Barbe+V.%22"
+                    >
+                      Barbe V.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22de+Berardinis+V.%22"
+                    >
+                      de Berardinis V.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Weissenbach+J.%22"
+                    >
+                      Weissenbach J.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/12508121"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/12508121"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and analysis of human chromosome 14.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Heilig+R.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/12508121"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Heilig R.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Eckenberg+R.%22"
-                        >
-                          Eckenberg R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Petit+J.L.%22"
-                        >
-                          Petit J.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fonknechten+N.%22"
-                        >
-                          Fonknechten N.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Da+Silva+C.%22"
-                        >
-                          Da Silva C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Cattolico+L.%22"
-                        >
-                          Cattolico L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Levy+M.%22"
-                        >
-                          Levy M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Barbe+V.%22"
-                        >
-                          Barbe V.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22de+Berardinis+V.%22"
-                        >
-                          de Berardinis V.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Weissenbach+J.%22"
-                        >
-                          Weissenbach J.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/12508121"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature01348"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 421:601-607 (
+                            <time
+                              datetime="2003-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/12508121"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature01348"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 421:601-607 (
-                                <time
-                                  datetime="2003-01-01T00:00:00.000Z"
-                                >
-                                  2003
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2003
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/12815422"
+                    >
+                      The male-specific region of the human Y chromosome is a mosaic of discrete sequence classes.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Skaletsky+H.%22"
+                    >
+                      Skaletsky H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kuroda-Kawaguchi+T.%22"
+                    >
+                      Kuroda-Kawaguchi T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Minx+P.J.%22"
+                    >
+                      Minx P.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cordum+H.S.%22"
+                    >
+                      Cordum H.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hillier+L.%22"
+                    >
+                      Hillier L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Brown+L.G.%22"
+                    >
+                      Brown L.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Repping+S.%22"
+                    >
+                      Repping S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Pyntikova+T.%22"
+                    >
+                      Pyntikova T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ali+J.%22"
+                    >
+                      Ali J.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Page+D.C.%22"
+                    >
+                      Page D.C.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/12815422"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/12815422"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The male-specific region of the human Y chromosome is a mosaic of discrete sequence classes.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Skaletsky+H.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/12815422"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Skaletsky H.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kuroda-Kawaguchi+T.%22"
-                        >
-                          Kuroda-Kawaguchi T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Minx+P.J.%22"
-                        >
-                          Minx P.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Cordum+H.S.%22"
-                        >
-                          Cordum H.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hillier+L.%22"
-                        >
-                          Hillier L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Brown+L.G.%22"
-                        >
-                          Brown L.G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Repping+S.%22"
-                        >
-                          Repping S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Pyntikova+T.%22"
-                        >
-                          Pyntikova T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ali+J.%22"
-                        >
-                          Ali J.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Page+D.C.%22"
-                        >
-                          Page D.C.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/12815422"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature01722"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 423:825-837 (
+                            <time
+                              datetime="2003-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/12815422"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature01722"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 423:825-837 (
-                                <time
-                                  datetime="2003-01-01T00:00:00.000Z"
-                                >
-                                  2003
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2003
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/12853948"
+                    >
+                      The DNA sequence of human chromosome 7.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hillier+L.W.%22"
+                    >
+                      Hillier L.W.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fulton+R.S.%22"
+                    >
+                      Fulton R.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fulton+L.A.%22"
+                    >
+                      Fulton L.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Graves+T.A.%22"
+                    >
+                      Graves T.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Pepin+K.H.%22"
+                    >
+                      Pepin K.H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wagner-McPherson+C.%22"
+                    >
+                      Wagner-McPherson C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Layman+D.%22"
+                    >
+                      Layman D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Maas+J.%22"
+                    >
+                      Maas J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Jaeger+S.%22"
+                    >
+                      Jaeger S.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wilson+R.K.%22"
+                    >
+                      Wilson R.K.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/12853948"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/12853948"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence of human chromosome 7.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Hillier+L.W.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/12853948"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Hillier L.W.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fulton+R.S.%22"
-                        >
-                          Fulton R.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fulton+L.A.%22"
-                        >
-                          Fulton L.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Graves+T.A.%22"
-                        >
-                          Graves T.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Pepin+K.H.%22"
-                        >
-                          Pepin K.H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wagner-McPherson+C.%22"
-                        >
-                          Wagner-McPherson C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Layman+D.%22"
-                        >
-                          Layman D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Maas+J.%22"
-                        >
-                          Maas J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Jaeger+S.%22"
-                        >
-                          Jaeger S.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wilson+R.K.%22"
-                        >
-                          Wilson R.K.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/12853948"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature01782"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 424:157-164 (
+                            <time
+                              datetime="2003-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/12853948"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature01782"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 424:157-164 (
-                                <time
-                                  datetime="2003-01-01T00:00:00.000Z"
-                                >
-                                  2003
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2003
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/14574404"
+                    >
+                      The DNA sequence and analysis of human chromosome 6.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Mungall+A.J.%22"
+                    >
+                      Mungall A.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Palmer+S.A.%22"
+                    >
+                      Palmer S.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sims+S.K.%22"
+                    >
+                      Sims S.K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Edwards+C.A.%22"
+                    >
+                      Edwards C.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ashurst+J.L.%22"
+                    >
+                      Ashurst J.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wilming+L.%22"
+                    >
+                      Wilming L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Jones+M.C.%22"
+                    >
+                      Jones M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Horton+R.%22"
+                    >
+                      Horton R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
+                    >
+                      Hunt S.E.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Beck+S.%22"
+                    >
+                      Beck S.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/14574404"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/14574404"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and analysis of human chromosome 6.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Mungall+A.J.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/14574404"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Mungall A.J.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Palmer+S.A.%22"
-                        >
-                          Palmer S.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sims+S.K.%22"
-                        >
-                          Sims S.K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Edwards+C.A.%22"
-                        >
-                          Edwards C.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ashurst+J.L.%22"
-                        >
-                          Ashurst J.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wilming+L.%22"
-                        >
-                          Wilming L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Jones+M.C.%22"
-                        >
-                          Jones M.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Horton+R.%22"
-                        >
-                          Horton R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
-                        >
-                          Hunt S.E.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Beck+S.%22"
-                        >
-                          Beck S.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/14574404"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02055"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 425:805-811 (
+                            <time
+                              datetime="2003-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/14574404"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02055"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 425:805-811 (
-                                <time
-                                  datetime="2003-01-01T00:00:00.000Z"
-                                >
-                                  2003
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2003
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15057823"
+                    >
+                      The DNA sequence and analysis of human chromosome 13.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dunham+A.%22"
+                    >
+                      Dunham A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Matthews+L.H.%22"
+                    >
+                      Matthews L.H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Burton+J.%22"
+                    >
+                      Burton J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ashurst+J.L.%22"
+                    >
+                      Ashurst J.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
+                    >
+                      Howe K.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ashcroft+K.J.%22"
+                    >
+                      Ashcroft K.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Beare+D.M.%22"
+                    >
+                      Beare D.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Burford+D.C.%22"
+                    >
+                      Burford D.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
+                    >
+                      Hunt S.E.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ross+M.T.%22"
+                    >
+                      Ross M.T.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15057823"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15057823"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and analysis of human chromosome 13.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Dunham+A.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15057823"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Dunham A.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Matthews+L.H.%22"
-                        >
-                          Matthews L.H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Burton+J.%22"
-                        >
-                          Burton J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ashurst+J.L.%22"
-                        >
-                          Ashurst J.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
-                        >
-                          Howe K.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ashcroft+K.J.%22"
-                        >
-                          Ashcroft K.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Beare+D.M.%22"
-                        >
-                          Beare D.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Burford+D.C.%22"
-                        >
-                          Burford D.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
-                        >
-                          Hunt S.E.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ross+M.T.%22"
-                        >
-                          Ross M.T.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15057823"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02379"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 428:522-528 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15057823"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02379"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 428:522-528 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15057824"
+                    >
+                      The DNA sequence and biology of human chromosome 19.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Grimwood+J.%22"
+                    >
+                      Grimwood J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
+                    >
+                      Gordon L.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Olsen+A.%22"
+                    >
+                      Olsen A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
+                    >
+                      Terry A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Schmutz+J.%22"
+                    >
+                      Schmutz J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lamerdin+J.%22"
+                    >
+                      Lamerdin J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hellsten+U.%22"
+                    >
+                      Hellsten U.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Goodstein+D.%22"
+                    >
+                      Goodstein D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Couronne+O.%22"
+                    >
+                      Couronne O.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lucas+S.M.%22"
+                    >
+                      Lucas S.M.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15057824"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15057824"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and biology of human chromosome 19.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Grimwood+J.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15057824"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Grimwood J.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
-                        >
-                          Gordon L.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Olsen+A.%22"
-                        >
-                          Olsen A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
-                        >
-                          Terry A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Schmutz+J.%22"
-                        >
-                          Schmutz J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lamerdin+J.%22"
-                        >
-                          Lamerdin J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hellsten+U.%22"
-                        >
-                          Hellsten U.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Goodstein+D.%22"
-                        >
-                          Goodstein D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Couronne+O.%22"
-                        >
-                          Couronne O.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lucas+S.M.%22"
-                        >
-                          Lucas S.M.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15057824"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02399"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 428:529-535 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15057824"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02399"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 428:529-535 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15164053"
+                    >
+                      DNA sequence and analysis of human chromosome 9.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Humphray+S.J.%22"
+                    >
+                      Humphray S.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Oliver+K.%22"
+                    >
+                      Oliver K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hunt+A.R.%22"
+                    >
+                      Hunt A.R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Plumb+R.W.%22"
+                    >
+                      Plumb R.W.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Loveland+J.E.%22"
+                    >
+                      Loveland J.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
+                    >
+                      Howe K.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Andrews+T.D.%22"
+                    >
+                      Andrews T.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Searle+S.%22"
+                    >
+                      Searle S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
+                    >
+                      Hunt S.E.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dunham+I.%22"
+                    >
+                      Dunham I.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15164053"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15164053"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          DNA sequence and analysis of human chromosome 9.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Humphray+S.J.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15164053"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Humphray S.J.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Oliver+K.%22"
-                        >
-                          Oliver K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hunt+A.R.%22"
-                        >
-                          Hunt A.R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Plumb+R.W.%22"
-                        >
-                          Plumb R.W.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Loveland+J.E.%22"
-                        >
-                          Loveland J.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
-                        >
-                          Howe K.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Andrews+T.D.%22"
-                        >
-                          Andrews T.D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Searle+S.%22"
-                        >
-                          Searle S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hunt+S.E.%22"
-                        >
-                          Hunt S.E.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dunham+I.%22"
-                        >
-                          Dunham I.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15164053"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02465"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 429:369-374 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15164053"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02465"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 429:369-374 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15164054"
+                    >
+                      The DNA sequence and comparative analysis of human chromosome 10.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Deloukas+P.%22"
+                    >
+                      Deloukas P.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Earthrowl+M.E.%22"
+                    >
+                      Earthrowl M.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Grafham+D.V.%22"
+                    >
+                      Grafham D.V.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rubenfield+M.%22"
+                    >
+                      Rubenfield M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22French+L.%22"
+                    >
+                      French L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Steward+C.A.%22"
+                    >
+                      Steward C.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sims+S.K.%22"
+                    >
+                      Sims S.K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Jones+M.C.%22"
+                    >
+                      Jones M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Searle+S.%22"
+                    >
+                      Searle S.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
+                    >
+                      Rogers J.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15164054"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15164054"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and comparative analysis of human chromosome 10.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Deloukas+P.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15164054"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Deloukas P.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Earthrowl+M.E.%22"
-                        >
-                          Earthrowl M.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Grafham+D.V.%22"
-                        >
-                          Grafham D.V.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rubenfield+M.%22"
-                        >
-                          Rubenfield M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22French+L.%22"
-                        >
-                          French L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Steward+C.A.%22"
-                        >
-                          Steward C.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sims+S.K.%22"
-                        >
-                          Sims S.K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Jones+M.C.%22"
-                        >
-                          Jones M.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Searle+S.%22"
-                        >
-                          Searle S.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rogers+J.%22"
-                        >
-                          Rogers J.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15164054"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02462"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 429:375-381 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15164054"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02462"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 429:375-381 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15372022"
+                    >
+                      The DNA sequence and comparative analysis of human chromosome 5.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Schmutz+J.%22"
+                    >
+                      Schmutz J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Martin+J.%22"
+                    >
+                      Martin J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
+                    >
+                      Terry A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Couronne+O.%22"
+                    >
+                      Couronne O.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Grimwood+J.%22"
+                    >
+                      Grimwood J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lowry+S.%22"
+                    >
+                      Lowry S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
+                    >
+                      Gordon L.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Scott+D.%22"
+                    >
+                      Scott D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Xie+G.%22"
+                    >
+                      Xie G.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rubin+E.M.%22"
+                    >
+                      Rubin E.M.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15372022"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15372022"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and comparative analysis of human chromosome 5.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Schmutz+J.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15372022"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Schmutz J.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Martin+J.%22"
-                        >
-                          Martin J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
-                        >
-                          Terry A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Couronne+O.%22"
-                        >
-                          Couronne O.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Grimwood+J.%22"
-                        >
-                          Grimwood J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lowry+S.%22"
-                        >
-                          Lowry S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
-                        >
-                          Gordon L.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Scott+D.%22"
-                        >
-                          Scott D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Xie+G.%22"
-                        >
-                          Xie G.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rubin+E.M.%22"
-                        >
-                          Rubin E.M.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15372022"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature02919"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 431:268-274 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15372022"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature02919"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 431:268-274 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15496913"
+                    >
+                      Finishing the euchromatic sequence of the human genome.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22International+Human+Genome+Sequencing+Consortium%22"
+                    >
+                      International Human Genome Sequencing Consortium
+                    </a>
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22%22"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15496913"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15496913"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Finishing the euchromatic sequence of the human genome.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22International+Human+Genome+Sequencing+Consortium%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15496913"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          International Human Genome Sequencing Consortium
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        <br />
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22%22"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15496913"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature03001"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 431:931-945 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15496913"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature03001"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 431:931-945 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15616553"
+                    >
+                      The sequence and analysis of duplication-rich human chromosome 16.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Martin+J.%22"
+                    >
+                      Martin J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Han+C.%22"
+                    >
+                      Han C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
+                    >
+                      Gordon L.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
+                    >
+                      Terry A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Prabhakar+S.%22"
+                    >
+                      Prabhakar S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22She+X.%22"
+                    >
+                      She X.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Xie+G.%22"
+                    >
+                      Xie G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hellsten+U.%22"
+                    >
+                      Hellsten U.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chan+Y.M.%22"
+                    >
+                      Chan Y.M.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Pennacchio+L.A.%22"
+                    >
+                      Pennacchio L.A.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15616553"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15616553"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The sequence and analysis of duplication-rich human chromosome 16.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Martin+J.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15616553"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Martin J.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Han+C.%22"
-                        >
-                          Han C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gordon+L.A.%22"
-                        >
-                          Gordon L.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Terry+A.%22"
-                        >
-                          Terry A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Prabhakar+S.%22"
-                        >
-                          Prabhakar S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22She+X.%22"
-                        >
-                          She X.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Xie+G.%22"
-                        >
-                          Xie G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Hellsten+U.%22"
-                        >
-                          Hellsten U.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chan+Y.M.%22"
-                        >
-                          Chan Y.M.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Pennacchio+L.A.%22"
-                        >
-                          Pennacchio L.A.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15616553"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature03187"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 432:988-994 (
+                            <time
+                              datetime="2004-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15616553"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature03187"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 432:988-994 (
-                                <time
-                                  datetime="2004-01-01T00:00:00.000Z"
-                                >
-                                  2004
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2004
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15772651"
+                    >
+                      The DNA sequence of the human X chromosome.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ross+M.T.%22"
+                    >
+                      Ross M.T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Grafham+D.V.%22"
+                    >
+                      Grafham D.V.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Coffey+A.J.%22"
+                    >
+                      Coffey A.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Scherer+S.%22"
+                    >
+                      Scherer S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McLay+K.%22"
+                    >
+                      McLay K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Muzny+D.%22"
+                    >
+                      Muzny D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Platzer+M.%22"
+                    >
+                      Platzer M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Howell+G.R.%22"
+                    >
+                      Howell G.R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Burrows+C.%22"
+                    >
+                      Burrows C.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Bentley+D.R.%22"
+                    >
+                      Bentley D.R.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15772651"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15772651"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence of the human X chromosome.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Ross+M.T.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15772651"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Ross M.T.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Grafham+D.V.%22"
-                        >
-                          Grafham D.V.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Coffey+A.J.%22"
-                        >
-                          Coffey A.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Scherer+S.%22"
-                        >
-                          Scherer S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McLay+K.%22"
-                        >
-                          McLay K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Muzny+D.%22"
-                        >
-                          Muzny D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Platzer+M.%22"
-                        >
-                          Platzer M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Howell+G.R.%22"
-                        >
-                          Howell G.R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Burrows+C.%22"
-                        >
-                          Burrows C.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Bentley+D.R.%22"
-                        >
-                          Bentley D.R.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15772651"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature03440"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 434:325-337 (
+                            <time
+                              datetime="2005-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15772651"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature03440"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 434:325-337 (
-                                <time
-                                  datetime="2005-01-01T00:00:00.000Z"
-                                >
-                                  2005
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2005
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/15815621"
+                    >
+                      Generation and annotation of the DNA sequences of human chromosomes 2 and 4.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Hillier+L.W.%22"
+                    >
+                      Hillier L.W.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Graves+T.A.%22"
+                    >
+                      Graves T.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fulton+R.S.%22"
+                    >
+                      Fulton R.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Fulton+L.A.%22"
+                    >
+                      Fulton L.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Pepin+K.H.%22"
+                    >
+                      Pepin K.H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Minx+P.%22"
+                    >
+                      Minx P.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wagner-McPherson+C.%22"
+                    >
+                      Wagner-McPherson C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Layman+D.%22"
+                    >
+                      Layman D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wylie+K.%22"
+                    >
+                      Wylie K.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wilson+R.K.%22"
+                    >
+                      Wilson R.K.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/15815621"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/15815621"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Generation and annotation of the DNA sequences of human chromosomes 2 and 4.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Hillier+L.W.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/15815621"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Hillier L.W.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Graves+T.A.%22"
-                        >
-                          Graves T.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fulton+R.S.%22"
-                        >
-                          Fulton R.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Fulton+L.A.%22"
-                        >
-                          Fulton L.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Pepin+K.H.%22"
-                        >
-                          Pepin K.H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Minx+P.%22"
-                        >
-                          Minx P.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wagner-McPherson+C.%22"
-                        >
-                          Wagner-McPherson C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Layman+D.%22"
-                        >
-                          Layman D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wylie+K.%22"
-                        >
-                          Wylie K.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wilson+R.K.%22"
-                        >
-                          Wilson R.K.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/15815621"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature03466"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 434:724-731 (
+                            <time
+                              datetime="2005-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/15815621"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature03466"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 434:724-731 (
-                                <time
-                                  datetime="2005-01-01T00:00:00.000Z"
-                                >
-                                  2005
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2005
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16177791"
+                    >
+                      DNA sequence and analysis of human chromosome 18.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                    >
+                      Nusbaum C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                    >
+                      Zody M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Borowsky+M.L.%22"
+                    >
+                      Borowsky M.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kamal+M.%22"
+                    >
+                      Kamal M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kodira+C.D.%22"
+                    >
+                      Kodira C.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
+                    >
+                      Taylor T.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Whittaker+C.A.%22"
+                    >
+                      Whittaker C.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chang+J.L.%22"
+                    >
+                      Chang J.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cuomo+C.A.%22"
+                    >
+                      Cuomo C.A.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
+                    >
+                      Lander E.S.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16177791"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16177791"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          DNA sequence and analysis of human chromosome 18.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16177791"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Nusbaum C.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
-                        >
-                          Zody M.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Borowsky+M.L.%22"
-                        >
-                          Borowsky M.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kamal+M.%22"
-                        >
-                          Kamal M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kodira+C.D.%22"
-                        >
-                          Kodira C.D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
-                        >
-                          Taylor T.D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Whittaker+C.A.%22"
-                        >
-                          Whittaker C.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chang+J.L.%22"
-                        >
-                          Chang J.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Cuomo+C.A.%22"
-                        >
-                          Cuomo C.A.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
-                        >
-                          Lander E.S.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16177791"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature03983"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 437:551-555 (
+                            <time
+                              datetime="2005-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16177791"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature03983"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 437:551-555 (
-                                <time
-                                  datetime="2005-01-01T00:00:00.000Z"
-                                >
-                                  2005
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2005
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16421571"
+                    >
+                      DNA sequence and analysis of human chromosome 8.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                    >
+                      Nusbaum C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Mikkelsen+T.S.%22"
+                    >
+                      Mikkelsen T.S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                    >
+                      Zody M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Asakawa+S.%22"
+                    >
+                      Asakawa S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Taudien+S.%22"
+                    >
+                      Taudien S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
+                    >
+                      Garber M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kodira+C.D.%22"
+                    >
+                      Kodira C.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Schueler+M.G.%22"
+                    >
+                      Schueler M.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Shimizu+A.%22"
+                    >
+                      Shimizu A.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
+                    >
+                      Lander E.S.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16421571"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16421571"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          DNA sequence and analysis of human chromosome 8.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16421571"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Nusbaum C.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Mikkelsen+T.S.%22"
-                        >
-                          Mikkelsen T.S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
-                        >
-                          Zody M.C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Asakawa+S.%22"
-                        >
-                          Asakawa S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Taudien+S.%22"
-                        >
-                          Taudien S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
-                        >
-                          Garber M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kodira+C.D.%22"
-                        >
-                          Kodira C.D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Schueler+M.G.%22"
-                        >
-                          Schueler M.G.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Shimizu+A.%22"
-                        >
-                          Shimizu A.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lander+E.S.%22"
-                        >
-                          Lander E.S.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16421571"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04406"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 439:331-335 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16421571"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04406"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 439:331-335 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16625196"
+                    >
+                      DNA sequence of human chromosome 17 and analysis of rearrangement in the human lineage.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                    >
+                      Zody M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
+                    >
+                      Garber M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Adams+D.J.%22"
+                    >
+                      Adams D.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sharpe+T.%22"
+                    >
+                      Sharpe T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Harrow+J.%22"
+                    >
+                      Harrow J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lupski+J.R.%22"
+                    >
+                      Lupski J.R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nicholson+C.%22"
+                    >
+                      Nicholson C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Searle+S.M.%22"
+                    >
+                      Searle S.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wilming+L.%22"
+                    >
+                      Wilming L.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                    >
+                      Nusbaum C.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16625196"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16625196"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          DNA sequence of human chromosome 17 and analysis of rearrangement in the human lineage.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16625196"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Zody M.C.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
-                        >
-                          Garber M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Adams+D.J.%22"
-                        >
-                          Adams D.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sharpe+T.%22"
-                        >
-                          Sharpe T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Harrow+J.%22"
-                        >
-                          Harrow J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lupski+J.R.%22"
-                        >
-                          Lupski J.R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Nicholson+C.%22"
-                        >
-                          Nicholson C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Searle+S.M.%22"
-                        >
-                          Searle S.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wilming+L.%22"
-                        >
-                          Wilming L.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
-                        >
-                          Nusbaum C.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16625196"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04689"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 440:1045-1049 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16625196"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04689"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 440:1045-1049 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16641997"
+                    >
+                      The DNA sequence, annotation and analysis of human chromosome 3.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Muzny+D.M.%22"
+                    >
+                      Muzny D.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Scherer+S.E.%22"
+                    >
+                      Scherer S.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kaul+R.%22"
+                    >
+                      Kaul R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Wang+J.%22"
+                    >
+                      Wang J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Yu+J.%22"
+                    >
+                      Yu J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sudbrak+R.%22"
+                    >
+                      Sudbrak R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Buhay+C.J.%22"
+                    >
+                      Buhay C.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chen+R.%22"
+                    >
+                      Chen R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cree+A.%22"
+                    >
+                      Cree A.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gibbs+R.A.%22"
+                    >
+                      Gibbs R.A.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16641997"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16641997"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence, annotation and analysis of human chromosome 3.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Muzny+D.M.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16641997"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Muzny D.M.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Scherer+S.E.%22"
-                        >
-                          Scherer S.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kaul+R.%22"
-                        >
-                          Kaul R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Wang+J.%22"
-                        >
-                          Wang J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Yu+J.%22"
-                        >
-                          Yu J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sudbrak+R.%22"
-                        >
-                          Sudbrak R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Buhay+C.J.%22"
-                        >
-                          Buhay C.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chen+R.%22"
-                        >
-                          Chen R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Cree+A.%22"
-                        >
-                          Cree A.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gibbs+R.A.%22"
-                        >
-                          Gibbs R.A.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16641997"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04728"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 440:1194-1198 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16641997"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04728"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 440:1194-1198 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16541075"
+                    >
+                      The finished DNA sequence of human chromosome 12.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Baylor+College+of+Medicine+Human+Genome+Sequencing+Center+Sequence+Production+Team%22"
+                    >
+                      Baylor College of Medicine Human Genome Sequencing Center Sequence Production Team
+                    </a>
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Scherer+S.E.%22"
+                    >
+                      Scherer S.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Muzny+D.M.%22"
+                    >
+                      Muzny D.M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Buhay+C.J.%22"
+                    >
+                      Buhay C.J.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chen+R.%22"
+                    >
+                      Chen R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Cree+A.%22"
+                    >
+                      Cree A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Ding+Y.%22"
+                    >
+                      Ding Y.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dugan-Rocha+S.%22"
+                    >
+                      Dugan-Rocha S.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gill+R.%22"
+                    >
+                      Gill R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gunaratne+P.%22"
+                    >
+                      Gunaratne P.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gibbs+R.A.%22"
+                    >
+                      Gibbs R.A.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16541075"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16541075"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The finished DNA sequence of human chromosome 12.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Baylor+College+of+Medicine+Human+Genome+Sequencing+Center+Sequence+Production+Team%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16541075"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Baylor College of Medicine Human Genome Sequencing Center Sequence Production Team
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        <br />
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Scherer+S.E.%22"
-                        >
-                          Scherer S.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Muzny+D.M.%22"
-                        >
-                          Muzny D.M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Buhay+C.J.%22"
-                        >
-                          Buhay C.J.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chen+R.%22"
-                        >
-                          Chen R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Cree+A.%22"
-                        >
-                          Cree A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Ding+Y.%22"
-                        >
-                          Ding Y.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dugan-Rocha+S.%22"
-                        >
-                          Dugan-Rocha S.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gill+R.%22"
-                        >
-                          Gill R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gunaratne+P.%22"
-                        >
-                          Gunaratne P.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Gibbs+R.A.%22"
-                        >
-                          Gibbs R.A.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16541075"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04569"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 440:346-351 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16541075"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04569"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 440:346-351 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16554811"
+                    >
+                      Human chromosome 11 DNA sequence and analysis including novel gene identification.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
+                    >
+                      Taylor T.D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Noguchi+H.%22"
+                    >
+                      Noguchi H.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Totoki+Y.%22"
+                    >
+                      Totoki Y.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Toyoda+A.%22"
+                    >
+                      Toyoda A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kuroki+Y.%22"
+                    >
+                      Kuroki Y.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dewar+K.%22"
+                    >
+                      Dewar K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Lloyd+C.%22"
+                    >
+                      Lloyd C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Itoh+T.%22"
+                    >
+                      Itoh T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Takeda+T.%22"
+                    >
+                      Takeda T.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sakaki+Y.%22"
+                    >
+                      Sakaki Y.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16554811"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16554811"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Human chromosome 11 DNA sequence and analysis including novel gene identification.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Taylor+T.D.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16554811"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Taylor T.D.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Noguchi+H.%22"
-                        >
-                          Noguchi H.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Totoki+Y.%22"
-                        >
-                          Totoki Y.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Toyoda+A.%22"
-                        >
-                          Toyoda A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kuroki+Y.%22"
-                        >
-                          Kuroki Y.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dewar+K.%22"
-                        >
-                          Dewar K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Lloyd+C.%22"
-                        >
-                          Lloyd C.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Itoh+T.%22"
-                        >
-                          Itoh T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Takeda+T.%22"
-                        >
-                          Takeda T.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sakaki+Y.%22"
-                        >
-                          Sakaki Y.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16554811"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04632"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 440:497-500 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16554811"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04632"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 440:497-500 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16572171"
+                    >
+                      Analysis of the DNA sequence and duplication history of human chromosome 15.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                    >
+                      Zody M.C.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
+                    >
+                      Garber M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Sharpe+T.%22"
+                    >
+                      Sharpe T.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Young+S.K.%22"
+                    >
+                      Young S.K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Rowen+L.%22"
+                    >
+                      Rowen L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22O%27Neill+K.%22"
+                    >
+                      O'Neill K.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Whittaker+C.A.%22"
+                    >
+                      Whittaker C.A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kamal+M.%22"
+                    >
+                      Kamal M.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Chang+J.L.%22"
+                    >
+                      Chang J.L.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
+                    >
+                      Nusbaum C.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16572171"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16572171"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Analysis of the DNA sequence and duplication history of human chromosome 15.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Zody+M.C.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16572171"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Zody M.C.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Garber+M.%22"
-                        >
-                          Garber M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Sharpe+T.%22"
-                        >
-                          Sharpe T.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Young+S.K.%22"
-                        >
-                          Young S.K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Rowen+L.%22"
-                        >
-                          Rowen L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22O%27Neill+K.%22"
-                        >
-                          O'Neill K.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Whittaker+C.A.%22"
-                        >
-                          Whittaker C.A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kamal+M.%22"
-                        >
-                          Kamal M.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Chang+J.L.%22"
-                        >
-                          Chang J.L.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Nusbaum+C.%22"
-                        >
-                          Nusbaum C.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16572171"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04601"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 440:671-675 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16572171"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04601"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 440:671-675 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-      <li>
-        <section
-          class="card"
-        >
-          <div
-            class="card__container"
-          >
-            <div
-              class="card__content"
+            </article>
+          </li>
+          <li>
+            <article
+              class="inline-publication publication"
             >
               <div
-                class="card-content"
+                class="publication__columns"
               >
-                <article
-                  class="publication"
+                <div
+                  class="publication__columns__main"
+                >
+                  <h3
+                    class="publication__heading small"
+                  >
+                    <a
+                      href="/citations/16710414"
+                    >
+                      The DNA sequence and biological annotation of human chromosome 1.
+                    </a>
+                  </h3>
+                  <div
+                    class="publication__authors"
+                  >
+                    <br />
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Gregory+S.G.%22"
+                    >
+                      Gregory S.G.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Barlow+K.F.%22"
+                    >
+                      Barlow K.F.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22McLay+K.E.%22"
+                    >
+                      McLay K.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Kaul+R.%22"
+                    >
+                      Kaul R.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Swarbreck+D.%22"
+                    >
+                      Swarbreck D.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Dunham+A.%22"
+                    >
+                      Dunham A.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Scott+C.E.%22"
+                    >
+                      Scott C.E.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
+                    >
+                      Howe K.L.
+                    </a>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Woodfine+K.%22"
+                    >
+                      Woodfine K.
+                    </a>
+                    <button
+                      aria-expanded="false"
+                      class="button tertiary ellipsis-reveal"
+                      title="Show more"
+                      type="button"
+                    >
+                      [...]
+                    </button>
+                    , 
+                    <a
+                      href="/uniprotkb?query=lit_author%3A%22Prigmore+E.%22"
+                    >
+                      Prigmore E.
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="publication__columns__side"
                 >
                   <div
-                    class="publication__columns"
+                    class="publication__columns__side__item"
                   >
-                    <div
-                      class="publication__columns__main"
+                    <test-file-stub
+                      height="2em"
+                      width="1.875em"
+                    />
+                    <ul
+                      class="no-bullet"
                     >
-                      <h3
-                        class="publication__heading small"
-                      >
+                      <li>
                         <a
-                          href="/citations/16710414"
+                          class="external-link"
+                          href="https://pubmed.ncbi.nlm.nih.gov/16710414"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          The DNA sequence and biological annotation of human chromosome 1.
+                          PubMed
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                      </h3>
-                      <div
-                        class="publication__authors"
-                      >
-                        <br />
+                      </li>
+                      <li>
                         <a
-                          href="/uniprotkb?query=lit_author%3A%22Gregory+S.G.%22"
+                          class="external-link"
+                          href="//europepmc.org/article/MED/16710414"
+                          rel="noopener"
+                          target="_blank"
                         >
-                          Gregory S.G.
+                          Europe PMC
+                          <test-file-stub
+                            data-testid="external-link-icon"
+                            width="12.5"
+                          />
                         </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Barlow+K.F.%22"
-                        >
-                          Barlow K.F.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22McLay+K.E.%22"
-                        >
-                          McLay K.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Kaul+R.%22"
-                        >
-                          Kaul R.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Swarbreck+D.%22"
-                        >
-                          Swarbreck D.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Dunham+A.%22"
-                        >
-                          Dunham A.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Scott+C.E.%22"
-                        >
-                          Scott C.E.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Howe+K.L.%22"
-                        >
-                          Howe K.L.
-                        </a>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Woodfine+K.%22"
-                        >
-                          Woodfine K.
-                        </a>
-                        <button
-                          aria-expanded="false"
-                          class="button tertiary ellipsis-reveal"
-                          title="Show more"
-                          type="button"
-                        >
-                          [...]
-                        </button>
-                        , 
-                        <a
-                          href="/uniprotkb?query=lit_author%3A%22Prigmore+E.%22"
-                        >
-                          Prigmore E.
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="publication__columns__side"
-                    >
-                      <div
-                        class="publication__columns__side__item"
-                      >
-                        <test-file-stub
-                          height="2em"
-                          width="1.875em"
-                        />
-                        <ul
-                          class="no-bullet"
-                        >
-                          <li>
-                            <a
-                              class="external-link"
-                              href="https://pubmed.ncbi.nlm.nih.gov/16710414"
-                              rel="noopener"
-                              target="_blank"
+                      </li>
+                      <li>
+                        <small>
+                          <a
+                            class="external-link"
+                            href="https://dx.doi.org/10.1038/nature04727"
+                            rel="noopener"
+                            target="_blank"
+                          >
+                            Nature 441:315-321 (
+                            <time
+                              datetime="2006-01-01T00:00:00.000Z"
                             >
-                              PubMed
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <a
-                              class="external-link"
-                              href="//europepmc.org/article/MED/16710414"
-                              rel="noopener"
-                              target="_blank"
-                            >
-                              Europe PMC
-                              <test-file-stub
-                                data-testid="external-link-icon"
-                                width="12.5"
-                              />
-                            </a>
-                          </li>
-                          <li>
-                            <small>
-                              <a
-                                class="external-link"
-                                href="https://dx.doi.org/10.1038/nature04727"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                Nature 441:315-321 (
-                                <time
-                                  datetime="2006-01-01T00:00:00.000Z"
-                                >
-                                  2006
-                                </time>
-                                )
-                                <test-file-stub
-                                  data-testid="external-link-icon"
-                                  width="12.5"
-                                />
-                              </a>
-                            </small>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
+                              2006
+                            </time>
+                            )
+                            <test-file-stub
+                              data-testid="external-link-icon"
+                              width="12.5"
+                            />
+                          </a>
+                        </small>
+                      </li>
+                    </ul>
                   </div>
-                </article>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
-      </li>
-    </ul>
+            </article>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+  <section
+    class="card"
+  >
+    <div
+      class="card__container"
+    >
+      <div
+        class="card__header card__header--with-separator"
+      >
+        <h2>
+          <span
+            data-article-id="proteome_similarity"
+          >
+            Similar reference proteomes
+          </span>
+           
+          <button
+            class="chip chip--compact"
+            type="button"
+          >
+            New
+          </button>
+        </h2>
+      </div>
+      <div
+        class="card__content"
+      >
+        <p
+          data-article-id="proteome_similarity"
+        >
+          No similarity score is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
+        </p>
+      </div>
+    </div>
   </section>
 </DocumentFragment>
 `;

--- a/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
+++ b/src/proteomes/components/entry/__tests__/__snapshots__/EntryMain.spec.tsx.snap
@@ -32,6 +32,41 @@ exports[`EntryMain view should render 1`] = `
         class="card__header card__header--with-separator"
       >
         <h2>
+          <span
+            data-article-id="proteome_similarity"
+          >
+            Proteome similarity
+          </span>
+           
+          <button
+            class="chip chip--compact"
+            type="button"
+          >
+            New
+          </button>
+        </h2>
+      </div>
+      <div
+        class="card__content"
+      >
+        <p
+          data-article-id="proteome_similarity"
+        >
+          No similarity score is available for this proteome. This is typically because the proteome is the only one for its species, or because no other reference proteome is similar enough to be listed here.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section
+    class="card"
+  >
+    <div
+      class="card__container"
+    >
+      <div
+        class="card__header card__header--with-separator"
+      >
+        <h2>
           Components
         </h2>
       </div>

--- a/src/proteomes/components/styles/publications.module.scss
+++ b/src/proteomes/components/styles/publications.module.scss
@@ -1,0 +1,4 @@
+.inline-publication {
+  border-bottom: 1px solid var(--fr--color-pastel-blue);
+  padding: 1rem 0;
+}

--- a/src/proteomes/components/styles/similar-proteomes.module.scss
+++ b/src/proteomes/components/styles/similar-proteomes.module.scss
@@ -1,0 +1,3 @@
+.table {
+  margin-top: 1rem;
+}

--- a/src/proteomes/config/ProteomesEntryConfig.tsx
+++ b/src/proteomes/config/ProteomesEntryConfig.tsx
@@ -4,6 +4,7 @@ import { type ProteomesUIModel } from '../adapters/proteomesConverter';
 import Components from '../components/entry/Components';
 import Description from '../components/entry/Description';
 import Publications from '../components/entry/Publications';
+import SimilarProteomes from '../components/entry/SimilarProteomes';
 import EntrySection from '../types/entrySection';
 
 const ProteomesEntryConfig: {
@@ -14,6 +15,16 @@ const ProteomesEntryConfig: {
     id: EntrySection.Description,
     sectionContent: (data) =>
       data.description ? <Description>{data.description}</Description> : null,
+  },
+  {
+    id: EntrySection.SimilarProteomes,
+    sectionContent: ({ relatedProteomes, proteomeType, exclusionReasons }) => (
+      <SimilarProteomes
+        relatedProteomes={relatedProteomes}
+        proteomeType={proteomeType}
+        exclusionReasons={exclusionReasons}
+      />
+    ),
   },
   {
     id: EntrySection.Components,

--- a/src/proteomes/config/ProteomesEntryConfig.tsx
+++ b/src/proteomes/config/ProteomesEntryConfig.tsx
@@ -17,16 +17,6 @@ const ProteomesEntryConfig: {
       data.description ? <Description>{data.description}</Description> : null,
   },
   {
-    id: EntrySection.SimilarProteomes,
-    sectionContent: ({ relatedProteomes, proteomeType, exclusionReasons }) => (
-      <SimilarProteomes
-        relatedProteomes={relatedProteomes}
-        proteomeType={proteomeType}
-        exclusionReasons={exclusionReasons}
-      />
-    ),
-  },
-  {
     id: EntrySection.Components,
     sectionContent: ({
       components,
@@ -49,6 +39,16 @@ const ProteomesEntryConfig: {
   {
     id: EntrySection.Publications,
     sectionContent: ({ citations }) => <Publications citations={citations} />,
+  },
+  {
+    id: EntrySection.SimilarProteomes,
+    sectionContent: ({ relatedProteomes, proteomeType, exclusionReasons }) => (
+      <SimilarProteomes
+        relatedProteomes={relatedProteomes}
+        proteomeType={proteomeType}
+        exclusionReasons={exclusionReasons}
+      />
+    ),
   },
 ];
 

--- a/src/proteomes/types/entrySection.ts
+++ b/src/proteomes/types/entrySection.ts
@@ -1,5 +1,6 @@
 enum EntrySection {
   Description = 'description',
+  SimilarProteomes = 'similar_proteomes',
   Components = 'components',
   Publications = 'publications',
 }


### PR DESCRIPTION
## Purpose

Display similar reference proteomes section inside Proteomes Entry pages. Also changed the publication view so it fits more with the card style of the entry page.

## Approach

Use cards format for the new similar reference proteome section and the publication section

## Testing

Tested with feedback from consortium

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [x] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
