### PR TITLE
Fix proteome bug

### DIFF
--- a/src/uniparc/components/entry/XRefsSection.tsx
+++ b/src/uniparc/components/entry/XRefsSection.tsx
@@ -46,6 +46,7 @@ const XRefsSection = ({ entryData }: Props) => {
   const initialApiUrl = useXref({
     accession: entryData.uniParcId,
     withFacets: false,
+    includeSources: true,
   });
 
   const xRefDataObject = usePagination<UniParcXRef, UniParcXRef>(initialApiUrl);

--- a/src/uniparc/components/entry/hooks/useXref.ts
+++ b/src/uniparc/components/entry/hooks/useXref.ts
@@ -22,9 +22,15 @@ type Arg = {
   accession?: string;
   size?: number;
   withFacets?: boolean;
+  includeSources?: boolean;
 };
 
-const useXref = ({ accession, size, withFacets = false }: Arg = {}) => {
+const useXref = ({
+  accession,
+  size,
+  withFacets = false,
+  includeSources = false,
+}: Arg = {}) => {
   const { search: queryParamFromUrl } = useLocation();
 
   const [{ selectedFacets }] = getParamsFromURL(queryParamFromUrl);
@@ -43,7 +49,7 @@ const useXref = ({ accession, size, withFacets = false }: Arg = {}) => {
       ...Object.fromEntries(
         selectedFacets.map(({ name, value }) => [name, value])
       ),
-      includeSources: true,
+      includeSources: includeSources || undefined,
     };
 
     return stringifyUrl(xrefApiPrefix, options);

--- a/src/uniparc/components/entry/hooks/useXref.ts
+++ b/src/uniparc/components/entry/hooks/useXref.ts
@@ -43,6 +43,7 @@ const useXref = ({ accession, size, withFacets = false }: Arg = {}) => {
       ...Object.fromEntries(
         selectedFacets.map(({ name, value }) => [name, value])
       ),
+      includeSources: true,
     };
 
     return stringifyUrl(xrefApiPrefix, options);

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -21,7 +21,7 @@ import {
   XRefsInternalDatabasesEnum,
 } from '../adapters/uniParcConverter';
 import Timeline from '../components/entry/Timeline';
-import { getSubEntryPath } from '../utils/subEntry';
+import { getSubEntryPath, getSubEntryProteomes } from '../utils/subEntry';
 import { getXrefId } from '../utils/uniparcXref';
 
 export enum UniParcXRefsColumn {
@@ -264,27 +264,22 @@ UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.proteome, {
         </span>
       ));
     }
-    const xrefSources = xref.properties?.filter(
-      (property) => property.key === 'sources'
+    const sourceProteomes = Object.entries(
+      getSubEntryProteomes(xref.properties)
     );
-    if (xrefSources?.length) {
-      return xrefSources.map((property) => {
-        const [, , proteomeId, ...component] = property.value.split(':');
-        if (proteomeId && component.length) {
-          return (
-            <span
-              key={`${proteomeId}-${component.join(':')}`}
-              className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
-            >
-              <Link to={getEntryPath(Namespace.proteomes, proteomeId)}>
-                {proteomeId}
-              </Link>
-              {component.length ? ` (${component.join(':')})` : undefined}
-              <br />
-            </span>
-          );
-        }
-      });
+    if (sourceProteomes.length) {
+      return sourceProteomes.map(([proteomeId, component], i) => (
+        <span
+          key={`${proteomeId}-${component}`}
+          className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
+        >
+          <Link to={getEntryPath(Namespace.proteomes, proteomeId)}>
+            {proteomeId}
+          </Link>
+          {component ? ` (${component})` : undefined}
+          {i < sourceProteomes.length - 1 && <br />}
+        </span>
+      ));
     }
     return null;
   },

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -21,7 +21,7 @@ import {
   XRefsInternalDatabasesEnum,
 } from '../adapters/uniParcConverter';
 import Timeline from '../components/entry/Timeline';
-import { getSubEntryPath, getSubEntryProteomes } from '../utils/subEntry';
+import { getSubEntryPath } from '../utils/subEntry';
 import { getXrefId } from '../utils/uniparcXref';
 
 export enum UniParcXRefsColumn {

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -21,7 +21,7 @@ import {
   XRefsInternalDatabasesEnum,
 } from '../adapters/uniParcConverter';
 import Timeline from '../components/entry/Timeline';
-import { getSubEntryPath } from '../utils/subEntry';
+import { getSubEntryPath, getSubEntryProteomes } from '../utils/subEntry';
 import { getXrefId } from '../utils/uniparcXref';
 
 export enum UniParcXRefsColumn {
@@ -249,21 +249,45 @@ UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.protein, {
 
 UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.proteome, {
   label: 'Proteome',
-  render: (xref) =>
-    xref.proteomes?.length
-      ? xref.proteomes.map((proteome, i) => (
-          <span
-            key={`${proteome.id}-${proteome.component}`}
-            className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
-          >
-            <Link to={getEntryPath(Namespace.proteomes, proteome.id)}>
-              {proteome.id}
-            </Link>
-            {proteome.component ? ` (${proteome.component})` : undefined}
-            {i < (xref.proteomes?.length ?? 0) - 1 && <br />}
-          </span>
-        ))
-      : null,
+  render: (xref) => {
+    if (xref.proteomes?.length) {
+      return xref.proteomes.map((proteome, i) => (
+        <span
+          key={`${proteome.id}-${proteome.component}`}
+          className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
+        >
+          <Link to={getEntryPath(Namespace.proteomes, proteome.id)}>
+            {proteome.id}
+          </Link>
+          {proteome.component ? ` (${proteome.component})` : undefined}
+          {i < (xref.proteomes?.length ?? 0) - 1 && <br />}
+        </span>
+      ));
+    }
+    const xrefSources = xref.properties?.filter(
+      (property) => property.key === 'sources'
+    );
+    if (xrefSources?.length) {
+      return xrefSources.map((property) => {
+        const [, , proteomeId, ...component] = property.value.split(':');
+        if (proteomeId && component.length) {
+          return (
+            <span
+              key={`${proteomeId}-${component.join(':')}`}
+              className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
+            >
+              <Link to={getEntryPath(Namespace.proteomes, proteomeId)}>
+                {proteomeId}
+              </Link>
+              {component.length ? ` (${component.join(':')})` : undefined}
+              <br />
+            </span>
+          );
+        }
+      });
+    }
+    return null;
+  },
 });
 
 UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.active, {

--- a/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
+++ b/src/uniparc/config/UniParcXRefsColumnConfiguration.tsx
@@ -250,38 +250,22 @@ UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.protein, {
 UniParcXRefsColumnConfiguration.set(UniParcXRefsColumn.proteome, {
   label: 'Proteome',
   render: (xref) => {
-    if (xref.proteomes?.length) {
-      return xref.proteomes.map((proteome, i) => (
-        <span
-          key={`${proteome.id}-${proteome.component}`}
-          className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
-        >
-          <Link to={getEntryPath(Namespace.proteomes, proteome.id)}>
-            {proteome.id}
-          </Link>
-          {proteome.component ? ` (${proteome.component})` : undefined}
-          {i < (xref.proteomes?.length ?? 0) - 1 && <br />}
-        </span>
-      ));
+    const proteomes: [id: string, component?: string][] = xref.proteomes?.length
+      ? xref.proteomes.map(({ id, component }) => [id, component])
+      : Object.entries(getSubEntryProteomes(xref.properties));
+    if (!proteomes.length) {
+      return null;
     }
-    const sourceProteomes = Object.entries(
-      getSubEntryProteomes(xref.properties)
-    );
-    if (sourceProteomes.length) {
-      return sourceProteomes.map(([proteomeId, component], i) => (
-        <span
-          key={`${proteomeId}-${component}`}
-          className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
-        >
-          <Link to={getEntryPath(Namespace.proteomes, proteomeId)}>
-            {proteomeId}
-          </Link>
-          {component ? ` (${component})` : undefined}
-          {i < sourceProteomes.length - 1 && <br />}
-        </span>
-      ));
-    }
-    return null;
+    return proteomes.map(([id, component], i) => (
+      <span
+        key={`${id}-${component}`}
+        className={`xref-proteome${xref.active ? '' : ' xref-inactive'}`}
+      >
+        <Link to={getEntryPath(Namespace.proteomes, id)}>{id}</Link>
+        {component ? ` (${component})` : undefined}
+        {i < proteomes.length - 1 && <br />}
+      </span>
+    ));
   },
 });
 

--- a/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
+++ b/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
@@ -1,8 +1,11 @@
+import { screen } from '@testing-library/react';
+
+import customRender from '../../../shared/__test-helpers__/customRender';
 import testColumnConfiguration from '../../../shared/__test-helpers__/testColumnConfiguration';
 import data from '../../__mocks__/uniparcXrefsModelData';
 import { type UniParcXRef } from '../../adapters/uniParcConverter';
 import UniParcXRefsColumnConfiguration, {
-  type UniParcXRefsColumn,
+  UniParcXRefsColumn,
 } from '../UniParcXRefsColumnConfiguration';
 
 jest.mock('../../../shared/workers/jobs/utils/storage');
@@ -14,4 +17,49 @@ describe('UniParcXRefsColumnConfiguration component', () => {
     UniParcXRefsColumnConfiguration,
     xrefData
   );
+
+  describe('proteome column, falling back to the "sources" property', () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { render } = UniParcXRefsColumnConfiguration.get(
+      UniParcXRefsColumn.proteome
+    )!;
+
+    it('renders a proteome link even when the sources value has no component segment', () => {
+      const xref: UniParcXRef = {
+        properties: [{ key: 'sources', value: 'EMBL:CAA12345:UP000005640' }],
+      };
+      customRender(<>{render(xref)}</>);
+      expect(screen.getByRole('link', { name: 'UP000005640' })).toHaveAttribute(
+        'href',
+        expect.stringContaining('UP000005640')
+      );
+      expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+    });
+
+    it('renders the component alongside the proteome link when present', () => {
+      const xref: UniParcXRef = {
+        properties: [
+          { key: 'sources', value: 'EMBL:CAA12345:UP000005640:Chromosome 1' },
+        ],
+      };
+      customRender(<>{render(xref)}</>);
+      expect(
+        screen.getByRole('link', { name: 'UP000005640' })
+      ).toBeInTheDocument();
+      expect(screen.getByText('(Chromosome 1)')).toBeInTheDocument();
+    });
+
+    it('deduplicates sources that point at the same proteome', () => {
+      const xref: UniParcXRef = {
+        properties: [
+          { key: 'sources', value: 'EMBL:CAA12345:UP000005640:Chromosome 1' },
+          { key: 'sources', value: 'EMBL:CAA99999:UP000005640:Chromosome 1' },
+        ],
+      };
+      customRender(<>{render(xref)}</>);
+      expect(screen.getAllByRole('link', { name: 'UP000005640' })).toHaveLength(
+        1
+      );
+    });
+  });
 });

--- a/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
+++ b/src/uniparc/config/__tests__/UniParcXRefsColumnConfiguration.spec.tsx
@@ -29,11 +29,12 @@ describe('UniParcXRefsColumnConfiguration component', () => {
         properties: [{ key: 'sources', value: 'EMBL:CAA12345:UP000005640' }],
       };
       customRender(<>{render(xref)}</>);
-      expect(screen.getByRole('link', { name: 'UP000005640' })).toHaveAttribute(
+      const link = screen.getByRole('link', { name: 'UP000005640' });
+      expect(link).toHaveAttribute(
         'href',
         expect.stringContaining('UP000005640')
       );
-      expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+      expect(link.parentElement).toHaveTextContent(/^UP000005640$/);
     });
 
     it('renders the component alongside the proteome link when present', () => {


### PR DESCRIPTION
## Purpose

https://embl.atlassian.net/browse/TRM-34242

## Approach

The proteome information is now shown in the xref table of uniparc entry page. `includeSources` query parameter fetches that information and it is parsed and populated in proteome column
Data taken from https://rest.uniprot.org/uniparc/UPI000227E3E6/databases?id=G0SUT6&includeSources=true

More examples
https://rest.uniprot.org/uniparc/UPI0000000001/databases?id=Q6RZL4&includeSources=true
https://rest.uniprot.org/uniparc/UPI0000000001/databases?id=Q76QK2&includeSources=true

## Testing

Updated test

## Checklist

- [x] My PR is scoped properly, and “does one thing only”
- [x] I have reviewed my own code
- [x] I have checked that linting checks pass and type safety is respected
- [x] I have checked that tests pass and coverage has at least improved, and if not explained the reasons why
- [ ] If needed, the changes have been previewed (eg on wwwdev) by all interested parties.
