### PR TITLE
Show only the first similar protein tab which has content; fix section outlines; fix offset when scrolling.

### DIFF
--- a/src/app/components/styles/app.scss
+++ b/src/app/components/styles/app.scss
@@ -26,6 +26,12 @@
   }
 }
 
+// InPageNav focuses the hash-targeted section (tabindex="-1") for screen
+// readers; don't draw an outline around the whole section.
+[data-entry-section]:focus {
+  outline: none;
+}
+
 /* contextual help */
 /* global style now to avoid layout shift when loading logic later */
 [data-article-id] {

--- a/src/shared/components/entry/styles/entry-page.scss
+++ b/src/shared/components/entry/styles/entry-page.scss
@@ -13,7 +13,9 @@
 
 .entry-page {
   *[id] {
-    scroll-margin-top: 4.2em;
+    // Add the sticky compact bar's height (0 unless stuck) so anchored sections
+    // clear it instead of landing behind it.
+    scroll-margin-top: calc(4.2em + var(--compact-bar-height, 0rem));
   }
 
   & .tabs__header {

--- a/src/shared/components/entry/styles/entry-sticky-header.module.scss
+++ b/src/shared/components/entry/styles/entry-sticky-header.module.scss
@@ -9,8 +9,9 @@
 // do not adopt this pattern.
 
 // Default: compact bar takes no space; the existing tabs__header sticks at top: 0.
+// Kept as a length (0rem, not 0) so it composes in `calc()` for scroll-margin.
 .container {
-  --compact-bar-height: 0;
+  --compact-bar-height: 0rem;
 }
 
 // When there's no sidebar, extend both sticky rows leftward by --sidebar-size

--- a/src/uniparc/components/sub-entry/SubEntrySimilarProteins.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySimilarProteins.tsx
@@ -1,24 +1,35 @@
 import { Loader, Tab, Tabs } from 'franklin-sites';
 import { groupBy } from 'lodash-es';
+import { useCallback, useEffect, useState } from 'react';
 
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
 import useDataApi from '../../../shared/hooks/useDataApi';
 import { Namespace } from '../../../shared/types/namespaces';
 import { type SearchResults } from '../../../shared/types/results';
+import SimilarProteinsError from '../../../uniprotkb/components/entry/similar-proteins/SimilarProteinsError';
 import {
   type UniRefEntryType,
   uniRefEntryTypeToPercent,
   type UniRefLiteAPIModel,
 } from '../../../uniref/adapters/uniRefConverter';
-import SubEntrySimilarProteinsTabContent from './SubEntrySimilarProteinsTabContent';
+import SubEntrySimilarProteinsTabContent, {
+  type LevelPartition,
+  partitionLevel,
+} from './SubEntrySimilarProteinsTabContent';
 
-export type ClusterMapping = Record<
-  UniRefEntryType,
-  Record<string, UniRefLiteAPIModel>
->;
+// Stable empty fallback so a level missing from the grouping keeps a constant
+// reference across renders.
+const EMPTY_CLUSTERS: UniRefLiteAPIModel[] = [];
 
 type Props = {
   uniparcId: string;
+};
+
+type Data = {
+  mapping: Record<string, UniRefLiteAPIModel[]>;
+  // Only levels visited by the scan; the rest load lazily when their tab opens.
+  partitions: Partial<Record<UniRefEntryType, LevelPartition>>;
+  defaultLevel?: UniRefEntryType;
 };
 
 const SimilarProteins = ({ uniparcId }: Props) => {
@@ -26,13 +37,92 @@ const SimilarProteins = ({ uniparcId }: Props) => {
     `${apiUrls.search.searchPrefix(Namespace.uniref)}?query=(upi:${uniparcId})`
   );
 
-  if (unirefData.loading || !unirefData.data) {
+  const results = unirefData.data?.results;
+
+  const [data, setData] = useState<Data | null>(null);
+  const [scanLoading, setScanLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [reload, setReload] = useState(0);
+
+  useEffect(() => {
+    if (!results) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    const mapping = groupBy(results, 'entryType');
+    // Stop at the first level with similar proteins: clusters are nested, so
+    // every lower-identity level has them too. The rest load on open.
+    (async () => {
+      const partitions: Partial<Record<UniRefEntryType, LevelPartition>> = {};
+      let defaultLevel: UniRefEntryType | undefined;
+      for (const level of Object.keys(
+        uniRefEntryTypeToPercent
+      ) as UniRefEntryType[]) {
+        // eslint-disable-next-line no-await-in-loop -- intentionally sequential: stop as soon as a level has data
+        const partition = await partitionLevel(
+          mapping[level] || EMPTY_CLUSTERS,
+          controller.signal
+        );
+        partitions[level] = partition;
+        if (partition.hasSimilar.length > 0) {
+          defaultLevel = level;
+          break;
+        }
+      }
+      setData({ mapping, partitions, defaultLevel });
+      setScanLoading(false);
+    })().catch(() => {
+      if (!controller.signal.aborted) {
+        setError(true);
+        setScanLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, [results, reload]);
+
+  // Cache a level's data once a tab finishes loading it, so revisiting is
+  // instant (no loader, no refetch).
+  const handleLoaded = useCallback(
+    (clusterType: string, partition: LevelPartition) => {
+      setData(
+        (current) =>
+          current && {
+            ...current,
+            partitions: {
+              ...current.partitions,
+              [clusterType as UniRefEntryType]: partition,
+            },
+          }
+      );
+    },
+    []
+  );
+
+  if (error) {
+    return (
+      <SimilarProteinsError
+        onRetry={() => {
+          setError(false);
+          setScanLoading(true);
+          setReload((n) => n + 1);
+        }}
+      />
+    );
+  }
+
+  if (scanLoading || !data) {
     return <Loader />;
   }
-  const mappingData =
-    unirefData.data.results.length &&
-    groupBy(unirefData.data.results, 'entryType');
-  return mappingData ? (
+
+  if (Object.keys(data.mapping).length === 0) {
+    return (
+      <div>
+        <em>No similar UniProtKB entry found.</em>
+      </div>
+    );
+  }
+
+  return (
     <Tabs bordered>
       {Object.entries(uniRefEntryTypeToPercent).map(
         ([clusterType, percentValue]) => (
@@ -40,19 +130,18 @@ const SimilarProteins = ({ uniparcId }: Props) => {
             id={clusterType}
             title={`${percentValue} identity`}
             key={clusterType}
+            defaultSelected={clusterType === data.defaultLevel}
           >
             <SubEntrySimilarProteinsTabContent
               clusterType={clusterType}
-              clusters={mappingData[clusterType]}
+              clusters={data.mapping[clusterType] || EMPTY_CLUSTERS}
+              initialPartition={data.partitions[clusterType as UniRefEntryType]}
+              onLoaded={handleLoaded}
             />
           </Tab>
         )
       )}
     </Tabs>
-  ) : (
-    <div>
-      <em>No similar UniProtKB entry found.</em>
-    </div>
   );
 };
 

--- a/src/uniparc/components/sub-entry/SubEntrySimilarProteinsTabContent.tsx
+++ b/src/uniparc/components/sub-entry/SubEntrySimilarProteinsTabContent.tsx
@@ -1,85 +1,116 @@
 import { Loader } from 'franklin-sites';
 import { zip } from 'lodash-es';
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Location, LocationToPath } from '../../../app/config/urls';
 import apiUrls from '../../../shared/config/apiUrls/apiUrls';
-import useSafeState from '../../../shared/hooks/useSafeState';
 import { Namespace } from '../../../shared/types/namespaces';
 import fetchData from '../../../shared/utils/fetchData';
-import listFormat from '../../../shared/utils/listFormat';
-import { pluralise } from '../../../shared/utils/utils';
 import { type UniProtkbAPIModel } from '../../../uniprotkb/adapters/uniProtkbConverter';
+import SimilarProteinsError from '../../../uniprotkb/components/entry/similar-proteins/SimilarProteinsError';
 import SimilarProteinsTable, {
   columns,
 } from '../../../uniprotkb/components/entry/similar-proteins/SimilarProteinsTable';
+import useLazySimilarityLevel from '../../../uniprotkb/components/entry/similar-proteins/useLazySimilarityLevel';
 import {
   type UniRefEntryType,
   uniRefEntryTypeToPercent,
   type UniRefLiteAPIModel,
 } from '../../../uniref/adapters/uniRefConverter';
 
-type Props = {
-  clusterType: string;
-  clusters: UniRefLiteAPIModel[];
-};
-
-type HasSimilarProteins = {
+export type HasSimilarProteins = {
   total: number;
   cluster: UniRefLiteAPIModel;
   uniprotkbResults: UniProtkbAPIModel[];
   uniprotkbQuery: string;
 };
 
+export type LevelPartition = {
+  hasSimilar: HasSimilarProteins[];
+};
+
 const getUniprotkbQuery = (cluster: UniRefLiteAPIModel) =>
   `(uniref_cluster_${cluster.entryType.replace('UniRef', '')}:${cluster.id})`;
 
-const SimilarProteinsTabContent = ({ clusterType, clusters }: Props) => {
-  const [partitionedProteins, setPartitionedProteins] = useSafeState<
-    [string[], HasSimilarProteins[]]
-  >([[], []]);
-  const [loading, setLoading] = useSafeState(true);
-
-  useEffect(() => {
-    const promises = clusters.map((cluster) => {
-      const url = apiUrls.search.search({
+// Fetch each cluster's UniProtKB members for one level (a cluster may be
+// UniParc-only). Exported so the parent reuses it during its scan and lazy
+// tabs call it on open.
+export const partitionLevel = async (
+  clusters: UniRefLiteAPIModel[],
+  signal: AbortSignal
+): Promise<LevelPartition> => {
+  const promises = clusters.map((cluster) =>
+    fetchData<{
+      results: UniProtkbAPIModel[];
+    }>(
+      apiUrls.search.search({
         namespace: Namespace.uniprotkb,
         query: getUniprotkbQuery(cluster),
         columns,
         size: 10,
+      }),
+      undefined,
+      { signal }
+    )
+  );
+  const responses = await Promise.all(promises);
+  const hasSimilar: HasSimilarProteins[] = [];
+  for (const [cluster, response] of zip(clusters, responses)) {
+    const total = +(response?.headers?.['x-total-results'] || 0);
+    if (total && response?.data.results && cluster) {
+      hasSimilar.push({
+        total,
+        cluster,
+        uniprotkbResults: response.data.results,
+        uniprotkbQuery: getUniprotkbQuery(cluster),
       });
-      return fetchData<{
-        results: UniProtkbAPIModel[];
-      }>(url);
-    });
-    Promise.all(promises).then((responses) => {
-      // May not have uniprotkb entries and consist only of uniparc entries
-      const hasSimilar: HasSimilarProteins[] = [];
-      const noSimilar: string[] = [];
-      for (const [cluster, response] of zip(clusters, responses)) {
-        const total = +(response?.headers?.['x-total-results'] || 0);
-        if (total && response?.data.results && cluster) {
-          hasSimilar.push({
-            total,
-            cluster,
-            uniprotkbResults: response?.data.results,
-            uniprotkbQuery: getUniprotkbQuery(cluster),
-          });
-        } else {
-          noSimilar.push();
-        }
-      }
-      setPartitionedProteins([noSimilar, hasSimilar]);
-      setLoading(false);
-    });
-  }, [clusters, setLoading, setPartitionedProteins]);
+    }
+  }
+  return { hasSimilar };
+};
 
-  if (loading) {
-    return <Loader />;
+type Props = {
+  clusterType: string;
+  clusters: UniRefLiteAPIModel[];
+  // Set once a level is loaded (by the scan or a previous visit).
+  initialPartition?: LevelPartition;
+  onLoaded: (clusterType: string, partition: LevelPartition) => void;
+};
+
+const SimilarProteinsTabContent = ({
+  clusterType,
+  clusters,
+  initialPartition,
+  onLoaded,
+}: Props) => {
+  // Loaded levels arrive via `initialPartition`; others fetch on first open.
+  const fetcher = useCallback(
+    (signal: AbortSignal) => partitionLevel(clusters, signal),
+    [clusters]
+  );
+  const { error, retry } = useLazySimilarityLevel({
+    clusterType,
+    initialPartition,
+    fetcher,
+    onLoaded,
+  });
+
+  if (!initialPartition) {
+    return error ? <SimilarProteinsError onRetry={retry} /> : <Loader />;
   }
 
-  const [noSimilarProteins, hasSimilarProteins] = partitionedProteins;
+  const { hasSimilar: hasSimilarProteins } = initialPartition;
+
+  if (hasSimilarProteins.length === 0) {
+    return (
+      <section className="text-block">
+        {`No similar proteins at ${
+          uniRefEntryTypeToPercent[clusterType as UniRefEntryType]
+        } identity.`}
+      </section>
+    );
+  }
 
   return (
     <>
@@ -95,26 +126,6 @@ const SimilarProteinsTabContent = ({ clusterType, clusters }: Props) => {
             <hr />
           </section>
         )
-      )}
-      {!!noSimilarProteins.length && (
-        <section key="no-similar-proteins" className="text-block">
-          <h4>
-            {noSimilarProteins.map((isoform, index) => (
-              <span key={isoform}>
-                {listFormat(index, noSimilarProteins)}
-                {isoform}
-              </span>
-            ))}
-          </h4>
-          {`No similar proteins at ${
-            uniRefEntryTypeToPercent[clusterType as UniRefEntryType]
-          } identity for ${pluralise(
-            'this isoform.',
-            noSimilarProteins.length,
-            'these isoforms.'
-          )}`}
-          <hr />
-        </section>
       )}
       <Link
         className="button primary"

--- a/src/uniparc/components/sub-entry/__tests__/SubEntrySimilarProteins.spec.tsx
+++ b/src/uniparc/components/sub-entry/__tests__/SubEntrySimilarProteins.spec.tsx
@@ -1,0 +1,96 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+import customRender from '../../../../shared/__test-helpers__/customRender';
+import uniprotkbClusterSearch from '../../../../uniprotkb/components/entry/similar-proteins/__tests__/__mocks__/uniprotkbClusterSearch';
+import SubEntrySimilarProteins from '../SubEntrySimilarProteins';
+
+// Three UniRef clusters (one per level) for the UniParc entry.
+const unirefClusters = {
+  results: [
+    { id: 'UniRef100_UPI0002633FF6', entryType: 'UniRef100', memberCount: 1 },
+    { id: 'UniRef90_T2PM54', entryType: 'UniRef90', memberCount: 42 },
+    { id: 'UniRef50_T2PM54', entryType: 'UniRef50', memberCount: 42 },
+  ],
+};
+
+const axiosMock = new MockAdapter(axios);
+
+const renderSection = () =>
+  act(async () => {
+    customRender(<SubEntrySimilarProteins uniparcId="UPI0002633FF6" />);
+  });
+
+describe('SubEntrySimilarProteins', () => {
+  afterEach(() => axiosMock.reset());
+
+  it('shows a message on levels that have no similar proteins', async () => {
+    axiosMock
+      .onGet(/\/uniref\/search/)
+      .reply(200, unirefClusters)
+      // No UniProtKB members at any level
+      .onGet(/\/uniprotkb\/search/)
+      .reply(200, { results: [] }, { 'x-total-results': 0 });
+
+    await renderSection();
+    await screen.findByText(/No similar proteins at 100% identity/);
+    fireEvent.click(screen.getByRole('tab', { name: '90% identity' }));
+    await screen.findByText(/No similar proteins at 90% identity/);
+  });
+
+  describe('with similar proteins below UniRef100', () => {
+    beforeEach(() => {
+      axiosMock
+        .onGet(/\/uniref\/search/)
+        .reply(200, unirefClusters)
+        // UniRef100 has no UniProtKB members; UniRef90 / UniRef50 do
+        .onGet(/uniref_cluster_100/)
+        .reply(200, { results: [] }, { 'x-total-results': 0 })
+        .onGet(/\/uniprotkb\/search/)
+        .reply(200, uniprotkbClusterSearch, { 'x-total-results': 2 });
+    });
+
+    it('defaults to the first level with similar proteins and renders its table', async () => {
+      await renderSection();
+      await screen.findByRole('link', { name: 'UniRef90_T2PM54' });
+      expect(screen.getByRole('tab', { name: '90% identity' })).toHaveClass(
+        'tabs__header__item--active'
+      );
+    });
+
+    it('updates content when switching between levels', async () => {
+      await renderSection();
+      await screen.findByRole('link', { name: 'UniRef90_T2PM54' });
+
+      fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+      await screen.findByRole('link', { name: 'UniRef50_T2PM54' });
+
+      fireEvent.click(screen.getByRole('tab', { name: '90% identity' }));
+      await screen.findByRole('link', { name: 'UniRef90_T2PM54' });
+      expect(
+        screen.queryByRole('link', { name: 'UniRef50_T2PM54' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('caches a lazily-loaded level and does not refetch on revisit', async () => {
+      await renderSection();
+      await screen.findByRole('link', { name: 'UniRef90_T2PM54' });
+      const cluster50Requests = () =>
+        axiosMock.history.get.filter((request) =>
+          request.url?.includes('uniref_cluster_50')
+        ).length;
+
+      fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+      await screen.findByRole('link', { name: 'UniRef50_T2PM54' });
+      const afterFirstVisit = cluster50Requests();
+      expect(afterFirstVisit).toBeGreaterThan(0);
+
+      fireEvent.click(screen.getByRole('tab', { name: '90% identity' }));
+      await screen.findByRole('link', { name: 'UniRef90_T2PM54' });
+      fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+      await screen.findByRole('link', { name: 'UniRef50_T2PM54' });
+      expect(cluster50Requests()).toBe(afterFirstVisit);
+    });
+  });
+});

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteins.tsx
@@ -1,6 +1,6 @@
 import { Loader, Tab, Tabs } from 'franklin-sites';
 import { isEqual, zip } from 'lodash-es';
-import { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import apiUrls from '../../../../shared/config/apiUrls/apiUrls';
 import { Namespace } from '../../../../shared/types/namespaces';
@@ -11,7 +11,11 @@ import {
   type UniRefLiteAPIModel,
 } from '../../../../uniref/adapters/uniRefConverter';
 import { UniRefColumn } from '../../../../uniref/config/UniRefColumnConfiguration';
-import SimilarProteinsTabContent from './SimilarProteinsTabContent';
+import SimilarProteinsError from './SimilarProteinsError';
+import SimilarProteinsTabContent, {
+  type LevelPartition,
+  partitionLevel,
+} from './SimilarProteinsTabContent';
 
 export type IsoformsAndCluster = {
   isoforms: string[];
@@ -55,9 +59,18 @@ type Props = {
   isoforms: string[];
 };
 
+type Data = {
+  mapping: ClusterMapping;
+  // Only levels visited by the scan; the rest load lazily when their tab opens.
+  partitions: Partial<Record<UniRefEntryType, LevelPartition>>;
+  defaultLevel?: UniRefEntryType;
+};
+
 const SimilarProteins = ({ canonical, isoforms }: Props) => {
-  const [mappingData, setMappingData] = useState<ClusterMapping | null>(null);
-  const [mappingLoading, setMappingLoading] = useState(true);
+  const [data, setData] = useState<Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [reload, setReload] = useState(0);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -77,25 +90,100 @@ const SimilarProteins = ({ canonical, isoforms }: Props) => {
         { signal: controller.signal }
       )
     );
-    Promise.all(promises).then(
-      (responses) => {
-        const clusterData = responses.map((response) => response.data.results);
-        const mapping = getClusterMapping(isoforms, clusterData);
-        setMappingData(mapping);
-        setMappingLoading(false);
-      },
-      () => {
-        /* ignore fetch errors */
+    (async () => {
+      const responses = await Promise.all(promises);
+      const clusterData = responses.map((response) => response.data.results);
+      const mapping = getClusterMapping(isoforms, clusterData);
+      // Stop at the first level with similar proteins: clusters are nested,
+      // so every lower-identity level has them too. The rest load on open.
+      const partitions: Partial<Record<UniRefEntryType, LevelPartition>> = {};
+      let defaultLevel: UniRefEntryType | undefined;
+      for (const level of Object.keys(
+        uniRefEntryTypeToPercent
+      ) as UniRefEntryType[]) {
+        // eslint-disable-next-line no-await-in-loop -- intentionally sequential: stop as soon as a level has data
+        const partition = await partitionLevel(
+          Object.values(mapping[level]),
+          canonical,
+          controller.signal
+        );
+        partitions[level] = partition;
+        if (partition.hasSimilar.length > 0) {
+          defaultLevel = level;
+          break;
+        }
       }
-    );
+      setData({ mapping, partitions, defaultLevel });
+      setLoading(false);
+    })().catch(() => {
+      if (!controller.signal.aborted) {
+        setError(true);
+        setLoading(false);
+      }
+    });
     return () => controller.abort();
-  }, [canonical, isoforms]);
+  }, [canonical, isoforms, reload]);
 
-  if (mappingLoading) {
+  // Cache a level's data once a tab finishes loading it, so revisiting is
+  // instant (no loader, no refetch).
+  const handleLoaded = useCallback(
+    (level: string, partition: LevelPartition) => {
+      setData(
+        (current) =>
+          current && {
+            ...current,
+            partitions: {
+              ...current.partitions,
+              [level as UniRefEntryType]: partition,
+            },
+          }
+      );
+    },
+    []
+  );
+
+  // Stable per-level arrays so a lazy tab doesn't refetch on unrelated renders.
+  const mapping = data?.mapping;
+  const isoformsAndClustersByLevel = useMemo<
+    Record<string, IsoformsAndCluster[]>
+  >(
+    () =>
+      mapping
+        ? Object.fromEntries(
+            Object.keys(mapping).map((level) => [
+              level,
+              Object.values(mapping[level as UniRefEntryType]),
+            ])
+          )
+        : {},
+    [mapping]
+  );
+
+  if (loading) {
     return <Loader />;
   }
 
-  return mappingData ? (
+  if (error) {
+    return (
+      <SimilarProteinsError
+        onRetry={() => {
+          setError(false);
+          setLoading(true);
+          setReload((n) => n + 1);
+        }}
+      />
+    );
+  }
+
+  if (!data) {
+    return (
+      <div>
+        <em>No similar UniProtKB entry found.</em>
+      </div>
+    );
+  }
+
+  return (
     <Tabs bordered>
       {Object.entries(uniRefEntryTypeToPercent).map(
         ([clusterType, percentValue]) => (
@@ -103,22 +191,19 @@ const SimilarProteins = ({ canonical, isoforms }: Props) => {
             id={clusterType}
             title={`${percentValue} identity`}
             key={clusterType}
+            defaultSelected={clusterType === data.defaultLevel}
           >
             <SimilarProteinsTabContent
               canonical={canonical}
               clusterType={clusterType}
-              isoformsAndClusters={Object.values(
-                mappingData[clusterType as UniRefEntryType]
-              )}
+              isoformsAndClusters={isoformsAndClustersByLevel[clusterType]}
+              initialPartition={data.partitions[clusterType as UniRefEntryType]}
+              onLoaded={handleLoaded}
             />
           </Tab>
         )
       )}
     </Tabs>
-  ) : (
-    <div>
-      <em>No similar UniProtKB entry found.</em>
-    </div>
   );
 };
 

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsError.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsError.tsx
@@ -1,0 +1,17 @@
+import { Button, Message } from 'franklin-sites';
+
+type Props = {
+  onRetry: () => void;
+};
+
+// Shown when loading a UniRef level fails, instead of an indefinite spinner.
+const SimilarProteinsError = ({ onRetry }: Props) => (
+  <Message level="failure" noShadow>
+    Something went wrong loading similar proteins.{' '}
+    <Button variant="secondary" onClick={onRetry}>
+      Try again
+    </Button>
+  </Message>
+);
+
+export default SimilarProteinsError;

--- a/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTabContent.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/SimilarProteinsTabContent.tsx
@@ -1,6 +1,6 @@
 import { Loader } from 'franklin-sites';
 import { zip } from 'lodash-es';
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Location, LocationToPath } from '../../../../app/config/urls';
@@ -17,20 +17,21 @@ import {
 } from '../../../../uniref/adapters/uniRefConverter';
 import { type UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
 import { type IsoformsAndCluster } from './SimilarProteins';
+import SimilarProteinsError from './SimilarProteinsError';
 import SimilarProteinsTable, { columns } from './SimilarProteinsTable';
+import useLazySimilarityLevel from './useLazySimilarityLevel';
 
-type Props = {
-  canonical: string;
-  clusterType: string;
-  isoformsAndClusters: IsoformsAndCluster[];
-};
-
-type HasSimilarProteins = {
+export type HasSimilarProteins = {
   total: number;
   isoforms: string[];
   cluster: UniRefLiteAPIModel;
   uniprotkbResults: UniProtkbAPIModel[];
   uniprotkbQuery: string;
+};
+
+export type LevelPartition = {
+  noSimilar: string[];
+  hasSimilar: HasSimilarProteins[];
 };
 
 const getUniprotkbQuery = (
@@ -47,74 +48,92 @@ const getUniprotkbQuery = (
     )
     .join('')}`;
 
+// Partition one level's clusters into isoforms that have similar proteins and
+// those that don't. Exported so the parent reuses it during its scan and lazy
+// tabs call it on open.
+export const partitionLevel = async (
+  isoformsAndClusters: IsoformsAndCluster[],
+  canonical: string,
+  signal: AbortSignal
+): Promise<LevelPartition> => {
+  const promises = isoformsAndClusters.map(({ isoforms, cluster }) => {
+    if (isoforms.length <= 1 && cluster.memberCount <= 1) {
+      return null;
+    }
+    const url = apiUrls.search.search({
+      namespace: Namespace.uniprotkb,
+      query: getUniprotkbQuery(cluster, isoforms, canonical),
+      facets: null,
+      columns,
+      size: 10,
+    });
+    return fetchData<{
+      results: UniProtkbAPIModel[];
+    }>(url, undefined, { signal });
+  });
+  const responses = await Promise.all(promises);
+  const hasSimilar: HasSimilarProteins[] = [];
+  const noSimilar: string[] = [];
+  for (const [isoformsAndCluster, response] of zip(
+    isoformsAndClusters,
+    responses
+  )) {
+    /* istanbul ignore if */
+    if (!isoformsAndCluster) {
+      break; // Shouldn't happen, used to restrict types
+    }
+    const { isoforms, cluster } = isoformsAndCluster;
+    const total = +(response?.headers?.['x-total-results'] || 0);
+    if (total && response?.data.results && isoforms && cluster) {
+      hasSimilar.push({
+        total,
+        isoforms,
+        cluster,
+        uniprotkbResults: response.data.results,
+        uniprotkbQuery: getUniprotkbQuery(cluster, isoforms, canonical),
+      });
+    } else if (isoforms) {
+      noSimilar.push(...isoforms);
+    }
+  }
+  return { noSimilar, hasSimilar };
+};
+
+type Props = {
+  canonical: string;
+  clusterType: string;
+  isoformsAndClusters: IsoformsAndCluster[];
+  // Set once a level is loaded (by the scan or a previous visit).
+  initialPartition?: LevelPartition;
+  onLoaded: (clusterType: string, partition: LevelPartition) => void;
+};
+
 const SimilarProteinsTabContent = ({
   canonical,
   clusterType,
   isoformsAndClusters,
+  initialPartition,
+  onLoaded,
 }: Props) => {
-  const [partitionedProteins, setPartitionedProteins] = useState<
-    [string[], HasSimilarProteins[]]
-  >([[], []]);
-  const [loading, setLoading] = useState(true);
+  // Loaded levels arrive via `initialPartition`; others fetch on first open.
+  const fetcher = useCallback(
+    (signal: AbortSignal) =>
+      partitionLevel(isoformsAndClusters, canonical, signal),
+    [isoformsAndClusters, canonical]
+  );
+  const { error, retry } = useLazySimilarityLevel({
+    clusterType,
+    initialPartition,
+    fetcher,
+    onLoaded,
+  });
 
-  useEffect(() => {
-    const controller = new AbortController();
-    const promises = isoformsAndClusters.map(({ isoforms, cluster }) => {
-      if (isoforms.length <= 1 && cluster.memberCount <= 1) {
-        return null;
-      }
-      const url = apiUrls.search.search({
-        namespace: Namespace.uniprotkb,
-        query: getUniprotkbQuery(cluster, isoforms, canonical),
-        facets: null,
-        columns,
-        size: 10,
-      });
-      return fetchData<{
-        results: UniProtkbAPIModel[];
-      }>(url, undefined, { signal: controller.signal });
-    });
-    Promise.all(promises).then(
-      (responses) => {
-        const hasSimilar: HasSimilarProteins[] = [];
-        const noSimilar: string[] = [];
-        for (const [isoformsAndCluster, response] of zip(
-          isoformsAndClusters,
-          responses
-        )) {
-          /* istanbul ignore if */
-          if (!isoformsAndCluster) {
-            break; // Shouldn't happen, used to restrict types
-          }
-          const { isoforms, cluster } = isoformsAndCluster;
-          const total = +(response?.headers?.['x-total-results'] || 0);
-          if (total && response?.data.results && isoforms && cluster) {
-            hasSimilar.push({
-              total,
-              isoforms,
-              cluster,
-              uniprotkbResults: response?.data.results,
-              uniprotkbQuery: getUniprotkbQuery(cluster, isoforms, canonical),
-            });
-          } else if (isoforms) {
-            noSimilar.push(...isoforms);
-          }
-        }
-        setPartitionedProteins([noSimilar, hasSimilar]);
-        setLoading(false);
-      },
-      () => {
-        /* ignore fetch errors */
-      }
-    );
-    return () => controller.abort();
-  }, [isoformsAndClusters, canonical]);
-
-  if (loading) {
-    return <Loader />;
+  if (!initialPartition) {
+    return error ? <SimilarProteinsError onRetry={retry} /> : <Loader />;
   }
 
-  const [noSimilarProteins, hasSimilarProteins] = partitionedProteins;
+  const { noSimilar: noSimilarProteins, hasSimilar: hasSimilarProteins } =
+    initialPartition;
 
   return (
     <>

--- a/src/uniprotkb/components/entry/similar-proteins/__tests__/SimilarProteins.spec.tsx
+++ b/src/uniprotkb/components/entry/similar-proteins/__tests__/SimilarProteins.spec.tsx
@@ -64,3 +64,173 @@ describe('getClusterMapping', () => {
     expect(getClusterMapping(allAccessions, clusterData)).toEqual(mapping);
   });
 });
+
+describe('SimilarProteins default tab selection', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock
+      // find clusters for canonical and isoform 4
+      .onGet(/query=uniprotkb%3AP05067$/)
+      .reply(200, unirefP05067)
+      .onGet(/query=uniprotkb%3AP05067-4$/)
+      .reply(200, unirefP05067isoform4)
+      // UniRef100 clusters have no similar UniProtKB proteins
+      .onGet(/uniref_cluster_100/)
+      .reply(200, { results: [] }, { 'x-total-results': 0 })
+      // the other levels do
+      .onGet(/\/uniprotkb\/search/)
+      .reply(200, uniprotkbClusterSearch, { 'x-total-results': 2 });
+  });
+
+  it('opens the first level that has similar proteins instead of UniRef100', async () => {
+    await act(async () => {
+      customRender(
+        <SimilarProteins
+          isoforms={['P05067-1', 'P05067-4']}
+          canonical="P05067-1"
+        />
+      );
+    });
+    // UniRef100 has none, so the section should default to the 90% identity tab
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: '90% identity' })).toHaveClass(
+        'tabs__header__item--active'
+      )
+    );
+    expect(screen.getByRole('tab', { name: '100% identity' })).not.toHaveClass(
+      'tabs__header__item--active'
+    );
+    // Early-exit: UniRef50 is below the first level with data, so it is not
+    // requested until its tab is opened.
+    expect(
+      axiosMock.history.get.some((request) =>
+        request.url?.includes('uniref_cluster_50')
+      )
+    ).toBe(false);
+  });
+
+  it('shows each tab its own level when switching between tabs', async () => {
+    await act(async () => {
+      customRender(
+        <SimilarProteins
+          isoforms={['P05067-1', 'P05067-4']}
+          canonical="P05067-1"
+        />
+      );
+    });
+    // Defaults to the 90% tab
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+
+    // Open the lazily-loaded 50% tab
+    fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+    await screen.findByRole('link', { name: 'UniRef50_P05067' });
+
+    // Switching back must show the 90% content again, not the stale 50% one
+    fireEvent.click(screen.getByRole('tab', { name: '90% identity' }));
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+    expect(
+      screen.queryByRole('link', { name: 'UniRef50_P05067' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a loader, not stale content, while a lazy level is loading', async () => {
+    axiosMock.reset();
+    axiosMock
+      .onGet(/query=uniprotkb%3AP05067$/)
+      .reply(200, unirefP05067)
+      .onGet(/query=uniprotkb%3AP05067-4$/)
+      .reply(200, unirefP05067isoform4)
+      .onGet(/uniref_cluster_100/)
+      .reply(200, { results: [] }, { 'x-total-results': 0 })
+      // UniRef50 request never resolves (slow / hung network)
+      .onGet(/uniref_cluster_50/)
+      .reply(() => new Promise(() => {}))
+      .onGet(/\/uniprotkb\/search/)
+      .reply(200, uniprotkbClusterSearch, { 'x-total-results': 2 });
+
+    await act(async () => {
+      customRender(
+        <SimilarProteins
+          isoforms={['P05067-1', 'P05067-4']}
+          canonical="P05067-1"
+        />
+      );
+    });
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+
+    // Opening the still-loading 50% tab must drop the previous level's content
+    fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('link', { name: 'UniRef90_P05067' })
+      ).not.toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('link', { name: 'UniRef50_P05067' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('caches a lazily-loaded level and does not refetch it on revisit', async () => {
+    await act(async () => {
+      customRender(
+        <SimilarProteins
+          isoforms={['P05067-1', 'P05067-4']}
+          canonical="P05067-1"
+        />
+      );
+    });
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+
+    const cluster50Requests = () =>
+      axiosMock.history.get.filter((request) =>
+        request.url?.includes('uniref_cluster_50')
+      ).length;
+
+    // First visit loads the 50% level
+    fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+    await screen.findByRole('link', { name: 'UniRef50_P05067' });
+    const afterFirstVisit = cluster50Requests();
+    expect(afterFirstVisit).toBeGreaterThan(0);
+
+    // Leave and come back — the cached level renders without a new request
+    fireEvent.click(screen.getByRole('tab', { name: '90% identity' }));
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+    fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+    await screen.findByRole('link', { name: 'UniRef50_P05067' });
+    expect(cluster50Requests()).toBe(afterFirstVisit);
+  });
+
+  it('shows a retry on a failed level load and recovers when retried', async () => {
+    axiosMock.reset();
+    axiosMock
+      .onGet(/query=uniprotkb%3AP05067$/)
+      .reply(200, unirefP05067)
+      .onGet(/query=uniprotkb%3AP05067-4$/)
+      .reply(200, unirefP05067isoform4)
+      .onGet(/uniref_cluster_100/)
+      .reply(200, { results: [] }, { 'x-total-results': 0 })
+      // The 50% level's first request fails, then succeeds
+      .onGet(/uniref_cluster_50/)
+      .networkErrorOnce()
+      .onGet(/\/uniprotkb\/search/)
+      .reply(200, uniprotkbClusterSearch, { 'x-total-results': 2 });
+
+    await act(async () => {
+      customRender(
+        <SimilarProteins
+          isoforms={['P05067-1', 'P05067-4']}
+          canonical="P05067-1"
+        />
+      );
+    });
+    await screen.findByRole('link', { name: 'UniRef90_P05067' });
+
+    // Opening the 50% tab fails → error with a retry button (not an endless loader)
+    fireEvent.click(screen.getByRole('tab', { name: '50% identity' }));
+    const retry = await screen.findByRole('button', { name: /try again/i });
+
+    // Retrying succeeds → the table renders
+    fireEvent.click(retry);
+    await screen.findByRole('link', { name: 'UniRef50_P05067' });
+  });
+});

--- a/src/uniprotkb/components/entry/similar-proteins/useLazySimilarityLevel.ts
+++ b/src/uniprotkb/components/entry/similar-proteins/useLazySimilarityLevel.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+type UseLazySimilarityLevelOptions<T> = {
+  // The similarity level (UniRef cluster type) this tab shows; errors are keyed
+  // on it so the reused instance never shows another level's error.
+  clusterType: string;
+  // Set once the level is loaded (by the parent scan or a previous visit).
+  initialPartition?: T;
+  // Fetch the level's data; called only when it isn't already loaded.
+  fetcher: (signal: AbortSignal) => Promise<T>;
+  // Report the loaded data up so the parent can cache it.
+  onLoaded: (clusterType: string, partition: T) => void;
+};
+
+// Drives a lazily-loaded similarity level (UniRef cluster) shared by the
+// UniProtKB and UniParc tab content: fetches when the level isn't already
+// loaded, reports the result up for caching, and exposes an `error` flag +
+// `retry`. A slow or failed fetch keeps the caller on its loader/error rather
+// than showing stale content.
+const useLazySimilarityLevel = <T>({
+  clusterType,
+  initialPartition,
+  fetcher,
+  onLoaded,
+}: UseLazySimilarityLevelOptions<T>) => {
+  const [erroredLevel, setErroredLevel] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+
+  useEffect(() => {
+    if (initialPartition) {
+      return undefined; // already loaded and cached by the parent
+    }
+    const controller = new AbortController();
+    fetcher(controller.signal).then(
+      (result) => onLoaded(clusterType, result),
+      () => {
+        if (!controller.signal.aborted) {
+          setErroredLevel(clusterType);
+        }
+      }
+    );
+    return () => controller.abort();
+  }, [initialPartition, fetcher, clusterType, onLoaded, reload]);
+
+  return {
+    error: erroredLevel === clusterType,
+    retry: () => {
+      setErroredLevel(null);
+      setReload((n) => n + 1);
+    },
+  };
+};
+
+export default useLazySimilarityLevel;


### PR DESCRIPTION
## Purpose

The **Similar Proteins** section always opened on the UniRef100 tab, which is frequently empty ("No similar proteins at 100% identity"), so users had to click through to find results. Also fixes two entry-page anchor issues: the whole section getting a focus outline, and the section title hidden behind the new sticky compact bar.

## Approach

- Open on the first UniRef identity level that actually has similar proteins (top-down early-exit scan); lazy-load lower levels on demand and cache them in the parent so revisits are instant. Applies to UniProtKB and UniParc/SAP via a shared
`useLazySimilarityLevel` hook.
- Loading is more robust: a loader (never stale content) while a level loads, an error + retry on failure, and a "No similar proteins" message for empty levels.
- CSS: drop the focus outline on hash-targeted sections; add the compact bar's height to `scroll-margin-top`.

## Testing

Created new tests.

## Checklist

- [ ] My PR is scoped properly, and "does one thing only"
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.