### PR TITLE
Add zoom hint to feature viewer

### DIFF
--- a/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
@@ -1,5 +1,5 @@
 import { Loader, Message } from 'franklin-sites';
-import { use, useCallback, useEffect, useRef } from 'react';
+import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { getEntryPath } from '../../../../app/config/urls';
@@ -32,6 +32,28 @@ const FeatureViewer = ({
   const hideTooltip = useRef<ReturnType<
     typeof showTooltipAtCoordinates
   > | null>(null);
+
+  // Show a "scroll to zoom" hint the very first time the user scrolls over the
+  // feature viewer, then never again.
+  const [showZoomHint, setShowZoomHint] = useState(false);
+  const zoomHintShown = useRef(false);
+  const zoomHintTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onScrollOrWheel = useCallback(() => {
+    if (zoomHintShown.current) {
+      return;
+    }
+    zoomHintShown.current = true;
+    setShowZoomHint(true);
+    zoomHintTimeout.current = setTimeout(() => setShowZoomHint(false), 3000);
+  }, []);
+  useEffect(
+    () => () => {
+      if (zoomHintTimeout.current) {
+        clearTimeout(zoomHintTimeout.current);
+      }
+    },
+    []
+  );
   // just to make sure not to render protvista-uniprot if we won't get any data
   const { loading, status } = useDataApi<UniProtkbAPIModel>(
     apiUrls.proteinsApi.proteins(accession),
@@ -166,10 +188,21 @@ const FeatureViewer = ({
       )}
 
       {shouldRender ? (
-        <protvistaUniprotElement.name
-          accession={accession}
-          ref={protvistaUniprotRef}
-        />
+        <div
+          className={tabsStyles['feature-viewer-container']}
+          onScroll={onScrollOrWheel}
+          onWheel={onScrollOrWheel}
+        >
+          <protvistaUniprotElement.name
+            accession={accession}
+            ref={protvistaUniprotRef}
+          />
+          {showZoomHint && (
+            <div className={tabsStyles['zoom-hint']}>
+              <span>Use [CTRL] + scroll to zoom</span>
+            </div>
+          )}
+        </div>
       ) : (
         <div className={tabsStyles['too-many']}>
           <Message>

--- a/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/FeatureViewer.tsx
@@ -1,5 +1,5 @@
 import { Loader, Message } from 'franklin-sites';
-import { use, useCallback, useEffect, useRef, useState } from 'react';
+import { use, useCallback, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { getEntryPath } from '../../../../app/config/urls';
@@ -14,6 +14,7 @@ import { type UniProtkbAPIModel } from '../../../adapters/uniProtkbConverter';
 import { TabLocation } from '../../../types/entry';
 import NightingaleZoomTool from '../../protein-data-views/NightingaleZoomTool';
 import tabsStyles from './styles/tabs-styles.module.scss';
+import ZoomHint from './ZoomHint';
 
 const hideTooltipEvents = new Set([undefined, 'reset', 'click']);
 
@@ -33,27 +34,6 @@ const FeatureViewer = ({
     typeof showTooltipAtCoordinates
   > | null>(null);
 
-  // Show a "scroll to zoom" hint the very first time the user scrolls over the
-  // feature viewer, then never again.
-  const [showZoomHint, setShowZoomHint] = useState(false);
-  const zoomHintShown = useRef(false);
-  const zoomHintTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const onScrollOrWheel = useCallback(() => {
-    if (zoomHintShown.current) {
-      return;
-    }
-    zoomHintShown.current = true;
-    setShowZoomHint(true);
-    zoomHintTimeout.current = setTimeout(() => setShowZoomHint(false), 3000);
-  }, []);
-  useEffect(
-    () => () => {
-      if (zoomHintTimeout.current) {
-        clearTimeout(zoomHintTimeout.current);
-      }
-    },
-    []
-  );
   // just to make sure not to render protvista-uniprot if we won't get any data
   const { loading, status } = useDataApi<UniProtkbAPIModel>(
     apiUrls.proteinsApi.proteins(accession),
@@ -188,21 +168,12 @@ const FeatureViewer = ({
       )}
 
       {shouldRender ? (
-        <div
-          className={tabsStyles['feature-viewer-container']}
-          onScroll={onScrollOrWheel}
-          onWheel={onScrollOrWheel}
-        >
+        <ZoomHint>
           <protvistaUniprotElement.name
             accession={accession}
             ref={protvistaUniprotRef}
           />
-          {showZoomHint && (
-            <div className={tabsStyles['zoom-hint']}>
-              <span>Use [CTRL] + scroll to zoom</span>
-            </div>
-          )}
-        </div>
+        </ZoomHint>
       ) : (
         <div className={tabsStyles['too-many']}>
           <Message>

--- a/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
+++ b/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
@@ -48,7 +48,7 @@ const ZoomHint = ({ children }: { children: ReactNode }) => {
       {children}
       {showZoomHint && (
         <div className={styles['zoom-hint']}>
-          <span>Use [CTRL] + scroll to zoom</span>
+          <span>Use [CTRL/CMD] + scroll to zoom</span>
         </div>
       )}
     </div>

--- a/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
+++ b/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
@@ -1,0 +1,58 @@
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import styles from './styles/zoom-hint.module.scss';
+
+// How long the hint stays visible after the first scroll/wheel interaction.
+const ZOOM_HINT_DURATION = 3000;
+
+// Wraps its children and shows a "scroll to zoom" hint the very first time the
+// user scrolls over them, then never again.
+const ZoomHint = ({ children }: { children: ReactNode }) => {
+  const [showZoomHint, setShowZoomHint] = useState(false);
+  const zoomHintShown = useRef(false);
+  const zoomHintTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const onScrollOrWheel = useCallback(() => {
+    if (zoomHintShown.current) {
+      return;
+    }
+    zoomHintShown.current = true;
+    setShowZoomHint(true);
+    zoomHintTimeout.current = setTimeout(
+      () => setShowZoomHint(false),
+      ZOOM_HINT_DURATION
+    );
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (zoomHintTimeout.current) {
+        clearTimeout(zoomHintTimeout.current);
+      }
+    },
+    []
+  );
+
+  return (
+    <div
+      className={styles['zoom-hint-container']}
+      onScroll={onScrollOrWheel}
+      onWheel={onScrollOrWheel}
+    >
+      {children}
+      {showZoomHint && (
+        <div className={styles['zoom-hint']}>
+          <span>Use [CTRL] + scroll to zoom</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ZoomHint;

--- a/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
+++ b/src/uniprotkb/components/entry/tabs/ZoomHint.tsx
@@ -8,17 +8,17 @@ import {
 
 import styles from './styles/zoom-hint.module.scss';
 
-// How long the hint stays visible after the first scroll/wheel interaction.
+// How long the hint stays visible after the first wheel interaction.
 const ZOOM_HINT_DURATION = 3000;
 
 // Wraps its children and shows a "scroll to zoom" hint the very first time the
-// user scrolls over them, then never again.
+// user scrolls (wheels) over them, then never again.
 const ZoomHint = ({ children }: { children: ReactNode }) => {
   const [showZoomHint, setShowZoomHint] = useState(false);
   const zoomHintShown = useRef(false);
   const zoomHintTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const onScrollOrWheel = useCallback(() => {
+  const onWheel = useCallback(() => {
     if (zoomHintShown.current) {
       return;
     }
@@ -40,11 +40,7 @@ const ZoomHint = ({ children }: { children: ReactNode }) => {
   );
 
   return (
-    <div
-      className={styles['zoom-hint-container']}
-      onScroll={onScrollOrWheel}
-      onWheel={onScrollOrWheel}
-    >
+    <div className={styles['zoom-hint-container']} onWheel={onWheel}>
       {children}
       {showZoomHint && (
         <div className={styles['zoom-hint']}>

--- a/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
+++ b/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
@@ -18,3 +18,29 @@
   display: flow-root;
   float: right;
 }
+
+.feature-viewer-container {
+  position: relative;
+}
+
+.zoom-hint {
+  position: absolute;
+  top: 0.5rem;
+  left: 0;
+  right: 0;
+  height: 2.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1;
+
+  span {
+    padding: 0.5rem 1rem;
+    border-radius: 0.3rem;
+    background: rgb(0 0 0 / 70%);
+    color: white;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+}

--- a/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
+++ b/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
@@ -16,4 +16,5 @@
 // its height and the feature viewer's navigation rail below stays aligned.
 .zoom-tool-row {
   display: flow-root;
+  float: right;
 }

--- a/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
+++ b/src/uniprotkb/components/entry/tabs/styles/tabs-styles.module.scss
@@ -18,29 +18,3 @@
   display: flow-root;
   float: right;
 }
-
-.feature-viewer-container {
-  position: relative;
-}
-
-.zoom-hint {
-  position: absolute;
-  top: 0.5rem;
-  left: 0;
-  right: 0;
-  height: 2.5rem;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  pointer-events: none;
-  z-index: 1;
-
-  span {
-    padding: 0.5rem 1rem;
-    border-radius: 0.3rem;
-    background: rgb(0 0 0 / 70%);
-    color: white;
-    font-size: 1.1rem;
-    font-weight: 600;
-  }
-}

--- a/src/uniprotkb/components/entry/tabs/styles/zoom-hint.module.scss
+++ b/src/uniprotkb/components/entry/tabs/styles/zoom-hint.module.scss
@@ -1,0 +1,25 @@
+.zoom-hint-container {
+  position: relative;
+}
+
+.zoom-hint {
+  position: absolute;
+  top: 0.5rem;
+  left: 0;
+  right: 0;
+  height: 2.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1;
+
+  span {
+    padding: 0.5rem 1rem;
+    border-radius: 0.3rem;
+    background: rgb(0 0 0 / 70%);
+    color: white;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+}

--- a/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
+++ b/src/uniprotkb/components/entry/tabs/variation-viewer/VariationViewer.tsx
@@ -45,6 +45,7 @@ import { type TransformedVariant } from '../../../../types/variation';
 import { sortByLocation } from '../../../../utils';
 import UniProtKBEvidenceTag from '../../../protein-data-views/UniProtKBEvidenceTag';
 import tabsStyles from '../styles/tabs-styles.module.scss';
+import ZoomHint from '../ZoomHint';
 import styles from './styles/variation-viewer.module.scss';
 
 const VisualVariationView = lazy(
@@ -577,10 +578,12 @@ const VariationViewer = ({
         highlight={getHighlightedCoordinates(highlightedVariant)}
       >
         <Suspense fallback={null}>
-          <VisualVariationView
-            sequence={transformedData.sequence}
-            variants={filteredVariants}
-          />
+          <ZoomHint>
+            <VisualVariationView
+              sequence={transformedData.sequence}
+              variants={filteredVariants}
+            />
+          </ZoomHint>
         </Suspense>
       </NightingaleManagerComponent>
       <TableFromData


### PR DESCRIPTION
## Purpose

https://embl.atlassian.net/browse/TRM-30968

## Approach

- Move the zoom buttons to the right (closer to the viewer)
- Show key shortcut (ctrl/cmd + scroll) hint on first scroll and discard after 3s in bot feature viewer and variation viewer

## Testing

What test(s) did you write to validate and verify your changes?

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
