### PR TITLE
Use variation canvas pr4

### DIFF
--- a/src/shared/components/table/TableFromData.tsx
+++ b/src/shared/components/table/TableFromData.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import { Message } from 'franklin-sites';
 import {
   type HTMLAttributes,
+  memo,
   type ReactNode,
   useCallback,
   useEffect,
@@ -17,7 +18,7 @@ import Table from './Table';
 
 const UNFILTERED_OPTION = 'All' as const;
 
-export const VIRTUALIZE_ROW_THRESHOLD = 200;
+export const VIRTUALIZE_ROW_THRESHOLD = 1000;
 const VIRTUALIZE_ROW_OVERSCAN = 10;
 const VIRTUALIZE_ESTIMATED_ROW_HEIGHT = 36;
 
@@ -94,6 +95,62 @@ type Props<T> = HTMLAttributes<HTMLTableElement> & {
 type ColumnsToSelectedFilter = Record<string, string | undefined>;
 
 const collator = new Intl.Collator('en');
+
+type TableFromDataRowProps<T> = {
+  datum: T;
+  isOdd: boolean;
+  columns: TableFromDataColumn<T>[];
+  rowExtraContent?: (datum: T) => React.ReactNode;
+  rowId: string;
+  isMarkedBackground: boolean;
+  isMarkedBorder: boolean;
+  onClick?: (datum: T, expanded: boolean) => void;
+};
+
+function TableFromDataRowComponent<T>({
+  datum,
+  isOdd,
+  columns,
+  rowExtraContent,
+  rowId,
+  isMarkedBackground,
+  isMarkedBorder,
+  onClick,
+}: TableFromDataRowProps<T>) {
+  const handleClick = useCallback(
+    (expanded: boolean) => onClick?.(datum, expanded),
+    [datum, onClick]
+  );
+
+  return (
+    <Table.Row
+      isOdd={isOdd}
+      extraContent={
+        rowExtraContent && (
+          <td colSpan={columns.length}>{rowExtraContent(datum)}</td>
+        )
+      }
+      onClick={handleClick}
+      className={cn({
+        [styles['mark-background']]: isMarkedBackground,
+        [styles['mark-border']]: isMarkedBorder,
+      })}
+      data-id={rowId}
+    >
+      {columns.map((column) => (
+        <td key={column.id}>{column.render(datum)}</td>
+      ))}
+    </Table.Row>
+  );
+}
+
+// React.memo with a generic component requires the cast to preserve the type
+// signature. Memoising the row is the main win for large non-virtualized
+// tables: only rows whose props actually changed (e.g. the previously- and
+// newly-highlighted row) re-render, instead of the whole list.
+const TableFromDataRow = memo(
+  TableFromDataRowComponent
+) as typeof TableFromDataRowComponent;
 
 function TableFromData<T>({
   data,
@@ -207,31 +264,24 @@ function TableFromData<T>({
         )}
         {virtualItems.map((virtualItem) => {
           const datum = filteredData[virtualItem.index];
+          const rowId = getRowId(datum);
           return (
             <tbody
-              key={getRowId(datum)}
+              key={rowId}
               data-index={virtualItem.index}
               ref={virtualizer.measureElement}
               translate={noTranslateBody ? 'no' : undefined}
             >
-              <Table.Row
+              <TableFromDataRow
+                datum={datum}
                 isOdd={virtualItem.index % 2 === 1}
-                extraContent={
-                  rowExtraContent && (
-                    <td colSpan={columns.length}>{rowExtraContent(datum)}</td>
-                  )
-                }
-                onClick={(expanded: boolean) => onRowClick?.(datum, expanded)}
-                className={cn({
-                  [styles['mark-background']]: markBackground?.(datum),
-                  [styles['mark-border']]: markBorder?.(datum),
-                })}
-                data-id={getRowId(datum)}
-              >
-                {columns.map((column) => (
-                  <td key={column.id}>{column.render(datum)}</td>
-                ))}
-              </Table.Row>
+                columns={columns}
+                rowExtraContent={rowExtraContent}
+                rowId={rowId}
+                isMarkedBackground={Boolean(markBackground?.(datum))}
+                isMarkedBorder={Boolean(markBorder?.(datum))}
+                onClick={onRowClick}
+              />
             </tbody>
           );
         })}
@@ -264,27 +314,22 @@ function TableFromData<T>({
       </Table.Head>
       <Table.Body translate={noTranslateBody ? 'no' : undefined}>
         {filteredData.length ? (
-          filteredData.map((datum, index) => (
-            <Table.Row
-              isOdd={index % 2 === 1}
-              extraContent={
-                rowExtraContent && (
-                  <td colSpan={columns.length}>{rowExtraContent(datum)}</td>
-                )
-              }
-              key={getRowId(datum)}
-              onClick={(expanded: boolean) => onRowClick?.(datum, expanded)}
-              className={cn({
-                [styles['mark-background']]: markBackground?.(datum),
-                [styles['mark-border']]: markBorder?.(datum),
-              })}
-              data-id={getRowId(datum)}
-            >
-              {columns.map((column) => (
-                <td key={column.id}>{column.render(datum)}</td>
-              ))}
-            </Table.Row>
-          ))
+          filteredData.map((datum, index) => {
+            const rowId = getRowId(datum);
+            return (
+              <TableFromDataRow
+                key={rowId}
+                datum={datum}
+                isOdd={index % 2 === 1}
+                columns={columns}
+                rowExtraContent={rowExtraContent}
+                rowId={rowId}
+                isMarkedBackground={Boolean(markBackground?.(datum))}
+                isMarkedBorder={Boolean(markBorder?.(datum))}
+                onClick={onRowClick}
+              />
+            );
+          })
         ) : (
           <tr>
             <td

--- a/src/shared/components/table/TableFromData.tsx
+++ b/src/shared/components/table/TableFromData.tsx
@@ -5,6 +5,7 @@ import {
   type HTMLAttributes,
   type ReactNode,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -16,7 +17,7 @@ import Table from './Table';
 
 const UNFILTERED_OPTION = 'All' as const;
 
-const VIRTUALIZE_ROW_THRESHOLD = 200;
+export const VIRTUALIZE_ROW_THRESHOLD = 200;
 const VIRTUALIZE_ROW_OVERSCAN = 10;
 const VIRTUALIZE_ESTIMATED_ROW_HEIGHT = 36;
 
@@ -165,9 +166,11 @@ function TableFromData<T>({
 
   // Forward the virtualizer instance to the parent via ref. Used by the
   // scroll-to-row hook to jump to rows that aren't currently mounted.
-  if (virtualizerRef) {
-    virtualizerRef.current = shouldVirtualize ? virtualizer : null;
-  }
+  useEffect(() => {
+    if (virtualizerRef) {
+      virtualizerRef.current = shouldVirtualize ? virtualizer : null;
+    }
+  }, [shouldVirtualize, virtualizer, virtualizerRef]);
 
   if (shouldVirtualize) {
     const virtualItems = virtualizer.getVirtualItems();
@@ -209,7 +212,6 @@ function TableFromData<T>({
               key={getRowId(datum)}
               data-index={virtualItem.index}
               ref={virtualizer.measureElement}
-              className={styles['virtual-row']}
               translate={noTranslateBody ? 'no' : undefined}
             >
               <Table.Row

--- a/src/shared/components/table/__tests__/TableFromData.spec.tsx
+++ b/src/shared/components/table/__tests__/TableFromData.spec.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import customRender from '../../../__test-helpers__/customRender';
-import TableFromData, { type TableFromDataColumn } from '../TableFromData';
+import TableFromData, {
+  type TableFromDataColumn,
+  VIRTUALIZE_ROW_THRESHOLD,
+} from '../TableFromData';
 
 type Row = { id: string; name: string; age: number };
 
@@ -36,11 +39,11 @@ describe('TableFromData', () => {
       <TableFromData
         virtualize
         columns={columns}
-        data={makeRows(50)}
+        data={makeRows(VIRTUALIZE_ROW_THRESHOLD)}
         getRowId={(d) => d.id}
       />
     );
-    // Below the 200 threshold, virtualization is not engaged.
+    // At or below the threshold, virtualization is not engaged.
     // The bounded scroll container (.virtualize-container) should NOT be present.
     expect(
       document.querySelector('[class*="virtualize-container"]')
@@ -49,7 +52,7 @@ describe('TableFromData', () => {
   });
 
   it('engages virtualized rendering above the threshold', () => {
-    const data = makeRows(300);
+    const data = makeRows(VIRTUALIZE_ROW_THRESHOLD + 1);
     customRender(
       <TableFromData
         virtualize

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -154,10 +154,13 @@
 }
 
 .frozen {
-  opacity: 0.6;
+  opacity: 0.4;
+  filter: saturate(0.5);
   pointer-events: none;
-  transition: opacity 120ms;
-  will-change: opacity;
+  transition:
+    opacity 160ms ease,
+    filter 160ms ease;
+  will-change: opacity, filter;
 }
 
 .virtual-spacer > tr > td {

--- a/src/shared/components/table/styles/table.module.scss
+++ b/src/shared/components/table/styles/table.module.scss
@@ -153,6 +153,10 @@
   overflow-y: auto;
 }
 
+.frozen-container {
+  position: relative;
+}
+
 .frozen {
   opacity: 0.4;
   filter: saturate(0.5);
@@ -161,6 +165,16 @@
     opacity 160ms ease,
     filter 160ms ease;
   will-change: opacity, filter;
+}
+
+.frozen-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .virtual-spacer > tr > td {

--- a/src/shared/custom-elements/NightingaleVariationCanvas.tsx
+++ b/src/shared/custom-elements/NightingaleVariationCanvas.tsx
@@ -7,4 +7,5 @@ const NightingaleVariationCanvasComponent = createComponent({
   elementClass: NightingaleVariationCanvas,
   react: React,
 });
+
 export default NightingaleVariationCanvasComponent;

--- a/src/shared/hooks/useNightingaleFeatureTableScroll.ts
+++ b/src/shared/hooks/useNightingaleFeatureTableScroll.ts
@@ -1,5 +1,5 @@
 import { type Virtualizer } from '@tanstack/react-virtual';
-import { type RefObject, useCallback } from 'react';
+import { type RefObject, useCallback, useRef } from 'react';
 
 function useNightingaleFeatureTableScroll<T>(
   getRowId: (feature: T) => string,
@@ -10,6 +10,11 @@ function useNightingaleFeatureTableScroll<T>(
   virtualizerRef?: RefObject<Virtualizer<HTMLDivElement, Element> | null>,
   data?: T[] | null
 ) {
+  // Keep a ref to the latest data so the callback never needs to be recreated
+  // when filtered data changes, preventing unnecessary listener re-attaches.
+  const dataRef = useRef(data);
+  dataRef.current = data;
+
   return useCallback(
     (feature: T) => {
       const rowId = getRowId(feature);
@@ -39,14 +44,14 @@ function useNightingaleFeatureTableScroll<T>(
 
       // Row isn't currently in the DOM (virtualized off-screen): jump by index.
       const virtualizer = virtualizerRef?.current;
-      if (virtualizer && data) {
-        const idx = data.findIndex((d) => getRowId(d) === rowId);
+      if (virtualizer && dataRef.current) {
+        const idx = dataRef.current.findIndex((d) => getRowId(d) === rowId);
         if (idx >= 0) {
           virtualizer.scrollToIndex(idx, { align: 'center' });
         }
       }
     },
-    [getRowId, tableId, virtualizerRef, data]
+    [getRowId, tableId, virtualizerRef]
   );
 }
 

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -19,9 +19,15 @@ import {
   useReducer,
   useRef,
   useState,
+  useTransition,
 } from 'react';
 import { type PartialDeep, type SetRequired } from 'type-fest';
 
+import { addMessage } from '../../../../../messages/state/messagesActions';
+import {
+  MessageFormat,
+  MessageLevel,
+} from '../../../../../messages/types/messagesTypes';
 import { Dataset } from '../../../../../shared/components/entry/EntryDownload';
 import EntryDownloadButton from '../../../../../shared/components/entry/EntryDownloadButton';
 import EntryDownloadPanel from '../../../../../shared/components/entry/EntryDownloadPanel';
@@ -30,12 +36,14 @@ import ExternalLink from '../../../../../shared/components/ExternalLink';
 import tableStyles from '../../../../../shared/components/table/styles/table.module.scss';
 import TableFromData, {
   type TableFromDataColumn,
+  VIRTUALIZE_ROW_THRESHOLD,
 } from '../../../../../shared/components/table/TableFromData';
 import apiUrls from '../../../../../shared/config/apiUrls/apiUrls';
 import externalUrls from '../../../../../shared/config/externalUrls';
 import NightingaleManagerComponent from '../../../../../shared/custom-elements/NightingaleManager';
 import useDataApi from '../../../../../shared/hooks/useDataApi';
 import { useSmallScreen } from '../../../../../shared/hooks/useMatchMedia';
+import useMessagesDispatch from '../../../../../shared/hooks/useMessagesDispatch';
 import useNightingaleFeatureTableScroll from '../../../../../shared/hooks/useNightingaleFeatureTableScroll';
 import helper from '../../../../../shared/styles/helper.module.scss';
 import {
@@ -463,8 +471,11 @@ const VariationViewer = ({
   const liveRangeRef = useRef<NightingaleViewRange | undefined>(undefined);
   const idleTimerRef = useRef<number | undefined>(undefined);
 
+  const messagesDispatch = useMessagesDispatch();
   const [displayDownloadPanel, setDisplayDownloadPanel] = useState(false);
 
+  // Previously gated on VARIANT_COUNT_LIMIT; the canvas renderer and virtual
+  // scrolling now handle large datasets, so we always fetch once the count is known.
   const { loading, data, progress, error, status } =
     useDataApi<ProteinsAPIVariation>(
       importedVariants !== 'loading'
@@ -473,6 +484,7 @@ const VariationViewer = ({
     );
 
   const [filters, setFilters] = useState<string[]>([]);
+  const [isFiltering, startFilterTransition] = useTransition();
   const managerRef = useRef<NightingaleManager>(null);
 
   // We pass the transformed data to both the variation viewer and the
@@ -500,6 +512,10 @@ const VariationViewer = ({
     [sortedVariants, filters]
   );
 
+  const isVirtualized = Boolean(
+    filteredVariants && filteredVariants.length > VIRTUALIZE_ROW_THRESHOLD
+  );
+
   const tableScroll = useNightingaleFeatureTableScroll(
     getRowId,
     tableId,
@@ -517,7 +533,9 @@ const VariationViewer = ({
     const listener = (event: Event) => {
       const { detail } = event as CustomEvent;
       if (detail?.type === 'filters') {
-        setFilters(detail.value);
+        // Filter updates touch thousands of rows; mark as a transition so
+        // React can interrupt the heavy re-render to handle further clicks.
+        startFilterTransition(() => setFilters(detail.value));
       } else if (detail?.eventType === 'click' && detail?.feature) {
         dispatch({ type: 'setHighlight', variant: detail.feature });
         tableScroll(detail.feature);
@@ -583,6 +601,7 @@ const VariationViewer = ({
 
   const [tableReady, setTableReady] = useState(false);
   useEffect(() => {
+    // Guard is a no-op in this SPA, but kept to future-proof for SSR adoption.
     if (typeof window === 'undefined') {
       return undefined;
     }
@@ -595,6 +614,28 @@ const VariationViewer = ({
     const handle = window.setTimeout(() => setTableReady(true), 0);
     return () => window.clearTimeout(handle);
   }, []);
+
+  useEffect(() => {
+    if (!isVirtualized) {
+      return;
+    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        messagesDispatch(
+          addMessage({
+            id: 'variation-viewer-search-hint',
+            content:
+              "Too many rows for the browser's find to search - use the column filters instead.",
+            format: MessageFormat.POP_UP,
+            level: MessageLevel.INFO,
+            displayTime: 5_000,
+          })
+        );
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isVirtualized, messagesDispatch]);
 
   const memoizedColumns = useMemo(
     () => getColumns(primaryAccession),
@@ -698,7 +739,7 @@ const VariationViewer = ({
       {tableReady && (
         <div
           className={cn({
-            [tableStyles.frozen]: isNavigating,
+            [tableStyles.frozen]: isNavigating || isFiltering,
           })}
         >
           <TableFromData

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -113,18 +113,15 @@ const applyFilters = (variants: TransformedVariant[], filters: string[]) => {
     .map((f) => getFilter(provenanceFilters, f))
     .filter(Boolean);
 
-  const filteredVariants = variants
-    ?.filter((variant) =>
+  return variants?.filter(
+    (variant) =>
       selectedConsequenceFilters.some((filter) =>
         filter?.filterPredicate(variant)
-      )
-    )
-    .filter((variant) =>
+      ) &&
       selectedProvenanceFilters.some((filter) =>
         filter?.filterPredicate(variant)
       )
-    );
-  return filteredVariants;
+  );
 };
 
 const getHighlightedCoordinates = (feature?: TransformedVariant) =>
@@ -485,6 +482,40 @@ const VariationViewer = ({
 
   const [filters, setFilters] = useState<string[]>([]);
   const [isFiltering, startFilterTransition] = useTransition();
+  // Hold the dim+spinner feedback for a minimum of 1s after the transition
+  // starts so fast filter operations don't flash on/off.
+  const MIN_FILTER_FEEDBACK_MS = 750;
+  const [filteringFeedbackActive, setFilteringFeedbackActive] = useState(false);
+  const filteringStartTimeRef = useRef<number | undefined>(undefined);
+  const filteringFeedbackTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (isFiltering) {
+      setFilteringFeedbackActive(true);
+      filteringStartTimeRef.current = Date.now();
+      if (filteringFeedbackTimerRef.current !== undefined) {
+        window.clearTimeout(filteringFeedbackTimerRef.current);
+        filteringFeedbackTimerRef.current = undefined;
+      }
+      return undefined;
+    }
+    if (filteringStartTimeRef.current === undefined) {
+      return undefined;
+    }
+    const elapsed = Date.now() - filteringStartTimeRef.current;
+    const remaining = Math.max(0, MIN_FILTER_FEEDBACK_MS - elapsed);
+    filteringFeedbackTimerRef.current = window.setTimeout(() => {
+      setFilteringFeedbackActive(false);
+      filteringFeedbackTimerRef.current = undefined;
+      filteringStartTimeRef.current = undefined;
+    }, remaining);
+    return () => {
+      if (filteringFeedbackTimerRef.current !== undefined) {
+        window.clearTimeout(filteringFeedbackTimerRef.current);
+        filteringFeedbackTimerRef.current = undefined;
+      }
+    };
+  }, [isFiltering]);
   const managerRef = useRef<NightingaleManager>(null);
 
   // We pass the transformed data to both the variation viewer and the
@@ -620,12 +651,17 @@ const VariationViewer = ({
       return;
     }
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        !e.altKey &&
+        !e.shiftKey &&
+        e.key === 'f'
+      ) {
         messagesDispatch(
           addMessage({
             id: 'variation-viewer-search-hint',
             content:
-              "Too many rows for the browser's find to search - use the column filters instead.",
+              "Too many rows for the browser's find to search. Use the column filters instead.",
             format: MessageFormat.POP_UP,
             level: MessageLevel.INFO,
             displayTime: 5_000,
@@ -724,36 +760,69 @@ const VariationViewer = ({
         )}
       </div>
       <EntryDownloadButton handleToggle={handleToggleDownload} />
-      <NightingaleManagerComponent
-        reflected-attributes="highlight,display-start,display-end,activefilters,filters,selectedid"
-        ref={managerRef}
-        highlight={getHighlightedCoordinates(highlightedVariant)}
-      >
-        <Suspense fallback={null}>
-          <VisualVariationView
-            sequence={transformedData.sequence}
-            variants={filteredVariants}
-          />
-        </Suspense>
-      </NightingaleManagerComponent>
-      {tableReady && (
+      <div className={tableStyles['frozen-container']}>
         <div
           className={cn({
-            [tableStyles.frozen]: isNavigating || isFiltering,
+            // Dim only while filters are recomputing on large datasets; we don't
+            // dim during navigation because the canvas is what the user is driving.
+            [tableStyles.frozen]: filteringFeedbackActive && isVirtualized,
           })}
         >
-          <TableFromData
-            id={tableId}
-            virtualize
-            virtualizerRef={variationTableVirtualizerRef}
-            columns={memoizedColumns}
-            data={filteredVariants}
-            getRowId={getRowId}
-            onRowClick={handleRowClick}
-            rowExtraContent={RowExtraContent}
-            markBackground={memoizedMarkBackground}
-            markBorder={memoizedMarkBorder}
-          />
+          <NightingaleManagerComponent
+            reflected-attributes="highlight,display-start,display-end,activefilters,filters,selectedid"
+            ref={managerRef}
+            highlight={getHighlightedCoordinates(highlightedVariant)}
+          >
+            <Suspense fallback={null}>
+              <VisualVariationView
+                sequence={transformedData.sequence}
+                variants={filteredVariants}
+              />
+            </Suspense>
+          </NightingaleManagerComponent>
+        </div>
+        {filteringFeedbackActive && isVirtualized && (
+          <div
+            className={tableStyles['frozen-overlay']}
+            role="status"
+            aria-live="polite"
+            aria-label="Filtering variants"
+          >
+            <Loader />
+          </div>
+        )}
+      </div>
+      {tableReady && (
+        <div className={tableStyles['frozen-container']}>
+          <div
+            className={cn({
+              [tableStyles.frozen]:
+                (isNavigating || filteringFeedbackActive) && isVirtualized,
+            })}
+          >
+            <TableFromData
+              id={tableId}
+              virtualize
+              virtualizerRef={variationTableVirtualizerRef}
+              columns={memoizedColumns}
+              data={filteredVariants}
+              getRowId={getRowId}
+              onRowClick={handleRowClick}
+              rowExtraContent={RowExtraContent}
+              markBackground={memoizedMarkBackground}
+              markBorder={memoizedMarkBorder}
+            />
+          </div>
+          {filteringFeedbackActive && isVirtualized && (
+            <div
+              className={tableStyles['frozen-overlay']}
+              role="status"
+              aria-live="polite"
+              aria-label="Filtering variants"
+            >
+              <Loader />
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/__snapshots__/VariationViewer.spec.tsx.snap
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/__tests__/__snapshots__/VariationViewer.spec.tsx.snap
@@ -13,616 +13,628 @@ exports[`VariationViewer component renders on data 1`] = `
       <test-file-stub />
       Download
     </button>
-    <nightingale-manager
-      reflected-attributes="highlight,display-start,display-end,activefilters,filters,selectedid"
-      style="display: block; line-height: 0;"
-    />
     <div
-      class=""
+      class="frozen-container"
     >
-      <table
-        class="table"
+      <div
+        class=""
       >
-        <thead
-          class=""
+        <nightingale-manager
+          reflected-attributes="highlight,display-start,display-end,activefilters,filters,selectedid"
+          style="display: block; line-height: 0;"
+        />
+      </div>
+    </div>
+    <div
+      class="frozen-container"
+    >
+      <div
+        class=""
+      >
+        <table
+          class="table"
         >
-          <tr
-            class="row"
+          <thead
+            class=""
           >
-            <th>
-              <div
-                aria-expanded="false"
-                aria-haspopup="true"
-                class="dropdown"
-              >
-                <button
-                  class="button tertiary"
-                  type="button"
-                >
-                  ±
-                </button>
-              </div>
-            </th>
-            <th>
-              Variant
-              <br />
-              ID(s)
-            </th>
-            <th>
-              Position(s)
-            </th>
-            <th>
-              Change
-            </th>
-            <th>
-              Description
-            </th>
-            <th>
-              Clinical
-              <br />
-              significance
-            </th>
-            <th>
-              Provenance
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          class=""
-        >
-          <tr
-            class="row has-extra-content"
-            data-id="0.02"
-          >
-            <td>
-              <button
-                aria-controls="3"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              22
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N22S"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
-                >
-                  N&gt;S
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content"
-            hidden=""
-            id="3"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row odd has-extra-content"
-            data-id="0.03"
-          >
-            <td>
-              <button
-                aria-controls="4"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              39-44
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                NK
-                <button
+            <tr
+              class="row"
+            >
+              <th>
+                <div
                   aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
-                  type="button"
+                  aria-haspopup="true"
+                  class="dropdown"
                 >
-                  [...]
-                </button>
-                &gt;SK
+                  <button
+                    class="button tertiary"
+                    type="button"
+                  >
+                    ±
+                  </button>
+                </div>
+              </th>
+              <th>
+                Variant
+                <br />
+                ID(s)
+              </th>
+              <th>
+                Position(s)
+              </th>
+              <th>
+                Change
+              </th>
+              <th>
+                Description
+              </th>
+              <th>
+                Clinical
+                <br />
+                significance
+              </th>
+              <th>
+                Provenance
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class=""
+          >
+            <tr
+              class="row has-extra-content"
+              data-id="0.02"
+            >
+              <td>
                 <button
+                  aria-controls="3"
                   aria-expanded="false"
-                  class="button tertiary ellipsis-reveal"
-                  title="Show more"
                   type="button"
                 >
-                  [...]
+                  +
                 </button>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content odd"
-            hidden=""
-            id="4"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row has-extra-content"
-            data-id="0.04"
-          >
-            <td>
-              <button
-                aria-controls="5"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              74
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N74D"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+              </td>
+              <td />
+              <td>
+                22
+              </td>
+              <td>
+                <span
+                  class="change"
                 >
-                  N&gt;D
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content"
-            hidden=""
-            id="5"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row odd has-extra-content"
-            data-id="0.05"
-          >
-            <td>
-              <button
-                aria-controls="6"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              88-89
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                GD&gt;TN
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content odd"
-            hidden=""
-            id="6"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row has-extra-content"
-            data-id="0.06"
-          >
-            <td>
-              <button
-                aria-controls="7"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              98
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N98D"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N22S"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    N&gt;S
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
                 >
-                  N&gt;D
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content"
-            hidden=""
-            id="7"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row odd has-extra-content"
-            data-id="0.07"
-          >
-            <td>
-              <button
-                aria-controls="8"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              106
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I106L"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
                 >
-                  I&gt;L
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content odd"
-            hidden=""
-            id="8"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row has-extra-content"
-            data-id="0.08"
-          >
-            <td>
-              <button
-                aria-controls="9"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              120
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I120T"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content"
+              hidden=""
+              id="3"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row odd has-extra-content"
+              data-id="0.03"
+            >
+              <td>
+                <button
+                  aria-controls="4"
+                  aria-expanded="false"
+                  type="button"
                 >
-                  I&gt;T
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content"
-            hidden=""
-            id="9"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row odd has-extra-content"
-            data-id="0.09"
-          >
-            <td>
-              <button
-                aria-controls="10"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              125
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 M125I"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                39-44
+              </td>
+              <td>
+                <span
+                  class="change"
                 >
-                  M&gt;I
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content odd"
-            hidden=""
-            id="10"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row has-extra-content"
-            data-id="0.1"
-          >
-            <td>
-              <button
-                aria-controls="11"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              133
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 S133N"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  NK
+                  <button
+                    aria-expanded="false"
+                    class="button tertiary ellipsis-reveal"
+                    title="Show more"
+                    type="button"
+                  >
+                    [...]
+                  </button>
+                  &gt;SK
+                  <button
+                    aria-expanded="false"
+                    class="button tertiary ellipsis-reveal"
+                    title="Show more"
+                    type="button"
+                  >
+                    [...]
+                  </button>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
                 >
-                  S&gt;N
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content"
-            hidden=""
-            id="11"
-          >
-            <td />
-          </tr>
-          <tr
-            class="row odd has-extra-content"
-            data-id="0.11"
-          >
-            <td>
-              <button
-                aria-controls="12"
-                aria-expanded="false"
-                type="button"
-              >
-                +
-              </button>
-            </td>
-            <td />
-            <td>
-              267
-            </td>
-            <td>
-              <span
-                class="change"
-              >
-                <a
-                  class="external-link"
-                  href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 H267N"
-                  rel="noopener"
-                  target="_blank"
-                  title="View in ProtVar"
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
                 >
-                  H&gt;N
-                </a>
-              </span>
-            </td>
-            <td>
-              <div
-                class="bold"
-              >
-                strain: Type C / C-6814 (UniProt)
-              </div>
-            </td>
-            <td />
-            <td>
-              <span
-                class="bold"
-              >
-                UniProt
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="row extra-content odd"
-            hidden=""
-            id="12"
-          >
-            <td />
-          </tr>
-        </tbody>
-      </table>
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content odd"
+              hidden=""
+              id="4"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row has-extra-content"
+              data-id="0.04"
+            >
+              <td>
+                <button
+                  aria-controls="5"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                74
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N74D"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    N&gt;D
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content"
+              hidden=""
+              id="5"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row odd has-extra-content"
+              data-id="0.05"
+            >
+              <td>
+                <button
+                  aria-controls="6"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                88-89
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  GD&gt;TN
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content odd"
+              hidden=""
+              id="6"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row has-extra-content"
+              data-id="0.06"
+            >
+              <td>
+                <button
+                  aria-controls="7"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                98
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 N98D"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    N&gt;D
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content"
+              hidden=""
+              id="7"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row odd has-extra-content"
+              data-id="0.07"
+            >
+              <td>
+                <button
+                  aria-controls="8"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                106
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I106L"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    I&gt;L
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content odd"
+              hidden=""
+              id="8"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row has-extra-content"
+              data-id="0.08"
+            >
+              <td>
+                <button
+                  aria-controls="9"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                120
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 I120T"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    I&gt;T
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content"
+              hidden=""
+              id="9"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row odd has-extra-content"
+              data-id="0.09"
+            >
+              <td>
+                <button
+                  aria-controls="10"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                125
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 M125I"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    M&gt;I
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content odd"
+              hidden=""
+              id="10"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row has-extra-content"
+              data-id="0.1"
+            >
+              <td>
+                <button
+                  aria-controls="11"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                133
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 S133N"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    S&gt;N
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content"
+              hidden=""
+              id="11"
+            >
+              <td />
+            </tr>
+            <tr
+              class="row odd has-extra-content"
+              data-id="0.11"
+            >
+              <td>
+                <button
+                  aria-controls="12"
+                  aria-expanded="false"
+                  type="button"
+                >
+                  +
+                </button>
+              </td>
+              <td />
+              <td>
+                267
+              </td>
+              <td>
+                <span
+                  class="change"
+                >
+                  <a
+                    class="external-link"
+                    href="https://www.ebi.ac.uk/ProtVar/query?search=P0DPR0 H267N"
+                    rel="noopener"
+                    target="_blank"
+                    title="View in ProtVar"
+                  >
+                    H&gt;N
+                  </a>
+                </span>
+              </td>
+              <td>
+                <div
+                  class="bold"
+                >
+                  strain: Type C / C-6814 (UniProt)
+                </div>
+              </td>
+              <td />
+              <td>
+                <span
+                  class="bold"
+                >
+                  UniProt
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="row extra-content odd"
+              hidden=""
+              id="12"
+            >
+              <td />
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </section>
 </DocumentFragment>


### PR DESCRIPTION
## Changes

- Memoised the per-row component so highlight and view-range changes only re-render the affected rows
- Wrapped `setFilters` in `useTransition` with a dim overlay (min 750 ms) so heavy filter recomputes don't block clicks or flash on/off
- Detect `Ctrl/Cmd+F` on large datasets and surface a pop-up via the existing messages API explaining browser find can't reach undisplayed rows
- Combined the two-pass filter predicate into a single pass; latest-ref pattern in `useNightingaleFeatureTableScroll` keeps the scroll callback stable across filter changes

## Testing

Updated

## Checklist

- [x] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.